### PR TITLE
Add autopay card status on Current Subscription page

### DIFF
--- a/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
@@ -170,6 +170,21 @@
             </div>
           </div>
         {% endif %}
+        <div class="form-group">
+          <label class="control-label col-sm-2">
+            {% trans "Autopay" %}
+          </label>
+          <div class="col-sm-10">
+            <p class="form-control-text">
+              {% if autopay_enabled %}
+                <span class="label label-success"><i class="fa fa-check"></i> {% trans "ENABLED" %}</span>
+              {% else %}
+                <span class="label label-warning"><i class="fa fa-warning"></i> {% trans "NOT SET" %}</span>
+              {% endif %}
+              (<a href="{{ manage_autopay_url }}">Manage</a>)
+            </p>
+          </div>
+        </div>
         {% if plan.next_subscription.exists and not plan.next_subscription.is_paused %}
           <div class="form-group">
             <label class="control-label col-sm-2">

--- a/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
@@ -181,7 +181,7 @@
               {% else %}
                 <span class="label label-warning"><i class="fa fa-warning"></i> {% trans "NOT SET" %}</span>
               {% endif %}
-              (<a href="{{ manage_autopay_url }}">Manage</a>)
+              (<a href="{{ manage_autopay_url }}#payment-methods">Manage</a>)
             </p>
           </div>
         </div>

--- a/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
@@ -177,7 +177,7 @@
               {% else %}
                 <span class="badge text-bg-warning"><i class="fa fa-warning"></i> {% trans "NOT SET" %}</span>
               {% endif %}
-              (<a href="{{ manage_autopay_url }}">Manage</a>)
+              (<a href="{{ manage_autopay_url }}#payment-methods">Manage</a>)
             </p>
           </div>
         </div>

--- a/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
@@ -166,6 +166,21 @@
             </div>
           </div>
         {% endif %}
+        <div class="mb-3">
+          <label class="form-label col-md-2">
+            {% trans "Autopay" %}
+          </label>
+          <div class="col-sm-10">
+            <p class="form-control-text">
+              {% if autopay_enabled %}
+                <span class="badge text-bg-success"><i class="fa fa-check"></i> {% trans "ENABLED" %}</span>
+              {% else %}
+                <span class="badge text-bg-warning"><i class="fa fa-warning"></i> {% trans "NOT SET" %}</span>
+              {% endif %}
+              (<a href="{{ manage_autopay_url }}">Manage</a>)
+            </p>
+          </div>
+        </div>
         {% if plan.next_subscription.exists and not plan.next_subscription.is_paused %}
           <div class="form-group">  {# todo B5: css-form-group #}
             <label class="form-label col-md-2">

--- a/corehq/apps/domain/templates/domain/update_billing_contact_info.html
+++ b/corehq/apps/domain/templates/domain/update_billing_contact_info.html
@@ -19,7 +19,7 @@
       {% crispy billing_account_info_form %}
     </div>
   </div>
-  <div class="mt-3 card">
+  <div class="mt-3 card" id="payment-methods">
     <h5 class="card-header">
       {% trans "Payment Methods" %}
     </h5>

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -433,6 +433,8 @@ class DomainSubscriptionView(DomainAccountingSettings):
                 for feature in self.plan.get('features')
             ),
             'can_change_subscription': subs and subs.user_can_change_subscription(self.request.user),
+            'autopay_enabled': self.account.auto_pay_enabled,
+            'manage_autopay_url': reverse(EditExistingBillingAccountView.urlname, args=[self.domain]),
         }
 
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
@@ -88,7 +88,7 @@
                    >
                      {% if plan.is_auto_renew %}
                        {% trans "Disable Auto Renewal" %}
-@@ -160,40 +156,40 @@
+@@ -160,55 +156,55 @@
              </div>
            {% endif %}
            <div data-bind="foreach: products">
@@ -105,6 +105,25 @@
              </div>
            </div>
          {% endif %}
+-        <div class="form-group">
+-          <label class="control-label col-sm-2">
++        <div class="mb-3">
++          <label class="form-label col-md-2">
+             {% trans "Autopay" %}
+           </label>
+           <div class="col-sm-10">
+             <p class="form-control-text">
+               {% if autopay_enabled %}
+-                <span class="label label-success"><i class="fa fa-check"></i> {% trans "ENABLED" %}</span>
++                <span class="badge text-bg-success"><i class="fa fa-check"></i> {% trans "ENABLED" %}</span>
+               {% else %}
+-                <span class="label label-warning"><i class="fa fa-warning"></i> {% trans "NOT SET" %}</span>
++                <span class="badge text-bg-warning"><i class="fa fa-warning"></i> {% trans "NOT SET" %}</span>
+               {% endif %}
+               (<a href="{{ manage_autopay_url }}#payment-methods">Manage</a>)
+             </p>
+           </div>
+         </div>
          {% if plan.next_subscription.exists and not plan.next_subscription.is_paused %}
 -          <div class="form-group">
 -            <label class="control-label col-sm-2">
@@ -141,7 +160,7 @@
                <p class="form-control-text">
                  {{ plan.next_subscription.price }}
                </p>
-@@ -206,26 +202,26 @@
+@@ -221,26 +217,26 @@
          <div class="form form-horizontal">
            {% if plan.has_credits_in_non_general_credit_line %}
              <div data-bind="foreach: products">
@@ -174,7 +193,7 @@
                  <p class="form-control-text js-general-credit">
                    {{ plan.general_credit.amount }}
                  </p>
-@@ -233,29 +229,29 @@
+@@ -248,29 +244,29 @@
              </div>
            {% endif %}
            <div data-bind="with: prepayments">
@@ -212,7 +231,7 @@
                      <i class="fa fa-info-circle"></i>
                      {% trans "Not Billing Admin, Can't Add Credit" %}
                    </span>
-@@ -268,8 +264,8 @@
+@@ -283,8 +279,8 @@
            <legend>{% trans 'Account Credit' %}</legend>
            <div class="form form-horizontal">
              <div data-bind="foreach: products">
@@ -223,7 +242,7 @@
                    {% trans 'Plan Credit' %}
                    <div class="hq-help">
                      <a
-@@ -284,7 +280,7 @@
+@@ -299,7 +295,7 @@
                      </a>
                    </div>
                  </label>
@@ -232,7 +251,7 @@
                    <p
                      class="form-control-text"
                      data-bind="text: accountAmount"
-@@ -293,8 +289,8 @@
+@@ -308,8 +304,8 @@
                </div>
              </div>
              {% if plan.account_general_credit and plan.account_general_credit.is_visible %}
@@ -243,7 +262,7 @@
                    {% trans 'General Credit' %}
                    <div class="hq-help">
                      <a
-@@ -310,7 +306,7 @@
+@@ -325,7 +321,7 @@
                      </a>
                    </div>
                  </label>
@@ -252,7 +271,7 @@
                    <p class="form-control-text">
                      {{ plan.account_general_credit.amount }}
                    </p>
-@@ -380,8 +376,8 @@
+@@ -395,8 +391,8 @@
  
  {% block modals %}
    {{ block.super }}


### PR DESCRIPTION
## Product Description
This adds the status of whether autopay is "enabled" or "not set", with a Manage link after linking to the Billing Information page where folks can manage the autopay method.

This will apply to all accounts. Later, I will introduce a PR that will put an alert below the status if no autopay method is set.

when autopay is not set:
<img width="618" height="686" alt="Screenshot 2025-10-09 at 9 40 33 PM" src="https://github.com/user-attachments/assets/a11c35de-5d07-4a2d-9d26-4f8792ceade3" />

when autopay is enabled:
<img width="696" height="701" alt="Screenshot 2025-10-09 at 9 40 57 PM" src="https://github.com/user-attachments/assets/4018485a-303c-44a8-93c2-990028f23749" />



## Safety Assurance

### Safety story
safe change, just a ui change and a link

### Automated test coverage
n/a

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
