### PR TITLE
Modify error on 3+ login attempts when user can select server location

### DIFF
--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -60,11 +60,12 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
             if not self.cleaned_data.get('captcha'):
                 raise ValidationError(_("Please enter valid CAPTCHA"))
 
+        if self.request is not None:
+            self.request.session['login_attempts'] = self.request.session.get('login_attempts', 0) + 1
+
         try:
             cleaned_data = super(EmailAuthenticationForm, self).clean()
         except ValidationError:
-            if self.request is not None:
-                self.request.session['login_attempts'] = self.request.session.get('login_attempts', 0) + 1
             user = CouchUser.get_by_username(username)
             if user and user.is_locked_out():
                 metrics_counter('commcare.auth.lockouts')

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -61,12 +61,11 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
             if not self.cleaned_data.get('captcha'):
                 raise ValidationError(_("Please enter valid CAPTCHA"))
 
-        if self.request:
-            self.request.session['login_attempts'] = self.request.session.get('login_attempts', 0) + 1
-
         try:
             cleaned_data = super(EmailAuthenticationForm, self).clean()
         except ValidationError:
+            if self.request:
+                self.request.session['login_attempts'] = self.request.session.get('login_attempts', 0) + 1
             user = CouchUser.get_by_username(username)
             if user and user.is_locked_out():
                 metrics_counter('commcare.auth.lockouts')

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -30,7 +30,7 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
     if settings.ADD_CAPTCHA_FIELD_TO_FORMS:
         captcha = ReCaptchaField(label="")
 
-    def __init__(self, can_select_server=False, *args, **kwargs):
+    def __init__(self, *args, can_select_server=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.can_select_server = can_select_server
         if settings.ENFORCE_SSO_LOGIN:

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -20,6 +20,7 @@ LOCKOUT_MESSAGE = mark_safe(_(  # nosec: no user input
     'Sorry - you have attempted to login with an incorrect password too many times. '
     'Please <a href="/accounts/password_reset_email/">click here</a> to reset your password '
     'or contact the domain administrator.'))
+LOGIN_ATTEMPTS_FOR_CLOUD_MESSAGE = 3
 
 
 class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
@@ -84,7 +85,7 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
     def get_invalid_login_error(self):
         if (
             self.request is not None
-            and self.request.session.get('login_attempts', 0) > 2
+            and self.request.session.get('login_attempts', 0) >= LOGIN_ATTEMPTS_FOR_CLOUD_MESSAGE
             and self.can_select_server
         ):
             return ValidationError(

--- a/corehq/apps/hqwebapp/tests/test_forms.py
+++ b/corehq/apps/hqwebapp/tests/test_forms.py
@@ -144,3 +144,15 @@ class TestEmailAuthenticationFormValidationError(TestCase):
             can_select_server=True,
             expected_message="Please enter a correct %(username)s and password.",
         )
+
+    def test_increments_login_attempts_on_failure(self):
+        request = RequestFactory().get('/')
+        request.session = {}
+        form = self.create_form(request=request)
+        form.full_clean()
+        assert not form.is_valid()
+        assert form.request.session['login_attempts'] == 1
+
+        form.full_clean()
+        assert not form.is_valid()
+        assert form.request.session['login_attempts'] == 2

--- a/corehq/apps/hqwebapp/tests/test_forms.py
+++ b/corehq/apps/hqwebapp/tests/test_forms.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from corehq.apps.users.models import WebUser
 
 from ..forms import (
+    LOGIN_ATTEMPTS_FOR_CLOUD_MESSAGE,
     EmailAuthenticationForm,
     HQAuthenticationTokenForm,
     HQBackupTokenForm,
@@ -112,8 +113,8 @@ class TestEmailAuthenticationFormValidationError(TestCase):
     def test_cloud_location_message_on_repeated_failures(self):
         request = RequestFactory().get('/')
         request.session = {}
-        for i in range(1, 3):
-            if i < 3:
+        for i in range(1, LOGIN_ATTEMPTS_FOR_CLOUD_MESSAGE + 1):
+            if i < LOGIN_ATTEMPTS_FOR_CLOUD_MESSAGE:
                 message = "Please enter a correct %(username)s and password."
             else:
                 message = "Still having trouble?"
@@ -127,7 +128,7 @@ class TestEmailAuthenticationFormValidationError(TestCase):
     def test_original_message_if_not_can_select_server(self):
         request = RequestFactory().get('/')
         request.session = {}
-        for i in range(1, 3):
+        for i in range(1, LOGIN_ATTEMPTS_FOR_CLOUD_MESSAGE + 1):
             self.run_form_and_assert(
                 request=request,
                 can_select_server=False,
@@ -136,7 +137,7 @@ class TestEmailAuthenticationFormValidationError(TestCase):
             )
 
     def test_original_message_if_no_request_object(self):
-        for _ in range(1, 3):
+        for _ in range(1, LOGIN_ATTEMPTS_FOR_CLOUD_MESSAGE + 1):
             self.run_form_and_assert(
                 request=None,
                 can_select_server=True,

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -547,6 +547,8 @@ class HQLoginView(LoginView):
         kwargs = super().get_form_kwargs(step)
         # The forms need the request to properly log authentication failures
         kwargs.setdefault('request', self.request)
+        if step == self.AUTH_STEP:
+            kwargs['can_select_server'] = self.can_select_server()
         return kwargs
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
## Product Description
Modifies the error message on 3+ failed login attempts, when the user has the ability to select the cloud location on the login screen:
<img width="487" height="548" alt="image" src="https://github.com/user-attachments/assets/7fd0abf6-d047-4c18-8040-a8a31c199b2e" />

In other cases, such as domain-specific logins or on the first 2 failed login attempts, users will continue to see the current error message:
<img width="489" height="566" alt="image" src="https://github.com/user-attachments/assets/a10ea9ac-9ba1-4993-839a-8531f4bb064e" />


## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/SAAS-18490), [Design](https://docs.google.com/document/d/1yR8JK0Qa6wUFUKOGdmiKAxdqUMsSP26TZMmj1j-jCXs/edit?tab=t.1gjpn7r8n8qs)
Adds a `login_attempts` property on the session that increments for each failed username/password login attempt and is reset when the username/password are entered correctly. Uses the inherited `get_invalid_login_error` method to conditionally change the error message on failed login attempts 3+, when the user can see the option to select a cloud location.

## Safety Assurance

### Safety story
Tested locally with basic login and on staging with plain login, 2fa, and sso. This doesn't change the circumstances under which we accept or reject the login - only the content of the error message - and doesn't give the user any potentially risky information, since the only factor for the alternate message is how many failed login attempts are on _their own current session_.

### Automated test coverage
Added automated tests for this error message, and to see that the login_attempts is incremented correctly on the request session.

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
