### PR TITLE
Add DATA_DICT_TYPES privilege

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -162,6 +162,7 @@ advanced_v0 = pro_v1 + [
     privileges.CUSTOM_DOMAIN_ALERTS,
     privileges.APP_DEPENDENCIES,
     privileges.BULK_DATA_EDITING,
+    privileges.DATA_DICT_TYPES,
 ]
 
 enterprise_v0 = advanced_v0 + [

--- a/corehq/apps/accounting/migrations/0111_data_dict_types_priv.py
+++ b/corehq/apps/accounting/migrations/0111_data_dict_types_priv.py
@@ -1,0 +1,55 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.privileges import DATA_DICT_TYPES
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+editions_below_adv = ','.join((
+    SoftwarePlanEdition.PAUSED,
+    SoftwarePlanEdition.FREE,
+    SoftwarePlanEdition.STANDARD,
+    SoftwarePlanEdition.PRO,
+))
+
+
+@skip_on_fresh_install
+def _grandfather_data_dict_types_priv(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        DATA_DICT_TYPES,
+        skip_edition=editions_below_adv,
+        noinput=True,
+    )
+
+
+def _revoke_data_dict_types_priv(apps, schema_editor):
+    from corehq.apps.hqadmin.management.commands import cchq_prbac_bootstrap
+
+    call_command(
+        'cchq_prbac_revoke_privs',
+        DATA_DICT_TYPES,
+        skip_edition=editions_below_adv,
+        delete_privs=False,
+        check_privs_exist=True,
+        noinput=True,
+    )
+    command = cchq_prbac_bootstrap.Command()
+    command.OLD_PRIVILEGES.append(DATA_DICT_TYPES)
+    call_command(command)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0110_alter_customerinvoicecommunicationhistory_communication_type_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _grandfather_data_dict_types_priv,
+            reverse_code=_revoke_data_dict_types_priv,
+        ),
+    ]

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -246,6 +246,9 @@ class Command(BaseCommand):
              name='Two Stage Mobile Worker Account Creation',
              description='Allows two-stage user provisioning '
                          '(users confirm and set their own passwords via email)'),
+        Role(slug=privileges.DATA_DICT_TYPES,
+             name='Data Dictionary case properties have data types',
+             description='Data Dictionary case properties have data types.'),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -125,6 +125,7 @@ TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION = 'two_stage_mobile_worker_account_crea
 CASE_DEDUPE = 'case_deduplicate'
 CUSTOM_DOMAIN_ALERTS = 'custom_domain_alerts'
 APP_DEPENDENCIES = 'app_dependencies'
+DATA_DICT_TYPES = 'data_dict_types'
 
 # "Enable All Application Add-Ons" in Project Settings > Basic and
 # "Enable All Add-Ons" in Application Settings > "Add-Ons"
@@ -197,6 +198,7 @@ MAX_PRIVILEGES = [
     SHOW_ENABLE_ALL_ADD_ONS,
     BULK_DATA_EDITING,
     TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION,
+    DATA_DICT_TYPES,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -279,4 +281,5 @@ class Titles(object):
             APP_DEPENDENCIES: _("App Dependencies"),
             SHOW_ENABLE_ALL_ADD_ONS: _('Show "Enable All Add-Ons" button'),
             TWO_STAGE_MOBILE_WORKER_ACCOUNT_CREATION: _("Two-stage Mobile Worker Account Creation"),
+            DATA_DICT_TYPES: _("Data Dictionary case properties have data types")
         }.get(privilege, privilege)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2340,7 +2340,8 @@ DATA_REGISTRY_CASE_UPDATE_REPEATER = StaticToggle(
     parent_toggles=[DATA_REGISTRY]
 )
 
-CASE_IMPORT_DATA_DICTIONARY_VALIDATION = StaticToggle(
+CASE_IMPORT_DATA_DICTIONARY_VALIDATION = FrozenPrivilegeToggle(
+    privileges.DATA_DICT_TYPES,
     'case_import_data_dictionary_validaton',
     'USH: Validate data per data dictionary definitions during case import',
     TAG_CUSTOM,

--- a/migrations.lock
+++ b/migrations.lock
@@ -130,6 +130,7 @@ accounting
  0108_subscription_auto_renew_and_more
  0109_enable_all_add_ons_priv
  0110_alter_customerinvoicecommunicationhistory_communication_type_and_more
+ 0111_data_dict_types_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Technical Summary

This commit contains the migration for PR https://github.com/dimagi/commcare-hq/pull/37035

Merging that PR has been delayed pending further discussion, so I'm opening this PR to unblock other people who have migrations in the `accounting` app/module.

## Feature Flag

`CASE_IMPORT_DATA_DICTIONARY_VALIDATION`

## Safety Assurance

### Safety story

Only a migration to add a new Role for a new privilege. No other code change included.

### Automated test coverage

Existing tests cover the associated feature flag. (Code and tests in the delayed follow-up PR switch from the feature flag to the privilege.)

### QA Plan

No

### Migrations

- [x] The migrations in this code can be safely applied first independently of the code

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
