### PR TITLE
Catch RuntimeError when indexing design docs

### DIFF
--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -1,9 +1,13 @@
+import logging
+
 from django.conf import settings
 
 from corehq.apps.celery import periodic_task
 from corehq.preindex.accessors import get_preindex_designs, index_design_doc
 from corehq.util.celery_utils import deserialize_run_every_setting
 from corehq.util.decorators import serial_task
+
+logger = logging.getLogger(__name__)
 
 couch_reindex_schedule = deserialize_run_every_setting(settings.COUCH_REINDEX_SCHEDULE)
 
@@ -20,4 +24,7 @@ def run_continuous_indexing_task():
 @serial_task('couch-continuous-indexing', timeout=60 * 60, queue=settings.CELERY_PERIODIC_QUEUE, max_retries=0)
 def preindex_couch_views():
     for design in get_preindex_designs():
-        index_design_doc(design)
+        try:
+            index_design_doc(design)
+        except RuntimeError:
+            logger.error(f'Failed to index design doc {design.app_label}')

--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -26,5 +26,8 @@ def preindex_couch_views():
     for design in get_preindex_designs():
         try:
             index_design_doc(design)
-        except RuntimeError:
-            logger.error(f'Failed to index design doc {design.app_label}')
+        except RuntimeError as e:
+            if 'Failed to verify design document' in str(e):
+                logger.error(f'Failed to index design doc {design.app_label}')
+            else:
+                raise


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Stop this sentry error from being created: https://dimagi.sentry.io/issues/6794907539/?environment=production&project=136860&query=is%3Aunresolved&referrer=issue-stream

Would it be better to understand how we get into this state in the first place? Yes, but after some brief searching on slack, I decided to just do this for now to get [this celery task passing](https://app.datadoghq.com/dashboard/bdu-k5b-bz5/celery-overview?fromUser=true&fullscreen_end_ts=1760378567596&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1744567367596&fullscreen_widget=1387517464532404&refresh_mode=sliding&tpl_var_celery_task%5B0%5D=corehq.preindex.tasks.preindex_couch_views&from_ts=1744567365401&to_ts=1760378565401&live=true).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
