### PR TITLE
Close old connections if an error is encountered when storing task state

### DIFF
--- a/corehq/celery_monitoring/signals.py
+++ b/corehq/celery_monitoring/signals.py
@@ -49,8 +49,6 @@ def update_celery_state(sender=None, headers=None, **kwargs):
     except InterfaceError:
         close_old_connections()
         backend.store_result(headers['id'], None, CELERY_STATE_SENT)
-    finally:
-        close_old_connections()
 
 
 @task_prerun.connect

--- a/corehq/celery_monitoring/signals.py
+++ b/corehq/celery_monitoring/signals.py
@@ -2,14 +2,17 @@ import datetime
 import inspect
 import logging
 
-from django.core.cache import cache
-
-from celery.signals import before_task_publish, task_postrun, task_prerun
-
+from celery import current_app
+from celery.signals import after_task_publish, before_task_publish, task_postrun, task_prerun
 from dimagi.utils.parsing import string_to_utc_datetime
+from django.core.cache import cache
+from django.db import close_old_connections
+from psycopg2._psycopg import InterfaceError
 
 from corehq.util.metrics import push_metrics
 from corehq.util.quickcache import quickcache
+
+CELERY_STATE_SENT = "SENT"
 
 
 @before_task_publish.connect
@@ -20,6 +23,34 @@ def celery_add_time_sent(headers=None, body=None, **kwargs):
     if eta:
         eta = TimeToStartTimer.parse_iso8601(eta)
     TimeToStartTimer(task_id).start_timing(eta)
+
+
+@after_task_publish.connect
+def update_celery_state(sender=None, headers=None, **kwargs):
+    """Updates the celery task progress to "SENT"
+
+    When fetching an task from celery using the form AsyncResponse(task_id), if
+    task_id never exists, celery will not throw an error, it will just hang.
+    This function updates each task sent to celery to have a progress value of "SENT",
+    which means we can check that a task exists with the following pattern:
+    `AsyncResponse(task_id).status == "SENT"`
+
+    See
+    http://stackoverflow.com/questions/9824172/find-out-whether-celery-task-exists/10089358
+    for more info
+
+    """
+
+    task = current_app.tasks.get(sender)
+    backend = task.backend if task else current_app.backend
+
+    try:
+        backend.store_result(headers['id'], None, CELERY_STATE_SENT)
+    except InterfaceError:
+        close_old_connections()
+        backend.store_result(headers['id'], None, CELERY_STATE_SENT)
+    finally:
+        close_old_connections()
 
 
 @task_prerun.connect

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -28,8 +28,7 @@ from itertools import chain, islice
 
 from casexml.apps.case.const import CASE_INDEX_EXTENSION as EXTENSION
 from casexml.apps.phone.const import ASYNC_RETRY_AFTER
-from casexml.apps.phone.tasks import ASYNC_RESTORE_SENT
-
+from corehq.celery_monitoring.signals import CELERY_STATE_SENT
 from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
 from corehq.sql_db.routers import read_from_plproxy_standbys
 from corehq.toggles import LIVEQUERY_READ_FROM_STANDBYS, NAMESPACE_USER
@@ -377,7 +376,7 @@ def init_progress(async_task, total):
 
     def update_progress(done):
         async_task.update_state(
-            state=ASYNC_RESTORE_SENT,
+            state=CELERY_STATE_SENT,
             meta={
                 'done': done,
                 'total': total,

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -10,30 +10,29 @@ from uuid import uuid4
 from wsgiref.util import FileWrapper
 from xml.etree import cElementTree as ElementTree
 
-from django.conf import settings
-from django.http import HttpResponse, StreamingHttpResponse
-from django.utils.text import slugify
-
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult
-from looseversion import LooseVersion
-from memoized import memoized
-
-from casexml.apps.case.xml import V1, check_version
 from couchforms.openrosa_response import (
     ResponseNature,
     get_response_element,
     get_simple_response_xml,
 )
 from dimagi.utils.logging import notify_error
+from django.conf import settings
+from django.http import HttpResponse, StreamingHttpResponse
+from django.utils.text import slugify
+from looseversion import LooseVersion
+from memoized import memoized
 
+from casexml.apps.case.xml import V1, check_version
 from corehq.apps.app_manager.exceptions import CannotRestoreException
 from corehq.apps.domain.models import Domain
 from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.exceptions import NotFound
+from corehq.celery_monitoring.signals import CELERY_STATE_SENT
 from corehq.const import LOADTEST_HARD_LIMIT
 from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED
-from corehq.util.metrics import metrics_counter, metrics_histogram, limit_domains
+from corehq.util.metrics import limit_domains, metrics_counter, metrics_histogram
 from corehq.util.timer import TimingContext
 
 from .checksum import CaseStateHash
@@ -58,7 +57,7 @@ from .models import (
     get_properly_wrapped_sync_log,
 )
 from .restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
-from .tasks import ASYNC_RESTORE_SENT, get_async_restore_payload
+from .tasks import get_async_restore_payload
 from .utils import get_cached_items_with_count
 from .xml import (
     get_progress_element,
@@ -679,7 +678,7 @@ class RestoreConfig(object):
         task_id = self.async_restore_task_id_cache.get_value()
         if task_id:
             task = AsyncResult(task_id)
-            task_exists = task.status == ASYNC_RESTORE_SENT
+            task_exists = task.status == CELERY_STATE_SENT
         else:
             task = None
             task_exists = False

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -5,9 +5,8 @@ from django.conf import settings
 from django.db import connections, router
 from django.db.models import Min
 
-from celery import current_app, current_task
+from celery import current_task
 from celery.schedules import crontab
-from celery.signals import after_task_publish
 
 from casexml.apps.phone.models import SyncLogSQL
 from dimagi.utils.logging import notify_exception
@@ -18,7 +17,6 @@ from corehq.util.metrics import metrics_gauge
 log = logging.getLogger(__name__)
 
 ASYNC_RESTORE_QUEUE = 'async_restore_queue'
-ASYNC_RESTORE_SENT = "SENT"
 SYNCLOG_RETENTION_DAYS = 9 * 7  # 63 days
 
 
@@ -44,28 +42,6 @@ def get_async_restore_payload(restore_config, domain=None, username=None):
     restore_config.async_restore_task_id_cache.invalidate()
 
     return response.name
-
-
-@after_task_publish.connect
-def update_celery_state(sender=None, headers=None, **kwargs):
-    """Updates the celery task progress to "SENT"
-
-    When fetching an task from celery using the form AsyncResponse(task_id), if
-    task_id never exists, celery will not throw an error, it will just hang.
-    This function updates each task sent to celery to have a progress value of "SENT",
-    which means we can check that a task exists with the following pattern:
-    `AsyncResponse(task_id).status == "SENT"`
-
-    See
-    http://stackoverflow.com/questions/9824172/find-out-whether-celery-task-exists/10089358
-    for more info
-
-    """
-
-    task = current_app.tasks.get(sender)
-    backend = task.backend if task else current_app.backend
-
-    backend.store_result(headers['id'], None, ASYNC_RESTORE_SENT)
 
 
 @periodic_task(

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -1,33 +1,34 @@
-from unittest import mock
 from io import BytesIO
-from django.test import TestCase, SimpleTestCase, override_settings
-from casexml.apps.phone.models import SyncLogSQL
-from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
+from unittest import mock
 
-from corehq.apps.app_manager.tests.util import TestXmlMixin
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult
+from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
+from django.test import SimpleTestCase, TestCase, override_settings
 
-from casexml.apps.case.xml import V2
 from casexml.apps.case.tests.util import (
     delete_all_cases,
     delete_all_sync_logs,
 )
-from corehq.apps.domain.models import Domain
-from corehq.form_processor.tests.utils import sharded
+from casexml.apps.case.xml import V2
+from casexml.apps.phone.models import SyncLogSQL
 from casexml.apps.phone.restore import (
+    AsyncRestoreResponse,
+    RestoreCacheSettings,
     RestoreConfig,
     RestoreParams,
-    RestoreCacheSettings,
-    AsyncRestoreResponse,
     RestoreResponse,
 )
-from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
+from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
+from casexml.apps.phone.tasks import get_async_restore_payload
 from casexml.apps.phone.tests.utils import create_restore_user
-from corehq.apps.users.dbaccessors import delete_all_users
-from corehq.util.test_utils import flag_enabled
+from corehq.apps.app_manager.tests.util import TestXmlMixin
+from corehq.apps.domain.models import Domain
 from corehq.apps.receiverwrapper.util import submit_form_locally
-from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
+from corehq.apps.users.dbaccessors import delete_all_users
+from corehq.celery_monitoring.signals import CELERY_STATE_SENT
+from corehq.form_processor.tests.utils import sharded
+from corehq.util.test_utils import flag_enabled
 
 
 class BaseAsyncRestoreTest(TestCase):
@@ -124,7 +125,7 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         # the return value).
         restore_response = mock.MagicMock(return_value=RestoreResponse(None))
         with mock.patch.object(AsyncResult, 'get', restore_response) as get_result:
-            with mock.patch.object(AsyncResult, 'status', ASYNC_RESTORE_SENT):
+            with mock.patch.object(AsyncResult, 'status', CELERY_STATE_SENT):
                 subsequent_restore = self._restore_config(is_async=True)
                 self.assertIsNotNone(async_restore_task_id_cache.get_value())
                 subsequent_restore.get_payload()


### PR DESCRIPTION
Reverts dimagi/commcare-hq#37047 which reverted https://github.com/dimagi/commcare-hq/pull/37013, but with one modification.

Rather than always close old connections in the finally block, we really only need to close connections if we face an interface error and want to try again. The reason the original PR was reverted is because we observed celery tasks being queued inside of a transaction atomic block, which meant that this code was called in that transaction as well.

This isn't a good practice since it isn't like that task can be "rolled back", but we don't have a good way to prevent devs from doing this even if we fixed the problematic areas. Given how hard it can be to debug these issues ("where is my db connection getting killed?"), I wouldn't want to make it easy for devs to run into this scenario, hence the change.