### PR TITLE
Only log missing DomainMetrics if domain is active

### DIFF
--- a/corehq/apps/api/domain_metadata.py
+++ b/corehq/apps/api/domain_metadata.py
@@ -60,8 +60,9 @@ class DomainMetadataResource(CouchResourceMixin, HqBaseResource):
         try:
             base_properties = self._get_base_properties_from_domain_metrics(domain_obj.name)
             properties = self._add_extra_calculated_properties(base_properties, domain_obj.name, calc_prop_prefix)
-        except (DomainMetrics.DoesNotExist):
-            logging.exception('Problem getting calculated properties for {}'.format(domain_obj.name))
+        except DomainMetrics.DoesNotExist:
+            if domain_obj.is_active:
+                logging.exception('Problem getting calculated properties for {}'.format(domain_obj.name))
             return {}
         return properties
 


### PR DESCRIPTION
## Technical Summary
A domain that has never been active would never [have had DomainMetrics created](https://github.com/dimagi/commcare-hq/blob/564bf9cfc76816f867dec2d1d4a6374af56c623a/corehq/apps/data_analytics/tasks.py#L167), so there is no need to log that as an error state. It is possible for a domain to _be_ inactive _and have_ DomainMetrics, so we don't want to filter before trying to look up DomainMetrics (e.g. on the DomainES query). Should make [this Sentry error](https://dimagi.sentry.io/issues/6203056511/) much less noisy.

## Safety Assurance

### Safety story
Just affects when logging happens.

### Automated test coverage
Don't believe so.

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
