### PR TITLE
fix error in DomainGlobalSettingsForm when no privilege for enable_all_add_ons is available

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -671,6 +671,16 @@ class DomainGlobalSettingsForm(forms.Form):
         else:
             self._handle_exports_use_elasticsearch_setting_value()
 
+        checkbox_fields = [
+            hqcrispy.CheckboxField('release_mode_visibility'),
+        ]
+        if 'enable_all_add_ons' in self.fields:
+            checkbox_fields.append(hqcrispy.CheckboxField('enable_all_add_ons'))
+        checkbox_fields.extend([
+            hqcrispy.CheckboxField('orphan_case_alerts_warning'),
+            hqcrispy.CheckboxField('opt_out_of_data_sharing'),
+        ])
+
         self.helper = hqcrispy.HQFormHelper(self)
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
@@ -679,10 +689,7 @@ class DomainGlobalSettingsForm(forms.Form):
                 'project_description',
                 'default_timezone',
                 crispy.Div(*self.get_extra_fields()),
-                hqcrispy.CheckboxField('release_mode_visibility'),
-                hqcrispy.CheckboxField('enable_all_add_ons'),
-                hqcrispy.CheckboxField('orphan_case_alerts_warning'),
-                hqcrispy.CheckboxField('opt_out_of_data_sharing'),
+                *checkbox_fields,
             ),
             hqcrispy.FormActions(
                 StrictButton(


### PR DESCRIPTION
## Product Description
The project settings form is currently raising a 500 because the form is trying to render a field (`enable_all_add_ons`) when it was deleted due to a lack of privileges.

## Technical Summary
- only include field in the crispy layout if it is present in `self.fields`

## Safety Assurance

### Safety story
safe change, tested locally. fixes error

### Automated test coverage
n/a

### QA Plan
not needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
