### PR TITLE
Remove functionality from payments modal that allows users to modify autopayment method

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -507,12 +507,6 @@ var stripeCardModel = function () {
         self.newSavedCard(false);
     };
 
-    self.autopayCard = ko.computed(function () {
-        if (!self.newSavedCard()) {
-            return false;
-        }
-    });
-
     self.showCardData = ko.computed(function () {
         return ! self.isProcessing();
     });

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -162,10 +162,7 @@ var paymentMethodHandler = function (formId, opts) {
 
     self.handlers = [self];
 
-    self.showConfirmRemoveCard = ko.observable(false);
-    self.isRemovingCard = ko.observable(false);
     self.selectedCard = ko.computed(function () {
-        self.showConfirmRemoveCard(false);
         if (self.isSavedCard()) {
             return self.selectedSavedCard();
         }
@@ -229,45 +226,6 @@ var paymentMethodHandler = function (formId, opts) {
             self.paymentProcessing(true);
             self.submitForm();
         }
-    };
-
-
-    self.confirmRemoveSavedCard = function () {
-        self.showConfirmRemoveCard(true);
-    };
-
-    self.removeSavedCard = function () {
-        self.isRemovingCard(true);
-        self.showConfirmRemoveCard(false);
-        const $form = $('#' + self.formId);
-        let formData = new FormData($form.get(0));
-        formData.set("removeCard", true);
-        $.ajax({
-            url: $form.attr("action"),
-            method: "POST",
-            data: Object.fromEntries(formData),
-            success: function (response) {
-                self.handleProcessingErrors(response);
-                for (var i = 0; i < self.handlers.length; i++) {
-                    var handler = self.handlers[i];
-                    handler.savedCards(_.filter(handler.savedCards(), function (card) {
-                        return card.token() !== response.removedCard;
-                    }));
-                    if (!handler.savedCards().length) {
-                        handler.selectedCardType('new');
-                    }
-                }
-                self.isRemovingCard(false);
-            },
-            error: function () {
-                self.handleGeneralError();
-                self.isRemovingCard(false);
-            },
-        });
-    };
-
-    self.cancelRemoveSavedCard = function () {
-        self.showConfirmRemoveCard(false);
     };
 
     self.handleGeneralError = function (response, textStatus, errorThrown) {

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -526,7 +526,7 @@ var stripeCardModel = function () {
 
     self.loadSavedData = function (data) {
         self.number('************' + data.last4);
-        self.cardType(data.type);
+        self.cardType(data.brand);
         self.expMonth(data.exp_month);
         self.expYear(data.exp_year);
         self.token(data.id);

--- a/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
@@ -2,9 +2,11 @@
 
 <script type="text/html" id="select-stripe-card-template">
   <fieldset>
-    <legend>{% trans 'Select Payment Method' %}</legend>
+    <legend>{% trans "Select Payment Method" %}</legend>
     <div class="form-group">
-      <label class="control-label col-sm-3"> {% trans 'Card' %} </label>
+      <label class="control-label col-sm-3">
+        {% trans "Card" %}
+      </label>
       <div class="col-sm-9">
         <div class="radio">
           <label>
@@ -14,23 +16,32 @@
               data-bind="checked: selectedCardType"
               value="saved"
             />
-            {% trans 'Use a saved card' %}
+            {% trans "Use a saved card" %}
           </label>
         </div>
-        <div data-bind="visible: isSavedCard" class="row">
+        <div
+          data-bind="visible: isSavedCard"
+          class="row"
+        >
           <div class="col-sm-8">
             <select
               class="form-control m-0"
-              data-bind="options: savedCards,
-                               optionsText: 'cardName',
-                               value: selectedSavedCard"
+              data-bind="
+                options: savedCards,
+                optionsText: 'cardName',
+                value: selectedSavedCard
+              "
             ></select>
           </div>
           <div class="col-sm-3">
             <button
               type="button"
               class="btn btn-danger"
-              data-bind="event: {click: confirmRemoveSavedCard}"
+              data-bind="
+                event: {
+                  click: confirmRemoveSavedCard
+                }
+              "
             >
               <i class="fa fa-remove"></i>
             </button>
@@ -41,24 +52,27 @@
           style="margin-top:10px;"
           data-bind="visible: showConfirmRemoveCard"
         >
-          <p>{% trans 'Actually remove this card?' %}</p>
+          <p>{% trans "Actually remove this card?" %}</p>
           <button
             type="button"
             class="btn btn-danger"
             data-bind="event: {click: removeSavedCard}"
           >
-            <i class="fa fa-remove"></i> {% trans 'Yes, Remove' %}
+            <i class="fa fa-remove"></i> {% trans "Yes, Remove" %}
           </button>
           <button
             type="button"
             class="btn btn-default"
             data-bind="event: {click: cancelRemoveSavedCard}"
           >
-            {% trans 'Cancel' %}
+            {% trans "Cancel" %}
           </button>
         </div>
-        <div class="alert alert-info" data-bind="visible: isRemovingCard">
-          {% trans 'Removing card...' %}
+        <div
+          class="alert alert-info"
+          data-bind="visible: isRemovingCard"
+        >
+          {% trans "Removing card..." %}
         </div>
         <div class="radio">
           <label>
@@ -68,54 +82,76 @@
               data-bind="checked: selectedCardType"
               value="new"
             />
-            {% trans 'Use a different card' %}
+            {% trans "Use a different card" %}
           </label>
         </div>
       </div>
     </div>
     <div
-      data-bind="template: {
-                            data: selectedSavedCard,
-                            name: 'saved-stripe-card-ko-template',
-                            if: isSavedCard,
-                        }"
+      data-bind="
+        template: {
+          data: selectedSavedCard,
+          name: 'saved-stripe-card-ko-template',
+          if: isSavedCard,
+        }
+      "
     ></div>
     <div
-      data-bind="template: {
-                            data: newCard,
-                            name: 'new-stripe-card-ko-template',
-                            if: isNewCard
-                        }"
+      data-bind="
+        template: {
+          data: newCard,
+          name: 'new-stripe-card-ko-template',
+          if: isNewCard
+        }
+      "
     ></div>
   </fieldset>
 </script>
 
 <script type="text/html" id="select-new-stripe-card-template">
   <fieldset>
-    <legend>{% trans 'Card Information' %}</legend>
+    <legend>{% trans "Card Information" %}</legend>
     <div
-      data-bind="template: {
-                            data: $data,
-                            name: 'new-stripe-card-ko-template',
-                        }"
+      data-bind="
+        template: {
+          data: $data,
+          name: 'new-stripe-card-ko-template',
+        }
+      "
     ></div>
   </fieldset>
 </script>
 
 <script type="text/html" id="saved-stripe-card-ko-template">
-  <input type="hidden" name="stripeToken" data-bind="value: token" />
-  <p class="alert alert-success" data-bind="visible: isProcessing">
-    {% blocktrans %} Processing your payment... {% endblocktrans %}
+  <input
+    type="hidden"
+    name="stripeToken"
+    data-bind="value: token"
+  />
+  <p
+    class="alert alert-success"
+    data-bind="visible: isProcessing"
+  >
+    {% blocktrans %}
+      Processing your payment...
+    {% endblocktrans %}
   </p>
 </script>
 
 <script type="text/html" id="new-stripe-card-ko-template">
-  <p class="alert alert-danger" data-bind="visible: showErrors">
+  <p
+    class="alert alert-danger"
+    data-bind="visible: showErrors"
+  >
     <i class="fa-solid fa-triangle-exclamation"></i>
     <span data-bind="text: errorMsg"></span>
   </p>
 
-  <input type="hidden" name="stripeToken" data-bind="value: token" />
+  <input
+    type="hidden"
+    name="stripeToken"
+    data-bind="value: token"
+  />
 
   <div data-bind="visible: showCardData">
     <div class="form-group">
@@ -132,16 +168,18 @@
             name="saveCard"
             data-bind="checked: newSavedCard"
           />
-          {% trans 'Save card for later' %}
+          {% trans "Save card for later" %}
         </label>
         <label class="checkbox">
           <input
             type="checkbox"
             name="autopayCard"
-            data-bind="enable: newSavedCard,
-                                                                         checked: autopayCard"
+            data-bind="
+              enable: newSavedCard,
+              checked: autopayCard
+            "
           />
-          {% trans 'Use this card to autopay' %}
+          {% trans "Use this card to autopay" %}
         </label>
         <span class="help-block">
           <i class="fa fa-info-circle"></i>
@@ -153,11 +191,19 @@
     </div>
   </div>
 
-  <p class="alert alert-success" data-bind="visible: isProcessing">
-    {% blocktrans %} Processing your payment... {% endblocktrans %}
+  <p
+    class="alert alert-success"
+    data-bind="visible: isProcessing"
+  >
+    {% blocktrans %}
+      Processing your payment...
+    {% endblocktrans %}
   </p>
 
-  <p class="alert alert-info" data-bind="visible: isTestMode">
+  <p
+    class="alert alert-info"
+    data-bind="visible: isTestMode"
+  >
     <i class="fa fa-info-circle"></i>
     {% trans "Using Stripe's TEST API." %}
   </p>

--- a/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
@@ -130,17 +130,6 @@
           />
           {% trans "Save card for later" %}
         </label>
-        <label class="checkbox">
-          <input
-            type="checkbox"
-            name="autopayCard"
-            data-bind="
-              enable: newSavedCard,
-              checked: autopayCard
-            "
-          />
-          {% trans "Use this card to autopay" %}
-        </label>
         <span class="help-block">
           <i class="fa fa-info-circle"></i>
           {% blocktrans %} We use

--- a/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
@@ -33,46 +33,6 @@
               "
             ></select>
           </div>
-          <div class="col-sm-3">
-            <button
-              type="button"
-              class="btn btn-danger"
-              data-bind="
-                event: {
-                  click: confirmRemoveSavedCard
-                }
-              "
-            >
-              <i class="fa fa-remove"></i>
-            </button>
-          </div>
-        </div>
-        <div
-          class="alert alert-warning"
-          style="margin-top:10px;"
-          data-bind="visible: showConfirmRemoveCard"
-        >
-          <p>{% trans "Actually remove this card?" %}</p>
-          <button
-            type="button"
-            class="btn btn-danger"
-            data-bind="event: {click: removeSavedCard}"
-          >
-            <i class="fa fa-remove"></i> {% trans "Yes, Remove" %}
-          </button>
-          <button
-            type="button"
-            class="btn btn-default"
-            data-bind="event: {click: cancelRemoveSavedCard}"
-          >
-            {% trans "Cancel" %}
-          </button>
-        </div>
-        <div
-          class="alert alert-info"
-          data-bind="visible: isRemovingCard"
-        >
-          {% trans "Removing card..." %}
         </div>
         <div class="radio">
           <label>

--- a/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
@@ -4,46 +4,56 @@
   <fieldset>
     <legend>{% trans 'Select Payment Method' %}</legend>
     <div class="form-group">
-      <label class="control-label col-sm-3">
-        {% trans 'Card' %}
-      </label>
+      <label class="control-label col-sm-3"> {% trans 'Card' %} </label>
       <div class="col-sm-9">
         <div class="radio">
           <label>
-            <input type="radio"
-                   name="selectedCardType"
-                   data-bind="checked: selectedCardType"
-                   value="saved">
+            <input
+              type="radio"
+              name="selectedCardType"
+              data-bind="checked: selectedCardType"
+              value="saved"
+            />
             {% trans 'Use a saved card' %}
           </label>
         </div>
         <div data-bind="visible: isSavedCard" class="row">
           <div class="col-sm-8">
-            <select class="form-control m-0"
-                    data-bind="options: savedCards,
+            <select
+              class="form-control m-0"
+              data-bind="options: savedCards,
                                optionsText: 'cardName',
-                               value: selectedSavedCard"></select>
+                               value: selectedSavedCard"
+            ></select>
           </div>
           <div class="col-sm-3">
-            <button type="button"
-                    class="btn btn-danger"
-                    data-bind="event: {click: confirmRemoveSavedCard}">
+            <button
+              type="button"
+              class="btn btn-danger"
+              data-bind="event: {click: confirmRemoveSavedCard}"
+            >
               <i class="fa fa-remove"></i>
             </button>
           </div>
         </div>
-        <div class="alert alert-warning"
-             style="margin-top:10px;"
-             data-bind="visible: showConfirmRemoveCard">
+        <div
+          class="alert alert-warning"
+          style="margin-top:10px;"
+          data-bind="visible: showConfirmRemoveCard"
+        >
           <p>{% trans 'Actually remove this card?' %}</p>
-          <button type="button"
-                  class="btn btn-danger"
-                  data-bind="event: {click: removeSavedCard}">
+          <button
+            type="button"
+            class="btn btn-danger"
+            data-bind="event: {click: removeSavedCard}"
+          >
             <i class="fa fa-remove"></i> {% trans 'Yes, Remove' %}
           </button>
-          <button type="button"
-                  class="btn btn-default"
-                  data-bind="event: {click: cancelRemoveSavedCard}">
+          <button
+            type="button"
+            class="btn btn-default"
+            data-bind="event: {click: cancelRemoveSavedCard}"
+          >
             {% trans 'Cancel' %}
           </button>
         </div>
@@ -52,47 +62,50 @@
         </div>
         <div class="radio">
           <label>
-            <input type="radio"
-                   name="selectedCardType"
-                   data-bind="checked: selectedCardType"
-                   value="new">
+            <input
+              type="radio"
+              name="selectedCardType"
+              data-bind="checked: selectedCardType"
+              value="new"
+            />
             {% trans 'Use a different card' %}
           </label>
         </div>
       </div>
     </div>
-    <div data-bind="template: {
+    <div
+      data-bind="template: {
                             data: selectedSavedCard,
                             name: 'saved-stripe-card-ko-template',
                             if: isSavedCard,
-                        }"></div>
-    <div data-bind="template: {
+                        }"
+    ></div>
+    <div
+      data-bind="template: {
                             data: newCard,
                             name: 'new-stripe-card-ko-template',
                             if: isNewCard
-                        }"></div>
+                        }"
+    ></div>
   </fieldset>
 </script>
 
 <script type="text/html" id="select-new-stripe-card-template">
   <fieldset>
     <legend>{% trans 'Card Information' %}</legend>
-    <div data-bind="template: {
+    <div
+      data-bind="template: {
                             data: $data,
                             name: 'new-stripe-card-ko-template',
-                        }"></div>
+                        }"
+    ></div>
   </fieldset>
 </script>
 
 <script type="text/html" id="saved-stripe-card-ko-template">
-  <input type="hidden"
-         name="stripeToken"
-         data-bind="value: token" />
-  <p class="alert alert-success"
-     data-bind="visible: isProcessing">
-    {% blocktrans %}
-      Processing your payment...
-    {% endblocktrans %}
+  <input type="hidden" name="stripeToken" data-bind="value: token" />
+  <p class="alert alert-success" data-bind="visible: isProcessing">
+    {% blocktrans %} Processing your payment... {% endblocktrans %}
   </p>
 </script>
 
@@ -102,43 +115,46 @@
     <span data-bind="text: errorMsg"></span>
   </p>
 
-  <input type="hidden"
-         name="stripeToken"
-         data-bind="value: token" />
+  <input type="hidden" name="stripeToken" data-bind="value: token" />
 
   <div data-bind="visible: showCardData">
     <div class="form-group">
       <div class="col-sm-9 col-sm-offset-3">
-        <div class="stripe-card-container"></div>{# populated by a card element from Stripe #}
+        <div class="stripe-card-container"></div>
+        {# populated by a card element from Stripe #}
       </div>
     </div>
     <div class="form-group">
       <div class="col-sm-9 col-sm-offset-3">
         <label class="checkbox">
-          <input type="checkbox" name="saveCard" data-bind="checked: newSavedCard"/>
+          <input
+            type="checkbox"
+            name="saveCard"
+            data-bind="checked: newSavedCard"
+          />
           {% trans 'Save card for later' %}
         </label>
         <label class="checkbox">
-          <input type="checkbox" name="autopayCard" data-bind="enable: newSavedCard,
-                                                                         checked: autopayCard"/>
+          <input
+            type="checkbox"
+            name="autopayCard"
+            data-bind="enable: newSavedCard,
+                                                                         checked: autopayCard"
+          />
           {% trans 'Use this card to autopay' %}
         </label>
         <span class="help-block">
-                    <i class="fa fa-info-circle"></i>
-          {% blocktrans %}
-            We use <a href="http://www.stripe.com/" target="_blank">Stripe</a>
-            to process this transaction.
-          {% endblocktrans %}
-                </span>
+          <i class="fa fa-info-circle"></i>
+          {% blocktrans %} We use
+          <a href="http://www.stripe.com/" target="_blank">Stripe</a>
+          to process this transaction. {% endblocktrans %}
+        </span>
       </div>
     </div>
   </div>
 
-  <p class="alert alert-success"
-     data-bind="visible: isProcessing">
-    {% blocktrans %}
-      Processing your payment...
-    {% endblocktrans %}
+  <p class="alert alert-success" data-bind="visible: isProcessing">
+    {% blocktrans %} Processing your payment... {% endblocktrans %}
   </p>
 
   <p class="alert alert-info" data-bind="visible: isTestMode">


### PR DESCRIPTION
## Product Description
Related JIRA ticket: https://dimagi.atlassian.net/browse/SAAS-18575

Moving forward, we will only allow users to set the autopay method and removing saved cards from the billing information page.

This PR affects the payment modal, which is seen when:
- paying an invoice in the Billing Statements view
- adding credits to an account from the Current Subscription page

Things that changed:
- saved cards can no longer be removed from saved cards list in payment modal
- "use this card for autopay" is no longer an option when adding a new card (it was not working properly in the first place)
- the `undefined` string where the card brand should be now correctly shows the card brand.

Before:
<img width="597" height="524" alt="Screenshot 2025-10-14 at 3 46 12 PM" src="https://github.com/user-attachments/assets/aaec590a-b521-49ea-bf9f-723ecb2def37" />

<img width="588" height="201" alt="Screenshot 2025-10-14 at 3 46 22 PM" src="https://github.com/user-attachments/assets/befa4125-1f4c-447e-8751-55caf2bf40fe" />


After:
<img width="600" height="526" alt="Screenshot 2025-10-14 at 3 45 39 PM" src="https://github.com/user-attachments/assets/fc92eaf1-a4b6-4627-b390-a05a1204eb7a" />
<img width="590" height="169" alt="Screenshot 2025-10-14 at 3 45 47 PM" src="https://github.com/user-attachments/assets/2b0906ab-742f-4e55-a206-05adf8127b43" />



## Technical Summary
In addition to the changes above, I also prettified some of the surrounding ko html.

## Safety Assurance

### Safety story
safe change, only affects the UI, very testable locally on both the Current Subscription and and Billing Statements view—both for existing and new accounts. issues would fail loudly in the UI and would be noticeable with local testing.

### Automated test coverage
no

### QA Plan
not needed. easy to test locally

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
