### PR TITLE
Deprecate DISABLE_COLUMN_LIMIT_IN_UCR

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1575,7 +1575,7 @@ EXPORTS_APPS_USE_ELASTICSEARCH = StaticToggle(
 DISABLE_COLUMN_LIMIT_IN_UCR = StaticToggle(
     'disable_column_limit_in_ucr',
     'Enikshay: Disable column limit in UCR',
-    TAG_CUSTOM,
+    TAG_DEPRECATED,
     [NAMESPACE_DOMAIN]
 )
 


### PR DESCRIPTION
## Technical Summary

Deprecates the `DISABLE_COLUMN_LIMIT_IN_UCR` feature flag

:t-rex: Jira: [SAAS-18642](https://dimagi.atlassian.net/browse/SAAS-18642)

## Feature Flag

`DISABLE_COLUMN_LIMIT_IN_UCR`

## Safety Assurance

### Safety story

This change only prevents users from enabling this feature flag for domains where it is not already enabled.

### Automated test coverage

Not applicable.

### QA Plan

Not applicable.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-18642]: https://dimagi.atlassian.net/browse/SAAS-18642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ