### PR TITLE
Deprecate OPENMRS_INTEGRATION

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1408,7 +1408,7 @@ CUSTOM_ASSERTIONS = StaticToggle(
 OPENMRS_INTEGRATION = StaticToggle(
     'openmrs_integration',
     'Enable OpenMRS integration',
-    TAG_SOLUTIONS_LIMITED,
+    TAG_DEPRECATED,
     [NAMESPACE_DOMAIN],
 )
 


### PR DESCRIPTION
## Technical Summary

Deprecates the `OPENMRS_INTEGRATION` feature flag

:t-rex: Jira: [SAAS-18643](https://dimagi.atlassian.net/browse/SAAS-18643)

## Feature Flag

`OPENMRS_INTEGRATION`

## Safety Assurance

### Safety story

This change only prevents users from enabling this feature flag for domains where it is not already enabled.

### Automated test coverage

Not applicable

### QA Plan

Not applicable

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-18643]: https://dimagi.atlassian.net/browse/SAAS-18643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ