### PR TITLE
Ensure form data is in context prior to building form classes

### DIFF
--- a/corehq/apps/app_manager/tests/test_app_view_context.py
+++ b/corehq/apps/app_manager/tests/test_app_view_context.py
@@ -1,0 +1,23 @@
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from corehq.apps.app_manager.models import Application
+from corehq.apps.app_manager.views.apps import get_app_view_context
+from corehq.apps.domain.shortcuts import create_domain
+
+
+class GetAppViewContextTests(TestCase):
+
+    def setUp(self):
+        self.domain = create_domain('test')
+        self.app = Application(domain=self.domain.name, langs=['en'])
+
+    def test_bulk_translation_forms(self):
+        request = Mock()
+        context = get_app_view_context(request, self.app)
+        # ensure form actions are the same as what is in the context data
+        app_form = context['bulk_app_translation_form']
+        ui_form = context['bulk_ui_translation_form']
+        assert ui_form.helper.form_action == context['bulk_ui_translation_upload']['action']
+        assert app_form.helper.form_action == context['bulk_app_translation_upload']['action']

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -3,6 +3,9 @@ import json
 import os
 from collections import defaultdict
 
+import urllib3
+from dimagi.utils.logging import notify_exception
+from dimagi.utils.web import json_request, json_response
 from django.contrib import messages
 from django.http import (
     HttpResponse,
@@ -14,12 +17,7 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_GET
-
-import urllib3
 from django_prbac.utils import has_privilege
-
-from dimagi.utils.logging import notify_exception
-from dimagi.utils.web import json_request, json_response
 
 from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
@@ -63,14 +61,12 @@ from corehq.apps.app_manager.models import (
     Module,
     ModuleNotFoundException,
     app_template_dir,
+    load_app_template,
 )
 from corehq.apps.app_manager.models import import_app as import_app_util
-from corehq.apps.app_manager.models import load_app_template
 from corehq.apps.app_manager.tasks import update_linked_app_and_notify_task
-from corehq.apps.app_manager.util import app_doc_types
-from corehq.apps.app_manager.util import \
-    enable_usercase as enable_usercase_util
 from corehq.apps.app_manager.util import (
+    app_doc_types,
     get_and_assert_practice_user_in_domain,
     get_latest_enabled_versions_per_profile,
     get_settings_values,

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -281,7 +281,17 @@ def get_app_view_context(request, app):
             'can_select_language': toggles.BULK_UPDATE_MULTIMEDIA_PATHS.enabled_for_request(request),
             'can_validate_app_translations': toggles.VALIDATE_APP_TRANSLATIONS.enabled_for_request(request),
         },
+        'smart_lang_display_enabled': getattr(app, 'smart_lang_display', False),
 
+        'is_linked_app': is_linked_app(app),
+        'is_remote_app': is_remote_app(app),
+
+        'all_add_ons_enabled': all_app_manager_add_ons_enabled(app.domain),
+    })
+
+    # dependent on bulk_ui_translation_upload and bulk_app_translation_upload
+    # keys existing in context
+    context.update({
         'bulk_ui_translation_form': get_bulk_upload_form(
             context,
             context_key="bulk_ui_translation_upload",
@@ -291,14 +301,8 @@ def get_app_view_context(request, app):
             context_key="bulk_app_translation_upload",
             form_class=AppTranslationsBulkUploadForm,
         ),
-
-        'smart_lang_display_enabled': getattr(app, 'smart_lang_display', False),
-
-        'is_linked_app': is_linked_app(app),
-        'is_remote_app': is_remote_app(app),
-
-        'all_add_ons_enabled': all_app_manager_add_ons_enabled(app.domain),
     })
+
     if isinstance(app, Application):
         context.update({'custom_assertions': [
             {'test': assertion.test, 'text': assertion.text.get(lang)}


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18644

In consolidating `context.update` calls, [this commit](https://github.com/dimagi/commcare-hq/commit/4588638) accidentally introduced this bug where `bulk_ui_translation_upload` and `bulk_app_translation_upload` were not available in the `context` when adding the `bulk_app_translation_form` and `bulk_ui_translation_form` keys.

This change effectively undoes that by ensuring the forms are not added to the context until after the context already contains the keys necessary to build the forms. This feels needlessly convoluted, but having already sunk enough time in trying to figure this out, I'm just resolving it for now and hoping the comment prevents this from happening again.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Reverting a recent change that introduced this bug. If anything, this just calls `context.update` more than we need to, but for now it looks like we _need_ to. This feels like a very safe change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
~No test coverage that I'm aware of.~ Added a regression test.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
