### PR TITLE
Require customer to agree to ToS when changing/renewing plan or enabling auto renew

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -20,9 +20,8 @@ var confirmPlanModel = function (isMonthlyUpgrade, isPaused, isAnnualPlan, isDow
     self.isDowngrade = isDowngrade;
     self.currentPlan = currentPlan;
 
-    // If the user is upgrading or subscribing to Pay Annually,
-    // don't let them continue until they agree to the minimum subscription terms
-    self.oUserAgreementSigned = ko.observable(!(isMonthlyUpgrade || isAnnualPlan));
+    // Require user to agree to ToS and any other listed terms when changing or renewing plan
+    self.oUserAgreementSigned = ko.observable(false);
 
     self.downgradeReasonList = [
         PROJECT_ENDED,

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -139,16 +139,23 @@
     </p>
   {% endif %}
 
-  {% if is_monthly_upgrade or is_annual_plan %}
-    <p>
-      <strong>
-        {% blocktrans %}
-          <input type="checkbox" data-bind="checked: oUserAgreementSigned" /> I
-          understand and wish to continue.
-        {% endblocktrans %}
-      </strong>
-    </p>
-  {% endif %}
+  <p>
+    {% blocktrans %}
+      By continuing you agree to Dimagi's
+      <a href="https://www.dimagi.com/terms/latest/tos/" target="_blank">
+        Terms of Service</a
+      >.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    <strong>
+      {% blocktrans %}
+        <input type="checkbox" data-bind="checked: oUserAgreementSigned" /> I
+        understand and wish to continue.
+      {% endblocktrans %}
+    </strong>
+  </p>
 </div>
 
 {% if downgrade_messages and not is_same_edition %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/renew_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/renew_plan.html
@@ -34,6 +34,15 @@
     <input type="hidden" name="plan_edition" value="{{ current_edition }}">
 
     <div class="text-center plan-next">
+      <p>
+        {% blocktrans %}
+          By continuing you agree to Dimagi's
+          <a href="https://www.dimagi.com/terms/latest/tos/" target="_blank">
+            Terms of Service</a
+          >.
+        {% endblocktrans %}
+      </p>
+
       {% if downgrade_messages %}
         <a class="btn btn-default btn-lg"
           href="{% url 'custom_plan_request_quote' domain %}">

--- a/corehq/apps/domain/templates/domain/bootstrap5/renew_plan.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/renew_plan.html
@@ -34,6 +34,15 @@
     <input type="hidden" name="plan_edition" value="{{ current_edition }}">
 
     <div class="text-center plan-next">
+      <p>
+        {% blocktrans %}
+          By continuing you agree to Dimagi's
+          <a href="https://www.dimagi.com/terms/latest/tos/" target="_blank">
+            Terms of Service</a
+          >.
+        {% endblocktrans %}
+      </p>
+
       {% if downgrade_messages %}
         <a class="btn btn-outline-primary btn-lg"
           href="{% url 'custom_plan_request_quote' domain %}">

--- a/corehq/apps/domain/templates/domain/partials/enable_auto_renew.html
+++ b/corehq/apps/domain/templates/domain/partials/enable_auto_renew.html
@@ -34,6 +34,14 @@
       {% endblocktrans %}
     {% endif %}
   </li>
+  <li>
+    {% blocktrans %}
+      You agree to Dimagi's
+      <a href="https://www.dimagi.com/terms/latest/tos/" target="_blank">
+        Terms of Service</a
+      >.
+    {% endblocktrans %}
+  </li>
 </ul>
 <p>
   {% blocktrans %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/renew_plan.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/renew_plan.html.diff.txt
@@ -13,9 +13,9 @@
  
  {% block plan_breadcrumbs %}{% endblock %}
  
-@@ -35,7 +35,7 @@
+@@ -44,7 +44,7 @@
+       </p>
  
-     <div class="text-center plan-next">
        {% if downgrade_messages %}
 -        <a class="btn btn-default btn-lg"
 +        <a class="btn btn-outline-primary btn-lg"


### PR DESCRIPTION
## Product Description
Adds a note to the Confirm Plan summary that "By continuing you agree to Dimagi's Terms of Service" and always requires the checkbox on that page:
<img width="453" height="127" alt="image" src="https://github.com/user-attachments/assets/7352bb67-b817-48e4-bd6f-28daf19ae5df" />

Adds a note to the Renew Plan page that "By continuing you agree to Dimagi's Terms of Service":
<img width="327" height="98" alt="image" src="https://github.com/user-attachments/assets/4ddb0c3f-fb6a-4286-b1cb-f819ac2c4ea1" />

Adds a note to the Enable Auto Renewal modal that "You agree to Dimagi's Terms of Service":
<img width="603" height="296" alt="image" src="https://github.com/user-attachments/assets/645d1803-284b-44fb-9a25-b0711b177140" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18635

## Safety Assurance

### Safety story
Primarily updates text, with a straightforward change to always show+require a checkbox that was previously only sometimes required. Tested locally to see the text shows up and, on the confirm plan summary, that the checkbox is correctly required.

### Automated test coverage
Not likely for UI.

### QA Plan
Not for this change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
