### PR TITLE
Don't give the option to set auto renewal for subscriptions on Customer Billing accounts

### DIFF
--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -224,6 +224,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
         subscription_eligible_for_auto_renewal = (
             self.current_subscription.service_type == SubscriptionType.PRODUCT
             and self.current_subscription.date_end is not None
+            and not self.current_subscription.account.is_customer_billing_account
         )
         subscription_is_auto_renew = self.current_subscription.auto_renew
         next_subscription = self.current_subscription.next_subscription


### PR DESCRIPTION
## Product Description
Hides "Enable Auto Renewal" if the account is a customer billing (grouped) billing account:
<img width="524" height="141" alt="image" src="https://github.com/user-attachments/assets/0ba79051-56c1-438d-9e62-5b791c02064a" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18639

## Feature Flag
SHOW_AUTO_RENEWAL

## Safety Assurance

### Safety story
Small change to a conditional, tested locally.

### Automated test coverage
Not here.

### QA Plan
Not for this minor change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
