### PR TITLE
PR template improvement: be more explicit about risky migration operations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,8 +35,7 @@ In particular consider how existing data may be impacted by this change.
 ### Migrations
 <!-- Delete this section if the PR does not contain any migrations -->
 <!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
-- [ ] The migrations in this code can be safely applied first independently of the code
-- [ ] High risk operations like `RemoveField`, `RenameField`, `RemoveConstraint`, and [others described here](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md) are planned carefully, often with a prior migration using `SeparateDatabaseAndState`.
+- [ ] The migrations in this code can be safely applied first independently of the code. Pay particular attention to _backward incompatible_ operations like `RemoveField`, `RenameField`, `RemoveConstraint`, and [others described here](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md) that can cause errors when migrations are applied to a live database.
 
 <!-- Please link to any past code changes that are coordinated with this migration -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,6 +36,7 @@ In particular consider how existing data may be impacted by this change.
 <!-- Delete this section if the PR does not contain any migrations -->
 <!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
 - [ ] The migrations in this code can be safely applied first independently of the code
+- [ ] High risk operations like `RemoveField`, `RenameField`, `RemoveConstraint`, and [others described here](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md) are planned carefully, often with a prior migration using `SeparateDatabaseAndState`.
 
 <!-- Please link to any past code changes that are coordinated with this migration -->
 


### PR DESCRIPTION
## Technical Summary
- provide resources to review, [like this](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md)
- and a path to follow next, like making sure you have used `SeparateDatabaseAndState` in a prior migration, increasing awareness of tools that might not be discovered by following the usual `makemigrations` workflow...

Short of adding a linter (and burden to dependencies) to explicitly flag and check for these migrations, this seems like the quickest way to increase awareness of what precisely is risky but overlooked, and how to approach it.

## Safety Assurance

### Safety story
safe change, just updating PR template

### Automated test coverage
N/A

### QA Plan
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
