### PR TITLE
Release smart links for web users flag

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -459,23 +459,6 @@ FormplayerFrontend.getChannel().reply('getAppDisplayProperties', function () {
     return FormplayerFrontend.DisplayProperties || {};
 });
 
-// Support for workflows that require Log In As before moving on to the
-// screen that the user originally requested.
-FormplayerFrontend.on('setLoginAsNextOptions', function (options) {
-    FormplayerFrontend.LoginAsNextOptions = options;
-    if (Object.freeze) {
-        Object.freeze(FormplayerFrontend.LoginAsNextOptions);
-    }
-});
-
-FormplayerFrontend.on('clearLoginAsNextOptions', function () {
-    return FormplayerFrontend.LoginAsNextOptions = null;
-});
-
-FormplayerFrontend.getChannel().reply('getLoginAsNextOptions', function () {
-    return FormplayerFrontend.LoginAsNextOptions || null;
-});
-
 function makeSyncRequest(route, requestData) {
     var options,
         complete,

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -272,18 +272,6 @@ FormplayerFrontend.getChannel().reply("app:select:menus", function (options) {
     });
     FormplayerFrontend.regions.getRegion('loadingProgress').show(progressView);
 
-    var user = UsersModels.getCurrentUser();
-    if (options.forceLoginAs && !user.restoreAs) {
-        // Workflow requires a mobile user, likely because we're trying to access
-        // a session endpoint as a web user. If user isn't logged in as, send them
-        // to Log In As and save the current request options for when that's done.
-        FormplayerFrontend.trigger("setLoginAsNextOptions", options);
-        FormplayerFrontend.trigger("restore_as:list");
-
-        // Caller expects a menu response, return a fake one
-        return {abort: true};
-    }
-
     // If an endpoint is provided, first claim any cases it references, then navigate
     return API.queryFormplayer(options, "get_endpoint");
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/users/views.js
@@ -81,16 +81,8 @@ var UserRowView = Marionette.View.extend({
             confirmText: gettext('Log in'),
             onConfirm: function () {
                 usersUtils.Users.logInAsUser(this.model.get('username'));
+                FormplayerFrontend.trigger('navigateHome');
                 FormplayerFrontend.showRestoreAs(usersModels.getCurrentUser());
-                var loginAsNextOptions = FormplayerFrontend.getChannel().request('getLoginAsNextOptions');
-                if (loginAsNextOptions) {
-                    FormplayerFrontend.trigger("clearLoginAsNextOptions");
-                    import("cloudcare/js/formplayer/menus/controller").then(function (MenusController) {
-                        MenusController.default.selectMenu(loginAsNextOptions);
-                    });
-                } else {
-                    FormplayerFrontend.trigger('navigateHome');
-                }
             }.bind(this),
         });
     },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/utils/utils.js
@@ -215,7 +215,6 @@ Utils.CloudcareUrl = function (options) {
     this.queryData = options.queryData;
     this.singleApp = options.singleApp;
     this.sortIndex = options.sortIndex;
-    this.forceLoginAs = options.forceLoginAs;
     this.requestInitiatedByTag = options.requestInitiatedByTag;
 
     this.setSelections = function (selections) {
@@ -357,7 +356,6 @@ Utils.CloudcareUrl.prototype.toJson = function () {
         queryData: self.queryData || {},    // formplayer can't handle a null
         singleApp: self.singleApp,
         sortIndex: self.sortIndex,
-        forceLoginAs: self.forceLoginAs,
         requestInitiatedByTag: self.requestInitiatedByTag,
     };
     return JSON.stringify(dict);
@@ -381,7 +379,6 @@ Utils.CloudcareUrl.fromJson = function (json) {
         'queryData': data.queryData,
         'singleApp': data.singleApp,
         'sortIndex': data.sortIndex,
-        'forceLoginAs': data.forceLoginAs,
         "requestInitiatedByTag": data.requestInitiatedByTag,
     };
     return new Utils.CloudcareUrl(options);

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -76,7 +76,6 @@ from corehq.apps.hqwebapp.decorators import (
     use_bootstrap5,
     waf_allow,
 )
-from corehq.apps.hqwebapp.templatetags.hq_shared_tags import can_use_restore_as
 from corehq.apps.integration.util import integration_contexts
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.formdetails import readable
@@ -550,13 +549,7 @@ def session_endpoint(request, domain, app_id, endpoint_id=None):
         if not build_id:
             return _fail(_("No corresponding application found in this project."))
 
-    restore_as_user, set_cookie = FormplayerMain.get_restore_as_user(request, domain)
-    force_login_as = (not toggles.SMART_LINKS_FOR_WEB_USERS.enabled(domain)
-                      and not restore_as_user.is_commcare_user())
-    if force_login_as and not can_use_restore_as(request):
-        return _fail(_("This user cannot access this link."))
-
-    state = {"appId": build_id, "forceLoginAs": force_login_as}
+    state = {"appId": build_id, "forceLoginAs": False}
     if endpoint_id is not None:
         state.update({
             "endpointId": endpoint_id,

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -549,7 +549,7 @@ def session_endpoint(request, domain, app_id, endpoint_id=None):
         if not build_id:
             return _fail(_("No corresponding application found in this project."))
 
-    state = {"appId": build_id, "forceLoginAs": False}
+    state = {"appId": build_id}
     if endpoint_id is not None:
         state.update({
             "endpointId": endpoint_id,

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2857,13 +2857,6 @@ APP_TESTING = StaticToggle(
     description=''
 )
 
-SMART_LINKS_FOR_WEB_USERS = StaticToggle(
-    slug='smart_links_for_web_users',
-    label='USH: Allow web users to use smart links without logging in as before',
-    tag=TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN],
-)
-
 CSQL_FIXTURE = StaticToggle(
     slug='module_badges',
     label='USH: CSQL Fixture (FKA Module Badges)',


### PR DESCRIPTION
## Product Description


## Technical Summary
https://dimagi.atlassian.net/browse/USH-6331
https://docs.google.com/document/d/1wJIFgcOtGt8Q8zawfekxGK-TmiYYM7fgzoQgQ9J-SN4/edit?tab=t.0

USH used to use a workflow where people would have web user accounts on HQ, but they’d be expected to use “login-as” to log in as a mobile worker before accessing web apps.  However, sometimes people would follow a [smart link](https://dimagi.atlassian.net/wiki/spaces/uss/pages/2146959762/Smart+Links) to perform an activity while not already logged in as a mobile worker, which could cause issues (I think particularly in a multi-domain project).  We addressed this somewhat inelegantly by making the session endpoints view (used by smart linking) always force web users to log in as mobile workers.  Later, when we switched to using web users directly, we made this feature flag to remove this restriction.

In my opinion, that behavior was a messy COVID-era hack.  It certainly doesn’t make sense to have that restriction in a world where we support web users doing data entry directly.

## Feature Flag

**affects**:  Enable session endpoints

**releases**:  USH: Allow web users to use smart links without logging in as before

## Safety Assurance


### Safety story

I intend to release the feature flag dynamically first, only merging this code when SaaS environments all return `True` for the enabled check anyways.


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
