### PR TITLE
Payment modal updates: allow payments with autopay card on file for account

### DIFF
--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -78,9 +78,9 @@ class BaseStripePaymentHandler(object):
         generic_error = {
             'error': {
                 'message': _(
-                    "Something went wrong while processing your payment. "
+                    'Something went wrong while processing your payment. '
                     "We're working quickly to resolve the issue. No charges "
-                    "were issued. Please try again in a few hours."
+                    'were issued. Please try again in a few hours.'
                 ),
             },
         }
@@ -88,15 +88,16 @@ class BaseStripePaymentHandler(object):
             with transaction.atomic():
                 if remove_card:
                     self.payment_method.remove_card(card)
-                    return {'success': True, 'removedCard': card, }
+                    return {
+                        'success': True,
+                        'removedCard': card,
+                    }
                 if save_card:
                     card = self.payment_method.create_card(card, billing_account, self.domain, autopay=autopay)
                 if save_card or is_saved_card:
                     customer = self.payment_method.customer
 
-                payment_record = PaymentRecord.create_record(
-                    self.payment_method, 'temp', amount
-                )
+                payment_record = PaymentRecord.create_record(self.payment_method, 'temp', amount)
                 self.update_credits(payment_record)
 
                 charge = self.create_charge(amount, card=card, customer=customer)
@@ -114,21 +115,18 @@ class BaseStripePaymentHandler(object):
             stripe.error.StripeError,
         ) as e:
             log_accounting_error(
-                "A payment for %(cost_item)s failed due "
-                "to a Stripe %(error_class)s: %(error_msg)s" % {
-                    'error_class': e.__class__.__name__,
-                    'cost_item': self.cost_item_name,
-                    'error_msg': e.json_body['error']
-                },
+                'A payment for {cost_item} failed due '
+                'to a Stripe {error_class}: {error_msg}'.format(
+                    error_class=e.__class__.__name__,
+                    cost_item=self.cost_item_name,
+                    error_msg=e.json_body['error'],
+                ),
                 show_stack_trace=True,
             )
             return generic_error
         except Exception as e:
             log_accounting_error(
-                "A payment for %(cost_item)s failed due to: %(error_msg)s" % {
-                    'cost_item': self.cost_item_name,
-                    'error_msg': e,
-                },
+                f'A payment for {self.cost_item_name} failed due to: {e}',
                 show_stack_trace=True,
             )
             return generic_error
@@ -137,10 +135,9 @@ class BaseStripePaymentHandler(object):
             self.send_email(payment_record)
         except Exception:
             log_accounting_error(
-                "Failed to send out an email receipt for "
-                "payment related to PaymentRecord No. %s. "
-                "Everything else succeeded."
-                % payment_record.id,
+                'Failed to send out an email receipt for '
+                f'payment related to PaymentRecord No. {payment_record.id}. '
+                'Everything else succeeded.',
                 show_stack_trace=True,
             )
 

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -88,22 +88,12 @@ class BaseStripePaymentHandler(object):
         }
         try:
             with transaction.atomic():
-                if new_saved_card or is_saved_card:
-                    payment_method = self.payment_method
-                elif is_autopay_card:
+                if is_autopay_card:
                     payment_method = StripePaymentMethod.objects.get(
                         web_user=billing_account.auto_pay_user
                     )
-
-                if payment_method is None:
-                    return {
-                        'error': {
-                            'message': _(
-                                'No payment method was found. Please '
-                                'contact support.'
-                            ),
-                        },
-                    }
+                else:
+                    payment_method = self.payment_method
 
                 customer = payment_method.customer
                 if new_saved_card:

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -95,7 +95,9 @@ class BaseStripePaymentHandler(object):
                 else:
                     payment_method = self.payment_method
 
-                customer = payment_method.customer
+                if hasattr(payment_method, 'customer'):
+                    customer = payment_method.customer
+
                 if new_saved_card:
                     card = self.payment_method.create_card(card, billing_account, self.domain)
                 payment_record = PaymentRecord.create_record(payment_method, 'temp', amount)

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -206,7 +206,7 @@ var paymentMethodHandler = function (formId, opts) {
         return self.paymentIsNotComplete() && self.savedCards().length > 0;
     });
     self.canSelectAutopayCard = ko.computed(function () {
-        return self.paymentIsNotComplete() && !! self.autopayCard();
+        return self.paymentIsNotComplete() && !!self.autopayCard();
     });
 
     self.isSubmitDisabled = ko.computed(function () {

--- a/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
@@ -8,7 +8,40 @@
         {% trans "Card" %}
       </label>
       <div class="col-sm-9">
-        <div class="radio">
+        <div
+          class="radio"
+          data-bind="visible: canSelectAutopayCard"
+        >
+          <label>
+            <input
+              type="radio"
+              name="selectedCardType"
+              data-bind="checked: selectedCardType"
+              value="autopay"
+            />
+            {% trans "Use account autopay card" %}
+          </label>
+        </div>
+        <div
+          data-bind="visible: isAutopayCard"
+          class="row"
+        >
+          <div
+            class="col-sm-8"
+            data-bind="with: autopayCard"
+          >
+            <div class="panel panel-default">
+              <div class="panel-body">
+                <p data-bind="text: cardName"></p>
+                <div><strong>{% trans "Owner" %}:</strong> <span data-bind="text: owner"></span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="radio"
+          data-bind="visible: canSelectSavedCard"
+        >
           <label>
             <input
               type="radio"
@@ -47,6 +80,15 @@
         </div>
       </div>
     </div>
+    <div
+      data-bind="
+        template: {
+          data: autopayCard,
+          name: 'saved-stripe-card-ko-template',
+          if: isAutopayCard,
+        }
+      "
+    ></div>
     <div
       data-bind="
         template: {

--- a/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
+++ b/corehq/apps/accounting/templates/accounting/partials/stripe_card_ko_template.html
@@ -60,9 +60,9 @@
             <select
               class="form-control m-0"
               data-bind="
-                options: savedCards,
-                optionsText: 'cardName',
-                value: selectedSavedCard
+                  options: savedCards,
+                  optionsText: 'cardName',
+                  value: selectedSavedCard
               "
             ></select>
           </div>
@@ -82,29 +82,29 @@
     </div>
     <div
       data-bind="
-        template: {
-          data: autopayCard,
-          name: 'saved-stripe-card-ko-template',
-          if: isAutopayCard,
-        }
+          template: {
+              data: autopayCard,
+              name: 'saved-stripe-card-ko-template',
+              if: isAutopayCard,
+          }
       "
     ></div>
     <div
       data-bind="
-        template: {
-          data: selectedSavedCard,
-          name: 'saved-stripe-card-ko-template',
-          if: isSavedCard,
-        }
+          template: {
+              data: selectedSavedCard,
+              name: 'saved-stripe-card-ko-template',
+              if: isSavedCard,
+          }
       "
     ></div>
     <div
       data-bind="
-        template: {
-          data: newCard,
-          name: 'new-stripe-card-ko-template',
-          if: isNewCard
-        }
+          template: {
+              data: newCard,
+              name: 'new-stripe-card-ko-template',
+              if: isNewCard
+          }
       "
     ></div>
   </fieldset>
@@ -115,10 +115,10 @@
     <legend>{% trans "Card Information" %}</legend>
     <div
       data-bind="
-        template: {
-          data: $data,
-          name: 'new-stripe-card-ko-template',
-        }
+          template: {
+              data: $data,
+              name: 'new-stripe-card-ko-template',
+          }
       "
     ></div>
   </fieldset>

--- a/corehq/apps/accounting/utils/cards.py
+++ b/corehq/apps/accounting/utils/cards.py
@@ -44,4 +44,5 @@ def serialize_account_card(card, owner):
         'exp_year': card.exp_year,
         'token': card.id,
         'owner': owner,
+        'id': card.id,
     }

--- a/corehq/apps/domain/static/domain/js/bootstrap3/billing_statements.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap3/billing_statements.js
@@ -32,6 +32,7 @@ var bulkPaymentHandler = paymentMethodHandler(
         submitBtnText: gettext("Submit Payment"),
         errorMessages: initialPageData.get("payment_error_messages"),
         submitURL: initialPageData.get("payment_urls").process_bulk_payment_url,
+        autopayCard: initialPageData.get("autopay_card"),
     },
 );
 
@@ -51,6 +52,7 @@ var paymentHandler = paymentMethodHandler(
         submitBtnText: gettext("Submit Payment"),
         errorMessages: initialPageData.get("payment_error_messages"),
         submitURL: initialPageData.get("payment_urls").process_invoice_payment_url,
+        autopayCard: initialPageData.get("autopay_card"),
     },
 );
 

--- a/corehq/apps/domain/static/domain/js/bootstrap5/billing_statements.js
+++ b/corehq/apps/domain/static/domain/js/bootstrap5/billing_statements.js
@@ -32,6 +32,7 @@ var bulkPaymentHandler = paymentMethodHandler(
         submitBtnText: gettext("Submit Payment"),
         errorMessages: initialPageData.get("payment_error_messages"),
         submitURL: initialPageData.get("payment_urls").process_bulk_payment_url,
+        autopayCard: initialPageData.get("autopay_card"),
     },
 );
 
@@ -51,6 +52,7 @@ var paymentHandler = paymentMethodHandler(
         submitBtnText: gettext("Submit Payment"),
         errorMessages: initialPageData.get("payment_error_messages"),
         submitURL: initialPageData.get("payment_urls").process_invoice_payment_url,
+        autopayCard: initialPageData.get("autopay_card"),
     },
 );
 

--- a/corehq/apps/domain/static/domain/js/current_subscription.js
+++ b/corehq/apps/domain/static/domain/js/current_subscription.js
@@ -13,6 +13,7 @@ $(function () {
             credit_card_url: initialPageData.reverse("domain_credits_payment"),
             wire_url: initialPageData.reverse("domain_wire_payment"),
             wire_email: initialPageData.get("user_email"),
+            autopayCard: initialPageData.get("autopay_card"),
         },
     );
     var plan = initialPageData.get("plan");

--- a/corehq/apps/domain/templates/domain/bootstrap3/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/billing_statements.html
@@ -7,6 +7,7 @@
   {% initial_page_data 'pagination' pagination %}
   {% initial_page_data 'stripe_cards' stripe_cards %}
   {% initial_page_data 'stripe_public_key' stripe_public_key %}
+  {% initial_page_data 'autopay_card' autopay_card|JSON %}
   {% initial_page_data 'payment_urls' payment_urls %}
   {% initial_page_data 'payment_error_messages' payment_error_messages %}
   {% initial_page_data 'item_creation_allowed' pagination.create.is_allowed %}

--- a/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
@@ -5,6 +5,7 @@
 
 {% block page_content %}
   {% initial_page_data "stripe_public_key" stripe_public_key %}
+  {% initial_page_data "autopay_card" autopay_card|JSON %}
   {% initial_page_data "payment_error_messages" payment_error_messages %}
   {% initial_page_data "wire_email" user_email %}
   {% initial_page_data "plan" plan %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/billing_statements.html
@@ -7,6 +7,7 @@
   {% initial_page_data 'pagination' pagination %}  {# todo B5: css-pagination #}
   {% initial_page_data 'stripe_cards' stripe_cards %}
   {% initial_page_data 'stripe_public_key' stripe_public_key %}
+  {% initial_page_data 'autopay_card' autopay_card|JSON %}
   {% initial_page_data 'payment_urls' payment_urls %}
   {% initial_page_data 'payment_error_messages' payment_error_messages %}
   {% initial_page_data 'item_creation_allowed' pagination.create.is_allowed %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
@@ -5,6 +5,7 @@
 
 {% block page_content %}
   {% initial_page_data "stripe_public_key" stripe_public_key %}
+  {% initial_page_data "autopay_card" autopay_card|JSON %}
   {% initial_page_data "payment_error_messages" payment_error_messages %}
   {% initial_page_data "wire_email" user_email %}
   {% initial_page_data "plan" plan %}

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -422,6 +422,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
     def page_context(self):
         from corehq.apps.domain.views.sms import SMSRatesView
         subs = self.current_subscription
+        autopay_card, autopay_owner = get_autopay_card_and_owner_for_billing_account(self.account)
         return {
             'plan': self.plan,
             'change_plan_url': reverse(SelectPlanView.urlname, args=[self.domain]),
@@ -440,6 +441,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
             'can_change_subscription': subs and subs.user_can_change_subscription(self.request.user),
             'autopay_enabled': self.account.auto_pay_enabled,
             'manage_autopay_url': reverse(EditExistingBillingAccountView.urlname, args=[self.domain]),
+            'autopay_card': serialize_account_card(autopay_card, autopay_owner) if autopay_card else None,
         }
 
 
@@ -632,6 +634,7 @@ class DomainBillingStatementsView(DomainAccountingSettings, CRUDPaginatedViewMix
     @property
     def page_context(self):
         pagination_context = self.pagination_context
+        autopay_card, autopay_owner = get_autopay_card_and_owner_for_billing_account(self.account)
         pagination_context.update({
             'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
             'stripe_cards': self.stripe_cards,
@@ -654,6 +657,7 @@ class DomainBillingStatementsView(DomainAccountingSettings, CRUDPaginatedViewMix
             'show_plan': True,
             'show_overdue_invoice_modal': False,
             'can_pay_by_wire': self.can_pay_by_wire,
+            'autopay_card': serialize_account_card(autopay_card, autopay_owner) if autopay_card else None,
         })
         return pagination_context
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/billing_statements.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/billing_statements.html.diff.txt
@@ -13,8 +13,8 @@
 +  {% initial_page_data 'pagination' pagination %}  {# todo B5: css-pagination #}
    {% initial_page_data 'stripe_cards' stripe_cards %}
    {% initial_page_data 'stripe_public_key' stripe_public_key %}
-   {% initial_page_data 'payment_urls' payment_urls %}
-@@ -24,8 +24,8 @@
+   {% initial_page_data 'autopay_card' autopay_card|JSON %}
+@@ -25,8 +25,8 @@
        <button
          type="button"
          class="btn btn-primary"
@@ -25,7 +25,7 @@
          id="bulkPaymentBtn"
        >
          {% trans 'Pay by Credit Card' %}
-@@ -36,8 +36,8 @@
+@@ -37,8 +37,8 @@
          <button
            type="button"
            class="btn btn-primary"
@@ -36,7 +36,7 @@
            id="bulkWirePaymentBtn"
          >
            {% trans 'Pay by Wire' %}
-@@ -72,21 +72,21 @@
+@@ -73,21 +73,21 @@
  {% block pagination_templates %}
    <script type="text/html" id="statement-row-template">
      <td
@@ -63,7 +63,7 @@
        <span
          data-bind="text: payment_status, attr: {class: payment_class}"
        ></span>
-@@ -94,14 +94,14 @@
+@@ -95,14 +95,14 @@
        <button
          type="button"
          class="btn btn-primary payment-button"
@@ -81,7 +81,7 @@
        <a
          class="btn btn-primary"
          data-bind="attr: { href: pdfUrl }"
-@@ -114,16 +114,16 @@
+@@ -115,16 +115,16 @@
    {% include 'accounting/partials/stripe_card_ko_template.html' %}
  
    <script type="text/html" id="cost-item-template">
@@ -101,7 +101,7 @@
          <div class="radio">
            <label>
              <input
-@@ -149,7 +149,7 @@
+@@ -150,7 +150,7 @@
              />
              {% blocktrans %} Pay a portion of the balance: {% endblocktrans %}
              <div class="input-group">
@@ -110,7 +110,7 @@
                <input
                  type="text"
                  class="form-control"
-@@ -218,12 +218,12 @@
+@@ -219,12 +219,12 @@
  {% block modals %}
    {{ block.super }}
    {% with process_invoice_payment_url as process_payment_url %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
@@ -10,7 +10,7 @@
  
  {% block page_content %}
    {% initial_page_data "stripe_public_key" stripe_public_key %}
-@@ -14,12 +14,12 @@
+@@ -15,12 +15,12 @@
    {% registerurl "domain_wire_payment" domain %}
  
    <div class="row">
@@ -27,7 +27,7 @@
              <div class="{{ plan.css_class }}">
                <h4>
                  {% if plan.is_paused %}
-@@ -60,7 +60,7 @@
+@@ -61,7 +61,7 @@
              {% endif %}
              {% if can_change_subscription %}
                {% if plan.is_annual_plan and not plan.upgrade_available %}
@@ -36,7 +36,7 @@
                    {% trans "Questions about your plan?" %}
                    <a href="{% url "annual_plan_request_quote" domain %}"
                      >{% trans "Contact us" %}</a
-@@ -68,11 +68,7 @@
+@@ -69,11 +69,7 @@
                  </div>
                {% else %}
                  <p>
@@ -49,7 +49,7 @@
                      {% if plan.is_paused %}
                        {% trans "Subscribe to Plan" %}
                      {% elif plan.is_annual_plan and plan.upgrade_available %}
-@@ -105,21 +101,21 @@
+@@ -106,21 +102,21 @@
          </div>
          {% if not plan.is_trial and not plan.is_paused %}
            {% if plan.date_start %}
@@ -77,7 +77,7 @@
                  <p class="form-control-text">{{ plan.date_end }}</p>
                  {% if plan.is_auto_renew %}
                    <div class="alert alert-success">
-@@ -146,8 +142,8 @@
+@@ -147,8 +143,8 @@
                    <button
                      type="button"
                      class="btn btn-default"
@@ -88,7 +88,7 @@
                    >
                      {% if plan.is_auto_renew %}
                        {% trans "Disable Auto Renewal" %}
-@@ -160,55 +156,55 @@
+@@ -161,55 +157,55 @@
              </div>
            {% endif %}
            <div data-bind="foreach: products">
@@ -160,7 +160,7 @@
                <p class="form-control-text">
                  {{ plan.next_subscription.price }}
                </p>
-@@ -221,26 +217,26 @@
+@@ -222,26 +218,26 @@
          <div class="form form-horizontal">
            {% if plan.has_credits_in_non_general_credit_line %}
              <div data-bind="foreach: products">
@@ -193,7 +193,7 @@
                  <p class="form-control-text js-general-credit">
                    {{ plan.general_credit.amount }}
                  </p>
-@@ -248,29 +244,29 @@
+@@ -249,29 +245,29 @@
              </div>
            {% endif %}
            <div data-bind="with: prepayments">
@@ -231,7 +231,7 @@
                      <i class="fa fa-info-circle"></i>
                      {% trans "Not Billing Admin, Can't Add Credit" %}
                    </span>
-@@ -283,8 +279,8 @@
+@@ -284,8 +280,8 @@
            <legend>{% trans 'Account Credit' %}</legend>
            <div class="form form-horizontal">
              <div data-bind="foreach: products">
@@ -242,7 +242,7 @@
                    {% trans 'Plan Credit' %}
                    <div class="hq-help">
                      <a
-@@ -299,7 +295,7 @@
+@@ -300,7 +296,7 @@
                      </a>
                    </div>
                  </label>
@@ -251,7 +251,7 @@
                    <p
                      class="form-control-text"
                      data-bind="text: accountAmount"
-@@ -308,8 +304,8 @@
+@@ -309,8 +305,8 @@
                </div>
              </div>
              {% if plan.account_general_credit and plan.account_general_credit.is_visible %}
@@ -262,7 +262,7 @@
                    {% trans 'General Credit' %}
                    <div class="hq-help">
                      <a
-@@ -325,7 +321,7 @@
+@@ -326,7 +322,7 @@
                      </a>
                    </div>
                  </label>
@@ -271,7 +271,7 @@
                    <p class="form-control-text">
                      {{ plan.account_general_credit.amount }}
                    </p>
-@@ -395,8 +391,8 @@
+@@ -396,8 +392,8 @@
  
  {% block modals %}
    {{ block.super }}


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/SAAS-18575

Adds the ability to pay with the autopay card on file for the account in payment modals (even when current user does not own the card). 

Previously, this was the only option:
<img width="590" height="232" alt="Screenshot 2025-10-22 at 2 48 45 PM" src="https://github.com/user-attachments/assets/378e4ad5-891e-4661-b5e8-88c3f8daabf5" />

If an autopay card exists on the account, the user now sees it as an option like this:
<img width="582" height="253" alt="Screenshot 2025-10-22 at 2 47 49 PM" src="https://github.com/user-attachments/assets/d2e76b2d-4052-43a1-8789-61a8b676eb02" />

use saved card appears as normal
<img width="589" height="199" alt="Screenshot 2025-10-22 at 2 47 55 PM" src="https://github.com/user-attachments/assets/2acb21c6-075b-4192-a429-0c05b1f11774" />

as does use a different card
<img width="587" height="265" alt="Screenshot 2025-10-22 at 2 48 00 PM" src="https://github.com/user-attachments/assets/8a180cbe-12bd-45d1-9a8b-9f84329abc26" />

if no autopay or saved cards available, the user sees this:
<img width="584" height="181" alt="Screenshot 2025-10-15 at 11 53 42 PM" src="https://github.com/user-attachments/assets/6d52b2da-cc69-4418-aaf7-ad14a3c2dba8" />

If autopay is available, but the user has no saved cards, they will see this:
<img width="590" height="188" alt="Screenshot 2025-10-16 at 3 32 18 PM" src="https://github.com/user-attachments/assets/d6139828-bef3-4af3-9ad4-359f18c829bf" />


## Technical Summary
- Removes ability to set autopay and remove card in the payment handler ([this PR](https://github.com/dimagi/commcare-hq/pull/37057) already introduced these changes to the frontend)
- minor cleanup on indentation, formatting, and improving clarity with renames

## Safety Assurance

### Safety story
safe change, touches UI interaction only.

### Automated test coverage
n/a

### QA Plan
No QA needed. Tested extensively locally.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
