### PR TITLE
Autopay Customer Invoices

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -3768,7 +3768,8 @@ class CreditLine(models.Model):
         cls.add_credit(
             -payment_record.amount,
             account=billing_account,
-            invoice=invoice,
+            customer_invoice=invoice if invoice.is_customer_invoice else None,
+            invoice=invoice if not invoice.is_customer_invoice else None,
         )
 
 

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -383,6 +383,21 @@ class AutoPayInvoicePaymentHandler(object):
             except Exception as e:
                 log_accounting_error("Error autopaying invoice %d: %s" % (invoice.id, e))
 
+    def pay_autopayable_customer_invoices(self, date_due=Ellipsis, account=None):
+        """
+        Pays the full balance of all autopayable customer invoices on date_due
+        Note: we use Ellipsis as the default value for date_due because date_due
+        can actually be None in the db.
+        """
+        autopayable_invoices = CustomerInvoice.autopayable_invoices(date_due)
+        if account is not None:
+            autopayable_invoices = autopayable_invoices.filter(account__name=account)
+        for invoice in autopayable_invoices:
+            try:
+                self._pay_invoice(invoice)
+            except Exception as e:
+                log_accounting_error("Error autopaying customer invoice %d: %s" % (invoice.id, e))
+
     def _pay_invoice(self, invoice):
         invoice_label = "customer invoice" if invoice.is_customer_invoice else "invoice"
         log_accounting_info(

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -383,15 +383,15 @@ class AutoPayInvoicePaymentHandler(object):
             except Exception as e:
                 log_accounting_error("Error autopaying invoice %d: %s" % (invoice.id, e))
 
-    def pay_autopayable_customer_invoices(self, date_due=Ellipsis, account=None):
+    def pay_autopayable_customer_invoices(self, date_due=Ellipsis, account_name=None):
         """
         Pays the full balance of all autopayable customer invoices on date_due
         Note: we use Ellipsis as the default value for date_due because date_due
         can actually be None in the db.
         """
         autopayable_invoices = CustomerInvoice.autopayable_invoices(date_due)
-        if account is not None:
-            autopayable_invoices = autopayable_invoices.filter(account__name=account)
+        if account_name is not None:
+            autopayable_invoices = autopayable_invoices.filter(account__name=account_name)
         for invoice in autopayable_invoices:
             try:
                 self._pay_invoice(invoice)

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -160,7 +160,7 @@ class BaseStripePaymentHandler(object):
         additional_context = self.get_email_context()
         from corehq.apps.accounting.tasks import send_purchase_receipt
         send_purchase_receipt.delay(
-            payment_record.id, self.domain, self.account.name, self.receipt_email_template,
+            payment_record.id, self.domain, self.account.id, self.receipt_email_template,
             self.receipt_email_template_plaintext, additional_context
         )
 
@@ -459,7 +459,7 @@ class AutoPayInvoicePaymentHandler(object):
             send_purchase_receipt.delay(
                 payment_record.id,
                 invoice.get_domain(),
-                invoice.account.name,
+                invoice.account.id,
                 receipt_email_template,
                 receipt_email_template_plaintext,
                 context,

--- a/corehq/apps/accounting/task_utils.py
+++ b/corehq/apps/accounting/task_utils.py
@@ -31,7 +31,7 @@ def get_context_to_send_autopay_failed_email(invoice_id, is_customer_invoice=Fal
     auto_payer = account.auto_pay_user
     payment_method = StripePaymentMethod.objects.get(web_user=auto_payer)
     autopay_card = payment_method.get_autopay_card(account)
-    domain_name = invoice.get_domain()
+    domain_name = invoice.get_domain()  # returns None for CustomerInvoices
     web_user = WebUser.get_by_username(auto_payer)
     if web_user:
         if _user_active_in_domains(web_user, domain_name, account):
@@ -48,8 +48,10 @@ def get_context_to_send_autopay_failed_email(invoice_id, is_customer_invoice=Fal
         'autopay_card': autopay_card,
         'is_customer_invoice': is_customer_invoice,
         'subscription_plan': subscription_plan,
-        'domain_url': absolute_reverse('dashboard_default', args=[domain_name]),
-        'billing_info_url': absolute_reverse('domain_update_billing_info', args=[domain_name]),
+        'domain_url': absolute_reverse('dashboard_default', args=[domain_name]) if domain_name else None,
+        'billing_info_url': (
+            absolute_reverse('domain_update_billing_info', args=[domain_name]) if domain_name else None
+        ),
         'support_email': settings.INVOICING_CONTACT_EMAIL,
     }
 

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -519,8 +519,12 @@ def create_wire_credits_invoice(domain_name,
 
 
 @task(ignore_result=True, acks_late=True)
-def send_purchase_receipt(payment_record_id, domain, template_html, template_plaintext, additional_context):
-    context = get_context_to_send_purchase_receipt(payment_record_id, domain, additional_context)
+def send_purchase_receipt(
+    payment_record_id, domain_name, account_name, template_html, template_plaintext, additional_context
+):
+    context = get_context_to_send_purchase_receipt(
+        payment_record_id, domain_name, account_name, additional_context
+    )
 
     email_html = render_to_string(template_html, context['template_context'])
     email_plaintext = render_to_string(template_plaintext, context['template_context'])
@@ -535,8 +539,8 @@ def send_purchase_receipt(payment_record_id, domain, template_html, template_pla
 
 
 @task(queue='background_queue', ignore_result=True, acks_late=True)
-def send_autopay_failed(invoice_id):
-    context = get_context_to_send_autopay_failed_email(invoice_id)
+def send_autopay_failed(invoice_id, is_customer_invoice=False):
+    context = get_context_to_send_autopay_failed_email(invoice_id, is_customer_invoice=is_customer_invoice)
 
     template_html = 'accounting/email/autopay_failed.html'
     html_content = render_to_string(template_html, context['template_context'])

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -656,7 +656,9 @@ def weekly_digest():
 @periodic_task(run_every=crontab(hour=1, minute=0,), acks_late=True)
 def pay_autopay_invoices():
     """ Check for autopayable invoices every day and pay them """
-    AutoPayInvoicePaymentHandler().pay_autopayable_invoices(datetime.datetime.today())
+    today = datetime.datetime.today()
+    AutoPayInvoicePaymentHandler().pay_autopayable_invoices(today)
+    AutoPayInvoicePaymentHandler().pay_autopayable_customer_invoices(today)
 
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue='background_queue', acks_late=True)

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -520,10 +520,10 @@ def create_wire_credits_invoice(domain_name,
 
 @task(ignore_result=True, acks_late=True)
 def send_purchase_receipt(
-    payment_record_id, domain_name, account_name, template_html, template_plaintext, additional_context
+    payment_record_id, domain_name, account_id, template_html, template_plaintext, additional_context
 ):
     context = get_context_to_send_purchase_receipt(
-        payment_record_id, domain_name, account_name, additional_context
+        payment_record_id, domain_name, account_id, additional_context
     )
 
     email_html = render_to_string(template_html, context['template_context'])

--- a/corehq/apps/accounting/templates/accounting/email/autopay_failed.html
+++ b/corehq/apps/accounting/templates/accounting/email/autopay_failed.html
@@ -1,41 +1,81 @@
+{% load i18n %}
 <p>
-  Hello,
+  {% blocktrans %}
+    Hello,
+  {% endblocktrans %}
 </p>
 
-<p>
-  This is a notice to inform you that your credit card payment for your CommCare
-  subscription for project space:
-  <a href="{{ domain_url }}">{{ domain }}</a>
-  was declined. Please check to see
-  if your billing information correctly matches your credit card.
-</p>
+{% if is_customer_invoice %}
+  <p>
+    {% blocktrans %}
+      This is a notice to inform you that your credit card payment for your
+      CommCare subscription for billing account {{ domain_or_account }} was
+      declined. Please check to see if your billing information correctly
+      matches your credit card.
+    {% endblocktrans %}
+  </p>
+{% else %}
+  <p>
+    {% blocktrans %}
+      This is a notice to inform you that your credit card payment for your
+      CommCare subscription for project space:
+      <a href="{{ domain_url }}">{{ domain_or_account }}</a>
+      was declined. Please check to see if your billing information correctly
+      matches your credit card.
+    {% endblocktrans %}
+  </p>
+{% endif %}
 
 <p>
-  Here are the details of your declined payment:
-  <br/>
+  {% blocktrans %}
+    Here are the details of your declined payment:
+  {% endblocktrans %}
+</p>
 <ul>
-  <li>Billed To: {{ autopay_card.brand }} card with the last four digits {{ autopay_card.last4 }} expiring {{ autopay_card.exp_month }}/{{ autopay_card.exp_year }}</li>
-  <li>Subscription plan: {{ subscription_plan }}</li>
-  <li>Billing date: {{ billing_date }}</li>
-  <li>Invoice #: {{ invoice_number }}</li>
+  <li>
+    {% blocktrans brand=autopay_card.brand last4=autopay_card.last4 exp_month=autopay_card.exp_month exp_year=autopay_card.exp_year %}
+      Billed To: {{ brand }} card with the last four digits {{ last4 }} expiring
+      {{ exp_month }}/{{ exp_year }}
+    {% endblocktrans %}
+  </li>
+  {% if subscription_plan %}
+    <li>{% trans "Subscription plan" %}: {{ subscription_plan }}</li>
+  {% endif %}
+  <li>{% trans "Billing date" %}: {{ billing_date }}</li>
+  <li>{% trans "Invoice #" %}: {{ invoice_number }}</li>
 </ul>
+
+{% if is_customer_invoice %}
+  {% blocktrans %}
+    Please update your billing information at to prevent disruption to your
+    CommCare subscription.
+  {% endblocktrans %}
+{% else %}
+  <p>
+    {% blocktrans %}
+      Please update your billing information at
+      <a href="{{ billing_info_url }}">{{ billing_info_url }}</a>
+      to prevent disruption to your CommCare subscription.
+    {% endblocktrans %}
+  </p>
+{% endif %}
+
+<p>
+  {% blocktrans %}
+    You'll need to pay the prior invoice whose payment method was declined, but
+    future invoices will be paid via the updated billing information.
+  {% endblocktrans %}
 </p>
 
 <p>
-  Please update your billing information at
-  <a href="{{ billing_info_url }}">{{ billing_info_url }}</a>
-  to prevent disruption to your CommCare
-  subscription. You'll need to pay the prior invoice whose payment method was
-  declined, but future invoices will be paid via the updated billing
-  information.
+  {% blocktrans %}
+    If you have any questions, please contact {{ support_email }}.
+  {% endblocktrans %}
 </p>
 
 <p>
-  If you have any questions, please contact {{ support_email }}.
-</p>
-
-<p>
-  Thanks,
-  <br/>
-  -Dimagi
+  {% blocktrans %}
+    Thanks,<br />
+    -Dimagi
+  {% endblocktrans %}
 </p>

--- a/corehq/apps/accounting/templates/accounting/email/autopay_failed.html
+++ b/corehq/apps/accounting/templates/accounting/email/autopay_failed.html
@@ -47,7 +47,7 @@
 
 {% if is_customer_invoice %}
   {% blocktrans %}
-    Please update your billing information at to prevent disruption to your
+    Please update your billing information to prevent disruption to your
     CommCare subscription.
   {% endblocktrans %}
 {% else %}

--- a/corehq/apps/accounting/templates/accounting/email/autopay_failed.txt
+++ b/corehq/apps/accounting/templates/accounting/email/autopay_failed.txt
@@ -1,17 +1,46 @@
+{% load i18n %}
+{% blocktrans %}
 Hello,
+{% endblocktrans %}
 
+{% if is_customer_invoice %}
+{% blocktrans %}
 This is a notice to inform you that your credit card payment for your CommCare
-subscription for project space {{ domain }} was declined. Please check to see
-if your billing information correctly matches your credit card.
+subscription for billing account {{ domain_or_account }} was declined. Please
+check to see if your billing information correctly matches your credit card.
+{% endblocktrans %}
+{% else %}
+{% blocktrans %}
+This is a notice to inform you that your credit card payment for your CommCare
+subscription for project space {{ domain_or_account }} was declined. Please
+check to see if your billing information correctly matches your credit card.
+{% endblocktrans %}
+{% endif %}
 
+{% blocktrans with brand=autopay_card.brand last4=autopay_card.last4 exp_month=autopay_card.exp_month exp_year=autopay_card.exp_year %}
 Here are the details of your declined payment:
-Billed To: {{ autopay_card.brand }} card with last four digits {{ autopay_card.last4 }} expiring {{ autopay_card.exp_month }}/{{ autopay_card.exp_year }}
-Subscription plan: {{ subscription_plan }}
-Billing date: {{ billing_date }}
-Invoice #: {{ invoice_number }}
+Billed To: {{ brand }} card with last four digits {{ last4 }} expiring {{ exp_month }}/{{ exp_year }}
+{% endblocktrans %}
+{% if subscription_plan %}
+{% trans "Subscription plan" %}: {{ subscription_plan }}
+{% endif %}
+{% trans "Billing date" %}: {{ billing_date }}
+{% trans "Invoice #" %}: {{ invoice_number }}
 
+{% if is_customer_invoice %}
+{% blocktrans %}
+Please update your billing information to prevent disruption to your CommCare
+subscription.
+{% endblocktrans %}
+{% else %}
+{% blocktrans %}
 Please update your billing information at {{ billing_info_url }}
-to prevent disruption to your CommCare subscription. You'll need to pay the
+to prevent disruption to your CommCare subscription.
+{% endblocktrans %}
+{% endif %}
+
+{% blocktrans %}
+You'll need to pay the
 prior invoice whose payment method was declined, but future invoices will be
 paid via the updated billing information.
 
@@ -19,3 +48,4 @@ If you have any questions, please contact {{ support_email }}.
 
 Thanks,
 -Dimagi
+{% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/autopay_failed.txt
+++ b/corehq/apps/accounting/templates/accounting/email/autopay_failed.txt
@@ -1,45 +1,26 @@
-{% load i18n %}
-{% blocktrans %}
-Hello,
-{% endblocktrans %}
-
-{% if is_customer_invoice %}
-{% blocktrans %}
+{% load i18n %}{% blocktrans %}
+Hello,{% endblocktrans %}
+{% if is_customer_invoice %}{% blocktrans %}
 This is a notice to inform you that your credit card payment for your CommCare
 subscription for billing account {{ domain_or_account }} was declined. Please
-check to see if your billing information correctly matches your credit card.
-{% endblocktrans %}
-{% else %}
-{% blocktrans %}
+check to see if your billing information correctly matches your credit card.{% endblocktrans %}
+{% else %}{% blocktrans %}
 This is a notice to inform you that your credit card payment for your CommCare
 subscription for project space {{ domain_or_account }} was declined. Please
-check to see if your billing information correctly matches your credit card.
-{% endblocktrans %}
-{% endif %}
-
-{% blocktrans with brand=autopay_card.brand last4=autopay_card.last4 exp_month=autopay_card.exp_month exp_year=autopay_card.exp_year %}
+check to see if your billing information correctly matches your credit card.{% endblocktrans %}
+{% endif %}{% blocktrans with brand=autopay_card.brand last4=autopay_card.last4 exp_month=autopay_card.exp_month exp_year=autopay_card.exp_year %}
 Here are the details of your declined payment:
-Billed To: {{ brand }} card with last four digits {{ last4 }} expiring {{ exp_month }}/{{ exp_year }}
-{% endblocktrans %}
-{% if subscription_plan %}
-{% trans "Subscription plan" %}: {{ subscription_plan }}
-{% endif %}
+Billed To: {{ brand }} card with last four digits {{ last4 }} expiring {{ exp_month }}/{{ exp_year }}{% endblocktrans %}
+{% if subscription_plan %}{% trans "Subscription plan" %}: {{ subscription_plan }}{% endif %}
 {% trans "Billing date" %}: {{ billing_date }}
 {% trans "Invoice #" %}: {{ invoice_number }}
-
-{% if is_customer_invoice %}
-{% blocktrans %}
+{% if is_customer_invoice %}{% blocktrans %}
 Please update your billing information to prevent disruption to your CommCare
-subscription.
-{% endblocktrans %}
-{% else %}
-{% blocktrans %}
+subscription.{% endblocktrans %}
+{% else %}{% blocktrans %}
 Please update your billing information at {{ billing_info_url }}
-to prevent disruption to your CommCare subscription.
-{% endblocktrans %}
-{% endif %}
-
-{% blocktrans %}
+to prevent disruption to your CommCare subscription.{% endblocktrans %}
+{% endif %}{% blocktrans %}
 You'll need to pay the
 prior invoice whose payment method was declined, but future invoices will be
 paid via the updated billing information.
@@ -47,5 +28,4 @@ paid via the updated billing information.
 If you have any questions, please contact {{ support_email }}.
 
 Thanks,
--Dimagi
-{% endblocktrans %}
+-Dimagi{% endblocktrans %}

--- a/corehq/apps/accounting/templates/accounting/email/invoice_receipt.html
+++ b/corehq/apps/accounting/templates/accounting/email/invoice_receipt.html
@@ -6,12 +6,21 @@
   {% endblocktrans %}
 </p>
 
-<p>
-  {% blocktrans %}
-    This email is a receipt for your payment of {{ amount }} toward Invoice No.
-    {{ invoice_num }} for your project {{ project }}.
-  {% endblocktrans %}
-</p>
+{% if is_customer_invoice %}
+  <p>
+    {% blocktrans %}
+      This email is a receipt for your payment of {{ amount }} toward Invoice
+      No. {{ invoice_num }} for your billing account {{ domain_or_account }}.
+    {% endblocktrans %}
+  </p>
+{% else %}
+  <p>
+    {% blocktrans %}
+      This email is a receipt for your payment of {{ amount }} toward Invoice
+      No. {{ invoice_num }} for your project {{ domain_or_account }}.
+    {% endblocktrans %}
+  </p>
+{% endif %}
 
 {% if is_paid %}
   <p>
@@ -24,14 +33,18 @@
     <li><strong>{% trans 'Invoice No.' %}:</strong> {{ invoice_num }}</li>
     <li><strong>{% trans 'Amount Paid' %}:</strong> {{ amount }}</li>
     <li><strong>{% trans 'Payment Date' %}:</strong> {{ date_paid }}</li>
-    <li><strong>{% trans 'Transaction No.' %}:</strong> {{ transaction_id }}</li>
+    <li>
+      <strong>{% trans 'Transaction No.' %}:</strong> {{ transaction_id }}
+    </li>
   </ul>
 {% else %}
   <ul>
     <li><strong>{% trans 'Invoice No.' %}:</strong> {{ invoice_num }}</li>
     <li><strong>{% trans 'Amount Paid' %}:</strong> {{ amount }}</li>
     <li><strong>{% trans 'Payment Date' %}:</strong> {{ date_paid }}</li>
-    <li><strong>{% trans 'Transaction No.' %}:</strong> {{ transaction_id }}</li>
+    <li>
+      <strong>{% trans 'Transaction No.' %}:</strong> {{ transaction_id }}
+    </li>
     <li><strong>{% trans 'Remaining Balance' %}:</strong> {{ balance }}</li>
     <li><strong>{% trans 'Date Due' %}:</strong> {{ date_due }}</li>
   </ul>

--- a/corehq/apps/accounting/templates/accounting/email/invoice_receipt.txt
+++ b/corehq/apps/accounting/templates/accounting/email/invoice_receipt.txt
@@ -1,15 +1,31 @@
-{% load i18n %}{% blocktrans %}Dear {{ name }},
+{% load i18n %}
+{% blocktrans %}
+Dear {{ name }},
+{% endblocktrans%}
 
+{% if is_customer_invoice %}
+{% blocktrans %}
 This email is a receipt for your payment of {{ amount }} toward Invoice No.
-{{ invoice_num }} for your project {{ project }}.
+{{ invoice_num }} for your billing account {{ domain_or_account }}.
 {% endblocktrans %}
+{% else %}
+{% blocktrans %}
+This email is a receipt for your payment of {{ amount }} toward Invoice No.
+{{ invoice_num }} for your project {{ domain_or_account }}.
+{% endblocktrans %}
+{% endif %}
+
 {% if is_paid %}
+{% blocktrans %}
 This invoice is now marked as paid as of {{ date_paid }}.
 
 Invoice No.: {{ invoice_num }}
 Amount Paid: {{ amount }}
 Payment Date: {{ date_paid }}
-Transaction No.: {{ transaction_id }}{% else %}{% blocktrans %}
+Transaction No.: {{ transaction_id }}
+{% endblocktrans %}
+{% else %}
+{% blocktrans %}
 Please note that there is still a remaining balance on this Invoice.
 
 Invoice No.: {{ invoice_num }}
@@ -17,7 +33,9 @@ Amount Paid: {{ amount }}
 Payment Date: {{ date_paid }}
 Transaction No.: {{ transaction_id }}
 Remaining Balance: {{ balance }}
-Date Due: {{ date_due }}{% endblocktrans %}{% endif %}
+Date Due: {{ date_due }}
+{% endblocktrans %}
+{% endif %}
 
 {% blocktrans %}
 Thank you for using CommCare. If you have any questions, please don't

--- a/corehq/apps/accounting/templates/accounting/email/invoice_receipt.txt
+++ b/corehq/apps/accounting/templates/accounting/email/invoice_receipt.txt
@@ -1,31 +1,19 @@
-{% load i18n %}
-{% blocktrans %}
-Dear {{ name }},
-{% endblocktrans%}
-
-{% if is_customer_invoice %}
-{% blocktrans %}
+{% load i18n %}{% blocktrans %}
+Dear {{ name }},{% endblocktrans%}
+{% if is_customer_invoice %}{% blocktrans %}
 This email is a receipt for your payment of {{ amount }} toward Invoice No.
-{{ invoice_num }} for your billing account {{ domain_or_account }}.
-{% endblocktrans %}
-{% else %}
-{% blocktrans %}
+{{ invoice_num }} for your billing account {{ domain_or_account }}.{% endblocktrans %}
+{% else %}{% blocktrans %}
 This email is a receipt for your payment of {{ amount }} toward Invoice No.
-{{ invoice_num }} for your project {{ domain_or_account }}.
-{% endblocktrans %}
-{% endif %}
-
-{% if is_paid %}
-{% blocktrans %}
+{{ invoice_num }} for your project {{ domain_or_account }}.{% endblocktrans %}
+{% endif %}{% if is_paid %}{% blocktrans %}
 This invoice is now marked as paid as of {{ date_paid }}.
 
 Invoice No.: {{ invoice_num }}
 Amount Paid: {{ amount }}
 Payment Date: {{ date_paid }}
-Transaction No.: {{ transaction_id }}
-{% endblocktrans %}
-{% else %}
-{% blocktrans %}
+Transaction No.: {{ transaction_id }}{% endblocktrans %}
+{% else %}{% blocktrans %}
 Please note that there is still a remaining balance on this Invoice.
 
 Invoice No.: {{ invoice_num }}
@@ -33,10 +21,8 @@ Amount Paid: {{ amount }}
 Payment Date: {{ date_paid }}
 Transaction No.: {{ transaction_id }}
 Remaining Balance: {{ balance }}
-Date Due: {{ date_due }}
-{% endblocktrans %}
+Date Due: {{ date_due }}{% endblocktrans %}
 {% endif %}
-
 {% blocktrans %}
 Thank you for using CommCare. If you have any questions, please don't
 hesitate to contact {{ invoicing_contact_email }}.
@@ -47,5 +33,4 @@ www.commcarehq.org
 
 Email From:
 CommCare and the corporation Dimagi, Inc.
-245 Main Street, 2nd Floor, Cambridge, MA 02142 USA
-{% endblocktrans %}
+245 Main Street, 2nd Floor, Cambridge, MA 02142 USA{% endblocktrans %}


### PR DESCRIPTION
## Product Description
Allows Customer Invoices (for "customer billing" accounts) to be autopaid. There's no user-facing (customer or accounting admin) indication this wouldn't work, so likely it was just never implemented.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18346
Follows the existing implementation for autopaying single-project Invoices but adds a new method `pay_autopayable_customer_invoices`, called by the `pay_autopay_invoices` task to explicitly pay Customer Invoices. Updates email context, templates, and logging to indicate "invoice"/"project" or "customer invoice"/"billing account" as needed. Also adds translation tags in email templates where they were not previously.

Review by commit.

## Safety Assurance

### Safety story
Tested on staging by setting up a customer billing account, generating customer invoices, and calling `pay_autopayable_customer_invoices` with the account name specified, checking that the charge was made through Stripe's testing API, the invoice was credited correctly and marked as paid, and the email was sent out as expected. Did the same with regular invoices and `pay_autopayable_invoices` to confirm that functionality is unaffected as well.

Automated tests are also added or updated here for `CustomerInvoice`s to mirror what what we do for the `Invoice` autopay process.

### Automated test coverage
- `TestBillingAutoPayCustomerInvoices` is added mirroring the renamed `TestBillingAutoPayInvoices` (previously just `TestBillingAutoPay`.
- Autopay email context tests `TestGetContextToSendAutopayFailedEmail` and `TestGetContextToSendPurchaseReceipt` are also updated to ensure expected context with the changes made to accommodate customer invoices.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
