### PR TITLE
set custom-data-fieldset on parent div

### DIFF
--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -253,6 +253,8 @@ class CustomDataEditor(object):
         else:
             CustomDataForm.helper = HQFormHelper()
         CustomDataForm.helper.form_tag = False
+        CustomDataForm.helper.label_class = 'col-sm-3 col-md-2'
+        CustomDataForm.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
 
         form_fieldsets = self.make_fieldsets(form_fields, post_dict is not None)
 

--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -169,18 +169,22 @@ class CustomDataEditor(object):
             profile_names = []
 
         form_fieldsets = []
-        if profile_names:
-            form_fieldsets.append(Fieldset(
-                _("Profile"),
-                *profile_names
-            ))
-        if field_names:
-            form_fieldsets.append(FieldsetAccordionGroup(
-                _("Additional Information"),
-                *field_names,
-                active=True,
+        if profile_names or field_names:
+            user_data_div = Div(
                 css_class="custom-data-fieldset"
-            ))
+            )
+            form_fieldsets.append(user_data_div)
+            if profile_names:
+                user_data_div.append(Fieldset(
+                    _("Profile"),
+                    *profile_names
+                ))
+            if field_names:
+                user_data_div.append(FieldsetAccordionGroup(
+                    _("Additional Information"),
+                    *field_names,
+                    active=True
+                ))
         if not is_post:
             form_fieldsets.append(self.uncategorized_form)
         return form_fieldsets


### PR DESCRIPTION
## Product Description

In a recent PR I moved the profile field to its own FieldSet. That meant that `custom-data-fieldset` was not set on an ancestor node of the fields anymore breaking the knockout bindings. This moves the "Profile" and "Additional Information" FieldSets into a common parent div with that class fixing a bunch of broken behavior like:
* Disabling fields that are set by a profile
* The little x that lets you clear fields

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6323

## Feature Flag

USH: Enable additional fields in web user invite form for enhanced user details

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
