### PR TITLE
temporarily allow removing autopay method on monthly subscriptions

### DIFF
--- a/corehq/apps/domain/templates/domain/partials/payment_methods.html
+++ b/corehq/apps/domain/templates/domain/partials/payment_methods.html
@@ -102,7 +102,8 @@
               {% endif %}
             </td>
             <td class="align-middle">
-              {% if not card.is_autopay and not card.other_autopay_domains %}
+              {# rollback when ops is ready to: not card.is_autopay and not card.other_autopay_domains #}
+              {% if True %}
                 <button
                   class="btn btn-outline-danger"
                   type="button"

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1619,7 +1619,8 @@ class ConfirmBillingAccountInfoView(HqHtmxActionMixin, ConfirmSelectedPlanView, 
         )
 
     def is_autopay_required(self):
-        return not self.is_annual_plan or self.account.require_auto_pay
+        # rollback when ops is ready to: not self.is_annual_plan or self.account.require_auto_pay
+        return False
 
     @property
     def page_context(self):


### PR DESCRIPTION
## Product Description
We received feedback from ops to hold off on fully requiring autopay for monthly accounts until we update our terms. This softly rolls back that change for an easy revert when the terms are ready.

## Safety Assurance

### Safety story
safe--just UI changes and tested locally

### Automated test coverage
n/a

### QA Plan
not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
