### PR TITLE
Revert "Upgrade Django to 5.2"

### DIFF
--- a/corehq/apps/users/migrations/0026_sql_role_permissions.py
+++ b/corehq/apps/users/migrations/0026_sql_role_permissions.py
@@ -77,7 +77,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name='rolepermission',
             constraint=models.CheckConstraint(
-                condition=models.Q(('allow_all', True), ('allowed_items__len__gt', 0), _negated=True),
+                check=models.Q(('allow_all', True), ('allowed_items__len__gt', 0), _negated=True),
                 name='users_rolepermission_valid_allow'),
         ),
         migrations.AddField(

--- a/corehq/apps/users/models_role.py
+++ b/corehq/apps/users/models_role.py
@@ -292,7 +292,7 @@ class RolePermission(models.Model):
         constraints = [
             models.CheckConstraint(
                 name="users_rolepermission_valid_allow",
-                condition=~models.Q(allow_all=True, allowed_items__len__gt=0)
+                check=~models.Q(allow_all=True, allowed_items__len__gt=0)
             ),
         ]
 

--- a/corehq/motech/repeaters/migrations/0006_int_state_add_next_check_rm_repeater_id.py
+++ b/corehq/motech/repeaters/migrations/0006_int_state_add_next_check_rm_repeater_id.py
@@ -58,7 +58,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name='sqlrepeatrecord',
             constraint=models.CheckConstraint(
-                condition=models.Q(
+                check=models.Q(
                     ('next_check__isnull', True),
                     models.Q(('next_check__isnull', False), ('state', 1)),
                     models.Q(('next_check__isnull', False), ('state', 2)),

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1285,7 +1285,7 @@ class RepeatRecord(models.Model):
         constraints = [
             models.CheckConstraint(
                 name="next_check_pending_or_null",
-                condition=(
+                check=(
                     models.Q(next_check__isnull=True)
                     | models.Q(next_check__isnull=False, state=State.Pending)
                     | models.Q(next_check__isnull=False, state=State.Fail)

--- a/corehq/warnings.py
+++ b/corehq/warnings.py
@@ -2,7 +2,7 @@ import os
 import re
 import warnings
 
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import RemovedInDjango50Warning, RemovedInDjango51Warning
 
 from sqlalchemy.exc import SAWarning
 
@@ -25,8 +25,8 @@ WHITELIST = [
     ("eulxml", "pkg_resources is deprecated as an API"),
     ("pkg_resources", "pkg_resources.declare_namespace"),
 
-    ("django.conf", "FORMS_URLFIELD_ASSUME_HTTPS", RemovedInDjango60Warning),
-    ("field_audit", "CheckConstraint.check is deprecated", RemovedInDjango60Warning),
+    ("tastypie.compat", "The django.utils.datetime_safe module is deprecated.", RemovedInDjango50Warning),
+    ("django.db.models.options", "'index_together' is deprecated", RemovedInDjango51Warning),
 
     # warnings that can be resolved with HQ code changes
     ("", "datetime.datetime.utcnow() is deprecated"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "django-two-factor-auth @ git+https://github.com/jazzband/django-two-factor-auth.git@16f688bf329526d897a33594ab598bcd3fc8eaae", # waiting for next release after 1.16.0
     "django-user-agents",
     "django-websocket-redis @ https://raw.githubusercontent.com/dimagi/django-websocket-redis/0.6.0.1/releases/django_websocket_redis-0.6.0.1-py3-none-any.whl",
-    "django~=5.2.0",
+    "django>=4.2.16,<5.0",
     "djangorestframework",
     "dropbox",
     "elasticsearch6>=6.0.0,<7.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -586,7 +586,7 @@ requires-dist = [
     { name = "defusedxml" },
     { name = "diff-match-patch" },
     { name = "dimagi-memoized" },
-    { name = "django", specifier = "~=5.2.0" },
+    { name = "django", specifier = ">=4.2.16,<5.0" },
     { name = "django-autoslug" },
     { name = "django-braces" },
     { name = "django-bulk-update" },
@@ -931,16 +931,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.6"
+version = "4.2.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/8c/2a21594337250a171d45dda926caa96309d5136becd1f48017247f9cdea0/django-5.2.6.tar.gz", hash = "sha256:da5e00372763193d73cecbf71084a3848458cecf4cee36b9a1e8d318d114a87b", size = 10858861, upload-time = "2025-09-03T13:04:03.23Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/dd/33d2a11713f6b78493273a32d99bb449f2d93663ed4ec15a8b890d44ba04/Django-4.2.20.tar.gz", hash = "sha256:92bac5b4432a64532abb73b2ac27203f485e40225d2640a7fbef2b62b876e789", size = 10432686, upload-time = "2025-03-06T12:58:52.569Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/af/6593f6d21404e842007b40fdeb81e73c20b6649b82d020bb0801b270174c/django-5.2.6-py3-none-any.whl", hash = "sha256:60549579b1174a304b77e24a93d8d9fafe6b6c03ac16311f3e25918ea5a20058", size = 8303111, upload-time = "2025-09-03T13:03:47.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/5d/7571ba1c288ead056dda7adad46b25cbf64790576f095565282e996138b1/Django-4.2.20-py3-none-any.whl", hash = "sha256:213381b6e4405f5c8703fffc29cd719efdf189dec60c67c04f76272b3dc845b9", size = 7993584, upload-time = "2025-03-06T12:58:44.863Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Creating this PR as a precaution in case we need to quickly roll back due to unforeseen issues during or shortly after initial rollout. Of course it's likely a better idea to fix whatever issue that might come up rather than downgrading, but in an emergency this might be quicker.

Reverts dimagi/commcare-hq#37025