### PR TITLE
Revert 37023+37086

### DIFF
--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -169,22 +169,18 @@ class CustomDataEditor(object):
             profile_names = []
 
         form_fieldsets = []
-        if profile_names or field_names:
-            user_data_div = Div(
+        if profile_names:
+            form_fieldsets.append(Fieldset(
+                _("Profile"),
+                *profile_names
+            ))
+        if field_names:
+            form_fieldsets.append(FieldsetAccordionGroup(
+                _("Additional Information"),
+                *field_names,
+                active=True,
                 css_class="custom-data-fieldset"
-            )
-            form_fieldsets.append(user_data_div)
-            if profile_names:
-                user_data_div.append(Fieldset(
-                    _("Profile"),
-                    *profile_names
-                ))
-            if field_names:
-                user_data_div.append(FieldsetAccordionGroup(
-                    _("Additional Information"),
-                    *field_names,
-                    active=True
-                ))
+            ))
         if not is_post:
             form_fieldsets.append(self.uncategorized_form)
         return form_fieldsets
@@ -253,8 +249,6 @@ class CustomDataEditor(object):
         else:
             CustomDataForm.helper = HQFormHelper()
         CustomDataForm.helper.form_tag = False
-        CustomDataForm.helper.label_class = 'col-sm-3 col-md-2'
-        CustomDataForm.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
 
         form_fieldsets = self.make_fieldsets(form_fields, post_dict is not None)
 

--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -14,7 +14,7 @@ from corehq.apps.accounting.utils import domain_has_privilege
 from crispy_forms.layout import HTML, Div, Field, Fieldset, Layout
 from memoized import memoized
 
-from corehq.apps.hqwebapp.crispy import FieldsetAccordionGroup, HQFormHelper, HQModalFormHelper
+from corehq.apps.hqwebapp.crispy import HQFormHelper, HQModalFormHelper
 from corehq import privileges
 
 from .models import (
@@ -142,7 +142,6 @@ class CustomDataEditor(object):
     def make_fieldsets(self, form_fields, is_post, field_name_includes_prefix=False):
         if self.ko_model:
             field_names = []
-            profile_names = []
             for field_name, field in form_fields.items():
                 data_bind_field_name = (
                     without_prefix(field_name, self.prefix) if field_name_includes_prefix else field_name)
@@ -154,31 +153,18 @@ class CustomDataEditor(object):
                     data_binds.append("select2: " + json.dumps([
                         {"id": id, "text": text} for id, text in field.widget.choices
                     ]))
-                if field_name.endswith(PROFILE_SLUG):
-                    profile_names.append(Field(
-                        field_name,
-                        data_bind=", ".join(data_binds)
-                    ))
-                else:
-                    field_names.append(Field(
-                        field_name,
-                        data_bind=", ".join(data_binds)
-                    ))
+                field_names.append(Field(
+                    field_name,
+                    data_bind=", ".join(data_binds)
+                ))
         else:
             field_names = list(form_fields)
-            profile_names = []
 
         form_fieldsets = []
-        if profile_names:
-            form_fieldsets.append(Fieldset(
-                _("Profile"),
-                *profile_names
-            ))
         if field_names:
-            form_fieldsets.append(FieldsetAccordionGroup(
+            form_fieldsets.append(Fieldset(
                 _("Additional Information"),
                 *field_names,
-                active=True,
                 css_class="custom-data-fieldset"
             ))
         if not is_post:
@@ -322,13 +308,12 @@ class CustomDataEditor(object):
             self.field_view.urlname, args=[self.domain]
         ))
 
-        return FieldsetAccordionGroup(
+        return Fieldset(
             _("Unrecognized Information"),
             Div(
                 HTML(msg),
                 css_class="alert alert-warning",
                 css_id="js-unrecognized-data",
             ),
-            *help_div,
-            active=True
+            *help_div
         ) if len(help_div) else HTML('')

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap3/accordion_group.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap3/accordion_group.html
@@ -1,21 +1,18 @@
-<fieldset class="{{ div.css_class }}">
-  <legend>
-    <a
-      class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
-      data-toggle="collapse"
-      {% if div.data_parent %}
-        data-parent="#{{ div.data_parent }}"
-      {% endif %}
-      href="#{{ div.css_id }}"
-    >
-      <i class="fa fa-angle-double-down"></i>
-      {{ div.name }}
-    </a>
-  </legend>
-  <div
-    id="{{ div.css_id }}"
-    class="panel-body collapse{% if div.active %} in{% endif %}"
-  >
-    <div>{{ fields|safe }}</div>
-  </div>
+<fieldset>
+    <legend>
+        <a class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
+           data-toggle="collapse"
+           {% if div.data_parent %}
+           data-parent="#{{ div.data_parent }}"
+           {% endif %}
+           href="#{{ div.css_id }}">
+            <i class="fa fa-angle-double-down"></i>
+            {{ div.name }}
+        </a>
+    </legend>
+    <div id="{{ div.css_id }}" class="panel-body collapse{% if div.active %} in{% endif %}" >
+        <div>
+            {{ fields|safe }}
+        </div>
+    </div>
 </fieldset>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/accordion_group.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/accordion_group.html
@@ -1,21 +1,18 @@
-<fieldset class="{{ div.css_class }}">
-  <legend>
-    <a
-      class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
-      data-bs-toggle="collapse"
-      {% if div.data_parent %}
-        data-parent="#{{ div.data_parent }}"
-      {% endif %}
-      href="#{{ div.css_id }}"
-    >
-      <i class="fa fa-angle-double-down"></i>
-      {{ div.name }}
-    </a>
-  </legend>
-  <div
-    id="{{ div.css_id }}"
-    class="card-body collapse{% if div.active %} in{% endif %}"
-  >
-    <div>{{ fields|safe }}</div>
-  </div>
+<fieldset>
+    <legend>
+        <a class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
+           data-bs-toggle="collapse"
+           {% if div.data_parent %}
+           data-parent="#{{ div.data_parent }}"
+           {% endif %}
+           href="#{{ div.css_id }}">
+            <i class="fa fa-angle-double-down"></i>
+            {{ div.name }}
+        </a>
+    </legend>
+    <div id="{{ div.css_id }}" class="card-body collapse{% if div.active %} in{% endif %}" >
+        <div>
+            {{ fields|safe }}
+        </div>
+    </div>
 </fieldset>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/crispy/accordion_group.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/crispy/accordion_group.html.diff.txt
@@ -1,20 +1,20 @@
 --- 
 +++ 
-@@ -2,7 +2,7 @@
-   <legend>
-     <a
-       class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
--      data-toggle="collapse"
-+      data-bs-toggle="collapse"
-       {% if div.data_parent %}
-         data-parent="#{{ div.data_parent }}"
-       {% endif %}
-@@ -14,7 +14,7 @@
-   </legend>
-   <div
-     id="{{ div.css_id }}"
--    class="panel-body collapse{% if div.active %} in{% endif %}"
-+    class="card-body collapse{% if div.active %} in{% endif %}"
-   >
-     <div>{{ fields|safe }}</div>
-   </div>
+@@ -1,7 +1,7 @@
+ <fieldset>
+     <legend>
+         <a class="accordion-toggle{% if not div.active %} collapsed{% endif %}"
+-           data-toggle="collapse"
++           data-bs-toggle="collapse"
+            {% if div.data_parent %}
+            data-parent="#{{ div.data_parent }}"
+            {% endif %}
+@@ -10,7 +10,7 @@
+             {{ div.name }}
+         </a>
+     </legend>
+-    <div id="{{ div.css_id }}" class="panel-body collapse{% if div.active %} in{% endif %}" >
++    <div id="{{ div.css_id }}" class="card-body collapse{% if div.active %} in{% endif %}" >
+         <div>
+             {{ fields|safe }}
+         </div>

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1241,14 +1241,9 @@ class InviteWebUserView(BaseManageWebUserView):
         post_dict = None
         if self.request.method == 'POST':
             post_dict = self.request.POST
-
-        existing_custom_data = None
-        if self.invitation:
-            existing_custom_data = self.invitation.custom_user_data
         custom_data = CustomDataEditor(
             field_view=WebUserFieldsView,
             domain=self.domain,
-            existing_custom_data=existing_custom_data,
             post_dict=post_dict,
             ko_model="custom_fields",
             request_user=self.request.couch_user


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Reverts https://github.com/dimagi/commcare-hq/pull/37023  and  https://github.com/dimagi/commcare-hq/pull/37086
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
QA smoke tests figured issues with Additional Information Tag not opening up after the deploy - https://dimagi.atlassian.net/browse/QA-8190

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance
Tested the fix locally.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
