### PR TITLE
Fix pytest reusedb CouchDB reset

### DIFF
--- a/corehq/tests/pytest_plugins/reusedb.py
+++ b/corehq/tests/pytest_plugins/reusedb.py
@@ -268,6 +268,7 @@ def couch_sql_context(config):
             keepdb=config.skip_setup_for_reuse_db,
             serialized_aliases=(),
         )
+        call_command('sync_couch_views')  # sync design docs after creating dbs
 
     try:
         yield


### PR DESCRIPTION
## Technical Summary

The test database setup creates CouchDB databases but never syncs the design documents that define the views. This change ensures design documents are synced whenever test databases are created or reset.

## Safety Assurance

### Safety story

Only affects test runner, and only when CouchDB is reset.

### Automated test coverage

No

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
