### PR TITLE
chat widget upgrade

### DIFF
--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -688,7 +688,7 @@ class TestViewGeneric(ViewsBase):
         'commcare_hq_names', 'langs', 'title_context_block', 'timezone', 'has_mobile_workers',
         'multimedia_state', 'bulk_app_translation_upload', 'show_training_modules', 'forloop', 'secure_cookies',
         'IS_ANALYTICS_ENVIRONMENT', 'module_type', 'icon_class', 'form_submit_history_url', 'btn_style',
-        'chat_widget_config', 'ACCOUNTS_EMAIL', 'all_add_ons_enabled',
+        'ACCOUNTS_EMAIL', 'all_add_ons_enabled',
     }
 
     expected_keys_module = {
@@ -717,7 +717,7 @@ class TestViewGeneric(ViewsBase):
         'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'EULA_COMPLIANCE', 'sentry',
         'case_list_form_not_allowed_reasons', 'child_module_enabled', 'block', 'IS_ANALYTICS_ENVIRONMENT',
         'formats_supporting_case_list_optimizations', 'module_type', 'icon_class', 'form_submit_history_url',
-        'btn_style', 'chat_widget_config', 'ACCOUNTS_EMAIL',
+        'btn_style', 'ACCOUNTS_EMAIL',
     }
 
     expected_keys_form = {
@@ -747,7 +747,7 @@ class TestViewGeneric(ViewsBase):
         'env', 'False', 'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'allow_usercase',
         'module_loads_registry_case', 'EULA_COMPLIANCE', 'sentry', 'show_shadow_modules', 'show_custom_ref',
         'block', 'IS_ANALYTICS_ENVIRONMENT', 'module_type', 'icon_class', 'case_property_warning',
-        'form_submit_history_url', 'btn_style', 'chat_widget_config', 'ACCOUNTS_EMAIL',
+        'form_submit_history_url', 'btn_style', 'ACCOUNTS_EMAIL',
     }
 
 

--- a/corehq/apps/hqwebapp/docs/chat_widget_translations.md
+++ b/corehq/apps/hqwebapp/docs/chat_widget_translations.md
@@ -1,0 +1,44 @@
+# Chat Widget Translation Integration
+
+This document explains how CommCare HQ integrates with the Open Chat Studio widget's internationalization (i18n) features.
+
+## Overview
+
+As of version 0.5.0, the open-chat-studio-widget supports overriding UI translations via JSON files. This integration hooks into Django's existing translation framework to generate widget-compatible translation files.
+
+## Architecture
+
+The integration consists of three main components:
+
+### 1. Management Command
+
+**File:** `corehq/apps/hqwebapp/management/commands/generate_widget_translations.py`
+
+This command generates JSON translation files for each language configured in Django settings.
+
+**Usage:**
+```bash
+python manage.py generate_widget_translations
+```
+
+**Options:**
+- `--output-dir`: Specify a custom output directory (default: `STATIC_ROOT/ocs-widget`)
+
+### 2. Template Integration
+
+**File:** `corehq/apps/hqwebapp/templates/hqwebapp/base.html`
+
+The widget element now includes:
+- `language="{{ LANGUAGE_CODE }}"` - Sets the widget's UI language
+- `translations-url="{% static 'ocs-widget/' %}{{ LANGUAGE_CODE }}.json"` - Points to the generated translation file
+
+### 3. Translation Strings
+
+All widget UI strings are defined in the management command using Django's `gettext` (`_()`) function. This means they:
+- Are extracted by `makemessages` along with other Django translations
+- Can be translated using the standard Django translation workflow
+- Are compiled into the widget JSON files by the `generate_widget_translations` command
+
+## References
+
+- [Open Chat Studio Widget Documentation](https://docs.openchatstudio.com/chat_widget/reference/#internationalization)

--- a/corehq/apps/hqwebapp/management/commands/generate_widget_translations.py
+++ b/corehq/apps/hqwebapp/management/commands/generate_widget_translations.py
@@ -1,0 +1,116 @@
+"""
+Management command to generate translation JSON files for the Open Chat Studio widget.
+
+This command generates JSON files containing translated strings for the chat widget,
+hooking into Django's translation framework.
+
+Usage:
+    python manage.py generate_widget_translations
+"""
+import json
+import os
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils import translation
+from django.utils.translation import gettext as _
+
+
+class Command(BaseCommand):
+    help = "Generate translation JSON files for the Open Chat Studio widget"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--output-dir',
+            type=str,
+            default=None,
+            help='Output directory for translation files (default: STATIC_ROOT/ocs-widget)',
+        )
+
+    def handle(self, *args, **options):
+        output_dir = options['output_dir']
+        if not output_dir:
+            output_dir = os.path.join(settings.STATIC_ROOT, 'ocs-widget')
+
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+            self.stdout.write(self.style.SUCCESS(f'Created directory: {output_dir}'))
+
+        # Get all available languages from Django settings
+        languages = [lang[0] for lang in settings.LANGUAGES]
+
+        for language_code in languages:
+            translation.activate(language_code)
+
+            # Generate translation dictionary with all widget strings
+            translations = self._get_widget_translations()
+
+            # Write to JSON file
+            output_file = os.path.join(output_dir, f'{language_code}.json')
+            with open(output_file, 'w', encoding='utf-8') as f:
+                json.dump(translations, f, ensure_ascii=False, indent=2)
+
+            self.stdout.write(
+                self.style.SUCCESS(f'Generated {language_code}.json ({len(translations)} keys)')
+            )
+
+        translation.deactivate()
+
+    def _get_widget_translations(self):
+        """
+        Get all widget translation strings.
+        These are marked for translation and will be picked up by makemessages.
+        """
+        return {
+            # Launcher translations
+            "launcher.open": _("Open chat"),
+
+            # Window controls
+            "window.close": _("Close"),
+            "window.newChat": _("Start new chat"),
+            "window.fullscreen": _("Enter fullscreen"),
+            "window.exitFullscreen": _("Exit fullscreen"),
+
+            # Attachment actions
+            "attach.add": _("Attach files"),
+            "attach.remove": _("Remove file"),
+            "attach.success": _("File attached"),
+
+            # Status messages
+            "status.starting": _("Starting chat..."),
+            "status.typing": _("Finding the best answer"),
+            "status.uploading": _("Uploading"),
+
+            # Modal dialogs
+            "modal.newChatTitle": _("Start New Chat"),
+            "modal.newChatBody": _("Starting a new chat will clear your current conversation. Continue?"),
+            "modal.cancel": _("Cancel"),
+            "modal.confirm": _("Confirm"),
+
+            # Message composer
+            "composer.placeholder": _("Type a message..."),
+            "composer.send": _("Send message"),
+
+            # Error messages
+            "error.fileTooLarge": _("File too large"),
+            "error.totalTooLarge": _("Total file size too large"),
+            "error.unsupportedType": _("Unsupported file type"),
+            "error.connection": _("Connection error. Please try again."),
+            "error.sessionExpired": _("Session expired. Please start a new chat."),
+
+            "branding.poweredBy": _("Powered by"),
+            "branding.buttonText": _("Need Help?"),
+            "branding.headerText": "",
+
+            "content.welcomeMessages": [
+                _(
+                    "Hi there! I'm CommCare Companion, your personal guide to CommCare! "
+                    "What can I help you with today?"
+                )
+            ],
+            "content.starterQuestions": [
+                _("I need help with building my CommCare application."),
+                _("I need help troubleshooting my mobile application."),
+                _("I need help with exporting or understanding my data.")
+            ],
+        }

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -88,12 +88,9 @@
             visible="false"
             chatbot-id="5a912293-eccc-4cf8-8eff-207d99d59aeb"
             icon-url="{% static 'hqwebapp/images/chatbot_avatar.png' %}"
-            button-text="{{ chat_widget_config.button_text }}"
             position="right"
-            welcome-messages='["{{ chat_widget_config.welcome_message }}"]'
-            starter-questions="{{ chat_widget_config.starter_questions }}"
-            typing-indicator-text="{{ chat_widget_config.typing_indicator_text }}"
-            new-chat-confirmation-message="{{ chat_widget_config.new_chat_confirmation_message }}"
+            language="{{ LANGUAGE_CODE }}"
+            translations-url="{% static 'ocs-widget/' %}{{ LANGUAGE_CODE }}.json"
             user-id="{{ request.couch_user.user_id }}"
             user-name="{{ request.couch_user.username }}"
             >

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -3,7 +3,6 @@ import datetime
 from django.conf import settings
 from django.http import Http404
 from django.urls import resolve, reverse
-from django.utils.translation import gettext as _
 from django_prbac.utils import has_privilege
 
 from corehq import feature_previews, privileges, toggles
@@ -28,27 +27,6 @@ def base_template(request):
         'secure_cookies': settings.SECURE_COOKIES,
         'MINIMUM_ZXCVBN_SCORE': settings.MINIMUM_ZXCVBN_SCORE,
         'MINIMUM_PASSWORD_LENGTH': settings.MINIMUM_PASSWORD_LENGTH,
-    }
-
-
-def chat_widget_config(request):
-    """Global chat widget configuration with translated strings"""
-    return {
-        'chat_widget_config': {
-            'button_text': _("Need Help?"),
-            'welcome_message': _(
-                "Hi there! I'm CommCare Companion, your personal guide to CommCare! "
-                "What can I help you with today?"
-            ),
-            'starter_questions': [
-                _("I need help with building my CommCare application."),
-                _("I need help troubleshooting my mobile application."),
-                _("I need help with exporting or understanding my data.")
-            ],
-            'typing_indicator_text': _("Finding the best answer"),
-            'new_chat_confirmation_message': _("Starting a new chat will clear your current conversation. "
-                                               "Continue?"),
-        }
     }
 
 

--- a/hqscripts/management/commands/compilejsi18n.py
+++ b/hqscripts/management/commands/compilejsi18n.py
@@ -1,0 +1,14 @@
+from django.core.management import call_command
+from statici18n.management.commands import compilejsi18n
+
+
+class Command(compilejsi18n.Command):
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+
+    def handle(self, **options):
+        self.stdout.write('Generating JS translations...')
+        super().handle(**options)
+        self.stdout.write('\nGenerated Chat Widget translations...')
+        call_command("generate_widget_translations")

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "nprogress": "0.2.0",
         "nvd3": "1.1.10",
         "nvd3-1.8.6": "npm:nvd3#1.8.6",
-        "open-chat-studio-widget": "0.4.8",
+        "open-chat-studio-widget": "0.5.0",
         "quill": "2.0.3",
         "quill-delta-to-html-upate": "^0.13.0",
         "select2": "4.1.0-rc.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "nprogress": "0.2.0",
         "nvd3": "1.1.10",
         "nvd3-1.8.6": "npm:nvd3#1.8.6",
-        "open-chat-studio-widget": "0.5.0",
+        "open-chat-studio-widget": "0.5.2",
         "quill": "2.0.3",
         "quill-delta-to-html-upate": "^0.13.0",
         "select2": "4.1.0-rc.0",

--- a/settings.py
+++ b/settings.py
@@ -1306,7 +1306,6 @@ TEMPLATES = [
                 'corehq.util.context_processors.bootstrap5',
                 'corehq.util.context_processors.js_privileges',
                 'corehq.util.context_processors.server_location_display',
-                'corehq.util.context_processors.chat_widget_config',
             ],
             'debug': DEBUG,
             'loaders': [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6361,10 +6361,10 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-open-chat-studio-widget@0.4.8:
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/open-chat-studio-widget/-/open-chat-studio-widget-0.4.8.tgz#43b116ecda3d8fd864dbeb08ce42f4e50bed0dab"
-  integrity sha512-osBiF/tW1bxbVgzHUr/jL4bTJhLHXWiBkIMi2XDe1uQ/iXGX8yCIPZECYZzAuaAvr8hSBUu3Tvlf7tJ5GxYZvw==
+open-chat-studio-widget@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/open-chat-studio-widget/-/open-chat-studio-widget-0.5.0.tgz#5860562589573e673ff8ccade358f75404075237"
+  integrity sha512-mPIKBpgmZiy05Tya2U1n7/bI5NacM+xDOVWnCHlvF2lp8yLA2bniWA+sk7YFE4wHAaWxG0on+aZAdYCct06QxQ==
   dependencies:
     "@stencil/core" "^4.27.0"
     dompurify "^3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6361,10 +6361,10 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-open-chat-studio-widget@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/open-chat-studio-widget/-/open-chat-studio-widget-0.5.0.tgz#5860562589573e673ff8ccade358f75404075237"
-  integrity sha512-mPIKBpgmZiy05Tya2U1n7/bI5NacM+xDOVWnCHlvF2lp8yLA2bniWA+sk7YFE4wHAaWxG0on+aZAdYCct06QxQ==
+open-chat-studio-widget@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/open-chat-studio-widget/-/open-chat-studio-widget-0.5.2.tgz#b1ceb4494b81bcac1dd063058edca9b2961c6a9e"
+  integrity sha512-Da0yAkSrYU5eADKMCDI9jrf81w8X1SZ34uiErpPnHHuprfw6tpClx6nbHd5vTb30CjLO5Mv3nX3Drs8yjcb+vw==
   dependencies:
     "@stencil/core" "^4.27.0"
     dompurify "^3.0.5"


### PR DESCRIPTION
## Product Description
Upgrade the OCS chat widget:

* fully translatable UI
* draggable button

See https://docs.openchatstudio.com/chat_widget/changelog/#v050 for full changelog.


## Technical Summary
* Upgrade the OCS chat widget to 0.5.0
* Build management command to generate translation files for the chat widget
* Override the `compilejsi18n` management command to also generate the chat widget translation files

## Safety Assurance

### Safety story
Currently deployed to staging for testing.

### Automated test coverage
None

### QA Plan
Testing on staging

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
