### PR TITLE
Check pending invitations before deleting profile

### DIFF
--- a/corehq/apps/users/admin.py
+++ b/corehq/apps/users/admin.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 
 from django_digest.models import PartialDigest, UserNonce
 
-from .models import HQApiKey, UserHistory, InvitationHistory
+from .models import HQApiKey, Invitation, InvitationHistory, UserHistory
 from .user_data import SQLUserData
 
 
@@ -103,3 +103,4 @@ class UserDataAdmin(admin.ModelAdmin):
 
 admin.site.register(SQLUserData, UserDataAdmin)
 admin.site.register(InvitationHistory)
+admin.site.register(Invitation)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2816,7 +2816,12 @@ class Invitation(models.Model):
         super().delete()
 
     @classmethod
-    def by_domain(cls, domain, is_accepted=False, **filters):
+    def by_domain(cls, domain, is_accepted=False, expired=..., **filters):
+        one_month_ago = datetime.utcnow().date() - relativedelta(months=1)
+        if expired is True:
+            filters['invited_on__lt'] = one_month_ago
+        if expired is False:
+            filters['invited_on__gte'] = one_month_ago
         return Invitation.objects.filter(domain=domain, is_accepted=is_accepted, **filters)
 
     @classmethod


### PR DESCRIPTION
## Product Description
Prevents users from deleting a profile that is assigned to an open invitation, just as they are prevented from deleting a profile assigned to an active user.

<img width="1504" height="692" alt="image" src="https://github.com/user-attachments/assets/f384db6f-c574-46b7-a9bd-95320e40d5f4" />

(Yes, I don't like that it does a partial success here, but that's consistent with the existing behavior.  There's actually quite a lot about the existing behavior that I find sloppy or confusing, but I'm trying to avoid getting sucked into a rewrite of this whole thing).

## Technical Summary
https://dimagi.atlassian.net/browse/USH-6348


## Feature Flag


## Safety Assurance
Local testing

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change