### PR TITLE
Do not attempt to save dummy user in check_password

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from xml.etree import cElementTree as ElementTree
 
 from django.conf import settings
+from django.contrib.auth.hashers import check_password
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
@@ -810,9 +811,7 @@ class DjangoUserMixin(DocumentSchema):
 
     def check_password(self, password):
         """ Currently just for debugging"""
-        dummy = User()
-        dummy.password = self.password
-        return dummy.check_password(password)
+        return check_password(password, self.password)
 
 
 class EulaMixin(DocumentSchema):

--- a/corehq/apps/users/tests/test_models.py
+++ b/corehq/apps/users/tests/test_models.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
+from django.contrib.auth.hashers import get_hasher
 from django.db import IntegrityError, transaction
 from django.test import SimpleTestCase, TestCase
 
@@ -351,6 +352,17 @@ class CouchUserSaveRaceConditionTests(TestCase):
         super().setUpClass()
         cls.domain = create_domain('race-user-test')
         cls.addClassCleanup(cls.domain.delete)
+
+
+class TestCouchUser(TestCase):
+
+    def test_check_user(self):
+        user = CouchUser(username='test')
+        hasher = get_hasher('md5')  # get a hasher that is not the default
+        user.password = hasher.encode('test', hasher.salt())
+
+        # should not raise ValueError: Cannot force an update in save() with no primary key.
+        assert user.check_password('test')
 
 
 class ConnectIDUserLinkTests(TestCase):


### PR DESCRIPTION
Fixes `ValueError: Cannot force an update in save() with no primary key.`

The test was verified to fail with the expected `ValueError` prior to applying the fix.

## Safety Assurance

### Safety story

Added a test to verify the change fixes the bug.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations