### PR TITLE
Add backend support for handling case mappings within Form Builder

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -655,6 +655,20 @@ class OpenCaseAction(FormAction):
     def _update_has_name(self, update):
         return bool(update.question_path)
 
+    def get_assigned_names(self):
+        questions = []
+        if self.name_update_multi:
+            questions.extend(self.name_update_multi)
+
+        if self.name_update:
+            questions.append(self.name_update)
+
+        return [question.question_path for question in questions if question.question_path]
+
+    def assign_name_update(self, question_path):
+        self.name_update = ConditionalCaseUpdate(question_path=question_path)
+        self.name_update_multi = []
+
 
 class OpenSubCaseAction(FormAction, IndexedSchema):
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -740,6 +740,33 @@ class FormActionsDiff(DocumentSchema):
     open_case = SchemaProperty(OpenCaseDiff)
     update_case = SchemaProperty(UpdateCaseDiff)
 
+    @classmethod
+    def parse_universal_diff(cls, universal_diff_json, is_registration=False):
+        open_diff = OpenCaseDiff()
+        update_diff = UpdateCaseDiff(universal_diff_json)
+
+        if is_registration:
+            if 'name' in update_diff.add:
+                name_additions = update_diff.add['name']
+                open_diff.add = name_additions
+                del update_diff.add['name']
+
+            if 'name' in update_diff.update:
+                name_updates = update_diff.update['name']
+                open_diff.update = name_updates
+                del update_diff.update['name']
+
+            if 'name' in update_diff.delete:
+                name_deletions = update_diff.delete['name']
+                open_diff.delete = name_deletions
+                del update_diff.delete['name']
+
+        diff = FormActionsDiff()
+        diff.open_case = open_diff
+        diff.update_case = update_diff
+
+        return diff
+
 
 class FormActions(UpdateableDocument):
     open_case = SchemaProperty(OpenCaseAction)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1726,6 +1726,9 @@ class IndexedFormBase(FormBase, IndexedSchema, CommentMixin):
         """
         return self.get_case_updates().get(case_type, [])
 
+    def get_source_with_mappings(self):
+        return self.source
+
 
 class JRResourceProperty(StringProperty):
 
@@ -2112,6 +2115,14 @@ class Form(IndexedFormBase, FormMediaMixin, NavMenuItemMediaMixin):
                 case_relationships_by_child_type[child_case_type].add(
                     (parent_case_type, subcase.reference_id or 'parent'))
         return case_relationships_by_child_type
+
+    def get_source_with_mappings(self):
+        if not self._parent.case_type:
+            return self.source
+
+        xform = XForm(self.source)
+        xform.add_case_mappings(self)
+        return xform.render_pretty().decode('utf-8')
 
 
 class GraphAnnotations(IndexedSchema):

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -182,6 +182,19 @@ class OpenCaseActionTests(SimpleTestCase):
 
         self.assertEqual(action.name_update_multi, [])
 
+    def test_get_mappings_serializes_name_updates(self):
+        action = OpenCaseAction({
+            'name_update_multi': [{'question_path': 'one'}, {'question_path': 'two'}]
+        })
+
+        json = action.get_mappings()
+        self.assertEqual(json, {
+            'name': [
+                {'question_path': 'one', 'update_mode': 'always'},
+                {'question_path': 'two', 'update_mode': 'always'}
+            ]
+        })
+
 
 class OpenCaseAction_ApplyUpdates_Tests(SimpleTestCase):
     def test_no_changes(self):
@@ -412,6 +425,37 @@ class UpdateCaseActionTests(SimpleTestCase):
         })
 
         self.assertEqual(action.get_property_names(), {'one'})
+
+    def test_get_mappings_serializes_updates(self):
+        action = UpdateCaseAction({
+            'update_multi': {
+                'one': [{'question_path': '/A/'}, {'question_path': '/B/'}],
+                'two': [{'question_path': '/C/'}],
+            }
+        })
+
+        json = action.get_mappings()
+
+        self.assertEqual(json, {
+            'one': [
+                {'question_path': '/A/', 'update_mode': 'always'},
+                {'question_path': '/B/', 'update_mode': 'always'}
+            ],
+            'two': [{'question_path': '/C/', 'update_mode': 'always'}]
+        })
+
+    def test_get_mappings_removes_doc_type(self):
+        action = UpdateCaseAction({
+            'update': {
+                'one': {'question_path': '/A/', 'update_mode': 'edit', 'doc_type': 'TestDoc'},
+            }
+        })
+
+        json = action.get_mappings()
+
+        self.assertEqual(json, {
+            'one': [{'question_path': '/A/', 'update_mode': 'edit'}]
+        })
 
 
 class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -832,6 +832,54 @@ class FormActionsDiffTests(SimpleTestCase):
         assert diff.open_case.add[0].question_path == 'one'
         assert diff.update_case.delete['case_two'][0].question_path == 'two'
 
+    def test_parse_universal_diff_creates_diff_object(self):
+        universal_json = {
+            'add': {
+                'prop1': [{'question_path': 'one'}]
+            },
+            'update': {
+                'prop2': [{'question_path': 'two'}]
+            },
+            'delete': {
+                'prop3': [{'question_path': 'three'}]
+            }
+        }
+
+        diff = FormActionsDiff.parse_universal_diff(universal_json)
+
+        assert len(diff.update_case.add['prop1']) == 1
+        assert diff.update_case.add['prop1'][0].question_path == 'one'
+
+        assert len(diff.update_case.update['prop2']) == 1
+        assert diff.update_case.update['prop2'][0].question_path == 'two'
+
+        assert len(diff.update_case.delete['prop3']) == 1
+        assert diff.update_case.delete['prop3'][0].question_path == 'three'
+
+    def test_parse_universal_diff_non_registration_name_stays_in_update(self):
+        universal_json = {
+            'add': {
+                'name': [{'question_path': 'one'}]
+            }
+        }
+
+        diff = FormActionsDiff.parse_universal_diff(universal_json)
+
+        assert diff.update_case.add['name'][0].question_path == 'one'
+        assert 'name' not in diff.open_case.add
+
+    def test_parse_universal_diff_registration_name_is_in_open_case(self):
+        universal_json = {
+            'add': {
+                'name': [{'question_path': 'one'}]
+            }
+        }
+
+        diff = FormActionsDiff.parse_universal_diff(universal_json, is_registration=True)
+
+        assert diff.open_case.add[0].question_path == 'one'
+        assert 'name' not in diff.update_case.add
+
 
 class FormActionTests(SimpleTestCase):
     def test_get_action_properties_for_name_update(self):

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -160,6 +160,28 @@ class OpenCaseActionTests(SimpleTestCase):
 
         self.assertFalse(action.has_name_update())
 
+    def test_get_assigned_names_spans_update_and_update_multi(self):
+        action = OpenCaseAction({
+            'name_update': {'question_path': 'one'},
+            'name_update_multi': [{'question_path': 'two'}]
+        })
+
+        self.assertEqual(set(action.get_assigned_names()), {'one', 'two'})
+
+    def test_assign_name_update_sets_name_update(self):
+        action = OpenCaseAction()
+        action.assign_name_update('name_question')
+
+        self.assertEqual(action.name_update.question_path, 'name_question')
+
+    def test_assign_name_update_removes_update_multi(self):
+        action = OpenCaseAction({
+            'name_update_multi': [{'question_path': 'one'}, {'question_path': 'two'}]
+        })
+        action.assign_name_update('three')
+
+        self.assertEqual(action.name_update_multi, [])
+
 
 class OpenCaseAction_ApplyUpdates_Tests(SimpleTestCase):
     def test_no_changes(self):

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -168,6 +168,13 @@ class OpenCaseActionTests(SimpleTestCase):
 
         self.assertEqual(set(action.get_assigned_names()), {'one', 'two'})
 
+    def test_get_assigned_names_ignores_empty_values(self):
+        action = OpenCaseAction({
+            'name_update': {'question_path': None}
+        })
+
+        self.assertEqual(set(action.get_assigned_names()), set())
+
     def test_assign_name_update_sets_name_update(self):
         action = OpenCaseAction()
         action.assign_name_update('name_question')

--- a/corehq/apps/app_manager/tests/test_xform.py
+++ b/corehq/apps/app_manager/tests/test_xform.py
@@ -123,19 +123,18 @@ class XForm_CreateCaseMappingsTests(SimpleTestCase):
 
         form = Form(actions=actions)
 
-        xform = XForm('')
-        tree = xform.create_case_mappings(form)
+        tree = XForm.create_case_mappings(form)
         rendered_tree = etree.tostring(tree, encoding='unicode', pretty_print=True).strip()
 
         assert rendered_tree == """
-<case_mappings>
-  <mapping property="one">
-    <question question_path="q1" update_mode="always"/>
-  </mapping>
-  <mapping property="two">
-    <question question_path="q2" update_mode="always"/>
-  </mapping>
-</case_mappings>
+<ns0:case_mappings xmlns:ns0="http://www.w3.org/2002/xforms">
+  <ns0:mapping property="one">
+    <ns0:question question_path="q1" update_mode="always"/>
+  </ns0:mapping>
+  <ns0:mapping property="two">
+    <ns0:question question_path="q2" update_mode="always"/>
+  </ns0:mapping>
+</ns0:case_mappings>
 """.strip()
 
     def test_creates_open_case_mappings(self):
@@ -147,16 +146,15 @@ class XForm_CreateCaseMappingsTests(SimpleTestCase):
 
         form = Form(actions=actions)
 
-        xform = XForm('')
-        tree = xform.create_case_mappings(form)
+        tree = XForm.create_case_mappings(form)
         rendered_tree = etree.tostring(tree, encoding='unicode', pretty_print=True).strip()
 
         assert rendered_tree == """
-<case_mappings>
-  <mapping property="name">
-    <question question_path="name" update_mode="always"/>
-  </mapping>
-</case_mappings>
+<ns0:case_mappings xmlns:ns0="http://www.w3.org/2002/xforms">
+  <ns0:mapping property="name">
+    <ns0:question question_path="name" update_mode="always"/>
+  </ns0:mapping>
+</ns0:case_mappings>
 """.strip()
 
     def test_uses_name_from_open_case(self):
@@ -173,16 +171,15 @@ class XForm_CreateCaseMappingsTests(SimpleTestCase):
 
         form = Form(actions=actions)
 
-        xform = XForm('')
-        tree = xform.create_case_mappings(form)
+        tree = XForm.create_case_mappings(form)
         rendered_tree = etree.tounicode(tree, pretty_print=True).strip()
 
         assert rendered_tree == """
-<case_mappings>
-  <mapping property="name">
-    <question question_path="open_case_name" update_mode="always"/>
-  </mapping>
-</case_mappings>
+<ns0:case_mappings xmlns:ns0="http://www.w3.org/2002/xforms">
+  <ns0:mapping property="name">
+    <ns0:question question_path="open_case_name" update_mode="always"/>
+  </ns0:mapping>
+</ns0:case_mappings>
 """.strip()
 
 
@@ -226,8 +223,100 @@ class XForm_AddCaseMappingsTests(SimpleTestCase):
         xform.add_case_mappings(form)
         xform.add_case_mappings(form)
 
-        case_mapping_nodes = xform.findall('case_mappings')
+        case_mapping_nodes = xform.findall('{f}case_mappings')
         assert len(case_mapping_nodes) == 1
+
+    def _create_minimal_xform(self):
+        return XForm('''
+<html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <model>
+            <instance>
+                <data></data>
+            </instance>
+        </model>
+    </h:head>
+</html>
+''')
+
+
+class XForm_GetFormActionsTests(SimpleTestCase):
+    def test_no_mappings_returns_empty_dict(self):
+        xform = self._create_minimal_xform()
+        assert xform.get_form_actions() == {}
+
+    def test_returns_update_mappings(self):
+        actions = FormActions({
+            'update_case': {
+                'update': {
+                    'one': {'question_path': 'q1'},
+                    'two': {'question_path': 'q2'},
+                }
+            }
+        })
+        form = Form(actions=actions)
+        xform = self._create_minimal_xform()
+
+        xform.add_case_mappings(form)
+
+        mappings = xform.get_form_actions()
+
+        case_updates = mappings['update_case']['update_multi']
+
+        assert set(case_updates.keys()) == {'one', 'two'}
+        assert case_updates['one'] == [{'question_path': 'q1', 'update_mode': 'always'}]
+        assert case_updates['two'] == [{'question_path': 'q2', 'update_mode': 'always'}]
+
+    def test_name_updates_for_registration_forms_use_open_case(self):
+        actions = FormActions({
+            'open_case': {
+                'name_update': {'question_path': 'test_name'}
+            }
+        })
+        form = Form(actions=actions)
+        xform = self._create_minimal_xform()
+
+        xform.add_case_mappings(form)
+
+        mappings = xform.get_form_actions(for_registration_form=True)
+
+        name_updates = mappings['open_case']['name_update_multi']
+
+        assert name_updates == [{'question_path': 'test_name', 'update_mode': 'always'}]
+        assert 'update_case' not in mappings
+
+    def test_name_updates_for_update_forms_use_update_case(self):
+        actions = FormActions({
+            'update_case': {
+                'update': {'name': {'question_path': 'test_name'}},
+            }
+        })
+        form = Form(actions=actions)
+        xform = self._create_minimal_xform()
+
+        xform.add_case_mappings(form)
+
+        mappings = xform.get_form_actions(for_registration_form=False)
+
+        case_updates = mappings['update_case']['update_multi']
+
+        assert case_updates['name'] == [{'question_path': 'test_name', 'update_mode': 'always'}]
+        assert 'open_case' not in mappings
+
+    def test_can_be_turned_into_form_actions_object(self):
+        actions = FormActions({
+            'update_case': {
+                'update': {'name': {'question_path': 'test_name'}},
+            }
+        })
+        form = Form(actions=actions)
+        xform = self._create_minimal_xform()
+
+        xform.add_case_mappings(form)
+
+        mappings = xform.get_form_actions()
+        result = FormActions(mappings)
+        assert result.update_case.update_multi['name'][0].question_path == 'test_name'
 
     def _create_minimal_xform(self):
         return XForm('''

--- a/corehq/apps/app_manager/tests/test_xform.py
+++ b/corehq/apps/app_manager/tests/test_xform.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+from lxml import etree
 
 from django.test import SimpleTestCase
 
@@ -9,7 +10,8 @@ from ..exceptions import (
     XFormValidationError,
     XFormValidationFailed,
 )
-from ..xform import parse_xml, validate_xform
+from corehq.apps.app_manager.models import Form, FormActions
+from ..xform import parse_xml, validate_xform, XForm
 
 
 class ParseXMLTests(SimpleTestCase):
@@ -106,3 +108,136 @@ class ValidateXFormTests(SimpleTestCase):
             validate_xform(xml)
         except XFormValidationFailed as e:
             self.fail(f"validate_xform raised {e} unexpectedly")
+
+
+class XForm_CreateCaseMappingsTests(SimpleTestCase):
+    def test_creates_mappings(self):
+        actions = FormActions({
+            'update_case': {
+                'update': {
+                    'one': {'question_path': 'q1'},
+                    'two': {'question_path': 'q2'}
+                }
+            }
+        })
+
+        form = Form(actions=actions)
+
+        xform = XForm('')
+        tree = xform.create_case_mappings(form)
+        rendered_tree = etree.tostring(tree, encoding='unicode', pretty_print=True).strip()
+
+        assert rendered_tree == """
+<case_mappings>
+  <mapping property="one">
+    <question question_path="q1" update_mode="always"/>
+  </mapping>
+  <mapping property="two">
+    <question question_path="q2" update_mode="always"/>
+  </mapping>
+</case_mappings>
+""".strip()
+
+    def test_creates_open_case_mappings(self):
+        actions = FormActions({
+            'open_case': {
+                'name_update': {'question_path': 'name'}
+            }
+        })
+
+        form = Form(actions=actions)
+
+        xform = XForm('')
+        tree = xform.create_case_mappings(form)
+        rendered_tree = etree.tostring(tree, encoding='unicode', pretty_print=True).strip()
+
+        assert rendered_tree == """
+<case_mappings>
+  <mapping property="name">
+    <question question_path="name" update_mode="always"/>
+  </mapping>
+</case_mappings>
+""".strip()
+
+    def test_uses_name_from_open_case(self):
+        actions = FormActions({
+            'open_case': {
+                'name_update': {'question_path': 'open_case_name'}
+            },
+            'update_case': {
+                'update': {
+                    'name': {'question_path': 'update_case_name'}
+                }
+            }
+        })
+
+        form = Form(actions=actions)
+
+        xform = XForm('')
+        tree = xform.create_case_mappings(form)
+        rendered_tree = etree.tounicode(tree, pretty_print=True).strip()
+
+        assert rendered_tree == """
+<case_mappings>
+  <mapping property="name">
+    <question question_path="open_case_name" update_mode="always"/>
+  </mapping>
+</case_mappings>
+""".strip()
+
+
+class XForm_AddCaseMappingsTests(SimpleTestCase):
+    def test_adds_case_mappings(self):
+        actions = FormActions({
+            'update_case': {
+                'update': {
+                    'one': {'question_path': 'q1'}
+                }
+            }
+        })
+        form = Form(actions=actions)
+        xform = self._create_minimal_xform()
+
+        xform.add_case_mappings(form)
+
+        assert xform.find('case_mappings') is not None
+
+    def test_handles_no_mappings(self):
+        actions = FormActions()
+        form = Form(actions=actions)
+        xform = self._create_minimal_xform()
+
+        xform.add_case_mappings(form)
+
+        mappings_node = xform.find('case_mappings')
+        assert len(mappings_node) == 0
+
+    def test_does_not_create_duplicate_mapping_nodes(self):
+        actions = FormActions({
+            'update_case': {
+                'update': {
+                    'one': {'question_path': 'q1'}
+                }
+            }
+        })
+        form = Form(actions=actions)
+        xform = self._create_minimal_xform()
+
+        xform.add_case_mappings(form)
+        xform.add_case_mappings(form)
+
+        case_mapping_nodes = xform.findall('case_mappings')
+        assert len(case_mapping_nodes) == 1
+
+    def _create_minimal_xform(self):
+        return XForm('''
+<html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <model>
+            <instance>
+                <data></data>
+            </instance>
+        </model>
+    </h:head>
+</html>
+''')

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -213,19 +213,15 @@ def save_xform(app, form, xml):
 
     form.source = source_xml.decode('utf-8')
 
-    from corehq.apps.app_manager.models import ConditionalCaseUpdate
     if form.is_registration_form():
         # For registration forms, assume that the first question is the
         # case name unless something else has been specified
         questions = form.get_questions([app.default_language])
-        if hasattr(form.actions, 'open_case'):
-            path = getattr(form.actions.open_case.name_update, 'question_path', None)
-            if path:
-                name_questions = [q for q in questions if q['value'] == path]
-                if not len(name_questions):
-                    path = None
-            if not path and len(questions):
-                form.actions.open_case.name_update = ConditionalCaseUpdate(question_path=questions[0]['value'])
+        if questions and hasattr(form.actions, 'open_case'):
+            names = form.actions.open_case.get_assigned_names()
+            assigns_name = any(q for q in questions if q['value'] in names)
+            if not assigns_name:
+                form.actions.open_case.assign_name_update(questions[0]['value'])
 
     return xml
 

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -151,9 +151,7 @@ def generate_xmlns():
     return str(uuid.uuid4()).upper()
 
 
-def save_xform(app, form, xml):
-    from corehq.apps.app_manager.models import FormActions
-
+def save_xform(app, form, xml, mapping_diff=None):
     def update_xmlns(xform, old_xmlns, new_xmlns):
         data = xform.data_node.render().decode('utf-8')
         data = data.replace(old_xmlns, new_xmlns, 1)
@@ -168,20 +166,8 @@ def save_xform(app, form, xml):
         pass
     else:
         changed = False
-        # TODO: Clean this up
-        form_actions_dict = xform.get_form_actions(for_registration_form=form.is_registration_form())
-        if form_actions_dict:
-            actions = FormActions(form_actions_dict)
-            if actions.update_case.update_multi:
-                form.actions.update_case.update = {}
-                form.actions.update_case.update_multi = actions.update_case.update_multi
-                form.actions.update_case.normalize_update()
-
-            if actions.open_case.name_update_multi:
-                form.actions.open_case.name_update = None
-                form.actions.open_case.name_update_multi = actions.open_case.name_update_multi
-                form.actions.open_case.normalize_name_update()
-
+        if mapping_diff:
+            form.actions = form.actions.with_updates({}, mapping_diff)
             changed = True
 
         GENERIC_XMLNS = "http://www.w3.org/2002/xforms"

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -260,7 +260,9 @@ def _get_base_vellum_options(request, domain, form, displayLang):
     case_type = form.get_module().case_type
     if case_type and has_vellum_case_mapping:
         case_properties = get_all_case_properties_for_case_type(domain, case_type)
+        mappings = form.actions.get_mappings()
         options['caseManagement'] = {
+            'mappings': mappings,
             'properties': case_properties,
             'view_form_url': reverse('view_form', args=[domain, app.id, form.unique_id]),
         }

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -275,13 +275,12 @@ def _get_vellum_core_context(request, domain, app, module, form, lang):
     Returns the core context that will be passed into vellum when it is
     initialized.
     """
-    has_vellum_case_mapping = toggles.FORMBUILDER_SAVE_TO_CASE.enabled_for_request(request)
     core = {
         'dataSourcesEndpoint': reverse('get_form_data_schema',
                                        kwargs={'domain': domain,
                                                'app_id': app.id,
                                                'form_unique_id': form.get_unique_id()}),
-        'form': form.get_source_with_mappings() if has_vellum_case_mapping else form.source,
+        'form': form.source,
         'formId': form.get_unique_id(),
         'formName': translate(form.name, app.langs[0], app.langs),
         'saveType': 'patch',

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -38,7 +38,7 @@ from corehq.apps.app_manager.exceptions import (
     FormNotFoundException,
 )
 from corehq.apps.app_manager.helpers.validators import load_case_reserved_words
-from corehq.apps.app_manager.models import ModuleNotFoundException
+from corehq.apps.app_manager.models import ModuleNotFoundException, AdvancedForm
 from corehq.apps.app_manager.templatetags.xforms_extras import translate
 from corehq.apps.app_manager.util import (
     app_callout_templates,
@@ -257,9 +257,10 @@ def _get_base_vellum_options(request, domain, form, displayLang):
     }
 
     has_vellum_case_mapping = toggles.FORMBUILDER_SAVE_TO_CASE.enabled_for_request(request)
+    is_advanced_form = isinstance(form, AdvancedForm)
 
     case_type = form.get_module().case_type
-    if case_type and has_vellum_case_mapping:
+    if case_type and has_vellum_case_mapping and not is_advanced_form:
         case_properties = get_all_case_properties_for_case_type(domain, case_type)
         mappings = form.actions.get_mappings()
         options['caseManagement'] = {

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -37,6 +37,7 @@ from corehq.apps.app_manager.exceptions import (
     AppManagerException,
     FormNotFoundException,
 )
+from corehq.apps.app_manager.helpers.validators import load_case_reserved_words
 from corehq.apps.app_manager.models import ModuleNotFoundException
 from corehq.apps.app_manager.templatetags.xforms_extras import translate
 from corehq.apps.app_manager.util import (
@@ -265,6 +266,7 @@ def _get_base_vellum_options(request, domain, form, displayLang):
             'mappings': mappings,
             'properties': case_properties,
             'view_form_url': reverse('view_form', args=[domain, app.id, form.unique_id]),
+            'reserved_words': load_case_reserved_words(),
         }
 
     return options

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -304,7 +304,7 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
         return attribute in request.POST
 
     if 'sha1' in request.POST and (should_edit("xform") or "xform" in request.FILES):
-        conflict = _get_xform_conflict_response(form, request.POST['sha1'])
+        conflict = _get_xform_conflict_response(form.source, request.POST['sha1'])
         if conflict is not None:
             return conflict
 
@@ -523,12 +523,16 @@ def patch_xform(request, domain, app_id, form_unique_id):
 
     app = get_app(domain, app_id)
     form = app.get_form(form_unique_id)
+    uses_vellum_case_mapping = toggles.FORMBUILDER_SAVE_TO_CASE.enabled_for_request(request)
+    existing_xml = form.get_source_with_mappings() if uses_vellum_case_mapping else form.source
 
-    conflict = _get_xform_conflict_response(form, sha1_checksum)
+    conflict = _get_xform_conflict_response(existing_xml, sha1_checksum)
     if conflict is not None:
         return conflict
 
-    xml = apply_patch(patch, form.source)
+    xml = apply_patch(patch, existing_xml)
+
+    # TODO: Mirror this handling somewhere in _edit_form_attr
 
     try:
         xml = save_xform(app, form, xml.encode('utf-8'))
@@ -551,8 +555,7 @@ def apply_patch(patch, text):
     return dmp.patch_apply(dmp.patch_fromText(patch), text)[0]
 
 
-def _get_xform_conflict_response(form, sha1_checksum):
-    form_xml = form.source
+def _get_xform_conflict_response(form_xml, sha1_checksum):
     if hashlib.sha1(form_xml.encode('utf-8')).hexdigest() != sha1_checksum:
         return json_response({'status': 'conflict', 'xform': form_xml})
     return None


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
This is the HQ half of the Form Builder changes. This modifies the context we send down to Vellum so that Vellum's case management plugin has access to the current mappings and the case property suggestions.

Case property suggestions are populated by calling `get_all_case_properties_for_case_type`. It should be noted that this can be very slow, especially on large domains. It is currently the same call used within the data cleaning tool and the case management page, but because the use case of form builder is different, the slowness with this call is more severe here and likely requires a followup improvement. For these reasons, I'm considering this a "High Risk" PR until this changes (and would not suggest releasing it as is).

## Feature Flag
`saas_formbuilder_save_to_case`

## Safety Assurance

### Safety story
Tested locally, on staging, and run through QA.

### Automated test coverage

Various test suites added

### QA Plan

Currently running through QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
