### PR TITLE
Clean up unused user data fields properly

### DIFF
--- a/corehq/apps/smsforms/tests/test_app.py
+++ b/corehq/apps/smsforms/tests/test_app.py
@@ -25,10 +25,10 @@ from corehq.apps.users.models import WebUser
 from corehq.apps.users.tests.util import patch_user_data_db_layer
 from corehq.form_processor.models import CommCareCase
 from corehq.messaging.scheduling.util import utcnow
-from corehq.tests.util.context import add_context
 
 
 @patch('corehq.apps.smsforms.app.tfsms.start_session')
+@patch_user_data_db_layer
 class TestStartSession(TestCase):
     domain = "test-domain"
 
@@ -51,9 +51,6 @@ class TestStartSession(TestCase):
         cls.case = CommCareCase(domain=cls.domain, case_id=cls.case_id, case_json={'language_code': 'fr'})
         cls.web_user = WebUser(username='web-user@example.com', _id=uuid.uuid4().hex, language='hin')
         cls.addClassCleanup(SQLXFormsSession.objects.all().delete)
-
-    def setUp(self):
-        add_context(patch_user_data_db_layer(), self)
 
     def _start_session(self, yield_responses=False):
         if not self.recipient:

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -54,7 +54,6 @@ from corehq.apps.users.tests.util import patch_user_data_db_layer
 from corehq.apps.users.views.mobile.custom_data_fields import UserFieldsView
 from corehq.const import USER_CHANGE_VIA_BULK_IMPORTER
 from corehq.extensions.interface import disable_extensions
-from corehq.tests.util.context import add_context
 from corehq.util.test_utils import flag_enabled
 
 from dimagi.utils.dates import add_months_to_date
@@ -2262,6 +2261,7 @@ class TestWebUserBulkUpload(TestCase, DomainSubscriptionMixin, TestUserDataMixin
             local_tableau_users.get(username='george@eliot.com')
 
 
+@patch_user_data_db_layer
 class TestUserChangeLogger(SimpleTestCase):
     @classmethod
     def setUpClass(cls):
@@ -2272,9 +2272,6 @@ class TestUserChangeLogger(SimpleTestCase):
             domain=cls.domain_name,
             user_id=cls.uploading_user.get_id
         )
-
-    def setUp(self):
-        add_context(patch_user_data_db_layer(), self)
 
     def test_add_change_message_duplicate_slug_entry(self):
         user = CommCareUser()

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -263,7 +263,7 @@ class UserChoiceProviderTest(SimpleTestCase, ChoiceProviderTestMixin):
     domain = 'user-choice-provider'
 
     @classmethod
-    @patch_user_data_db_layer()
+    @patch_user_data_db_layer
     def make_mobile_worker(cls, username, domain=None):
         domain = domain or cls.domain
         user = CommCareUser(username=normalize_username(username, domain),

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1492,8 +1492,7 @@ class _UserFormSet(object):
         new_user_data = self.custom_data.get_data_to_save()
         new_profile_id = new_user_data.pop(PROFILE_SLUG, ...)
         changed = user_data.update(new_user_data, new_profile_id)
-        changed |= user_data.remove_unrecognized(
-            {f.slug for f in self.custom_data.model.get_fields()})
+        changed |= user_data.remove_unrecognized()
         return self.user_form.update_user(
             metadata_updated=changed,
             profile_updated=old_profile_id != new_profile_id

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -578,6 +578,7 @@ class _AuthorizableMixin(IsMemberOfMixin):
             user_data.update({}, profile_id=profile.id)
         if custom_user_data:
             user_data.update(custom_user_data)
+            user_data.remove_unrecognized()
         if TABLEAU_USER_SYNCING.enabled(domain) and (tableau_role or tableau_group_ids):
             if tableau_group_ids is None:
                 tableau_group_ids = []

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -42,6 +42,7 @@ from corehq.util.celery_utils import (
     run_periodic_task_again,
 )
 from corehq.util.metrics import metrics_counter
+from corehq.util.queries import queryset_to_iterator
 
 logger = get_task_logger(__name__)
 
@@ -302,18 +303,16 @@ def reset_demo_user_restore_task(commcare_user_id, domain):
 def remove_unused_custom_fields_from_users_task(domain):
     """Removes all unused custom data fields from all users in the domain"""
     from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
-    from corehq.apps.users.dbaccessors import get_all_users_by_domain
+    from corehq.apps.users.user_data import SQLUserData
     from corehq.apps.users.views.mobile.custom_data_fields import (
         CUSTOM_USER_DATA_FIELD_TYPE,
     )
     fields_definition = CustomDataFieldsDefinition.get(domain, CUSTOM_USER_DATA_FIELD_TYPE)
     assert fields_definition, 'remove_unused_custom_fields_from_users_task called without a valid definition'
     schema_fields = {f.slug for f in fields_definition.get_fields()}
-    for user in get_all_users_by_domain(domain):
-        user_data = user.get_user_data(domain)
-        changed = user_data.remove_unrecognized(schema_fields)
-        if changed:
-            user.save()
+    for sql_user_data in queryset_to_iterator(SQLUserData.objects.filter(domain=domain), SQLUserData):
+        if sql_user_data.remove_unrecognized(schema_fields):
+            sql_user_data.save()
 
 
 @task()

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -302,14 +302,14 @@ def reset_demo_user_restore_task(commcare_user_id, domain):
 def remove_unused_custom_fields_from_users_task(domain):
     """Removes all unused custom data fields from all users in the domain"""
     from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
-    from corehq.apps.users.dbaccessors import get_all_commcare_users_by_domain
+    from corehq.apps.users.dbaccessors import get_all_users_by_domain
     from corehq.apps.users.views.mobile.custom_data_fields import (
         CUSTOM_USER_DATA_FIELD_TYPE,
     )
     fields_definition = CustomDataFieldsDefinition.get(domain, CUSTOM_USER_DATA_FIELD_TYPE)
     assert fields_definition, 'remove_unused_custom_fields_from_users_task called without a valid definition'
     schema_fields = {f.slug for f in fields_definition.get_fields()}
-    for user in get_all_commcare_users_by_domain(domain):
+    for user in get_all_users_by_domain(domain):
         user_data = user.get_user_data(domain)
         changed = user_data.remove_unrecognized(schema_fields)
         if changed:

--- a/corehq/apps/users/tests/test_signals.py
+++ b/corehq/apps/users/tests/test_signals.py
@@ -10,7 +10,6 @@ from corehq.apps.es.tests.utils import es_test
 from corehq.apps.es.users import user_adapter
 from corehq.apps.reports.analytics.esaccessors import get_user_stubs
 from corehq.apps.users.tests.util import patch_user_data_db_layer
-from corehq.tests.util.context import add_context
 from corehq.util.es.testing import sync_users_to_es
 from corehq.util.test_utils import mock_out_couch
 
@@ -63,14 +62,12 @@ class TestUserSignals(SimpleTestCase):
 
 @mock_out_couch()
 @patch('corehq.apps.users.models.CouchUser.sync_to_django_user', new=MagicMock)
+@patch_user_data_db_layer
 @patch('corehq.apps.analytics.signals.update_hubspot_properties')
 @patch('corehq.apps.callcenter.tasks.sync_usercases')
 @patch('corehq.apps.cachehq.signals.invalidate_document')
 @es_test(requires=[user_adapter], setup_class=True)
 class TestUserSyncToEs(SimpleTestCase):
-
-    def setUp(self):
-        add_context(patch_user_data_db_layer(), self)
 
     @sync_users_to_es()
     def test_sync_to_es_create_update_delete(self, *mocks):

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -137,12 +137,7 @@ class UserData:
             raise UserDataError(_("User data profile not found")) from e
 
     def remove_unrecognized(self, schema_fields):
-        changed = False
-        for k in list(self._local_to_user):
-            if k not in schema_fields and not is_system_key(k):
-                del self[k]
-                changed = True
-        return changed
+        return _remove_unrecognized(self._local_to_user, schema_fields)
 
     def items(self):
         return self.to_dict().items()
@@ -203,6 +198,15 @@ class UserData:
             return ret
 
 
+def _remove_unrecognized(local_data, schema_fields):
+    changed = False
+    for k in list(local_data):
+        if k not in schema_fields and not is_system_key(k):
+            del local_data[k]
+            changed = True
+    return changed
+
+
 class SQLUserDataManager(models.Manager):
 
     def get_queryset(self):
@@ -229,6 +233,9 @@ class SQLUserData(models.Model):
     class Meta:
         unique_together = ("user_id", "domain")
         indexes = [models.Index(fields=['user_id', 'domain'])]
+
+    def remove_unrecognized(self, schema_fields):
+        return _remove_unrecognized(self.data, schema_fields)
 
 
 def get_all_profiles_by_id(domain):

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -78,18 +78,7 @@ class UserData:
 
     @cached_property
     def _schema_fields(self):
-        from corehq.apps.users.views.mobile.custom_data_fields import (
-            CUSTOM_USER_DATA_FIELD_TYPE,
-        )
-
-        try:
-            definition = CustomDataFieldsDefinition.objects.get(
-                domain=self.domain, field_type=CUSTOM_USER_DATA_FIELD_TYPE)
-            fields = definition.get_fields()
-        except CustomDataFieldsDefinition.DoesNotExist:
-            return []
-
-        return fields
+        return get_user_schema_fields(self.domain)
 
     @property
     def raw(self):
@@ -252,10 +241,9 @@ def get_user_schema_fields(domain):
     try:
         definition = CustomDataFieldsDefinition.objects.get(domain=domain, field_type=CUSTOM_USER_DATA_FIELD_TYPE)
     except CustomDataFieldsDefinition.DoesNotExist:
-        fields = []
+        return []
     else:
-        fields = definition.get_fields()
-    return fields
+        return definition.get_fields()
 
 
 def prime_user_data_caches(users, domain):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_restore_user.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_restore_user.py
@@ -32,8 +32,8 @@ def test_get_commtrack_location_id():
 ])
 @patch('corehq.apps.users.models._AuthorizableMixin.get_domain_membership',
        Mock(return_value=DomainMembership(domain=DOMAIN)))
+@patch_user_data_db_layer
 @use("db")
 def test_user_types(user, expected_type):
-    with patch_user_data_db_layer():
-        user_type = user.to_ota_restore_user(DOMAIN).user_session_data['commcare_user_type']
-        assert_equal(user_type, expected_type)
+    user_type = user.to_ota_restore_user(DOMAIN).user_session_data['commcare_user_type']
+    assert_equal(user_type, expected_type)

--- a/testapps/test_pillowtop/tests/test_grouptouser_pillow.py
+++ b/testapps/test_pillowtop/tests/test_grouptouser_pillow.py
@@ -134,7 +134,7 @@ def _create_es_user(user_id, domain):
         last_name='Casual',
         is_active=True,
     )
-    with patch_user_data_db_layer():
+    with patch_user_data_db_layer:
         user_adapter.index(user, refresh=True)
     return user
 


### PR DESCRIPTION
## Product Description


## Technical Summary
https://dimagi.atlassian.net/browse/USH-6349
Resolves two issues:
* Also wipes non-schema fields from web users (instead of only mobile workers)
* Removes unrecognized fields when accepting an invite (just as is done when a user is saved via the UI)

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
