### PR TITLE
Catch v2 Case API error where property is set twice

### DIFF
--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -28,6 +28,9 @@ def valid_properties_dict(d):
         elif not isinstance(v, str):
             raise BadValueError(f"Error with case property '{k}'. "
                                 f"Values must be strings, received '{v}'")
+        elif k in CaseBlock._built_ins:
+            raise BadValueError(f"Error with case property '{k}'. "
+                                "This must be specified at the top level.")
 
 
 def valid_indices_dict(d):

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -694,3 +694,18 @@ class TestCaseAPI(TestCase):
             )
             # These requests should return a 400 because of the bad body, not a 301 redirect
             self.assertEqual(res.status_code, 400)
+
+    def test_case_name_twice(self):
+        case = self._make_case()
+        res = self._update_case(case.case_id, {
+            'case_name': 'Beth Harmon',
+            'owner_id': 'us_chess_federation',
+            'properties': {
+                'rank': '2100',
+                'case_name': 'Beth Harmon',  # ERROR
+                'champion': 'true',
+            },
+        })
+        self.assertEqual(res.status_code, 400)
+        msg = "Error with case property 'case_name'. This must be specified at the top level."
+        self.assertEqual(res.json()['error'], msg)


### PR DESCRIPTION
## Product Description
Addresses a likely cause of https://dimagi.sentry.io/issues/6837527730/

## Technical Summary
Anticipates possible `CaseBlock._check_for_duplicate_properties` errors

## Feature Flag


## Safety Assurance
Relying wholly on automated testing here

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
