### PR TITLE
Remove FF additional fields in unser invite

### DIFF
--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -25,7 +25,6 @@ from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.models import ServerLocation
 from corehq.apps.programs.models import Program
 from corehq.apps.reports.models import TableauUser
-from corehq.toggles import WEB_USER_INVITE_ADDITIONAL_FIELDS
 from corehq.apps.users.forms import SelectUserLocationForm, BaseTableauUserForm
 from corehq.apps.users.models import CouchUser
 
@@ -569,11 +568,7 @@ class AdminInvitesUserForm(SelectUserLocationForm):
         if domain_obj:
             if self.custom_data:
                 prefixed_fields = {}
-                if WEB_USER_INVITE_ADDITIONAL_FIELDS.enabled(domain):
-                    prefixed_fields = add_prefix(self.custom_data.form.fields, self.custom_data.prefix)
-                elif PROFILE_SLUG in self.custom_data.form.fields:
-                    prefixed_profile_key = with_prefix(PROFILE_SLUG, self.custom_data.prefix)
-                    prefixed_fields[prefixed_profile_key] = self.custom_data.form.fields[PROFILE_SLUG]
+                prefixed_fields = add_prefix(self.custom_data.form.fields, self.custom_data.prefix)
                 self.fields.update(prefixed_fields)
             if domain_obj.commtrack_enabled:
                 self.fields['program'] = forms.ChoiceField(label="Program", choices=(), required=False)

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -567,7 +567,6 @@ class AdminInvitesUserForm(SelectUserLocationForm):
         self.fields['role'].choices = [('', _("Select a role"))] + role_choices
         if domain_obj:
             if self.custom_data:
-                prefixed_fields = {}
                 prefixed_fields = add_prefix(self.custom_data.form.fields, self.custom_data.prefix)
                 self.fields.update(prefixed_fields)
             if domain_obj.commtrack_enabled:

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2462,13 +2462,6 @@ RESTRICT_USER_PROFILE_ASSIGNMENT = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN]
 )
 
-WEB_USER_INVITE_ADDITIONAL_FIELDS = StaticToggle(
-    'web_user_invite_additional_fields',
-    'USH: Enable additional fields in web user invite form for enhanced user details',
-    TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN],
-)
-
 
 def _handle_attendance_tracking_role(domain, is_enabled):
     from corehq.apps.accounting.utils import domain_has_privilege


### PR DESCRIPTION
## Product Description

After releasing the FF. Remove it.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6343

## Feature Flag

~~WEB_USER_INVITE_ADDITIONAL_FIELDS~~

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
