### PR TITLE
Catch django's InterfaceError, not the psycopg2 one

### DIFF
--- a/corehq/celery_monitoring/signals.py
+++ b/corehq/celery_monitoring/signals.py
@@ -6,8 +6,7 @@ from celery import current_app
 from celery.signals import after_task_publish, before_task_publish, task_postrun, task_prerun
 from dimagi.utils.parsing import string_to_utc_datetime
 from django.core.cache import cache
-from django.db import close_old_connections
-from psycopg2._psycopg import InterfaceError
+from django.db import InterfaceError, close_old_connections
 
 from corehq.util.metrics import push_metrics
 from corehq.util.quickcache import quickcache


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Still seeing [this error](https://dimagi.sentry.io/issues/6911997184/?environment=staging&project=136860&query=celery&referrer=issue-stream) in sentry which doesn't make much sense other than a different InterfaceError being raised. Trying this one out...

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Will test on staging, otherwise generally safe since this doesn't seem to be getting caught currently, so changing it won't have much of an impact. In the worst case, it'll turn out that we should be catching both of these errors, but I'm hoping that this django error effectively wraps the psycopg2 error.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
