### PR TITLE
Improve FF page

### DIFF
--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -42,15 +42,16 @@ function toggleViewModel() {
                     dimagiUsers[value],
                 );
             });
-        self.items(_.sortBy(items, function (item) {
-            const lastUsed = item.last_used();
-            if (lastUsed === 'Not Found' || !lastUsed) {
-                return ['~', item.value()];  // '~' sorts after all dates/numbers
-            }
-            // Invert the date string for descending sort
-            const invertedDate = lastUsed.replace(/\d/g, d => 9 - parseInt(d));
-            return [invertedDate, item.value()];
-        }));
+        const sorted = _.chain(items)
+            .sortBy(function (item) { // sortBy is stable. secondary sort by name first
+                return item.value();
+            })
+            .sortBy(function (item) { // sortBy date low to high. 0 is highest
+                const lastUsed = item.last_used();
+                return (lastUsed === 'Not Found') || !lastUsed ? 0 : -Date.parse(lastUsed); // Date desc (secondary sort)
+            })
+            .value();
+        self.items(sorted);
     };
 
     self.addItem = function (namespace) {

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -43,7 +43,13 @@ function toggleViewModel() {
                 );
             });
         self.items(_.sortBy(items, function (item) {
-            return [item.last_used(), item.value()];
+            const lastUsed = item.last_used();
+            if (lastUsed === 'Not Found' || !lastUsed) {
+                return ['~', item.value()];  // '~' sorts after all dates/numbers
+            }
+            // Invert the date string for descending sort
+            const invertedDate = lastUsed.replace(/\d/g, d => 9 - parseInt(d));
+            return [invertedDate, item.value()];
         }));
     };
 

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -323,9 +323,11 @@
               {% endif %}
             </th>
             <th>Namespace</th>
-            <th>Latest Form Submission</th>
-            <th>Subscription Plan</th>
-            <th>Dimagi Users</th>
+            {% if usage_info %}
+              <th>Latest Form Submission</th>
+              <th>Subscription Plan</th>
+              <th>Dimagi Users</th>
+            {% endif %}
           </tr>
         </thead>
         <tbody data-bind="foreach: items">
@@ -372,9 +374,11 @@
                 <i class="fa fa-user"></i> user
               </span>
             </td>
-            <td class="col-sm-2" data-bind="text: last_used"></td>
-            <td class="col-sm-4" data-bind="text: service_type"></td>
-            <td class="col-sm-4" data-bind="text: dimagi_users"></td>
+            {% if usage_info %}
+              <td class="col-sm-2" data-bind="text: last_used"></td>
+              <td class="col-sm-4" data-bind="text: service_type"></td>
+              <td class="col-sm-4" data-bind="text: dimagi_users"></td>
+            {% endif %}
           </tr>
         </tbody>
       </table>

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -73,20 +73,24 @@
     </p>
   {% endif %}
 
-  {% if by_service %}
-    {% for service, domains in by_service.items %}
+  {% if service_type_nested %}
+    {% for service_type, by_plan_name in service_type_nested.items %}
       <table class="table table-striped table-hover">
         <thead>
           <tr>
-            <th class="col-sm-4">Subscription Type</th>
-            <th class="col-sm-8">List of Domains</th>
+            <th class="col-sm-2">Subscription Type</th>
+            <th class="col-sm-3">Plan Name</th>
+            <th class="col-sm-7">List of Domains</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>{{ service }}</td>
-            <td>{{ domains | join:", " }}</td>
-          </tr>
+          {% for plan_name, domains in by_plan_name.items %}
+            <tr>
+              <td>{{ service_type }}</td>
+              <td>{{ plan_name }}</td>
+              <td>{{ domains | join:", " }}</td>
+            </tr>
+          {% endfor %}
         </tbody>
       </table>
     {% endfor %}

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -7,23 +7,22 @@
 {% block title %}{% trans "Edit Feature Flag: " %}{{ static_toggle.label }}{% endblock %}
 
 {% block stylesheets %}
-<style>
-  .margin-vertical-sm {
-    margin-top: 5px;
-    margin-bottom: 5px;
-  }
+  <style>
+    .margin-vertical-sm {
+      margin-top: 5px;
+      margin-bottom: 5px;
+    }
 
-  .label-release {
-    background-color: #c22eff !important;
-  }
+    .label-release {
+      background-color: #c22eff !important;
+    }
 
-  /* B5: replace with table-borderless and align-middle */
-  #feature-flag-items tbody td {
-    border: 0;
-    vertical-align: middle;
-  }
-</style>
-
+    /* B5: replace with table-borderless and align-middle */
+    #feature-flag-items tbody td {
+      border: 0;
+      vertical-align: middle;
+    }
+  </style>
 {% endblock %}
 
 {% block page_content %}
@@ -172,7 +171,7 @@
 
   {% if not is_random %}
     <div
-      class="alert d-flex justify-content-between {% if toggle.status == 'active' %} alert-info {% else %} alert-warning {% endif %}"
+      class="alert d-flex justify-content-between {% if toggle.status == 'active' %}alert-info{% else %}alert-warning{% endif %}"
       role="alert"
     >
       <div>Toggle Status: <strong>{{ toggle.status }}</strong></div>
@@ -184,18 +183,35 @@
         See More {% if user.is_staff %}/ Edit{% endif %}
       </button>
     </div>
-    {% endif %}
+  {% endif %}
 
-  <div class="modal fade" id="change-toggle-status" tabindex="-1" role="dialog" aria-labelledby="change-toggle-status-label">
+  <div
+    class="modal fade"
+    id="change-toggle-status"
+    tabindex="-1"
+    role="dialog"
+    aria-labelledby="change-toggle-status-label"
+  >
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <button
+            type="button"
+            class="close"
+            data-dismiss="modal"
+            aria-label="Close"
+          >
             <span aria-hidden="true">&times;</span>
           </button>
-          <h4 class="modal-title" id="change-toggle-status-label">Change feature flag status</h4>
+          <h4 class="modal-title" id="change-toggle-status-label">
+            Change feature flag status
+          </h4>
         </div>
-        <form class="form" action="{% url 'toggle_status' toggle.slug %}" method="POST">
+        <form
+          class="form"
+          action="{% url 'toggle_status' toggle.slug %}"
+          method="POST"
+        >
           {% csrf_token %}
           <div class="modal-body">
             <p>
@@ -215,18 +231,18 @@
               for all projects and users.
             </p>
             {% for status_option in status_options %}
-            <div class="radio">
-              <label>
-                <input
-                  type="radio"
-                  name="toggle_status"
-                  value="{{ status_option }}"
-                  {% if status_option == toggle.status %}checked{% endif %}
-                  {% if not user.is_staff %}disabled{% endif %}
-                >
-                {{ status_option }}
-              </label>
-            </div>
+              <div class="radio">
+                <label>
+                  <input
+                    type="radio"
+                    name="toggle_status"
+                    value="{{ status_option }}"
+                    {% if status_option == toggle.status %}checked{% endif %}
+                    {% if not user.is_staff %}disabled{% endif %}
+                  />
+                  {{ status_option }}
+                </label>
+              </div>
             {% endfor %}
           </div>
           <div class="modal-footer">
@@ -300,8 +316,10 @@
             <th>
               {% trans "Enabled toggle items" %}
               {% if is_random %}
-              <span data-bind="makeHqHelp: {
-                description: '{% trans "Items added here will be enabled regardless of the randomness (or disabled if preceded by `!`)" %}'}"></span>
+                <span
+                  data-bind="makeHqHelp: {
+                description: '{% trans "Items added here will be enabled regardless of the randomness (or disabled if preceded by `!`)" %}'}"
+                ></span>
               {% endif %}
             </th>
             <th>Namespace</th>
@@ -331,34 +349,32 @@
                   {% if not can_edit_toggle %}disabled{% endif %}
                 />
                 <span class="input-group-addon">
-                  <i data-bind="class: (value() && value()[0] == '!') ? 'fa fa-circle-xmark' : 'fa fa-check'"></i>
+                  <i
+                    data-bind="class: (value() && value()[0] == '!') ? 'fa fa-circle-xmark' : 'fa fa-check'"
+                  ></i>
                 </span>
               </div>
             </td>
             <td class="col-sm-2">
-              <a style="display: none" data-bind="
+              <a
+                style="display: none"
+                data-bind="
                 visible: namespace() === 'domain',
                 attr: { href: domainUrl }
-              ">
+              "
+              >
                 domain <i class="fa fa-external-link"></i>
               </a>
-              <span style="display: none"
-                data-bind="visible: namespace() != 'domain'">
-                <i class='fa fa-user'></i> user
+              <span
+                style="display: none"
+                data-bind="visible: namespace() != 'domain'"
+              >
+                <i class="fa fa-user"></i> user
               </span>
             </td>
-            <td
-              class="col-sm-2"
-              data-bind="text: last_used"
-            ></td>
-            <td
-              class="col-sm-4"
-              data-bind="text: service_type"
-            ></td>
-            <td
-              class="col-sm-4"
-              data-bind="text: dimagi_users"
-            ></td>
+            <td class="col-sm-2" data-bind="text: last_used"></td>
+            <td class="col-sm-4" data-bind="text: service_type"></td>
+            <td class="col-sm-4" data-bind="text: dimagi_users"></td>
           </tr>
         </tbody>
       </table>

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -95,6 +95,27 @@
     {% endfor %}
   {% endif %}
 
+  {% if paused %}
+    <table class="table table-striped table-hover">
+      <thead>
+        <tr>
+          <th class="col-sm-2">Subscription Type</th>
+          <th class="col-sm-3">Plan Name</th>
+          <th class="col-sm-7">List of Domains</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for service_type, domains in paused.items %}
+          <tr>
+            <td>{{ service_type }}</td>
+            <td>CommCare Paused Edition</td>
+            <td>{{ domains | join:", " }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+
   {% if static_toggle.relevant_environments %}
     {% if debug or server_environment in static_toggle.relevant_environments %}
       <div class="alert alert-warning" role="alert">

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -105,10 +105,10 @@
         </tr>
       </thead>
       <tbody>
-        {% for service_type, domains in paused.items %}
+        {% for service_type_and_plan_name, domains in paused.items %}
           <tr>
-            <td>{{ service_type }}</td>
-            <td>CommCare Paused Edition</td>
+            <td>{{ service_type_and_plan_name.0 }}</td>
+            <td>{{ service_type_and_plan_name.1 }}</td>
             <td>{{ domains | join:", " }}</td>
           </tr>
         {% endfor %}

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -348,8 +348,8 @@ def _get_service_type(toggle):
             domain = _enabled_item_name(enabled)
             if subscription := Subscription.get_active_subscription_by_domain(domain):
                 service_type[domain] = f"{subscription.service_type} : {subscription.plan_version.plan.name}"
-                if subscription.plan_version.plan.name == "CommCare Paused Edition":
-                    paused[subscription.service_type].append(domain)
+                if subscription.plan_version.plan.name.startswith("CommCare Paused Edition"):
+                    paused[(subscription.service_type, subscription.plan_version.plan.name)].append(domain)
                 else:
                     nested[subscription.service_type][subscription.plan_version.plan.name].append(domain)
             else:

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -186,7 +186,7 @@ class ToggleEditView(BasePageView):
         }
         if self.usage_info:
             context['last_used'] = _get_usage_info(toggle)
-            context['service_type'], context['by_service'], context['service_type_nested'], context['paused'] =\
+            context['service_type'], context['service_type_nested'], context['paused'] =\
                 _get_service_type(toggle)
             context['dimagi_users'] = _get_dimagi_users(toggle)
 
@@ -226,7 +226,7 @@ class ToggleEditView(BasePageView):
         }
         if self.usage_info:
             data['last_used'] = _get_usage_info(toggle)
-            data['service_type'], data['by_service'], _, _ = _get_service_type(toggle)
+            data['service_type'], _, _ = _get_service_type(toggle)
         return JsonResponse(data)
 
     def _save_randomness(self, toggle, randomness):
@@ -356,15 +356,12 @@ def _get_service_type(toggle):
                 service_type[domain] = "<None>"
                 nested["<None>"]["<None>"].append(domain)
 
-    by_service = defaultdict(list)
-    for domain, _type in sorted(service_type.items()):
-        by_service[_type].append(domain)
     sorted_nested = {
         outer_key: dict(sorted(inner_dict.items()))
         for outer_key, inner_dict in sorted(nested.items())
     }
 
-    return service_type, dict(by_service), sorted_nested, dict(sorted(paused.items()))
+    return service_type, sorted_nested, dict(sorted(paused.items()))
 
 
 def _get_dimagi_users(toggle):

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -348,7 +348,7 @@ def _get_service_type(toggle):
             domain = _enabled_item_name(enabled)
             if subscription := Subscription.get_active_subscription_by_domain(domain):
                 service_type[domain] = f"{subscription.service_type} : {subscription.plan_version.plan.name}"
-                if subscription.plan_version.plan.name.startswith("CommCare Paused Edition"):
+                if subscription.plan_version.is_paused:
                     paused[(subscription.service_type, subscription.plan_version.plan.name)].append(domain)
                 else:
                     nested[subscription.service_type][subscription.plan_version.plan.name].append(domain)

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -186,7 +186,8 @@ class ToggleEditView(BasePageView):
         }
         if self.usage_info:
             context['last_used'] = _get_usage_info(toggle)
-            context['service_type'], context['by_service'] = _get_service_type(toggle)
+            context['service_type'], context['by_service'], context['service_type_nested'] =\
+                _get_service_type(toggle)
             context['dimagi_users'] = _get_dimagi_users(toggle)
 
         return context
@@ -220,13 +221,12 @@ class ToggleEditView(BasePageView):
         _notify_on_change(self.static_toggle, currently_enabled - previously_enabled, self.request.user.username)
         _call_save_fn_and_clear_cache_and_enable_dependencies(
             self.request.user.username, self.static_toggle, previously_enabled, currently_enabled)
-
         data = {
             'items': item_list
         }
         if self.usage_info:
             data['last_used'] = _get_usage_info(toggle)
-            data['service_type'], data['by_service'] = _get_service_type(toggle)
+            data['service_type'], data['by_service'], _ = _get_service_type(toggle)
         return JsonResponse(data)
 
     def _save_randomness(self, toggle, randomness):
@@ -341,19 +341,25 @@ def _get_service_type(toggle):
     """Returns subscription service type for each toggle
     """
     service_type = {}
+    nested = defaultdict(lambda: defaultdict(list))
     for enabled in toggle.enabled_users:
         if _namespace_domain(enabled):
             domain = _enabled_item_name(enabled)
             if subscription := Subscription.get_active_subscription_by_domain(domain):
                 service_type[domain] = f"{subscription.service_type} : {subscription.plan_version.plan.name}"
+                nested[subscription.service_type][subscription.plan_version.plan.name].append(domain)
             else:
                 service_type[domain] = "<None>"
 
     by_service = defaultdict(list)
     for domain, _type in sorted(service_type.items()):
         by_service[_type].append(domain)
+    sorted_nested = {
+        outer_key: dict(sorted(inner_dict.items()))
+        for outer_key, inner_dict in sorted(nested.items())
+    }
 
-    return service_type, dict(by_service)
+    return service_type, dict(by_service), sorted_nested
 
 
 def _get_dimagi_users(toggle):


### PR DESCRIPTION
## Product Description

When clicking on "Show Usage" group the domains by subscription type first then plan name. Also, sort the domain list by latest form submission descending.

<img width="780" height="625" alt="image" src="https://github.com/user-attachments/assets/a5ca3975-a096-4c51-af29-c2a693a6c49d" />

Hide the "Latest Form Submission", "Subscription Plan", "Dimagi Users" columns from the domain list on the page without usage requested.

<img width="796" height="247" alt="image" src="https://github.com/user-attachments/assets/a80ed349-2219-4b9c-80b6-ce8d311bcfaf" />

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6347

## Feature Flag

No

## Safety Assurance

### Safety story

Tested locally and on staging

### Automated test coverage

None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
