### PR TITLE
Set failOnAuthnContextMismatch False

### DIFF
--- a/corehq/apps/sso/configuration.py
+++ b/corehq/apps/sso/configuration.py
@@ -71,7 +71,7 @@ def _get_advanced_saml2_settings(identity_provider):
             "wantNameId": True,
             "wantMessagesSigned": False,  # Entra ID does not support this, premium or standard
             "wantNameIdEncrypted": False,  # Entra ID will not accept if True
-            "failOnAuthnContextMismatch": True,  # very important
+            "failOnAuthnContextMismatch": False,  # IdP ensures auth but cannot guarantee a particular context
             "signatureAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
             "digestAlgorithm": "http://www.w3.org/2001/04/xmlenc#sha256",
             "metadataValidUntil": metadata_valid_until.isoformat(),


### PR DESCRIPTION
## Product Description
Generally invisible. Should fix an SSO login bug `AADSTS75011: Authentication method 'MultiFactor, Fido' by which the user authenticated with the service doesn't match requested authentication method 'Password, ProtectedTransport'` for users/orgs using passkeys.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18784
It seems like the core of issue here is that FIDO2 is not in the list of auth context constants in `onelogin.saml2`. I believe that adding `force_authn=True` in #35936 worked to resolve the issue for X509 requests because X509 is a known auth context for `onelogin.saml2`.

My first hope here was to set `'requestedAuthnContextComparison': 'minimum'` which would ask the IdP (e.g. Entra) to use the requested auth context (defaults to `PasswordProtectedTransport`) [or stronger](https://stackoverflow.com/a/57236511). However Entra only supports `'exact'` for comparison, so setting this option broke SSO.

The other option then is to remove the `requestedAuthnContext` all together as [recommended by Microsoft](https://learn.microsoft.com/en-us/entra/identity-platform/support-fido2-authentication#requiring-specific-credentials), which means that any auth context is acceptable, or to set `failOnAuthnContextMismatch=False` which will still _request_ a `PasswordProtectedTransport` auth context initially, but does not require it. The latter is what I opted for here.

One other more explicit, arguably more secure but less maintainable option would be to hard-code `requestedAuthnContext` in our saml2 config as a list of acceptable contexts. This is prone to failure over time, requiring updates as Entra changes or improves its own offerings for auth methods, which we would likely only find out via customers encountering and reporting such failure. This would also seem to pull back some of the responsibility we're delegating to the IdP by using SSO in the first place.

Open to discussion on reasoning and security vs maintainability here.

## Safety Assurance

### Safety story
Code-wise, this change just sets an existing boolean property. Security-wise, this could be seen as making SSO less secure by not requiring a particular auth context with saml. Given that we only use this saml config with a trusted IdP (Entra) and already delegate general auth responsibility to the service, it seems reasonable that we would also let Entra determine what particular type of auth is appropriate for its own login. 

Tested on staging that SSO login works. However, I'm not able to test specifically with a FIDO2 passkey given limitations in our Entra account, so it would go back to support/customer to verify the bug is fixed.

### Automated test coverage
It seems we have good testing for SSO in general, and possible this change will break something.

### QA Plan
I don't think QA is needed here.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
