### PR TITLE
Optimize case deduplication pillow processor

### DIFF
--- a/corehq/apps/data_interfaces/deduplication.py
+++ b/corehq/apps/data_interfaces/deduplication.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from django.utils.text import slugify
 
-from casexml.apps.case.const import CASE_UI_OWNER_ID
+from casexml.apps.case.const import CASE_UI_NAME, CASE_UI_OWNER_ID
 
 from corehq.apps.case_search.const import INDEXED_METADATA_BY_KEY
 from corehq.apps.data_interfaces.utils import iter_cases_and_run_rules
@@ -13,6 +13,10 @@ from corehq.messaging.util import MessagingRuleProgressHelper
 
 DUPLICATE_LIMIT = 1000
 DEDUPE_XMLNS = 'http://commcarehq.org/hq_case_deduplication_rule'
+CASE_UI_PROPERTIES = {
+    CASE_UI_NAME,
+    CASE_UI_OWNER_ID,
+}
 
 
 def _get_es_filtered_case_query(domain, case, case_filter_criteria=None):

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1141,18 +1141,17 @@ class CaseDeduplicationActionDefinition(BaseUpdateCaseDefinition):
 
         return deduplicate_action_definition
 
-    def properties_fit_definition(self, updated_case_properties):
-        """Given a list of case properties, returns whether these will be pertinent in
+    def properties_fit_definition(self, case_properties):
+        """Given a set of case properties, returns whether these will be pertinent in
         finding duplicate cases.
         """
 
         definition_properties = set(self.case_properties)
-        updated_case_properties = set(updated_case_properties)
 
         if self.match_type == CaseDeduplicationMatchTypeChoices.ALL:
-            return updated_case_properties.issuperset(definition_properties)
+            return case_properties.issuperset(definition_properties)
         elif self.match_type == CaseDeduplicationMatchTypeChoices.ANY:
-            return updated_case_properties.intersection(definition_properties)
+            return case_properties.intersection(definition_properties)
 
         raise ValueError(f"Unknown match type: {self.match_type}")
 

--- a/corehq/apps/data_interfaces/pillow.py
+++ b/corehq/apps/data_interfaces/pillow.py
@@ -4,11 +4,12 @@ from pillowtop.processors import PillowProcessor
 
 from corehq.apps.data_interfaces.deduplication import is_dedupe_xmlns
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule, CaseDeduplicationActionDefinition
+from corehq.apps.data_interfaces.deduplication import CASE_UI_PROPERTIES
 from corehq.apps.data_interfaces.utils import run_rules_for_case
+from corehq.apps.hqcase.constants import UPDATE_REASON_RESAVE
 from corehq.form_processor.exceptions import XFormNotFound
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.models.forms import XFormInstance
-from corehq.apps.hqcase.constants import UPDATE_REASON_RESAVE
 from corehq.util.soft_assert import soft_assert
 
 from corehq.apps.commtrack.const import USER_LOCATION_OWNER_MAP_TYPE
@@ -73,7 +74,7 @@ class CaseDeduplicationProcessor(PillowProcessor):
         else:
             associated_form = self._get_associated_form(change)
             if associated_form and not is_dedupe_xmlns(associated_form.xmlns):
-                case_properties = set(case.case_json) | {"external_id", "owner_id", "name", "date_opened"}
+                case_properties = set(case.case_json) | CASE_UI_PROPERTIES
                 applicable_rules = [rule for rule in rules
                                     if self._is_applicable(rule, case, case_properties, form_id)]
             else:

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -22,7 +22,6 @@ from couchdbkit import ResourceNotFound
 from memoized import memoized
 from no_exceptions.exceptions import Http403
 
-from casexml.apps.case import const
 from dimagi.utils.logging import notify_exception
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context
@@ -41,6 +40,7 @@ from corehq.apps.data_dictionary.util import (
     is_case_type_deprecated,
 )
 from corehq.apps.data_interfaces.deduplication import (
+    CASE_UI_PROPERTIES,
     reset_and_backfill_deduplicate_rule,
 )
 from corehq.apps.data_interfaces.dispatcher import (
@@ -1125,7 +1125,7 @@ class DeduplicationRuleCreateView(DataInterfaceSection):
     @classmethod
     def get_augmented_data_dict_props_by_case_type(cls, domain):
         return {
-            t: sorted(names.union({const.CASE_UI_NAME, const.CASE_UI_OWNER_ID})) for t, names in
+            t: sorted(names | CASE_UI_PROPERTIES) for t, names in
             get_data_dict_props_by_case_type(domain).items()
         }
 

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -41,12 +41,13 @@ def get_sample_registry_data_source(**kwargs):
 
 
 def bootstrap_pillow(pillow, *configs, rebuild_adapters=False):
+    """Configure UCR processors and discard other pillow processors"""
     configs_by_domain = {}
     for config in configs:
         configs_by_domain.setdefault(config.domain, []).append(config)
 
     _SHARED_ADAPTER_CACHES.clear()
-    for proc in pillow.processors:
+    for proc in list(pillow.processors):
         if hasattr(proc, 'table_manager'):
             proc.table_manager.data_source_providers = [
                 MockDataSourceProvider(configs_by_domain)
@@ -56,6 +57,8 @@ def bootstrap_pillow(pillow, *configs, rebuild_adapters=False):
                     for config in configs:
                         proc.table_manager.rebuild_coordinator.reset(config._id)
                 proc.table_manager.get_adapters(domain)  # bootstrap
+        else:
+            pillow.processors.remove(proc)
 
 
 def cleanup_ucr(data_source):

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -24,6 +24,7 @@ from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.sql_db.connections import connection_manager
 
 from ..data_source_providers import MockDataSourceProvider
+from ..pillow import ConfigurableReportPillowProcessor
 
 
 def get_sample_report_config():
@@ -48,7 +49,7 @@ def bootstrap_pillow(pillow, *configs, rebuild_adapters=False):
 
     _SHARED_ADAPTER_CACHES.clear()
     for proc in list(pillow.processors):
-        if hasattr(proc, 'table_manager'):
+        if isinstance(proc, ConfigurableReportPillowProcessor):
             proc.table_manager.data_source_providers = [
                 MockDataSourceProvider(configs_by_domain)
             ]


### PR DESCRIPTION
Eliminate CPU-intensive call to `get_case_updates`, which spent the majority of its time parsing XML and (curiously) `datetime` strings. This is an attempt to reduce the CPU load on the case pillow so we can make more use of gevent to reduce process count, and hopefully significantly reduce memory usage on the case pillow machine.

https://dimagi.atlassian.net/browse/SAAS-18746

:blowfish: Review by commit.

## Safety Assurance

### Safety story

Case deduplication is fairly well covered by tests, and new tests were added where shortcomings were noticed. Most of the changes in this PR are in tests.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations