### PR TITLE
GA or Bust: Mark deprecated flags 2nd

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -838,7 +838,7 @@ DETAIL_LIST_TAB_NODESETS = StaticToggle(
 DHIS2_INTEGRATION = StaticToggle(
     'dhis2_integration',
     'DHIS2 Integration',
-    TAG_SOLUTIONS_LIMITED,
+    TAG_DEPRECATED,
     [NAMESPACE_DOMAIN]
 )
 
@@ -2252,7 +2252,7 @@ COWIN_INTEGRATION = StaticToggle(
 EXPRESSION_REPEATER = StaticToggle(
     'expression_repeater',
     'Integrate with generic APIs using UCR expressions',
-    TAG_SOLUTIONS_LIMITED,
+    TAG_DEPRECATED,
     namespaces=[NAMESPACE_DOMAIN],
     help_link="https://confluence.dimagi.com/display/saas/Configurable+Repeaters",
 )
@@ -2268,7 +2268,7 @@ UCR_EXPRESSION_REGISTRY = StaticToggle(
 ARCGIS_INTEGRATION = StaticToggle(
     'arcgis_integration',
     'Enable the ArcGIS Form Repeater integration. Used for forwarding form data to an ArcGIS account.',
-    TAG_SOLUTIONS_LIMITED,
+    TAG_DEPRECATED,
     namespaces=[NAMESPACE_DOMAIN],
 )
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Mark the following flags as deprecated
- Enable the ArcGIS Form Repeater integration
- Integrate with generic APIs using UCR expressions
- DHIS2 Integration

No changes to the feature flags implementations.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18813
https://dimagi.atlassian.net/browse/SAAS-18838
https://dimagi.atlassian.net/browse/SAAS-18850


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
ARCGIS_INTEGRATION
EXPRESSION_REPEATER
DHIS2_INTEGRATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just tag changes which are safe as they don't change the feature flag itself

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
