### PR TITLE
Bypass SSRF WAF rule when registering oauth apps

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/list_waf_allow_patterns.py
+++ b/corehq/apps/hqwebapp/management/commands/list_waf_allow_patterns.py
@@ -10,7 +10,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         resolver = get_resolver()
-        for kind, views in waf_allow.views.items():
+        for kind, views in sorted(waf_allow.views.items()):
             print(kind)
             print('--------')
             patterns = []

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -9,6 +9,7 @@ from corehq.apps.cloudcare.views import session_endpoint
 from corehq.apps.domain.forms import ConfidentialDomainPasswordResetForm
 from corehq.apps.domain.views.settings import DomainPasswordResetView
 from corehq.apps.domain.views.sms import PublicSMSRatesView
+from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.hqwebapp.session_details_endpoint.views import (
     SessionDetailsView,
 )
@@ -112,7 +113,7 @@ urlpatterns = [
         name='log_domain_email_event'),
     url(
         r'^oauth/applications/register/',
-        OauthApplicationRegistration.as_view(),
+        waf_allow('EC2MetaDataSSRF_BODY')(OauthApplicationRegistration.as_view()),
         name=OauthApplicationRegistration.urlname
     ),
     url(r'^oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -1,7 +1,7 @@
-from django.urls import include, re_path as url
 from django.conf import settings
+from django.urls import include
+from django.urls import re_path as url
 from django.utils.translation import gettext_lazy as _
-
 from two_factor.gateways.twilio.urls import urlpatterns as tf_twilio_urls
 from two_factor.urls import urlpatterns as tf_urls
 
@@ -15,14 +15,16 @@ from corehq.apps.hqwebapp.session_details_endpoint.views import (
 )
 from corehq.apps.hqwebapp.views import (
     BugReportView,
-    SolutionsFeatureRequestView,
     MaintenanceAlertsView,
+    OauthApplicationRegistration,
+    SolutionsFeatureRequestView,
+    check_sso_login_status,
     create_alert,
     debug_notify,
     domain_login,
+    domain_login_new_window,
     dropbox_upload,
     iframe_domain_login,
-    domain_login_new_window,
     iframe_sso_login_pending,
     jserror,
     log_email_event,
@@ -36,12 +38,10 @@ from corehq.apps.hqwebapp.views import (
     quick_find,
     redirect_to_default,
     redirect_to_dimagi,
-    OauthApplicationRegistration,
     retrieve_download,
     server_up,
     set_language,
     temporary_google_verify,
-    check_sso_login_status,
 )
 from corehq.apps.settings.views import (
     TwoFactorBackupTokensView,


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18861

Specifically when testing an oauth flow locally, it is very common to have a local development environment running on local IPs, which means you need to specify redirect URIs in the oauth application like "localhost:8000". The AWS WAF sees this as a potential SSRF threat and blocks it, but given how reasonable this is for registering oauth apps, we should allow it.

See the ticket for more details on how this was verified.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Testing on staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
No. Don't think testing WAF behavior in an automated way is something we can do.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
