### PR TITLE
Sort property calculation improvements for GA

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -138,7 +138,7 @@ class FormattedDetailColumn(object):
     @property
     def template(self):
         template = sx.Template(
-            text=sx.Text(xpath_function=self.xpath_function),
+            text=(sx.Text(xpath_function=self.xpath_function) if self.xpath_function else sx.Text()),
             form=self.template_form,
             width=self.template_width,
         )

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -629,14 +629,17 @@ class ModuleDetailValidatorMixin(object):
     def validate_details_for_build(self):
         errors = []
         for sort_element in self.module.detail_sort_elements:
-            try:
-                self._validate_detail_screen_field(sort_element.field)
-            except ValueError:
-                errors.append({
-                    'type': 'invalid sort field',
-                    'field': sort_element.field,
-                    'module': self.get_module_info(),
-                })
+            # validate field if no sort calculation
+            if not sort_element.sort_calculation:
+                try:
+                    self._validate_detail_screen_field(sort_element.field)
+                except ValueError:
+                    errors.append({
+                        'type': 'invalid sort field',
+                        'field': sort_element.field,
+                        'module': self.get_module_info(),
+                    })
+        # ToDo: Add validation for sort calculation
         if self.module.case_list_filter:
             try:
                 # get_filter_xpath returns a filter like `[age > 5]`, so prefix it

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -639,7 +639,6 @@ class ModuleDetailValidatorMixin(object):
                         'field': sort_element.field,
                         'module': self.get_module_info(),
                     })
-        # ToDo: Add validation for sort calculation
         if self.module.case_list_filter:
             try:
                 # get_filter_xpath returns a filter like `[age > 5]`, so prefix it

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2269,6 +2269,13 @@ class DetailColumn(IndexedSchema):
 
 
 class SortElement(IndexedSchema):
+    """
+    A sort entry for case list
+
+    It should either have a field or a sort calculation to sort by.
+    Having sort calculation makes field redundant.
+    For legacy sort element entries that have both present, sort calculation is considered.
+    """
     field = StringProperty()
     type = StringProperty()
     direction = StringProperty()

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2286,6 +2286,14 @@ class SortElement(IndexedSchema):
     def has_display_values(self):
         return any(s.strip() != '' for s in self.display.values())
 
+    def valid(self):
+        """
+        returns if object is valid; along with an error message in case invalid
+        """
+        if not self.field and not self.sort_calculation:
+            return False, _("Sort property needs a property or a calculation")
+        return True, None
+
 
 class CaseListLookupMixin(DocumentSchema):
     """

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -546,7 +546,11 @@ export default function (spec, config, options) {
             var sortRows = self.config.sortRows.sortRows();
             for (var i = 0; i < sortRows.length; i++) {
                 var row = sortRows[i];
-                if (!row.hasValidPropertyName()) {
+                if (row.useSortCalculation) {
+                    if (!row.sortCalculation().trim()) {
+                        row.showWarning(true);
+                    }
+                } else if (!row.hasValidPropertyName()) {
                     row.showWarning(true);
                 }
             }

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -537,11 +537,6 @@ export default function (spec, config, options) {
                 "Please update following properties: ");
             errors.push(msg + self.config.search.commonProperties());
         }
-        if (errors.length) {
-            alert(gettext("There are errors in your configuration.") + "\n" + errors.join("\n"));
-            return;
-        }
-
         if (self.containsSortConfiguration) {
             var sortRows = self.config.sortRows.sortRows();
             for (var i = 0; i < sortRows.length; i++) {
@@ -549,12 +544,20 @@ export default function (spec, config, options) {
                 if (row.useSortCalculation) {
                     if (!row.sortCalculation().trim()) {
                         row.showWarning(true);
+                        errors.push(gettext("Missing sort calculation."));
                     }
                 } else if (!row.hasValidPropertyName()) {
                     row.showWarning(true);
+                    errors.push(gettext("Missing sort property."));
                 }
             }
         }
+
+        if (errors.length) {
+            alert(gettext("There are errors in your configuration.") + "\n" + errors.join("\n"));
+            return;
+        }
+
         if (self.validate()) {
             self.saveButton.ajax({
                 url: self.saveUrl,

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen.js
@@ -537,21 +537,6 @@ export default function (spec, config, options) {
                 "Please update following properties: ");
             errors.push(msg + self.config.search.commonProperties());
         }
-        if (self.containsSortConfiguration) {
-            var sortRows = self.config.sortRows.sortRows();
-            for (var i = 0; i < sortRows.length; i++) {
-                var row = sortRows[i];
-                if (row.useSortCalculation) {
-                    if (!row.sortCalculation().trim()) {
-                        row.showWarning(true);
-                        errors.push(gettext("Missing sort calculation."));
-                    }
-                } else if (!row.hasValidPropertyName()) {
-                    row.showWarning(true);
-                    errors.push(gettext("Missing sort property."));
-                }
-            }
-        }
 
         if (errors.length) {
             alert(gettext("There are errors in your configuration.") + "\n" + errors.join("\n"));
@@ -571,10 +556,14 @@ export default function (spec, config, options) {
         }
     };
     self.validate = function () {
+        var valid = true;
         if (self.containsCaseListLookupConfiguration) {
-            return self.config.caseListLookup.validate();
+            valid = self.config.caseListLookup.validate() && valid;
         }
-        return true;
+        if (self.containsSortConfiguration) {
+            valid = self.config.sortRows.validate() && valid;
+        }
+        return valid;
     };
     self.serialize = function () {
         var columns = self.columns();

--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -168,6 +168,12 @@ const module = function (spec) {
                 );
             }
         }
+        // Subscribe here for changes to sort rows after they have been initialized,
+        // though we do manually fire change where possible.
+        // This was added for sorting/reordering that is handled via sortableList knockout binding
+        self.sortRows.sortRows.subscribe(function () {
+            self.shortScreen.saveButton.fire("change");
+        });
         self.customXMLViewModel = {
             enabled: toggles.toggleEnabled('CASE_LIST_CUSTOM_XML'),
             xml: ko.observable(spec.state.short.custom_xml || ""),

--- a/corehq/apps/app_manager/static/app_manager/js/details/sort_rows.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/sort_rows.js
@@ -6,8 +6,10 @@
  * sorting-related attributes like direction.
  */
 import ko from "knockout";
+import _ from "underscore";
 import uiElementSelect from "hqwebapp/js/ui_elements/bootstrap3/ui-element-select";
 import Utils from "app_manager/js/details/utils";
+import alertUser from "hqwebapp/js/bootstrap3/alert_user";
 
 var sortRow = function (params, useSortCalculation, saveButton) {
     var self = {};
@@ -156,6 +158,32 @@ var sortRows = function (properties, saveButton) {
         });
     };
 
+    self.validate = function () {
+        var errors = [];
+
+        $("#message-alerts > div").each(function () {
+            $(this).alert('close');
+        });
+
+        self.sortRows().forEach((row) => {
+            if (row.useSortCalculation) {
+                if (!row.sortCalculation().trim()) {
+                    row.showWarning(true);
+                    errors.push(gettext("Missing sort calculation."));
+                }
+            } else if (!row.hasValidPropertyName()) {
+                row.showWarning(true);
+                errors.push(gettext("Missing sort property."));
+            }
+        });
+        if (errors.length) {
+            _.each(errors, function (error) {
+                alertUser.alert_user(error, "danger");
+            });
+            return false;
+        }
+        return true;
+    };
     return self;
 };
 

--- a/corehq/apps/app_manager/static/app_manager/js/details/sort_rows.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/sort_rows.js
@@ -9,8 +9,11 @@ import ko from "knockout";
 import uiElementSelect from "hqwebapp/js/ui_elements/bootstrap3/ui-element-select";
 import Utils from "app_manager/js/details/utils";
 
-var sortRow = function (params, saveButton) {
+var sortRow = function (params, useSortCalculation, saveButton) {
     var self = {};
+    // set either when adding a new UI element to force rendering for sort calculation
+    // or overwritten if sortCalculation present which is for the objects being created on page load
+    self.useSortCalculation = useSortCalculation || (!!params.sortCalculation);
     params = params || {};
 
     self.selectField = uiElementSelect.new(params.properties).val(typeof params.field !== 'undefined' ? params.field : "");
@@ -107,7 +110,8 @@ var sortRows = function (properties, saveButton) {
     self.sortRows = ko.observableArray([]);
     self.properties = properties;
 
-    self.addSortRow = function (field, type, direction, blanks, display, notify, sortCalculation) {
+    self.addSortRow = function (field, type, direction, blanks, display, notify, sortCalculation,
+        useSortCalculation = false) {
         self.sortRows.push(sortRow({
             field: field,
             type: type,
@@ -116,7 +120,7 @@ var sortRows = function (properties, saveButton) {
             display: display,
             properties: [...self.properties],  // clone list here to avoid updates from select2 leaking out
             sortCalculation: sortCalculation,
-        }, saveButton));
+        }, useSortCalculation,  saveButton));
         if (notify) {
             saveButton.fire('change');
         }

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
@@ -246,7 +246,7 @@
                     class="form-group col-sm-2"
                     data-bind="css: {'has-error': showWarning}"
                   >
-                    <!-- ko ifnot: sortCalculation -->
+                    <!-- ko ifnot: useSortCalculation -->
                     <div data-bind="jqueryElement: selectField.ui"></div>
                     <div data-bind="visible: showWarning">
                       <span
@@ -256,7 +256,7 @@
                     </div>
                     <!-- /ko -->
                     {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
-                      <!-- ko if: sortCalculation -->
+                      <!-- ko if: useSortCalculation -->
                       <input
                         class="form-control"
                         type="text"
@@ -326,15 +326,59 @@
             </table>
           </div>
           <div class="form-group">
-            <button
-              class="btn btn-default btn-sm"
-              data-bind="click: function(data){
-                data.addSortRow(field='',type='',direction='',blanks='',display='',notify=true,sortCalculation='');
-              }"
-            >
-              <i class="fa fa-plus"></i>
-              {% trans "Add sort property" %}
-            </button>
+            {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
+              <div class="btn-group">
+                <button
+                  class="btn btn-default"
+                  data-bind="click: function(data){
+                    data.addSortRow(field='',type='',direction='',blanks='',display='',notify=true,
+                      sortCalculation=''
+                    );
+                  }"
+                >
+                  <i class="fa fa-plus"></i>
+                  {% trans "Add Sort Property" %}
+                </button>
+                <button
+                  class="btn btn-default dropdown-toggle"
+                  data-toggle="dropdown"
+                >
+                  <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu">
+                  <li
+                    data-bind="click: function(data){
+                      data.addSortRow(field='',type='',direction='',blanks='',display='',notify=true,
+                        sortCalculation=''
+                      );
+                    }"
+                  >
+                    <a>{% trans "Sort Property" %}</a>
+                  </li>
+                  <li
+                    data-bind="click: function(data){
+                      data.addSortRow(field='',type='',direction='',blanks='',display='',notify=true,
+                        sortCalculation='',useSortCalculation=true
+                      );
+                    }"
+                  >
+                    <a>{% trans "Sort Calculation" %}</a>
+                  </li>
+                </ul>
+              </div>
+            {% else %}
+              <button
+                class="btn btn-default btn-sm"
+                data-bind="click: function(data){
+                  data.addSortRow(field='',type='',direction='',blanks='',display='',notify=true,
+                    sortCalculation=''
+                  );
+                }"
+              >
+                <i class="fa fa-plus"></i>
+                {% trans "Add sort property" %}
+              </button>
+            {% endif %}
           </div>
         {% endif %}
       </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
@@ -190,7 +190,7 @@
                     {% trans "Sort Property" %}
                     <span
                       class="hq-help-template"
-                      data-title="{% trans "Sort Properties" %}"
+                      data-title="{% trans 'Sort Properties' %}"
                       data-content="{% blocktrans %}
                         Properties in this list determine how cases are ordered
                         in your case list. This is useful if for example you
@@ -207,7 +207,7 @@
                       {% trans "Display Blanks" %}
                       <span
                         class="hq-help-template"
-                        data-title="{% trans "Display Blanks" %}"
+                        data-title="{% trans 'Display Blanks' %}"
                         data-content="{% blocktrans %}
                           Should cases that don't have a value for the sort
                           property appear at the top or the bottom of the case
@@ -222,7 +222,7 @@
                     {% trans "Display Text" %}
                     <span
                       class="hq-help-template"
-                      data-title="{% trans "Display Text" %}"
+                      data-title="{% trans 'Display Text' %}"
                       data-content="{% blocktrans %}
                         The 'Display Text' is used for properties that are only
                         listed as Sort Properties and not as Display Properties
@@ -251,9 +251,7 @@
                     <div data-bind="visible: showWarning">
                       <span
                         class="help-block"
-                        data-bind="
-                                        text: warningText
-                                    "
+                        data-bind="text: warningText"
                       ></span>
                     </div>
                     <!-- /ko -->
@@ -266,9 +264,9 @@
                       />
                       <div class="label label-default">
                         {% trans "Sort Calculation" %}&nbsp;(#<span
-                        data-bind="text: $index() + 1"
-                      ></span
-                      >)
+                          data-bind="text: $index() + 1"
+                        ></span
+                        >)
                       </div>
                       <!-- /ko -->
                     {% endif %}
@@ -285,7 +283,6 @@
                       ></option>
                     </select>
                   </td>
-
                   {% if app.enable_case_list_sort_blanks %}
                     <td>
                       <select class="form-control" data-bind="value: blanks">
@@ -331,8 +328,9 @@
           <div class="form-group">
             <button
               class="btn btn-default btn-sm"
-              data-bind="
-                    click: function(data){data.addSortRow('', '', '', '', '', true, '');}"
+              data-bind="click: function(data){
+                data.addSortRow(field='',type='',direction='',blanks='',display='',notify=true,sortCalculation='');
+              }"
             >
               <i class="fa fa-plus"></i>
               {% trans "Add sort property" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
@@ -376,7 +376,7 @@
                 }"
               >
                 <i class="fa fa-plus"></i>
-                {% trans "Add sort property" %}
+                {% trans "Add Sort Property" %}
               </button>
             {% endif %}
           </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list.html
@@ -217,9 +217,6 @@
                       </span>
                     </th>
                   {% endif %}
-                  {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
-                    <th>{% trans "Sort Calculation" %}</th>
-                  {% endif %}
                   <th>{% trans "Format" %}</th>
                   <th>
                     {% trans "Display Text" %}
@@ -249,6 +246,7 @@
                     class="form-group col-sm-2"
                     data-bind="css: {'has-error': showWarning}"
                   >
+                    <!-- ko ifnot: sortCalculation -->
                     <div data-bind="jqueryElement: selectField.ui"></div>
                     <div data-bind="visible: showWarning">
                       <span
@@ -258,6 +256,22 @@
                                     "
                       ></span>
                     </div>
+                    <!-- /ko -->
+                    {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
+                      <!-- ko if: sortCalculation -->
+                      <input
+                        class="form-control"
+                        type="text"
+                        data-bind="value: sortCalculation"
+                      />
+                      <div class="label label-default">
+                        {% trans "Sort Calculation" %}&nbsp;(#<span
+                        data-bind="text: $index() + 1"
+                      ></span
+                      >)
+                      </div>
+                      <!-- /ko -->
+                    {% endif %}
                   </td>
                   <td>
                     <select class="form-control" data-bind="value: direction">
@@ -282,17 +296,6 @@
                       </select>
                     </td>
                   {% endif %}
-
-                  {% if request|toggle_enabled:'SORT_CALCULATION_IN_CASE_LIST' %}
-                    <td>
-                      <input
-                        class="form-control"
-                        type="text"
-                        data-bind="value: sortCalculation"
-                      />
-                    </td>
-                  {% endif %}
-
                   <td>
                     <select class="form-control" data-bind="value: type">
                       <option value="plain">{% trans "Plain" %}</option>

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -535,7 +535,7 @@ class BuildErrorsTest(TestCase):
             }]
         )
 
-        # do not valiate field if sort calculation present
+        # do not validate field if sort calculation present
         module.case_details.short.sort_elements = [
             SortElement(
                 field='',

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -21,6 +21,7 @@ from corehq.apps.app_manager.models import (
     DetailTab,
     FormLink,
     Module,
+    SortElement,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.util.test_utils import flag_enabled, privilege_enabled
@@ -509,3 +510,39 @@ class BuildErrorsTest(TestCase):
             'type': 'search on clear with auto select',
             'module': {'id': 0, 'unique_id': 'basic_module', 'name': {'en': 'basic module'}},
         }, errors)
+
+    def test_validate_details_for_build_valid_field_with_sort_elements(self, *args):
+        factory = AppFactory()
+        module, form = factory.new_basic_module('basic', 'person')
+        module.case_details.short.sort_elements = [
+            SortElement(
+                field='',
+                type='string',
+                direction='ascending'
+            )
+        ]
+        errors = module.validate_for_build()
+        self.assertListEqual(
+            errors,
+            [{
+                'type': 'invalid sort field',
+                'field': '',
+                'module': {
+                    'id': 0,
+                    'name': {'en': 'basic module'},
+                    'unique_id': 'basic_module'
+                }
+            }]
+        )
+
+        # do not valiate field if sort calculation present
+        module.case_details.short.sort_elements = [
+            SortElement(
+                field='',
+                type='string',
+                direction='ascending',
+                sort_calculation="ifcalculation"
+            )
+        ]
+        errors = module.validate_for_build()
+        self.assertListEqual(errors, [])

--- a/corehq/apps/app_manager/tests/test_suite_sorting.py
+++ b/corehq/apps/app_manager/tests/test_suite_sorting.py
@@ -223,6 +223,79 @@ class SuiteSortingTest(SimpleTestCase, SuiteMixin):
             "./detail[@id='m0_case_short']/field[1]"
         )
 
+    def test_multiple_sort_only_calculations(self):
+        app = Application.wrap(self.get_json('suite-advanced'))
+        detail = app.modules[0].case_details.short
+
+        detail.sort_elements = [
+            SortElement(
+                field='',
+                type='string',
+                direction='descending',
+                blanks='first',
+                display={'en': 'First'},
+                sort_calculation='now()'
+            ),
+            SortElement(
+                field='',
+                type='string',
+                direction='descending',
+                blanks='first',
+                display={'en': 'Second'},
+                sort_calculation='tomorrow()'
+            )
+        ]
+
+        sort_node_with_calculation_only_1 = """
+        <partial>
+          <field>
+            <header width="0">
+              <text>
+                <locale id="m0.case_short.case__2.header"/>
+              </text>
+            </header>
+            <template width="0">
+              <text/>
+            </template>
+            <sort direction="descending" blanks="first" order="1" type="string">
+              <text>
+                <xpath function="now()"/>
+              </text>
+            </sort>
+           </field>
+        </partial>
+        """
+        self.assertXmlPartialEqual(
+            sort_node_with_calculation_only_1,
+            app.create_suite(),
+            "./detail[@id='m0_case_short']/field[2]"
+        )
+
+        sort_node_with_calculation_only_2 = """
+        <partial>
+           <field>
+            <header width="0">
+              <text>
+                <locale id="m0.case_short.case__3.header"/>
+              </text>
+            </header>
+            <template width="0">
+              <text/>
+            </template>
+            <sort direction="descending" blanks="first" order="2" type="string">
+              <text>
+                <xpath function="tomorrow()"/>
+              </text>
+            </sort>
+           </field>
+        </partial>
+        """
+        self.assertXmlPartialEqual(
+            sort_node_with_calculation_only_2,
+            app.create_suite(),
+            "./detail[@id='m0_case_short']/field[3]"
+        )
+
     def test_calculated_property_as_sort_property(self):
         factory = AppFactory(build_version='2.3.0')
         module, form = factory.new_basic_module("my_module", "person")

--- a/corehq/apps/app_manager/tests/test_suite_sorting.py
+++ b/corehq/apps/app_manager/tests/test_suite_sorting.py
@@ -74,28 +74,153 @@ class SuiteSortingTest(SimpleTestCase, SuiteMixin):
     def test_sort_calculation(self, *args):
         app = Application.wrap(self.get_json('suite-advanced'))
         detail = app.modules[0].case_details.short
-        detail.sort_elements.append(
+        # sort element with field only
+        detail.sort_elements = [
             SortElement(
                 field=detail.columns[0].field,
                 type='string',
                 direction='descending',
                 blanks='first',
-                sort_calculation='random()'
+                display={'en': 'First'}
             )
-        )
-        sort_node = """
+        ]
+        sort_node_with_field_only = """
         <partial>
+          <field>
+            <header>
+              <text>
+                <locale id="m0.case_short.case_name_1.header"/>
+              </text>
+            </header>
+            <template>
+              <text>
+                <xpath function="case_name"/>
+              </text>
+            </template>
             <sort direction="descending" blanks="first" order="1" type="string">
               <text>
-                <xpath function="random()"/>
+                <xpath function="case_name"/>
               </text>
             </sort>
+          </field>
         </partial>
         """
         self.assertXmlPartialEqual(
-            sort_node,
+            sort_node_with_field_only,
             app.create_suite(),
-            "./detail[@id='m0_case_short']/field/sort"
+            "./detail[@id='m0_case_short']/field[1]"
+        )
+
+        # sort element with calculation only (new way where a sort calculation does not have a field set)
+        detail.sort_elements = [
+            SortElement(
+                field='',
+                type='string',
+                direction='descending',
+                blanks='first',
+                display={'en': 'First'},
+                sort_calculation='now()'
+            )
+        ]
+
+        sort_node_with_calculation_only = """
+        <partial>
+          <field>
+            <header width="0">
+              <text>
+                <locale id="m0.case_short.case__2.header"/>
+              </text>
+            </header>
+            <template width="0">
+              <text/>
+            </template>
+            <sort direction="descending" blanks="first" order="1" type="string">
+              <text>
+                <xpath function="now()"/>
+              </text>
+            </sort>
+           </field>
+        </partial>
+        """
+        self.assertXmlPartialEqual(
+            sort_node_with_calculation_only,
+            app.create_suite(),
+            "./detail[@id='m0_case_short']/field[2]"
+        )
+
+        # sort element with calculation only but no display
+        detail.sort_elements = [
+            SortElement(
+                field='',
+                type='string',
+                direction='descending',
+                blanks='first',
+                display={},
+                sort_calculation='now()'
+            )
+        ]
+
+        sort_node_with_calculation_only_and_no_display = """
+        <partial>
+          <field>
+            <header width="0">
+              <text/>
+            </header>
+            <template width="0">
+              <text/>
+            </template>
+            <sort direction="descending" blanks="first" order="1" type="string">
+              <text>
+                <xpath function="now()"/>
+              </text>
+            </sort>
+           </field>
+        </partial>
+        """
+
+        self.assertXmlPartialEqual(
+            sort_node_with_calculation_only_and_no_display,
+            app.create_suite(),
+            "./detail[@id='m0_case_short']/field[2]"
+        )
+
+        # sort element with field and calculation (to ensure support for legacy way of adding sort calculations)
+        detail.sort_elements = [
+            SortElement(
+                field=detail.columns[0].field,
+                type='string',
+                direction='descending',
+                blanks='first',
+                display={'en': 'First'},
+                sort_calculation='yesterday()'
+            )
+        ]
+
+        sort_node_with_field_and_calculation = """
+        <partial>
+          <field>
+            <header>
+              <text>
+                <locale id="m0.case_short.case_name_1.header"/>
+              </text>
+            </header>
+            <template>
+              <text>
+                <xpath function="case_name"/>
+              </text>
+            </template>
+            <sort direction="descending" blanks="first" order="1" type="string">
+              <text>
+                <xpath function="yesterday()"/>
+              </text>
+            </sort>
+          </field>
+        </partial>
+        """
+        self.assertXmlPartialEqual(
+            sort_node_with_field_and_calculation,
+            app.create_suite(),
+            "./detail[@id='m0_case_short']/field[1]"
         )
 
     def test_calculated_property_as_sort_property(self):

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -751,6 +751,95 @@ class TestViewGeneric(ViewsBase):
     }
 
 
+class TestModuleViewsBase(ViewsBase):
+    domain = 'test-module-views'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        factory = AppFactory(domain=cls.domain)
+        cls.app = factory.app
+        cls.module = factory.new_basic_module('open_case', 'house', with_form=False)
+        cls.app.save()
+
+    def setUp(self):
+        super().setUp()
+        self.client.login(username=self.username, password=self.password)
+
+
+class TestEditModuleDetailScreens(TestModuleViewsBase):
+    def test_edit_module_detail_screens(self, *args):
+        url = reverse('edit_module_detail_screens', kwargs={
+            'domain': self.app.domain,
+            'app_id': self.app.id,
+            'module_unique_id': self.module.unique_id,
+        })
+        update_params = {
+            "type": "case",
+            "sort_elements": json.dumps([
+                {
+                    "field": "",
+                    "type": "plain",
+                    "direction": "ascending",
+                    "blanks": "first",
+                    "display": "First",
+                    "sort_calculation": ""
+                }
+            ])
+        }
+        response = self.client.post(url, update_params)
+        self.assertEqual(response.status_code, 200)
+
+    @flag_enabled("SORT_CALCULATION_IN_CASE_LIST")
+    def test_sort_property(self, *args):
+        url = reverse('edit_module_detail_screens', kwargs={
+            'domain': self.app.domain,
+            'app_id': self.app.id,
+            'module_unique_id': self.module.unique_id,
+        })
+        update_params = {
+            "type": "case",
+            "sort_elements": json.dumps([
+                {
+                    "field": "",
+                    "type": "plain",
+                    "direction": "ascending",
+                    "blanks": "first",
+                    "display": "First",
+                    "sort_calculation": "now()"
+                }
+            ])
+        }
+
+        response = self.client.post(url, update_params)
+        self.assertEqual(response.status_code, 200)
+
+    @flag_enabled("SORT_CALCULATION_IN_CASE_LIST")
+    def test_sort_property_validations(self, *args):
+        url = reverse('edit_module_detail_screens', kwargs={
+            'domain': self.app.domain,
+            'app_id': self.app.id,
+            'module_unique_id': self.module.unique_id,
+        })
+        update_params = {
+            "type": "case",
+            "sort_elements": json.dumps([
+                {
+                    "field": "",
+                    "type": "plain",
+                    "direction": "ascending",
+                    "blanks": "first",
+                    "display": "First",
+                    "sort_calculation": ""
+                }
+            ])
+        }
+        response = self.client.post(url, update_params)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content.decode('utf-8'), 'Sort property needs a property or a calculation')
+
+
 class TestDownloadCaseSummaryViewByAPIKey(TestCase):
     """Test that the DownloadCaseSummaryView can be accessed with an API key."""
 

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -769,6 +769,11 @@ class TestModuleViewsBase(ViewsBase):
         cls.module = factory.new_basic_module('open_case', 'house', with_form=False)
         cls.app.save()
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.app.delete()
+        super().tearDownClass()
+
     def setUp(self):
         super().setUp()
         self.client.login(username=self.username, password=self.password)

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -596,20 +596,25 @@ def apps_modules_setup(test_case):
 class TestViewGeneric(ViewsBase):
     domain = 'test-view-generic'
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.app = Application.new_app(cls.domain, "TestApp")
+        cls.app.build_spec = BuildSpec.from_string('2.7.0/latest')
+        cls.module = cls.app.add_module(Module.new_module("Module0", "en"))
+        cls.form = cls.app.new_form(
+            cls.module.id, "Form0", "en",
+            attachment=get_simple_form(xmlns='xmlns-0.0'))
+        cls.app.save()
+        app_adapter.index(cls.app, refresh=True)  # Send to ES
+
     def setUp(self):
         self.client.login(username=self.username, password=self.password)
 
-        self.app = Application.new_app(self.domain, "TestApp")
-        self.app.build_spec = BuildSpec.from_string('2.7.0/latest')
-        self.module = self.app.add_module(Module.new_module("Module0", "en"))
-        self.form = self.app.new_form(
-            self.module.id, "Form0", "en",
-            attachment=get_simple_form(xmlns='xmlns-0.0'))
-        self.app.save()
-        app_adapter.index(self.app, refresh=True)  # Send to ES
-
-    def tearDown(self):
-        self.app.delete()
+    @classmethod
+    def tearDownClass(cls):
+        cls.app.delete()
+        super().tearDownClass()
 
     def test_view_app(self, mock1):
         url = reverse('view_app', kwargs={

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -18,6 +18,7 @@ from corehq.apps.app_manager.models import (
     Module,
     ReportModule,
     ShadowModule,
+    SortElement,
 )
 from corehq.apps.app_manager.tests.util import add_build, get_simple_form
 from corehq.apps.app_manager.views import (
@@ -843,6 +844,67 @@ class TestEditModuleDetailScreens(TestModuleViewsBase):
         response = self.client.post(url, update_params)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content.decode('utf-8'), 'Sort property needs a property or a calculation')
+
+    @flag_enabled("SORT_CALCULATION_IN_CASE_LIST")
+    def test_sort_property_translations_retention(self):
+        self.app = Application.get(self.app._id)
+        self.app.modules[0].case_details.short.sort_elements = [
+            SortElement(
+                field='name',
+                type='string',
+                direction='ascending',
+                blanks='first',
+                display={'en': 'Name', 'hin': 'Naam'},
+                sort_calculation=''
+            ),
+            SortElement(
+                field='',
+                type='int',
+                direction='descending',
+                blanks='last',
+                display={'en': 'Age', 'hin': 'Umar'},
+                sort_calculation='if(age>5,1,2)'
+            )
+        ]
+        self.app.save()
+        url = reverse('edit_module_detail_screens', kwargs={
+            'domain': self.app.domain,
+            'app_id': self.app.id,
+            'module_unique_id': self.module.unique_id,
+        })
+        update_params = {
+            "type": "case",
+            "sort_elements": json.dumps([
+                {
+                    "field": "name",
+                    "type": "string",
+                    "direction": "ascending",
+                    "blanks": "first",
+                    "display": "Nameeee",
+                    "sort_calculation": ""
+                },
+                {
+                    "field": "",
+                    "type": "int",
+                    "direction": "descending",
+                    "blanks": "first",
+                    "display": "Ageee",
+                    "sort_calculation": "if(age>5,1,2)"
+                }
+            ])
+        }
+        response = self.client.post(url, update_params)
+        self.assertEqual(response.status_code, 200)
+        app = Application.get(self.app._id)
+        new_sort_elements = app.modules[0].case_details.short.sort_elements
+        self.assertEqual(
+            new_sort_elements[0].display,
+            {'en': 'Nameeee', 'hin': 'Naam'}
+        )
+        self.assertEqual(
+            new_sort_elements[1].display,
+            {'en': 'Ageee', 'hin': 'Umar'}
+        )
 
 
 class TestDownloadCaseSummaryViewByAPIKey(TestCase):

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -571,6 +571,11 @@ def get_sort_and_sort_only_columns(detail_columns, sort_elements):
         # Assertion added for enforcing architecture decision & not for ensuring user behavior
         # This should ideally never be false
         assert (sort_element.field or sort_element.sort_calculation)
+
+        # If there is a field present we use that so we can club it with the display property in Suite file.
+        # This is true for sort elements sorting by display properties and legacy elements that had both
+        # field and sort calculation even for sort calculations.
+        # The order here is not functionally relevant and does not impact sorting indices/order.
         if sort_element.field:
             sort_elements_by_field[sort_element.field] = (sort_element, index + 1)
         elif sort_element.sort_calculation:

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -564,18 +564,18 @@ def get_sort_and_sort_only_columns(detail_columns, sort_elements):
     extracts out info about columns that are added as only sort fields and columns added as both
     sort and display fields
     """
-    sort_elements = OrderedDict((s.field, (s, i + 1)) for i, s in enumerate(sort_elements))
+    sort_elements_by_field = OrderedDict((s.field, (s, i + 1)) for i, s in enumerate(sort_elements))
     sort_columns = {}
     for column in detail_columns:
-        sort_element, order = sort_elements.pop(column.field, (None, None))
+        sort_element, order = sort_elements_by_field.pop(column.field, (None, None))
         if sort_element:
             sort_columns[column.field] = (sort_element, order)
 
     # pull out sort elements that refer to calculated columns
-    for field in list(sort_elements):
+    for field in list(sort_elements_by_field):
         match = re.match(CALCULATED_SORT_FIELD_RX, field)
         if match:
-            element, element_order = sort_elements.pop(field)
+            element, element_order = sort_elements_by_field.pop(field)
             column_index = int(match.group(1))
             try:
                 column = detail_columns[column_index]
@@ -589,7 +589,7 @@ def get_sort_and_sort_only_columns(detail_columns, sort_elements):
 
     sort_only_elements = [
         SortOnlyElement(field, element, element_order)
-        for field, (element, element_order) in sort_elements.items()
+        for field, (element, element_order) in sort_elements_by_field.items()
     ]
     return sort_only_elements, sort_columns
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1258,8 +1258,6 @@ def _update_sort_elements(domain, lang, detail, sort_elements):
             item.sort_calculation = sort_element['sort_calculation']
             if not item.field and not item.sort_calculation:
                 return HttpResponseBadRequest(_("Sort property needs a property or a calculation"))
-        else:
-            item.sort_calculation = ""
         if item.sort_calculation in old_elements_by_calculation:
             item.display = old_elements_by_calculation[item.sort_calculation].display
         elif item.field in old_elements_by_field:

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1259,9 +1259,9 @@ def _update_sort_elements(domain, lang, detail, sort_elements):
             is_valid, error_message = item.valid()
             if not is_valid:
                 return HttpResponseBadRequest(error_message)
-        if item.sort_calculation in old_elements_by_calculation:
+        if item.sort_calculation and item.sort_calculation in old_elements_by_calculation:
             item.display = old_elements_by_calculation[item.sort_calculation].display
-        elif item.field in old_elements_by_field:
+        elif item.field and item.field in old_elements_by_field:
             item.display = old_elements_by_field[item.field].display
         item.display[lang] = sort_element['display']
         detail.short.sort_elements.append(item)

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1240,6 +1240,8 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
             item.display[lang] = sort_element['display']
             if toggles.SORT_CALCULATION_IN_CASE_LIST.enabled(domain):
                 item.sort_calculation = sort_element['sort_calculation']
+                if not item.field and not item.sort_calculation:
+                    return HttpResponseBadRequest(_("Sort property needs a property or a calculation"))
             else:
                 item.sort_calculation = ""
             detail.short.sort_elements.append(item)

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1224,34 +1224,9 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
         detail.long.custom_variables_dict = custom_variables_dict['long']
 
     if sort_elements is not None:
-        # Attempt to map new elements to old so we don't lose translations
-        # Imperfect because the same field may be used multiple times, or user may change field
-        old_elements_by_field = {}
-        old_elements_by_calculation = {}
-        for sort_element in detail.short.sort_elements:
-            if sort_element.sort_calculation:
-                old_elements_by_calculation[sort_element.sort_calculation] = sort_element
-            elif sort_element.field:
-                old_elements_by_field[sort_element.field] = sort_element
-        detail.short.sort_elements = []
-        for sort_element in sort_elements:
-            item = SortElement()
-            item.field = sort_element['field']
-            item.type = sort_element['type']
-            item.direction = sort_element['direction']
-            item.blanks = sort_element['blanks']
-            if toggles.SORT_CALCULATION_IN_CASE_LIST.enabled(domain):
-                item.sort_calculation = sort_element['sort_calculation']
-                if not item.field and not item.sort_calculation:
-                    return HttpResponseBadRequest(_("Sort property needs a property or a calculation"))
-            else:
-                item.sort_calculation = ""
-            if item.sort_calculation in old_elements_by_calculation:
-                item.display = old_elements_by_calculation[item.sort_calculation].display
-            elif item.field in old_elements_by_field:
-                item.display = old_elements_by_field[item.field].display
-            item.display[lang] = sort_element['display']
-            detail.short.sort_elements.append(item)
+        error_response = _update_sort_elements(domain, lang, detail, sort_elements)
+        if error_response:
+            return error_response
     if parent_select is not None:
         module.parent_select = ParentSelect.wrap(parent_select)
         if module_case_hierarchy_has_circular_reference(module):
@@ -1264,6 +1239,42 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
     resp = {}
     app.save(resp)
     return JsonResponse(resp)
+
+
+def _update_sort_elements(domain, lang, detail, sort_elements):
+    # Attempt to map new elements to old so we don't lose translations
+    # Imperfect because the same field may be used multiple times, or user may change field
+    old_elements_by_field = {}
+    old_elements_by_calculation = {}
+    for sort_element in detail.short.sort_elements:
+        if sort_element.sort_calculation:
+            old_elements_by_calculation[sort_element.sort_calculation] = sort_element
+        elif sort_element.field:
+            old_elements_by_field[sort_element.field] = sort_element
+    detail.short.sort_elements = []
+    for sort_element in sort_elements:
+        item = _init_new_sort_element(sort_element)
+        if toggles.SORT_CALCULATION_IN_CASE_LIST.enabled(domain):
+            item.sort_calculation = sort_element['sort_calculation']
+            if not item.field and not item.sort_calculation:
+                return HttpResponseBadRequest(_("Sort property needs a property or a calculation"))
+        else:
+            item.sort_calculation = ""
+        if item.sort_calculation in old_elements_by_calculation:
+            item.display = old_elements_by_calculation[item.sort_calculation].display
+        elif item.field in old_elements_by_field:
+            item.display = old_elements_by_field[item.field].display
+        item.display[lang] = sort_element['display']
+        detail.short.sort_elements.append(item)
+
+
+def _init_new_sort_element(sort_element):
+    item = SortElement()
+    item.field = sort_element['field']
+    item.type = sort_element['type']
+    item.direction = sort_element['direction']
+    item.blanks = sort_element['blanks']
+    return item
 
 
 def _gather_and_update_search_properties(params, app, module, lang):

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1226,8 +1226,13 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
     if sort_elements is not None:
         # Attempt to map new elements to old so we don't lose translations
         # Imperfect because the same field may be used multiple times, or user may change field
-        old_elements_by_field = {e['field']: e for e in detail.short.sort_elements}
-
+        old_elements_by_field = {}
+        old_elements_by_calculation = {}
+        for sort_element in detail.short.sort_elements:
+            if sort_element.sort_calculation:
+                old_elements_by_calculation[sort_element.sort_calculation] = sort_element
+            elif sort_element.field:
+                old_elements_by_field[sort_element.field] = sort_element
         detail.short.sort_elements = []
         for sort_element in sort_elements:
             item = SortElement()
@@ -1235,15 +1240,17 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
             item.type = sort_element['type']
             item.direction = sort_element['direction']
             item.blanks = sort_element['blanks']
-            if item.field in old_elements_by_field:
-                item.display = old_elements_by_field[item.field].display
-            item.display[lang] = sort_element['display']
             if toggles.SORT_CALCULATION_IN_CASE_LIST.enabled(domain):
                 item.sort_calculation = sort_element['sort_calculation']
                 if not item.field and not item.sort_calculation:
                     return HttpResponseBadRequest(_("Sort property needs a property or a calculation"))
             else:
                 item.sort_calculation = ""
+            if item.sort_calculation in old_elements_by_calculation:
+                item.display = old_elements_by_calculation[item.sort_calculation].display
+            elif item.field in old_elements_by_field:
+                item.display = old_elements_by_field[item.field].display
+            item.display[lang] = sort_element['display']
             detail.short.sort_elements.append(item)
     if parent_select is not None:
         module.parent_select = ParentSelect.wrap(parent_select)

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1256,8 +1256,9 @@ def _update_sort_elements(domain, lang, detail, sort_elements):
         item = _init_new_sort_element(sort_element)
         if toggles.SORT_CALCULATION_IN_CASE_LIST.enabled(domain):
             item.sort_calculation = sort_element['sort_calculation']
-            if not item.field and not item.sort_calculation:
-                return HttpResponseBadRequest(_("Sort property needs a property or a calculation"))
+            is_valid, error_message = item.valid()
+            if not is_valid:
+                return HttpResponseBadRequest(error_message)
         if item.sort_calculation in old_elements_by_calculation:
             item.display = old_elements_by_calculation[item.sort_calculation].display
         elif item.field in old_elements_by_field:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
[Spec](https://docs.google.com/document/d/1nIwoeARFdVUDqxNPGfhEHPFM7GTqRvcFxKE8rcgOolE/edit?tab=t.wnpmcqjwerje#heading=h.o2r86n8x55yo)
In order to prep for releasing as GA, Some improvements to the feature flag that allows using calculations in sort properties for case list.

This is how it looks right now:

<img width="1554" height="700" alt="image" src="https://github.com/user-attachments/assets/79f8a193-284d-4357-8903-ae2736183ed0" />


Changes made:
- Decouple calculation from display/case property for a sort element, so,
  - a user should enter either of them since adding a calculation makes the property redundant
  - update the UI so that adding display property or a calculation for sorting looks same as adding case property or a calculation for display
- save is blocked if there are errors in sort calculations. Earlier, the save was not blocked but errors were still shown.
  - errors now shown using a better utility to show messages on top of page instead of browser popup.
- also resolved an edge case [bug](https://dimagi.atlassian.net/browse/QA-8256?) where the save button was not getting enabled when reordering sort elements, fixed in https://github.com/dimagi/commcare-hq/pull/37137/commits/3e051926fe8828f5f6215e0f6228706751313ee9

This is how it looks post change:

<img width="1554" height="889" alt="image" src="https://github.com/user-attachments/assets/0d5b074f-0626-4c5e-af18-ac2d0d1b4e31" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-17919
Review by commit :fish: 

Majority of the PR is allowing user to add either a case/display property or sort calculation by avoiding validations that made case/display property mandatory.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
SORT_CALCULATION_IN_CASE_LIST

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
It was evident from the UI itself that a display/case property is totally ignored when using a sort calculation. I was able to confirm with some initial testing that the sorting had nothing to do with the display/case property, and then [confirmed with the mobile team](https://dimagi.slack.com/archives/C02QEVA9P/p1757506972189309) that nothing breaks if the suite xml is updated to have no display/case property for sorting.

The role that display/case property was playing earlier was that, adding a display property with sort calculation just clubbed the sorting with the display property node in suite xml file and using a case property that was not in display properties would result in a separate node for the sorting, which is what would happen now always.
This was additionally confirmed to be a safe change with QA, including working of existing sorting added in applications.
Added tests as well.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Decent existing tests, added more.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
https://dimagi.atlassian.net/browse/QA-8246

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations
If this is reverted it would make any new sort elements added invalid, which should be okay temporarily till we figure out what went wrong and fix it.

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
