### PR TITLE
Save case list column config on child case menus

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -828,7 +828,7 @@ const CaseListView = Marionette.CollectionView.extend({
     getConfigStorageId: function (user) {
         const urlObject = formplayerUtils.currentUrlToObject();
         const selectionsWithoutUuid = urlObject.selections.map(function (s) {
-            if (s.match('^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$')) {
+            if (s.match('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')) {
                 return 'uuid';
             } else {
                 return s;


### PR DESCRIPTION
## Product Description

At present, case lists in web apps will only save the column configuration if the path to get to the case list doesn't involve selecting another case first (this is a bug).  This change makes child case lists save the config too

<img width="1216" height="658" alt="image" src="https://github.com/user-attachments/assets/ea3649a7-4632-4faa-8b61-cc920a848999" />

## Technical Summary
From https://github.com/dimagi/commcare-hq/security/code-scanning/462

The `\b` characters in here work if the expression is written as a regex literal (surrounded by slashes), but not as a string. They are unnecessary in this context though, so I just removed them.

From https://github.com/dimagi/commcare-hq/pull/35849 The impact of this bug was that the regex never returned a match, meaning that menus with UUIDs in the path (child case menus) would not save the selected set of columns unless the same UUID was selected first.


## Feature Flag


## Safety Assurance
Local testing

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
