### PR TITLE
Actually filter auto renewable subscriptions by domain when passed in

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -447,7 +447,9 @@ def _get_auto_renewable_subscriptions(domain_name=None):
         account__is_customer_billing_account=True,
     )
     if domain_name:
-        auto_renewable_subscriptions.filter(subscriber__domain=domain_name)
+        auto_renewable_subscriptions = auto_renewable_subscriptions.filter(
+            subscriber__domain=domain_name
+        )
     return auto_renewable_subscriptions
 
 

--- a/corehq/apps/accounting/tests/test_tasks.py
+++ b/corehq/apps/accounting/tests/test_tasks.py
@@ -175,83 +175,89 @@ class TestAutoRenewableSubscriptions(BaseInvoiceTestCase):
 
     def test_includes_subscription_exactly_30_days_left(self):
         self._set_auto_renew_properties(
-            date_end=datetime.date.today() + datetime.timedelta(days=30)
+            self.subscription,
+            date_end=datetime.date.today() + datetime.timedelta(days=30),
         )
         subscriptions = tasks._get_auto_renewable_subscriptions()
         assert self.subscription in subscriptions
 
     def test_includes_subscription_less_than_30_days_left(self):
-        self._set_auto_renew_properties(date_end=datetime.date.today())
+        self._set_auto_renew_properties(self.subscription, date_end=datetime.date.today())
         subscriptions = tasks._get_auto_renewable_subscriptions()
         assert self.subscription in subscriptions
 
     def test_excludes_subscription_more_than_30_days_left(self):
         self._set_auto_renew_properties(
-            date_end=datetime.date.today() + datetime.timedelta(days=31)
+            self.subscription,
+            date_end=datetime.date.today() + datetime.timedelta(days=31),
         )
         subscriptions = tasks._get_auto_renewable_subscriptions()
         assert self.subscription not in subscriptions
 
     def test_excludes_subscription_end_date_in_past(self):
         self._set_auto_renew_properties(
-            date_end=datetime.date.today() - datetime.timedelta(days=1)
+            self.subscription,
+            date_end=datetime.date.today() - datetime.timedelta(days=1),
         )
         subscriptions = tasks._get_auto_renewable_subscriptions()
         assert self.subscription not in subscriptions
 
     def test_excludes_auto_renew_false(self):
-        self._set_auto_renew_properties(
-            auto_renew=False,
-        )
+        self._set_auto_renew_properties(self.subscription, auto_renew=False)
         subscriptions = tasks._get_auto_renewable_subscriptions()
         assert self.subscription not in subscriptions
 
     def test_excludes_service_type_not_product(self):
-        self._set_auto_renew_properties(
-            service_type=SubscriptionType.IMPLEMENTATION,
-        )
+        self._set_auto_renew_properties(self.subscription, service_type=SubscriptionType.IMPLEMENTATION)
         subscriptions = tasks._get_auto_renewable_subscriptions()
         assert self.subscription not in subscriptions
 
     def test_excludes_customer_billing_account(self):
-        self._set_auto_renew_properties(
-            is_customer_billing_account=True,
-        )
+        self._set_auto_renew_properties(self.subscription, is_customer_billing_account=True)
         subscriptions = tasks._get_auto_renewable_subscriptions()
         assert self.subscription not in subscriptions
 
     def test_filters_by_domain(self):
-        self._set_auto_renew_properties(
-            date_end=datetime.date.today() + datetime.timedelta(days=30)
+        another_domain = generator.arbitrary_domain()
+        self.addCleanup(another_domain.delete)
+        another_auto_renewable_subscription = generator.generate_domain_subscription(
+            self.account,
+            another_domain,
+            date_start=datetime.date.today(),
+            date_end=datetime.date.today(),
         )
-        subscriptions = tasks._get_auto_renewable_subscriptions(domain_name='not-this-domain')
-        assert subscriptions.count() == 0
+        self._set_auto_renew_properties(another_auto_renewable_subscription)
+        self._set_auto_renew_properties(self.subscription)
 
-        subscriptions = tasks._get_auto_renewable_subscriptions(domain_name=self.domain.name)
+        subscriptions = tasks._get_auto_renewable_subscriptions()
+        assert subscriptions.count() == 2
+
+        subscriptions = tasks._get_auto_renewable_subscriptions(domain_name=another_domain.name)
         assert subscriptions.count() == 1
-        assert self.subscription in subscriptions
+        assert subscriptions.get() == another_auto_renewable_subscription
 
     def test_auto_renew_ignores_already_renewed(self):
-        self._set_auto_renew_properties()
+        self._set_auto_renew_properties(self.subscription)
         self.subscription.renew_subscription()
         with patch('corehq.apps.accounting.tasks.auto_renew_subscription') as mock_renew:
             tasks.auto_renew_subscriptions()
             assert not mock_renew.called
 
+    @staticmethod
     def _set_auto_renew_properties(
-        self,
+        subscription,
         date_end=datetime.date.today() + datetime.timedelta(days=30),
         service_type=SubscriptionType.PRODUCT,
         auto_renew=True,
         is_customer_billing_account=False,
     ):
-        self.subscription.date_end = date_end
-        self.subscription.service_type = service_type
-        self.subscription.auto_renew = auto_renew
-        self.subscription.save()
+        subscription.date_end = date_end
+        subscription.service_type = service_type
+        subscription.auto_renew = auto_renew
+        subscription.save()
 
-        self.account.is_customer_billing_account = is_customer_billing_account
-        self.account.save()
+        subscription.account.is_customer_billing_account = is_customer_billing_account
+        subscription.account.save()
 
 
 class TestAutoRenewSubscription(BaseInvoiceTestCase):

--- a/corehq/apps/accounting/tests/test_tasks.py
+++ b/corehq/apps/accounting/tests/test_tasks.py
@@ -246,11 +246,13 @@ class TestAutoRenewableSubscriptions(BaseInvoiceTestCase):
     @staticmethod
     def _set_auto_renew_properties(
         subscription,
-        date_end=datetime.date.today() + datetime.timedelta(days=30),
+        date_end=None,
         service_type=SubscriptionType.PRODUCT,
         auto_renew=True,
         is_customer_billing_account=False,
     ):
+        if not date_end:
+            date_end = datetime.date.today() + datetime.timedelta(days=30)
         subscription.date_end = date_end
         subscription.service_type = service_type
         subscription.auto_renew = auto_renew

--- a/corehq/apps/accounting/tests/test_tasks.py
+++ b/corehq/apps/accounting/tests/test_tasks.py
@@ -220,6 +220,17 @@ class TestAutoRenewableSubscriptions(BaseInvoiceTestCase):
         subscriptions = tasks._get_auto_renewable_subscriptions()
         assert self.subscription not in subscriptions
 
+    def test_filters_by_domain(self):
+        self._set_auto_renew_properties(
+            date_end=datetime.date.today() + datetime.timedelta(days=30)
+        )
+        subscriptions = tasks._get_auto_renewable_subscriptions(domain_name='not-this-domain')
+        assert subscriptions.count() == 0
+
+        subscriptions = tasks._get_auto_renewable_subscriptions(domain_name=self.domain.name)
+        assert subscriptions.count() == 1
+        assert self.subscription in subscriptions
+
     def test_auto_renew_ignores_already_renewed(self):
         self._set_auto_renew_properties()
         self.subscription.renew_subscription()


### PR DESCRIPTION
## Technical Summary

Fixes the filter on `_get_auto_renewable_subscriptions` to actually return the queryset filtered by domain, and adds a basic test case for this. [Came up during QA](https://dimagi.atlassian.net/browse/QA-8233?focusedCommentId=415463). In practice this option is only used by the Trigger Subscription Auto Renewal testing tool.

## Feature Flag
SHOW_AUTO_RENEWAL

## Safety Assurance

### Safety story
Just a bugfix. Currently feature flagged with planned release in the coming ~month.

### Automated test coverage
Adds a test case to see that the queryset is actually returned filtered by domain.

### QA Plan
Nope. This came out of QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
