### PR TITLE
Trick yarn into installing glob@10.5.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4200,9 +4200,9 @@ glob@7.1.2:
     path-is-absolute "^1.0.0"
 
 glob@^10.2.2, glob@^10.3.10, glob@^10.4.5:
-  version "10.4.5"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
-  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
   dependencies:
     foreground-child "^3.1.0"
     jackspeak "^3.1.2"


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-18871

Temporarily added to package.json resolutions: `"glob": "^10.5.0",`

While it removed many unaffected `glob` versions and dependencies, it showed that the dependencies did not change between 10.4.5 and 10.5.0:

```patch
-glob@^10.2.2, glob@^10.3.10, glob@^10.4.5:
-  version "10.4.5"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
-  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+glob@7.1.2, glob@^10.2.2, glob@^10.3.10, glob@^10.4.5, glob@^10.5.0, glob@^7.1.3, glob@~5.0.0, glob@~7.1.1, glob>
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
  dependencies:
    foreground-child "^3.1.0"
```

Other resolution patterns tried that did not work (some of these might work on yarn v2, but apparently not on v1):

```json
    "glob@^10.2.2, glob@^10.3.10, glob@^10.4.5": "^10.5.0",

    "glob@^10.2.2, ^10.3.10, ^10.4.5": "^10.5.0",

    "glob@>=10.2.0 <10.5.0": "glob@^10.5.0",

    "glob@>=10.2.0 <10.5.0": "^10.5.0",

    "glob@^10.4.5": "glob@^10.5.0",
    "glob@^10.3.10": "glob@^10.5.0",
    "glob@^10.2.2": "glob@^10.5.0",

    "glob@^10.4.5": "^10.5.0",
    "glob@^10.3.10": "^10.5.0",
    "glob@^10.2.2": "^10.5.0",
```

## Safety Assurance

### Safety story

Upgrade to indirect JS dependency.

### Automated test coverage

No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations