### PR TITLE
Update dockerfile to use node 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.authors="Dimagi <devops@dimagi.com>"
 ENV PYTHONUNBUFFERED=1 \
     PYTHONUSERBASE=/vendor \
     PATH=/vendor/bin:$PATH \
-    NODE_VERSION=20.11.1 \
+    NODE_VERSION=24.11.1 \
     # Compile bytecode during installation to improve startup time. Also
     # suppresses a couchdbkit syntax error that happens during bytecode
     # compilation.

--- a/Dockerfile_incl
+++ b/Dockerfile_incl
@@ -10,7 +10,7 @@ LABEL org.opencontainers.image.authors="Dimagi <devops@dimagi.com>"
 ENV PYTHONUNBUFFERED=1 \
     PYTHONUSERBASE=/vendor \
     PATH=/vendor/bin:$PATH \
-    NODE_VERSION=20.11.1 \
+    NODE_VERSION=24.11.1 \
     # Compile bytecode during installation to improve startup time. Also
     # suppresses a couchdbkit syntax error that happens during bytecode
     # compilation.


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
We use `dimagi/commcarehq-py3.13` docker image as base image for running tests. When I tried to update NodeJS in https://github.com/dimagi/commcare-hq/pull/37146 the tests were failing because the latest image is still using Node 20 and npm's latest version is not compatible with the node version on the existing docker image.

Cherry picked d1fad56270c038f8c61b9d9350e610c0d899497a from the PR

So we need to get this merged before we can test  https://github.com/dimagi/commcare-hq/pull/37146 


## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Only affects CI environments.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
