### PR TITLE
GA FF restrict_user_profile_assignment

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/users/partials/edit_role_modal.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/users/partials/edit_role_modal.html.diff.txt
@@ -515,7 +515,7 @@
 @@ -488,14 +488,14 @@
                </div>
              </div>
-             {% if request|request_has_privilege:"APP_USER_PROFILES" and request|toggle_enabled:"RESTRICT_USER_PROFILE_ASSIGNMENT" %}
+             {% if request|request_has_privilege:"APP_USER_PROFILES" %}
 -              <div class="form-group"
 +              <div class="form-group"  {# todo B5: css-form-group #}
                  data-bind="visible: permissions.edit_web_users() || permissions.edit_commcare_users()">

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -442,7 +442,6 @@ class TestLocationValidator(LocationHierarchyTestCase):
         delete_all_users()
 
 
-@flag_enabled('RESTRICT_USER_PROFILE_ASSIGNMENT')
 class TestProfileValidator(TestCase):
     domain = 'test-domain'
 

--- a/corehq/apps/users/templates/users/partials/bootstrap3/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/bootstrap3/edit_role_modal.html
@@ -487,7 +487,7 @@
                 </div>
               </div>
             </div>
-            {% if request|request_has_privilege:"APP_USER_PROFILES" and request|toggle_enabled:"RESTRICT_USER_PROFILE_ASSIGNMENT" %}
+            {% if request|request_has_privilege:"APP_USER_PROFILES" %}
               <div class="form-group"
                 data-bind="visible: permissions.edit_web_users() || permissions.edit_commcare_users()">
                 <label class="col-sm-4 control-label">

--- a/corehq/apps/users/templates/users/partials/bootstrap5/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/bootstrap5/edit_role_modal.html
@@ -487,7 +487,7 @@
                 </div>
               </div>
             </div>
-            {% if request|request_has_privilege:"APP_USER_PROFILES" and request|toggle_enabled:"RESTRICT_USER_PROFILE_ASSIGNMENT" %}
+            {% if request|request_has_privilege:"APP_USER_PROFILES" %}
               <div class="form-group"  {# todo B5: css-form-group #}
                 data-bind="visible: permissions.edit_web_users() || permissions.edit_commcare_users()">
                 <label class="col-md-4 form-label">

--- a/corehq/apps/users/views/mobile/custom_data_fields.py
+++ b/corehq/apps/users/views/mobile/custom_data_fields.py
@@ -8,7 +8,6 @@ from corehq.apps.users.decorators import require_can_edit_commcare_users, get_pe
 from corehq.apps.users.models import HqPermissions
 from corehq.apps.users.tasks import remove_unused_custom_fields_from_users_task
 from corehq.apps.users.views import BaseUserSettingsView
-from corehq.toggles import RESTRICT_USER_PROFILE_ASSIGNMENT
 
 CUSTOM_USER_DATA_FIELD_TYPE = 'UserFields'
 
@@ -71,8 +70,7 @@ class UserFieldsView(CustomDataModelMixin, BaseUserSettingsView):
     @classmethod
     def get_user_accessible_profiles(cls, domain, couch_user):
         all_profiles = cls.get_definition_for_domain(domain).get_profiles()
-        if (not RESTRICT_USER_PROFILE_ASSIGNMENT.enabled(domain)
-                or couch_user.has_permission(domain, get_permission_name(HqPermissions.edit_user_profile))):
+        if (couch_user.has_permission(domain, get_permission_name(HqPermissions.edit_user_profile))):
             return all_profiles
 
         permission = couch_user.get_role(domain).permissions
@@ -82,9 +80,6 @@ class UserFieldsView(CustomDataModelMixin, BaseUserSettingsView):
 
     @classmethod
     def get_displayable_profiles_and_edit_permission(cls, original_profile_id, domain, couch_user):
-        if not RESTRICT_USER_PROFILE_ASSIGNMENT.enabled(domain):
-            return cls.get_definition_for_domain(domain).get_profiles(), True
-
         can_edit_original_profile = True
 
         if original_profile_id:

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2440,13 +2440,6 @@ TABLEAU_USER_SYNCING = StaticToggle(
     help_link='https://confluence.dimagi.com/display/USH/Tableau+User+Syncing',
 )
 
-RESTRICT_USER_PROFILE_ASSIGNMENT = StaticToggle(
-    'restrict_user_profile_assignment',
-    'Limit which user profiles a web user can assign to other web users and mobile workers.',
-    TAG_INTERNAL,
-    namespaces=[NAMESPACE_DOMAIN]
-)
-
 
 def _handle_attendance_tracking_role(domain, is_enabled):
     from corehq.apps.accounting.utils import domain_has_privilege


### PR DESCRIPTION
## Product Description
Make the ability to restrict which profiles a role can assign the default

## Technical Summary

https://dimagi.atlassian.net/browse/USH-5410

## Feature Flag

GAing restrict_user_profile_assignment

## Safety Assurance

### Safety story

Tested locally. Released the FF in production. No related issues were raised.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
