### PR TITLE
Fix Location API when parent not provided

### DIFF
--- a/corehq/apps/locations/resources/v0_6.py
+++ b/corehq/apps/locations/resources/v0_6.py
@@ -145,7 +145,8 @@ class LocationResource(v0_5.LocationResource):
                                    site_code=site_code)
 
     def _validate_unique_among_siblings(self, location, name, parent, location_site_code):
-        if has_siblings_with_name(location, name, parent.location_id):
+        parent_id = None if parent is None else parent.location_id
+        if has_siblings_with_name(location, name, parent_id):
             raise LocationAPIError(
                 _("Location with same name and parent already exists."), site_code=location_site_code
             )

--- a/corehq/apps/locations/tests/test_api_resources.py
+++ b/corehq/apps/locations/tests/test_api_resources.py
@@ -237,6 +237,20 @@ class LocationV0_6Test(APIResourceTest):
             key_value_pair in created_location_json['metadata'].items()
             for key_value_pair in post_data_location_data.items()))
 
+    def test_minimal_post(self):
+        post_data = {
+            "location_type_code": "state",
+            "name": "Gratis",
+        }
+        response = self._assert_auth_post_resource(self.list_endpoint, post_data)
+        self.assertEqual(response.status_code, 201, response.content)
+
+        created_location = SQLLocation.objects.get(name="Gratis")
+        created_location_json = created_location.to_json()
+        self.assertTrue(all(
+            key_value_pair in created_location_json.items()
+            for key_value_pair in post_data.items()))
+
     def test_successful_put1(self):
         put_data = {
             "name": "New Denver",


### PR DESCRIPTION
Previously this caused a 500 error
```
AttributeError: 'NoneType' object has no attribute 'location_id'
```

https://dimagi.atlassian.net/browse/SAAS-18604

NOTE: auto-merge is enabled

## Safety Assurance

### Safety story

Tiny fix for location API.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations