### PR TITLE
Fix create multiple groups API

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -655,12 +655,15 @@ class GroupResource(v0_4.GroupResource):
         always_return_data = True
 
     def serialize(self, request, data, format, options=None):
-        if not isinstance(data, dict):
+        if not isinstance(data, dict) and not self._is_list(request, data):
             if 'error_message' in data.data:
                 data = {'error_message': data.data['error_message']}
             elif request.method == 'POST':
                 data = {'id': data.obj._id}
         return self._meta.serializer.serialize(data, format, options)
+
+    def _is_list(self, request, data):
+        return request.method == 'PATCH' and isinstance(data, list)
 
     def patch_list(self, request=None, **kwargs):
         return super().patch_list_replica(self.obj_create, request, **kwargs)

--- a/corehq/apps/api/tests/group_resources.py
+++ b/corehq/apps/api/tests/group_resources.py
@@ -109,6 +109,8 @@ class TestGroupResource(APIResourceTest):
                                                    method='PATCH')
         self.assertEqual(response.status_code, 202, response.content)
         groups = Group.by_domain(self.domain.name)
+        for group in groups:
+            self.addCleanup(group.delete)
         self.assertEqual({g._id for g in groups}, set(json.loads(response.content)))
         self.assertEqual({g.name for g in groups}, {"test group", "test group 2"})
         self.assertEqual({g.metadata["localization"] for g in groups}, {"Ghana", "Mali"})

--- a/corehq/apps/api/tests/group_resources.py
+++ b/corehq/apps/api/tests/group_resources.py
@@ -100,7 +100,6 @@ class TestGroupResource(APIResourceTest):
                 "name": "test group 2",
                 "reporting": True,
             }
-
         ]}
 
         response = self._assert_auth_post_resource(self.list_endpoint,


### PR DESCRIPTION
Previously this API caused a 500 error
```
AttributeError: 'list' object has no attribute 'data'
```

https://dimagi.atlassian.net/browse/SAAS-18785

NOTE: auto-merge is enabled.

## Safety Assurance

### Safety story

Tiny fix for groups API.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations