### PR TITLE
Add trailing slash to doc for group API

### DIFF
--- a/docs/api/user-group.rst
+++ b/docs/api/user-group.rst
@@ -172,7 +172,7 @@ Endpoint Specifications
 
 .. code-block:: text
 
-    https://www.commcarehq.org/a/[domain]/api/group/v1/[group_id]
+    https://www.commcarehq.org/a/[domain]/api/group/v1/[group_id]/
 
 **Supported Methods**
 


### PR DESCRIPTION
## Technical Summary
Related to: https://dimagi.atlassian.net/browse/SAAS-18800
Just updates docs to show a trailing slash should be used for this API, when using an ID.

## Safety Assurance

### Safety story
Just docs.

### Automated test coverage

### QA Plan
Not needed.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
