### PR TITLE
Fix calculated properties page on paused domains

### DIFF
--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -491,6 +491,7 @@ def _can_copy_toggle(toggle, domain, other_domain):
     )
 
 
+@always_allow_project_access
 @login_and_domain_required
 @require_superuser
 def calculated_properties(request, domain):


### PR DESCRIPTION
## Product Description
You can view the calculated properties page even on paused domains, but you can't actually load any of the properties.  This fixes that.

## Technical Summary
This is a utility view that's a child of another page which already has the decorator

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
