### PR TITLE
Add Autopay Terms to HQ

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -193,6 +193,10 @@ class CallCenterProperties(DocumentSchema):
         return pre != post
 
 
+class LicenseAgreementType:
+    EULA = "End User License Agreement"
+
+
 class LicenseAgreement(DocumentSchema):
     signed = BooleanProperty(default=False)
     type = StringProperty()

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -119,7 +119,9 @@ LICENSE_LINKS = {
     'cc-nc-nd': 'http://creativecommons.org/licenses/by-nc-nd/4.0',
 }
 
-EULA_CURRENT_VERSION = '3.0'  # Set this to the most up to date version of the eula
+# Set these to the most up to date version of LicenseAgreements
+EULA_CURRENT_VERSION = '3.0'
+AUTOPAY_TERMS_CURRENT_VERSION = 'AP_1.0'
 
 
 def cached_property(method):
@@ -197,6 +199,7 @@ class CallCenterProperties(DocumentSchema):
 
 class LicenseAgreementType:
     EULA = "End User License Agreement"
+    AUTOPAY_TERMS = "Autopay Terms"
 
 
 class LicenseAgreement(DocumentSchema):

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -119,6 +119,8 @@ LICENSE_LINKS = {
     'cc-nc-nd': 'http://creativecommons.org/licenses/by-nc-nd/4.0',
 }
 
+EULA_CURRENT_VERSION = '3.0'  # Set this to the most up to date version of the eula
+
 
 def cached_property(method):
     def find_cached(self):

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -121,7 +121,7 @@ LICENSE_LINKS = {
 
 # Set these to the most up to date version of LicenseAgreements
 EULA_CURRENT_VERSION = '3.0'
-AUTOPAY_TERMS_CURRENT_VERSION = 'AP_1.0'
+AUTOPAY_TERMS_CURRENT_VERSION = '1.0'
 
 
 def cached_property(method):

--- a/corehq/apps/domain/templates/domain/confirm_billing_info.html
+++ b/corehq/apps/domain/templates/domain/confirm_billing_info.html
@@ -2,7 +2,6 @@
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 {% load i18n %}
-
 {% js_entry 'domain/js/confirm_billing_info' %}
 
 {% block form_content %}
@@ -11,8 +10,9 @@
   {% registerurl "cards_view" domain %}
 
   <p class="lead text-center">
-    {% blocktrans with plan.name as p%}
-      You are about to subscribe to the <strong>{{ p }} Software Plan</strong>.<br/>
+    {% blocktrans with plan.name as p %}
+      You are about to subscribe to the
+      <strong>{{ p }} Software Plan</strong>.<br />
       Please update your billing information below before continuing.
     {% endblocktrans %}
   </p>
@@ -22,12 +22,15 @@
     method="post"
     x-data="requiredBillingDetails({{ is_autopay_required|BOOL }})"
   >
-
     <div class="card card-modern-gray card-form-only mb-3" id="billing-info">
       <div class="card-body">
         {% crispy billing_account_info_form %}
         {% if downgrade_email_note %}
-          <input type="hidden" name="downgrade_email_note" value="{{ downgrade_email_note }}" />
+          <input
+            type="hidden"
+            name="downgrade_email_note"
+            value="{{ downgrade_email_note }}"
+          />
         {% endif %}
       </div>
     </div>
@@ -41,7 +44,8 @@
           hx-trigger="load, refreshCards"
         >
           <div class="htmx-indicator mb-3 fs-4">
-            <i class="fa-solid fa-spinner fa-spin"></i> {% trans "Loading autopay cards, please wait..." %}
+            <i class="fa-solid fa-spinner fa-spin"></i>
+            {% trans "Loading autopay cards, please wait..." %}
           </div>
         </div>
         {% include "domain/partials/new_stripe_card_alpinejs.html" with card_container_id="manage-autopay-container" card_button_class="btn-outline-primary" %}
@@ -94,14 +98,18 @@
                 x-cloak=""
               >
                 {% blocktrans %}
-                  By subscribing to this <strong>annual subscription</strong>, you acknowledge that
-                  the autopay card above will be charged on a monthly basis for any on-demand fees (excess users, SMS).
+                  By subscribing to this <strong>annual subscription</strong>,
+                  you acknowledge that the autopay card above will be charged on
+                  a monthly basis for any on-demand fees (excess users, SMS).
                 {% endblocktrans %}
                 <p class="mt-2 mb-0">
                   {% blocktrans %}
-                    A separate annual invoice for the product cost will be generated and sent to the contact emails above.
-                    This invoice must be paid within {{ days_date_due_annual }} days or the subscription will be paused.
-                    The selected autopay card will not be automatically charged to pay this invoice&mdash;it must be paid directly.
+                    A separate annual invoice for the product cost will be
+                    generated and sent to the contact emails above. This invoice
+                    must be paid within {{ days_date_due_annual }} days or the
+                    subscription will be paused. The selected autopay card will
+                    not be automatically charged to pay this invoice&mdash;it
+                    must be paid directly.
                   {% endblocktrans %}
                 </p>
               </div>
@@ -112,19 +120,22 @@
                 x-cloak=""
               >
                 {% blocktrans %}
-                   By subscribing to this <strong>annual subscription</strong>, you acknowledge that you understand an
-                   annual invoice for the product cost will be generated and sent to the contact emails above.
-                   This invoice must be paid within {{ days_date_due_annual }} days or the subscription will be paused.
+                  By subscribing to this <strong>annual subscription</strong>,
+                  you acknowledge that you understand an annual invoice for the
+                  product cost will be generated and sent to the contact emails
+                  above. This invoice must be paid within
+                  {{ days_date_due_annual }} days or the subscription will be
+                  paused.
                 {% endblocktrans %}
                 <p class="mt-2 mb-0">
                   {% blocktrans %}
-                    You also acknowledge that by not selecting an autopay card, you must manually pay for any on-demand fees
-                    (excess users, SMS) on a monthly basis or the subscription will be paused.
+                    You also acknowledge that by not selecting an autopay card,
+                    you must manually pay for any on-demand fees (excess users,
+                    SMS) on a monthly basis or the subscription will be paused.
                   {% endblocktrans %}
                 </p>
               </div>
             {% endif %}
-
           </div>
 
           <div class="px-2 pt-2">
@@ -142,6 +153,5 @@
         </fieldset>
       </div>
     </div>
-
   </form>
 {% endblock form_content %}

--- a/corehq/apps/domain/templates/domain/confirm_billing_info.html
+++ b/corehq/apps/domain/templates/domain/confirm_billing_info.html
@@ -87,12 +87,12 @@
               {% endblocktrans %}
             </div>
 
-            <div
-              class="alert alert-info"
-              x-show="showAutopayConfirmNotice"
-              x-cloak=""
-            >
-              {% if is_annual_plan %}
+            {% if is_annual_plan %}
+              <div
+                class="alert alert-info"
+                x-show="showAutopayConfirmNotice"
+                x-cloak=""
+              >
                 {% blocktrans %}
                   By subscribing to this <strong>annual subscription</strong>, I acknowledge that
                   the autopay card above will be charged on a monthly basis for any on-demand fees (excess users, SMS).
@@ -104,14 +104,8 @@
                     The selected autopay card will not be automatically charged to pay this invoice&mdash;it must be paid directly.
                   {% endblocktrans %}
                 </p>
-              {% else %}
-                {% blocktrans %}
-                  By subscribing to this monthly subscription, I acknowledge that my autopay card will be charged on a monthly basis.
-                {% endblocktrans %}
-              {% endif %}
-            </div>
+              </div>
 
-            {% if is_annual_plan %}
               <div
                 class="alert alert-info"
                 x-show="showAnnualConfirmNotice"

--- a/corehq/apps/domain/templates/domain/confirm_billing_info.html
+++ b/corehq/apps/domain/templates/domain/confirm_billing_info.html
@@ -94,7 +94,7 @@
                 x-cloak=""
               >
                 {% blocktrans %}
-                  By subscribing to this <strong>annual subscription</strong>, I acknowledge that
+                  By subscribing to this <strong>annual subscription</strong>, you acknowledge that
                   the autopay card above will be charged on a monthly basis for any on-demand fees (excess users, SMS).
                 {% endblocktrans %}
                 <p class="mt-2 mb-0">
@@ -112,13 +112,13 @@
                 x-cloak=""
               >
                 {% blocktrans %}
-                   By subscribing to this <strong>annual subscription</strong>, I acknowledge that I understand an
+                   By subscribing to this <strong>annual subscription</strong>, you acknowledge that you understand an
                    annual invoice for the product cost will be generated and sent to the contact emails above.
                    This invoice must be paid within {{ days_date_due_annual }} days or the subscription will be paused.
                 {% endblocktrans %}
                 <p class="mt-2 mb-0">
                   {% blocktrans %}
-                    I also acknowledge that by not selecting an autopay card, I must manually pay for any on-demand fees
+                    You also acknowledge that by not selecting an autopay card, you must manually pay for any on-demand fees
                     (excess users, SMS) on a monthly basis or the subscription will be paused.
                   {% endblocktrans %}
                 </p>

--- a/corehq/apps/domain/templates/domain/partials/autopay_terms.html
+++ b/corehq/apps/domain/templates/domain/partials/autopay_terms.html
@@ -1,0 +1,231 @@
+{% load i18n %}
+{% url 'domain_update_billing_info' domain as billing_info_url %}
+{% url 'domain_select_plan' domain as select_plan_url %}
+
+<div class="accordion mb-3" id="autopay-tos">
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="autopay-tos-header">
+      <button
+        class="accordion-button collapsed"
+        type="button"
+        data-bs-toggle="collapse"
+        data-bs-target="#autopay-tos-content"
+        aria-expanded="false"
+        aria-controls="autopay-tos-content"
+      >
+        {% trans "Autopay Terms and Conditions" %}
+      </button>
+    </h2>
+    <div
+      id="autopay-tos-content"
+      class="accordion-collapse collapse"
+      aria-labelledby="autopay-tos-header"
+      data-bs-parent="#autopay-tos"
+    >
+      <div class="accordion-body">
+        <h3>1. {% trans "Affirmative Consent and Authorization" %}</h3>
+        <p>
+          <strong>1.1. {% trans "Enrollment" %}:</strong>
+          {% blocktrans %}
+            By enrolling in Autopay, you authorize Dimagi (referred to as "We",
+            "Us", or "Our") to treat your electronic agreement as evidence of
+            your voluntary and knowing consent to:
+          {% endblocktrans %}
+        </p>
+        <ul>
+          <li>
+            {% blocktrans %}
+              Save your designated debit card or credit card information.
+            {% endblocktrans %}
+          </li>
+          <li>
+            {% blocktrans %}
+              Initiate automatic electronic payment transactions from this
+              designated account.
+            {% endblocktrans %}
+          </li>
+        </ul>
+        <p>
+          {% blocktrans %}
+            You agree that this electronic authorization constitutes an
+            electronic signature and is intended to have the same force and
+            effect as a written signature for purposes of authorizing recurring
+            payments under these terms.
+          {% endblocktrans %}
+        </p>
+        <p>
+          <strong>1.2. {% trans "Recurring Payment Authorization" %}:</strong>
+          {% blocktrans %}
+            You authorize Us to automatically charge your designated credit card
+            or debit card each billing cycle for the
+            <strong>Amount Due</strong> on your account statement.
+          {% endblocktrans %}
+        </p>
+
+        <h3>2. {% trans "Disclosure of Recurring Charges" %}</h3>
+        <p>
+          <strong>2.1. {% trans "Charge Amount and Frequency" %}:</strong>
+          {% blocktrans %}
+            Your recurring charge will be for the full, current balance of your
+            monthly service fees, including applicable taxes and surcharges.
+            This charge will occur <strong>monthly</strong> on a recurring
+            basis.
+          {% endblocktrans %}
+        </p>
+        <p>
+          <strong>2.2. {% trans "Payment Date" %}:</strong>
+          {% blocktrans %}
+            The first charge will occur on your next invoice due date .
+            Thereafter, the automatic payment will be initiated on each
+            subsequent invoice due date.
+          {% endblocktrans %}
+        </p>
+        <p>
+          <strong>2.3. {% trans "Advance Notice of Payment" %}:</strong>
+          {% blocktrans %}
+            We will provide you with an electronic notice and invoice (via
+            email) at least <strong>ten (10) days</strong> before your scheduled
+            payment is processed, confirming the <strong>Amount Due</strong> and
+            the exact <strong>Payment Date</strong>.
+          {% endblocktrans %}
+        </p>
+
+        <h3>3. {% trans "Updates and Returned Payments" %}</h3>
+        <p>
+          <strong>3.1. {% trans "Payment Information Update" %}:</strong>
+          {% blocktrans %}
+            You are responsible for ensuring your payment information (including
+            the card number and expiration date) remains current.
+          {% endblocktrans %}
+        </p>
+        <p>
+          <strong>3.2. {% trans "Returned Payments" %}:</strong>
+          {% blocktrans %}
+            If an automatic payment toward an invoice is rejected or refused by
+            our payment processor for any reason, you will receive a
+            notification at the email address on your user account. If the
+            invoice is not paid by 10 calendar days following the invoice due
+            date, your Subscription
+            <a
+              href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing#Pause-Your-Subscription"
+              target="_blank"
+              >will automatically pause</a
+            >. Reinstatement will occur promptly upon our receipt of the full
+            payment.
+          {% endblocktrans %}
+        </p>
+        <p>
+          <strong
+            >3.3. {% trans "Customer Dispute/Chargeback Policy" %}:</strong
+          >
+          {% blocktrans %}
+            If you believe a charge is incorrect, you agree to contact us
+            directly via email within thirty (30) days of the charge date to
+            attempt to resolve the issue before initiating a chargeback or
+            payment dispute with your financial institution. If you initiate a
+            chargeback that results in fees or penalties to us, you will be
+            responsible for reimbursing us for all such fees.
+          {% endblocktrans %}
+        </p>
+        <p>
+          <strong>3.4. {% trans "Refund Policy" %}:</strong>
+          {% blocktrans %}
+            Except as otherwise required by law, all payments made via Autopay
+            are non-refundable. If we determine that a charge was made in error,
+            we will initiate a credit or refund to the designated payment method
+            within 5 business days of such determination.
+          {% endblocktrans %}
+        </p>
+
+        <h3>4. {% trans "Cancellation Mechanism" %}</h3>
+        <p>
+          <strong>4.1. {% trans "Easy Cancellation" %}:</strong>
+          {% blocktrans %}
+            You may cancel your Autopay enrollment at any time and for any
+            reason.
+          {% endblocktrans %}
+        </p>
+        <p>
+          <strong>4.2. {% trans "Cancellation Process" %}:</strong>
+        </p>
+        <ul>
+          <li>
+            {% blocktrans %}
+              If you are on a Pay Monthly Software Plan, you may cancel Autopay
+              by canceling your Subscription in your
+              <a href="{{ select_plan_url }}" target="_blank"
+                >project software plan options</a
+              >: select "Pause Subscription". The existing Subscription will be
+              canceled, and at the end of the billing period you will receive a
+              final invoice for any unbilled usage. We will attempt to
+              automatically pay this invoice on its due date.
+            {% endblocktrans %}
+          </li>
+          <li>
+            {% blocktrans %}
+              If you are on a Pay Annually software plan, you may cancel Autopay
+              by removing your autopay card from your
+              <a href="{{ billing_info_url }}" target="_blank"
+                >project billing information</a
+              >
+              at least 5 business days before your next scheduled Autopay date.
+            {% endblocktrans %}
+          </li>
+        </ul>
+
+        <h3>5. {% trans "Amendment Policy" %}</h3>
+        <p>
+          <strong>5.1 {% trans "Notification of Changes to Terms" %}:</strong>
+          {% blocktrans %}
+            We may revise these Autopay Terms and Conditions from time to time.
+            We will provide notice of any material revisions by posting them
+            under your
+            <a href="{{ billing_info_url }}" target="_blank"
+              >project billing information</a
+            >. Material revisions shall be effective no sooner than
+            <strong>thirty (30) days</strong> after being posted. If you do not
+            agree to the revisions, you must terminate your Autopay enrollment
+            immediately, as described in Section 4.
+          {% endblocktrans %}
+        </p>
+        <p>
+          <strong
+            >5.2
+            {% trans "Notification of Changes to Recurring Charge" %}:</strong
+          >
+          {% blocktrans %}
+            If the fundamental frequency of the charge changes (e.g., from
+            monthly to weekly) or if the method for calculating the recurring
+            charge is altered, we will notify you at least
+            <strong>thirty (30) days</strong> in advance of such change taking
+            effect.
+          {% endblocktrans %}
+        </p>
+        <p>
+          {% blocktrans %}
+            By continuing to use Autopay after revisions are in effect, you
+            accept and agree to all revisions.
+          {% endblocktrans %}
+        </p>
+
+        <h3>6. {% trans "Contact and Billing Inquiries" %}</h3>
+        <p>
+          {% blocktrans %}
+            For any questions or concerns regarding these Autopay Terms and
+            Conditions, your recurring charges, or if you wish to dispute a
+            transaction, please contact us immediately:
+          {% endblocktrans %}
+        </p>
+        <ul>
+          <li><strong>{% trans "Email" %}:</strong> {{ ACCOUNTS_EMAIL }}</li>
+        </ul>
+        <p>
+          {% blocktrans %}
+            Please allow us a reasonable time to investigate and respond to your
+            inquiry before taking any further action.
+          {% endblocktrans %}
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/corehq/apps/domain/templates/domain/partials/autopay_terms.html
+++ b/corehq/apps/domain/templates/domain/partials/autopay_terms.html
@@ -75,7 +75,7 @@
         <p>
           <strong>2.2. {% trans "Payment Date" %}:</strong>
           {% blocktrans %}
-            The first charge will occur on your next invoice due date .
+            The first charge will occur on your next invoice due date.
             Thereafter, the automatic payment will be initiated on each
             subsequent invoice due date.
           {% endblocktrans %}

--- a/corehq/apps/domain/templates/domain/partials/payment_methods.html
+++ b/corehq/apps/domain/templates/domain/partials/payment_methods.html
@@ -29,12 +29,19 @@
     </table>
   {% else %}
     <div class="alert alert-warning">
-      <i class="fa fa-warning"></i>
-      {% blocktrans %}
-        You don't have an autopay card set for your account.
-      {% endblocktrans %}
+      <p class="mb-0">
+        <i class="fa fa-warning"></i>
+        {% blocktrans %}
+          You don't have an autopay card set for your account. By providing your
+          payment information and selecting "Set as autopay card" or "Use this
+          card to autopay," you are completing the Autopay enrollment process
+          and giving your affirmative consent to these recurring payment terms.
+          Please read them carefully.
+        {% endblocktrans %}
+      </p>
     </div>
   {% endif %}
+  {% include "domain/partials/autopay_terms.html" %}
 </fieldset>
 
 <div class="htmx-indicator">

--- a/corehq/apps/domain/templates/domain/partials/select_autopay_method.html
+++ b/corehq/apps/domain/templates/domain/partials/select_autopay_method.html
@@ -23,12 +23,21 @@
     {% if has_autopay %}<span class="text-success ms-2"><i class="fa fa-check"></i></span>{% endif %}
   </legend>
   <div class="alert alert-info">
-    {% blocktrans %}
-      By providing your payment information and selecting "Set as autopay card"
-      or "Use this card to autopay," you are completing the Autopay
-      enrollment process and giving your affirmative consent to these
-      recurring payment terms. Please read them carefully.
-    {% endblocktrans %}
+    {% if has_autopay %}
+      {% blocktrans %}
+        You have provided your payment information. By clicking "Subscribe to
+        Plan" you are completing the Autopay enrollment process and giving your
+        affirmative consent to these recurring payment terms. Please read them
+        carefully.
+      {% endblocktrans %}
+    {% else %}
+      {% blocktrans %}
+        By providing your payment information and selecting "Set as autopay
+        card" or "Use this card to autopay" you are completing the Autopay
+        enrollment process and giving your affirmative consent to these
+        recurring payment terms. Please read them carefully.
+      {% endblocktrans %}
+    {% endif %}
   </div>
   {% include "domain/partials/autopay_terms.html" %}
   {% if available_cards %}

--- a/corehq/apps/domain/templates/domain/partials/select_autopay_method.html
+++ b/corehq/apps/domain/templates/domain/partials/select_autopay_method.html
@@ -22,6 +22,15 @@
     {% trans "Select Autopay Card" %}
     {% if has_autopay %}<span class="text-success ms-2"><i class="fa fa-check"></i></span>{% endif %}
   </legend>
+  <div class="alert alert-info">
+    {% blocktrans %}
+      By providing your payment information and selecting "Set as autopay card"
+      or "Use this card to autopay," you are completing the Autopay
+      enrollment process and giving your affirmative consent to these
+      recurring payment terms. Please read them carefully.
+    {% endblocktrans %}
+  </div>
+  {% include "domain/partials/autopay_terms.html" %}
   {% if available_cards %}
     <table
       class="table table-striped"

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1707,6 +1707,8 @@ class ConfirmBillingAccountInfoView(HqHtmxActionMixin, ConfirmSelectedPlanView, 
                 messages.success(
                     request, message
                 )
+                if self.account.auto_pay_enabled:
+                    sign_autopay_terms(request)
                 return HttpResponseRedirect(reverse(DomainSubscriptionView.urlname, args=[self.domain]))
 
             downgrade_date = next_subscription.date_start.strftime(USER_DATE_FORMAT)

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -452,25 +452,17 @@ class DomainSubscriptionView(DomainAccountingSettings):
 
 def sign_autopay_terms(request):
     current_user = CouchUser.from_django_user(request.user)
-    if not _autopay_terms_signed(current_user):
-        new_agreement = LicenseAgreement(
+    autopay_terms = current_user.get_eula(AUTOPAY_TERMS_CURRENT_VERSION, LicenseAgreementType.AUTOPAY_TERMS)
+    if not autopay_terms:
+        autopay_terms = LicenseAgreement(
             type=LicenseAgreementType.AUTOPAY_TERMS,
             version=AUTOPAY_TERMS_CURRENT_VERSION,
             signed=True,
             date=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
             user_ip=get_ip(request),
         )
-        current_user.eulas.append(new_agreement)
+        current_user.eulas.append(autopay_terms)
         current_user.save()
-
-
-def _autopay_terms_signed(current_user):
-    return any(
-        eula.type == LicenseAgreementType.AUTOPAY_TERMS
-        and eula.version == AUTOPAY_TERMS_CURRENT_VERSION
-        and eula.signed
-        for eula in current_user.eulas
-    )
 
 
 @method_decorator(use_bootstrap5, name='dispatch')

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -15,7 +15,7 @@ from corehq.apps.accounting.utils.cards import (
 )
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
-from dimagi.utils.web import json_response
+from dimagi.utils.web import get_ip, json_response
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import ValidationError
@@ -113,6 +113,11 @@ from corehq.apps.domain.forms import (
     EditBillingAccountInfoForm,
     SelectSubscriptionTypeForm,
 )
+from corehq.apps.domain.models import (
+    AUTOPAY_TERMS_CURRENT_VERSION,
+    LicenseAgreement,
+    LicenseAgreementType,
+)
 from corehq.apps.domain.views.base import DomainViewMixin
 from corehq.apps.domain.views.settings import (
     BaseAdminProjectSettingsView,
@@ -122,7 +127,7 @@ from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.hqwebapp.views import BasePageView, CRUDPaginatedViewMixin
 from corehq.apps.users.decorators import require_permission
-from corehq.apps.users.models import HqPermissions
+from corehq.apps.users.models import CouchUser, HqPermissions
 from corehq.const import USER_DATE_FORMAT
 from corehq.toggles import SHOW_AUTO_RENEWAL
 
@@ -445,6 +450,29 @@ class DomainSubscriptionView(DomainAccountingSettings):
         }
 
 
+def sign_autopay_terms(request):
+    current_user = CouchUser.from_django_user(request.user)
+    if not _autopay_terms_signed(current_user):
+        new_agreement = LicenseAgreement(
+            type=LicenseAgreementType.AUTOPAY_TERMS,
+            version=AUTOPAY_TERMS_CURRENT_VERSION,
+            signed=True,
+            date=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
+            user_ip=get_ip(request),
+        )
+        current_user.eulas.append(new_agreement)
+        current_user.save()
+
+
+def _autopay_terms_signed(current_user):
+    return any(
+        eula.type == LicenseAgreementType.AUTOPAY_TERMS
+        and eula.version == AUTOPAY_TERMS_CURRENT_VERSION
+        and eula.signed
+        for eula in current_user.eulas
+    )
+
+
 @method_decorator(use_bootstrap5, name='dispatch')
 class EditExistingBillingAccountView(HqHtmxActionMixin, DomainAccountingSettings, AsyncHandlerMixin):
     template_name = 'domain/update_billing_contact_info.html'
@@ -555,6 +583,7 @@ class EditExistingBillingAccountView(HqHtmxActionMixin, DomainAccountingSettings
                 self.account,
                 self.domain,
             )
+            sign_autopay_terms(request)
         except StripePaymentMethod.STRIPE_GENERIC_ERROR as e:
             error = e.json_body.get('error', {}).get(
                 'message', _('Unknown error setting autopay. Please contact Support.')
@@ -1779,6 +1808,7 @@ class ConfirmBillingAccountInfoView(HqHtmxActionMixin, ConfirmSelectedPlanView, 
                 self.account,
                 self.domain,
             )
+            sign_autopay_terms(request)
         except StripePaymentMethod.STRIPE_GENERIC_ERROR as e:
             error = e.json_body.get('error', {}).get(
                 'message', _('Unknown error setting autopay method. Please contact Support.')
@@ -2037,6 +2067,8 @@ class CardsView(BaseCardView):
         autopay = request.POST.get('autopay') == 'true'
         try:
             self.payment_method.create_card(stripe_token, self.account, domain, autopay)
+            if autopay:
+                sign_autopay_terms(request)
         except self.payment_method.STRIPE_GENERIC_ERROR as e:
             return self._stripe_error(e)
         except Exception:

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -27,7 +27,7 @@ from corehq.apps.analytics.tasks import (
     send_hubspot_form,
 )
 from corehq.apps.domain.exceptions import ErrorInitializingDomain
-from corehq.apps.domain.models import Domain
+from corehq.apps.domain.models import Domain, LicenseAgreementType
 from corehq.apps.hqmedia.models import LogoForSystemEmailsReference
 from corehq.apps.hqwebapp.tasks import send_html_email_async, send_mail_async
 from corehq.apps.registration.models import (
@@ -95,7 +95,7 @@ def activate_new_user(
     new_user.subscribed_to_commcare_users = False
     new_user.eula.signed = True
     new_user.eula.date = now
-    new_user.eula.type = 'End User License Agreement'
+    new_user.eula.type = LicenseAgreementType.EULA
     if ip:
         new_user.eula.user_ip = ip
 

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -39,6 +39,7 @@ from corehq.apps.domain.exceptions import (
 )
 from corehq.apps.domain.extension_points import has_custom_clean_password
 from corehq.apps.domain.models import (
+    EULA_CURRENT_VERSION,
     Domain,
     LicenseAgreement,
     LicenseAgreementType,
@@ -64,7 +65,6 @@ from corehq.apps.registration.utils import (
 )
 from corehq.apps.sso.models import IdentityProvider
 from corehq.apps.users.models import (
-    EULA_CURRENT_VERSION,
     CouchUser,
     Invitation,
     WebUser,

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -38,7 +38,11 @@ from corehq.apps.domain.exceptions import (
     NameUnavailableException,
 )
 from corehq.apps.domain.extension_points import has_custom_clean_password
-from corehq.apps.domain.models import Domain, LicenseAgreement
+from corehq.apps.domain.models import (
+    Domain,
+    LicenseAgreement,
+    LicenseAgreementType,
+)
 from corehq.apps.hqwebapp.models import ServerLocation
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.registration.forms import (
@@ -582,7 +586,7 @@ def eula_agreement(request):
             agreement.date = datetime.utcnow()
             agreement.user_ip = get_ip(request)
         else:
-            new_agreement = LicenseAgreement(type="End User License Agreement", version=EULA_CURRENT_VERSION)
+            new_agreement = LicenseAgreement(type=LicenseAgreementType.EULA, version=EULA_CURRENT_VERSION)
             new_agreement.signed = True
             new_agreement.date = datetime.utcnow()
             new_agreement.user_ip = get_ip(request)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -60,7 +60,11 @@ from dimagi.utils.web import get_static_url_prefix
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.cleanup.models import DeletedCouchDoc
 from corehq.apps.commtrack.const import USER_LOCATION_OWNER_MAP_TYPE
-from corehq.apps.domain.models import Domain, LicenseAgreement
+from corehq.apps.domain.models import (
+    Domain,
+    LicenseAgreement,
+    LicenseAgreementType,
+)
 from corehq.apps.domain.shortcuts import create_user
 from corehq.apps.domain.utils import (
     domain_restricts_superusers,
@@ -860,9 +864,9 @@ class EulaMixin(DocumentSchema):
     def eula(self, version=CURRENT_VERSION):
         current_eula = self.get_eula(version)
         if not current_eula:
-            current_eula = LicenseAgreement(type="End User License Agreement", version=version)
+            current_eula = LicenseAgreement(type=LicenseAgreementType.EULA, version=version)
             self.eulas.append(current_eula)
-        assert current_eula.type == "End User License Agreement"
+        assert current_eula.type == LicenseAgreementType.EULA
         return current_eula
 
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -61,6 +61,7 @@ from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.cleanup.models import DeletedCouchDoc
 from corehq.apps.commtrack.const import USER_LOCATION_OWNER_MAP_TYPE
 from corehq.apps.domain.models import (
+    EULA_CURRENT_VERSION,
     Domain,
     LicenseAgreement,
     LicenseAgreementType,
@@ -121,8 +122,6 @@ COMMCARE_USER = 'commcare'
 
 MAX_WEB_USER_LOGIN_ATTEMPTS = 5
 MAX_COMMCARE_USER_LOGIN_ATTEMPTS = 500
-
-EULA_CURRENT_VERSION = '3.0'  # Set this to the most up to date version of the eula
 
 
 def _add_to_list(list, obj, default):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -844,10 +844,10 @@ class EulaMixin(DocumentSchema):
             return current_eula.signed
         return False
 
-    def get_eula(self, version):
+    def get_eula(self, version, eula_type):
         current_eula = None
         for eula in self.eulas:
-            if eula.version == version:
+            if eula.version == version and eula.type == eula_type:
                 if not current_eula or eula.date > current_eula.date:
                     current_eula = eula
         return current_eula
@@ -860,12 +860,12 @@ class EulaMixin(DocumentSchema):
         return eulas_json
 
     @property
-    def eula(self, version=CURRENT_VERSION):
-        current_eula = self.get_eula(version)
+    def eula(self, version=CURRENT_VERSION, eula_type=LicenseAgreementType.EULA):
+        current_eula = self.get_eula(version, eula_type)
         if not current_eula:
-            current_eula = LicenseAgreement(type=LicenseAgreementType.EULA, version=version)
+            current_eula = LicenseAgreement(type=eula_type, version=version)
             self.eulas.append(current_eula)
-        assert current_eula.type == LicenseAgreementType.EULA
+        assert current_eula.type == eula_type
         return current_eula
 
 


### PR DESCRIPTION
## Product Description
Collapsed, billing information page:
<img width="1019" height="207" alt="image" src="https://github.com/user-attachments/assets/783dca4f-1f34-4543-b1a9-8642f1186417" />

Expanded (first couple of sections, continues on):
<img width="1009" height="484" alt="image" src="https://github.com/user-attachments/assets/a244be69-5f46-46fc-a52e-d3675ca3656e" />

Collapsed, confirm billing information page (during plan signup/change):
<img width="1023" height="226" alt="image" src="https://github.com/user-attachments/assets/37ad11f0-3454-4502-80c5-9276eb782960" />



## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18749
Adds an autopay terms html partial to HQ, separate from Dimagi's main terms of service, and asks customers to agree to this when setting an autopay method. Stores info about the agreed-to autopay terms in the user's `eulas` property as we do with the larger "End User License Agreement". Stores this info when a user sets an autopay card (which we state in the UI is agreeing to the terms). 


## Safety Assurance

### Safety story
Tested locally and on staging that autopay terms are shown and messaging is correct, as well as that the Autopay Terms shows up in the user's signed `eulas` property after enabling autopay.

### Automated test coverage
We have a lot of automated tests that use the `.eula` property, either to set or get info, so these would protect against regression in the `EulaMixin`.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
