### PR TITLE
Ignore case transactions with missing form

### DIFF
--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -126,7 +126,7 @@ class XFormInstanceManager(RequireDBManager):
         meta = self.get_attachment_by_name(form_id, attachment_name)
         return AttachmentContent(meta.content_type, meta.open(), meta.content_length)
 
-    def get_forms_with_attachments_meta(self, form_ids, ordered=False):
+    def get_forms_with_attachments_meta(self, form_ids):
         assert isinstance(form_ids, list)
         if not form_ids:
             return []
@@ -147,10 +147,6 @@ class XFormInstanceManager(RequireDBManager):
         )
         forms_by_id = {form.form_id: form for form in forms}
         attach_prefetch_models(forms_by_id, attachments, 'parent_id', 'attachments_list')
-
-        if ordered:
-            sort_with_id_list(forms, form_ids, 'form_id')
-
         return forms
 
     def modify_attachment_xml_and_metadata(self, form_data, form_attachment_new_xml):

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -125,11 +125,11 @@ class XFormInstanceManagerTest(TestCase):
         plain_form = create_form_for_test(DOMAIN)
 
         forms = XFormInstance.objects.get_forms_with_attachments_meta(
-            [form_with_pic.form_id, plain_form.form_id], ordered=True
+            [form_with_pic.form_id, plain_form.form_id]
         )
+
         self.assertEqual(2, len(forms))
-        form = forms[0]
-        self.assertEqual(form_with_pic.form_id, form.form_id)
+        form = [f for f in forms if f.form_id == form_with_pic.form_id][0]
         with self.assertNumQueries(0, using=form.db):
             expected = {
                 'form.xml': 'text/xml',
@@ -139,11 +139,12 @@ class XFormInstanceManagerTest(TestCase):
             self.assertEqual(2, len(attachments))
             self.assertEqual(expected, {att.name: att.content_type for att in attachments})
 
-        with self.assertNumQueries(0, using=forms[1].db):
+        form = [f for f in forms if f.form_id == plain_form.form_id][0]
+        with self.assertNumQueries(0, using=form.db):
             expected = {
                 'form.xml': 'text/xml',
             }
-            attachments = forms[1].get_attachments()
+            attachments = form.get_attachments()
             self.assertEqual(1, len(attachments))
             self.assertEqual(expected, {att.name: att.content_type for att in attachments})
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
A case rebuild will fail if it contains a case transaction that references a missing form, specifically if there is an existing BlobMeta for that form. This is obviously not ideal, and we want to get to the bottom of this, but we also want to unblock those that cannot rebuild cases because of it.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Addedd regression test

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
