### PR TITLE
Set requestedAuthnContext false

### DIFF
--- a/corehq/apps/sso/configuration.py
+++ b/corehq/apps/sso/configuration.py
@@ -69,9 +69,12 @@ def _get_advanced_saml2_settings(identity_provider):
             "wantAssertionsSigned": True,
             "wantAssertionsEncrypted": identity_provider.require_encrypted_assertions,
             "wantNameId": True,
-            "wantMessagesSigned": False,  # Entra ID does not support this, premium or standard
-            "wantNameIdEncrypted": False,  # Entra ID will not accept if True
-            "failOnAuthnContextMismatch": False,  # IdP ensures auth but cannot guarantee a particular context
+            # Entra ID does not support this, premium or standard
+            "wantMessagesSigned": False,
+            # Entra ID will not accept if True
+            "wantNameIdEncrypted": False,
+            # Entra ID otherwise fails if user cannot provide default PasswordProtectedTransport auth
+            "requestedAuthnContext": False,
             "signatureAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
             "digestAlgorithm": "http://www.w3.org/2001/04/xmlenc#sha256",
             "metadataValidUntil": metadata_valid_until.isoformat(),


### PR DESCRIPTION
## Product Description
Generally invisible. Should (hopefully for real this time) fix an SSO login bug `AADSTS75011: Authentication method 'MultiFactor, Fido' by which the user authenticated with the service doesn't match requested authentication method 'Password, ProtectedTransport'`.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18973
Follow-up to #37126. Entra ID does not check the `failOnAuthnContextMismatch` property and therefore fails if it cannot provide a `PasswordProtectedTransport` auth (our default) for the user, as in passwordless authentication. This change removes the request for a particular type of auth all together, as [recommended by Microsoft](https://learn.microsoft.com/en-us/troubleshoot/entra/entra-id/app-integration/error-code-aadsts75011-auth-method-mismatch#resolution), in order to allow Entra ID to use any auth type it deems acceptable -- like the `FIDO2` that is continually failing.

## Safety Assurance

### Safety story
Tested on staging to see that SSO auth still works in general. Our Entra ID account does not seem to support passwordless auth so I am not able to test that this change specifically addresses the issues with `FIDO2`.

### Automated test coverage
We don't test for this specific set of configs because it is hard-coded.

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
