### PR TITLE
Create toggle if it does not exist

### DIFF
--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -18,7 +18,6 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 from django.views.decorators.http import require_POST
 
-from couchdbkit import ResourceNotFound
 from django_prbac.decorators import requires_privilege_raise404
 from django_prbac.utils import has_privilege
 from memoized import memoized
@@ -522,10 +521,7 @@ class FeaturePreviewsView(BaseAdminProjectSettingsView):
     def get_toggle(self, slug):
         if slug not in [f.slug for f, _ in self.features()]:
             raise Http404()
-        try:
-            return Toggle.get(slug)
-        except ResourceNotFound:
-            return Toggle(slug=slug)
+        return Toggle.get_or_create(slug)
 
     @property
     def page_context(self):

--- a/corehq/apps/toggle_ui/migration_helpers.py
+++ b/corehq/apps/toggle_ui/migration_helpers.py
@@ -13,10 +13,7 @@ def move_toggles(from_toggle_id, to_toggle_id):
     except ResourceNotFound:
         # if no source found this is a noop
         return
-    try:
-        to_toggle = Toggle.get(to_toggle_id)
-    except ResourceNotFound:
-        to_toggle = Toggle(slug=to_toggle_id, enabled_users=[])
+    to_toggle = Toggle.get_or_create(to_toggle_id, enabled_users=[])
 
     for item in from_toggle.enabled_users:
         if item not in to_toggle.enabled_users:

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -162,10 +162,7 @@ class ToggleEditView(BasePageView):
     def get_toggle(self):
         if not self.static_toggle:
             raise Http404()
-        try:
-            return Toggle.get(self.toggle_slug)
-        except ResourceNotFound:
-            return Toggle(slug=self.toggle_slug)
+        return Toggle.get_or_create(self.toggle_slug)
 
     @property
     def page_context(self):
@@ -437,7 +434,7 @@ def toggle_status(request, toggle_slug):
     if status not in ToggleStatus:
         raise Exception('Invalid toggle status')
 
-    toggle = Toggle.get(toggle_slug)
+    toggle = Toggle.get_or_create(toggle_slug)
     toggle.status = status
     toggle.save()
     for entry in toggle.enabled_users:

--- a/corehq/toggles/models.py
+++ b/corehq/toggles/models.py
@@ -52,6 +52,13 @@ class Toggle(Document):
             docid = generate_toggle_id(docid)
         return super(Toggle, cls).get(docid, rev=None, db=None, dynamic_properties=True)
 
+    @classmethod
+    def get_or_create(cls, docid, **kwargs):
+        try:
+            return Toggle.get(docid)
+        except ResourceNotFound:
+            return Toggle(slug=docid, **kwargs)
+
     def add(self, item):
         """
         Adds an item to the toggle. Only saves if necessary.


### PR DESCRIPTION
## Product Description

Release toggle code did not work if there was not document for the toggle in CouchDB yet. Create it if is missing first.
Move the code in the a new function get_or_create and replace the other usages of the same try/except patter with a
call to the function.

## Technical Summary

No ticket

## Feature Flag

None

## Safety Assurance

### Safety story

Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
