### PR TITLE
[B5] Update migration script to handle migrating vellum templates and javascript

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
+++ b/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
@@ -229,7 +229,7 @@ class Command(BaseCommand):
     def do_bootstrap3_references_exist(self, app_name, bootstrap3_short_path, is_template):
         bootstrap3_references = get_references(app_name, bootstrap3_short_path, is_template=True)
         if not is_template:
-            requirejs_reference = get_requirejs_reference(bootstrap3_short_path)
+            requirejs_reference = get_requirejs_reference(app_name, bootstrap3_short_path)
             bootstrap3_references.extend(get_references(app_name, requirejs_reference, is_template=True))
             js_refs = get_references(app_name, requirejs_reference, is_template=False)
             # make sure the bootstrap3 version of the file isn't a reference
@@ -259,8 +259,8 @@ class Command(BaseCommand):
         if not is_template:
             references.extend(update_and_get_references(
                 app_name,
-                get_requirejs_reference(bootstrap5_short_path),
-                get_requirejs_reference(destination_short_path),
+                get_requirejs_reference(app_name, bootstrap5_short_path),
+                get_requirejs_reference(app_name, destination_short_path),
                 False
             ))
         self.stdout.write(self.style.SUCCESS(

--- a/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
+++ b/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
@@ -254,14 +254,14 @@ class Command(BaseCommand):
             self.stdout.write("\n".join(list_to_display))
             self.stdout.write("\n\n")
 
-    def suggest_commit_message(self, message, show_apply_commit=False):
+    def suggest_commit_message(self, message, show_apply_commit=False, working_directory=None):
         self.stdout.write("\nNow would be a good time to review changes with git and commit.")
         if show_apply_commit:
             confirm = get_confirmation("\nAutomatically commit these changes?", default='y')
             if confirm:
-                apply_commit(message)
+                apply_commit(message, working_directory)
                 return
-        commit_string = get_commit_string(message)
+        commit_string = get_commit_string(message, working_directory)
         self.stdout.write("\n\nSuggested command:\n")
         self.stdout.write(self.style.MIGRATE_HEADING(commit_string))
         self.stdout.write("\n")

--- a/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
+++ b/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
@@ -227,11 +227,11 @@ class Command(BaseCommand):
         bootstrap5_path.rename(destination_path)
 
     def do_bootstrap3_references_exist(self, app_name, bootstrap3_short_path, is_template):
-        bootstrap3_references = get_references(bootstrap3_short_path, is_template=True)
+        bootstrap3_references = get_references(app_name, bootstrap3_short_path, is_template=True)
         if not is_template:
             requirejs_reference = get_requirejs_reference(bootstrap3_short_path)
-            bootstrap3_references.extend(get_references(requirejs_reference, is_template=True))
-            js_refs = get_references(requirejs_reference, is_template=False)
+            bootstrap3_references.extend(get_references(app_name, requirejs_reference, is_template=True))
+            js_refs = get_references(app_name, requirejs_reference, is_template=False)
             # make sure the bootstrap3 version of the file isn't a reference
             js_refs = [r for r in js_refs if not str(r).endswith(bootstrap3_short_path)]
             bootstrap3_references.extend(js_refs)
@@ -250,9 +250,15 @@ class Command(BaseCommand):
 
     def update_references_and_print_summary(self, app_name, bootstrap5_short_path,
                                             destination_short_path, is_template):
-        references = update_and_get_references(bootstrap5_short_path, destination_short_path, is_template)
+        references = update_and_get_references(
+            app_name,
+            bootstrap5_short_path,
+            destination_short_path,
+            is_template,
+        )
         if not is_template:
             references.extend(update_and_get_references(
+                app_name,
                 get_requirejs_reference(bootstrap5_short_path),
                 get_requirejs_reference(destination_short_path),
                 False

--- a/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
+++ b/corehq/apps/hqwebapp/management/commands/complete_bootstrap5_migration.py
@@ -3,6 +3,7 @@ from django.core.management import BaseCommand
 from corehq.apps.hqwebapp.utils.bootstrap.git import (
     apply_commit,
     get_commit_string,
+    get_working_directory,
     has_pending_git_changes,
 )
 from corehq.apps.hqwebapp.utils.bootstrap.paths import (
@@ -43,7 +44,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, app_name, **options):
-        if has_pending_git_changes():
+        working_directory = get_working_directory(app_name)
+        working_changes = has_pending_git_changes(working_directory)
+        main_changes = has_pending_git_changes()
+        if working_changes or main_changes:
             self.stdout.write(self.style.ERROR(
                 "You have un-committed changes. Please commit these changes before proceeding...\n"
             ))
@@ -82,7 +86,10 @@ class Command(BaseCommand):
         )
 
     def mark_file_as_complete(self, app_name, filename, is_template):
+        working_directory = get_working_directory(app_name)
+        has_changes_app_working_directory = has_pending_git_changes(working_directory)
         has_changes = has_pending_git_changes()
+
         file_type = "template" if is_template else "js file"
         if is_template:
             relevant_paths = get_all_template_paths_for_app(app_name)
@@ -111,10 +118,21 @@ class Command(BaseCommand):
             mark_template_as_complete(app_name, destination_short_path)
         else:
             mark_javascript_as_complete(app_name, destination_short_path)
-        self.suggest_commit_message(
-            f"Marked {file_type} '{destination_short_path}' as complete and un-split files.",
-            show_apply_commit=not has_changes
-        )
+        if working_directory:
+            self.suggest_commit_message(
+                f"Un-split files: {file_type} '{destination_short_path}' when marking as complete.",
+                show_apply_commit=not has_changes_app_working_directory,
+                working_directory=working_directory
+            )
+            self.suggest_commit_message(
+                f"Marked {file_type} '{destination_short_path}' as complete.",
+                show_apply_commit=not has_changes
+            )
+        else:
+            self.suggest_commit_message(
+                f"Marked {file_type} '{destination_short_path}' as complete and un-split files.",
+                show_apply_commit=not has_changes
+            )
         self.show_next_steps(app_name)
 
     def verify_filename_and_get_paths(self, app_name, filename, relevant_paths, is_template):

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -512,10 +512,11 @@ class Command(BaseCommand):
             file_path, bootstrap3_path, bootstrap3_lines, bootstrap5_path, bootstrap5_lines
         )
         self.stdout.write("\nUpdating references...")
-        references = update_and_get_references(short_path, bootstrap3_short_path, is_template)
+        references = update_and_get_references(app_name, short_path, bootstrap3_short_path, is_template)
         if not is_template:
             # also check extension-less references for javascript files
             references.extend(update_and_get_references(
+                app_name,
                 get_requirejs_reference(short_path),
                 get_requirejs_reference(bootstrap3_short_path),
                 is_template=False
@@ -562,12 +563,14 @@ class Command(BaseCommand):
             new_reference = get_short_path(app_name, file_path, is_template)
             old_reference = new_reference.replace("/bootstrap3/", "/")
             references = update_and_get_references(
+                app_name,
                 old_reference,
                 new_reference,
                 is_template
             )
             if not is_template:
                 references.extend(update_and_get_references(
+                    app_name,
                     get_requirejs_reference(old_reference),
                     get_requirejs_reference(new_reference),
                     is_template=False

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -517,8 +517,8 @@ class Command(BaseCommand):
             # also check extension-less references for javascript files
             references.extend(update_and_get_references(
                 app_name,
-                get_requirejs_reference(short_path),
-                get_requirejs_reference(bootstrap3_short_path),
+                get_requirejs_reference(app_name, short_path),
+                get_requirejs_reference(app_name, bootstrap3_short_path),
                 is_template=False
             ))
         if references:
@@ -571,8 +571,8 @@ class Command(BaseCommand):
             if not is_template:
                 references.extend(update_and_get_references(
                     app_name,
-                    get_requirejs_reference(old_reference),
-                    get_requirejs_reference(new_reference),
+                    get_requirejs_reference(app_name, old_reference),
+                    get_requirejs_reference(app_name, new_reference),
                     is_template=False
                 ))
             if references:

--- a/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
+++ b/corehq/apps/hqwebapp/management/commands/migrate_app_to_bootstrap5.py
@@ -655,9 +655,9 @@ class Command(BaseCommand):
             "\nYou have un-committed changes! Please commit these changes before proceeding. Thank you!"
         ))
 
-    def suggest_commit_message(self, message, show_apply_commit=False):
+    def suggest_commit_message(self, message, show_apply_commit=False, working_directory=None):
         if self.skip_all and show_apply_commit:
-            apply_commit(message)
+            apply_commit(message, working_directory)
             return
 
         self.stdout.write("\nNow would be a good time to review changes with git and "
@@ -665,9 +665,9 @@ class Command(BaseCommand):
         if show_apply_commit:
             confirm = get_confirmation("\nAutomatically commit these changes?", default='y')
             if confirm:
-                apply_commit(message)
+                apply_commit(message, working_directory)
                 return
-        commit_string = get_commit_string(message)
+        commit_string = get_commit_string(message, working_directory)
         self.stdout.write("\n\nSuggested command:\n")
         self.stdout.write(self.style.MIGRATE_HEADING(commit_string))
         self.stdout.write("\n")

--- a/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
+++ b/corehq/apps/hqwebapp/tests/utils/test_bootstrap_changes.py
@@ -396,6 +396,15 @@ def test_add_todo_comments_for_flags_template():
     eq(line, """          <div class="form-inline nav"  {# todo B5: css-form-inline, css-nav #}\n""")
 
 
+def test_add_todo_comments_for_flags_template_submodule():
+    line = """          <div class="form-inline nav"\n"""
+    flags = flag_changed_css_classes(
+        line, get_spec('bootstrap_3_to_5')
+    )
+    line = add_todo_comments_for_flags(flags, line, is_template=True, is_submodule_app=True)
+    eq(line, """          <div class="form-inline nav"  <!-- todo B5: css-form-inline, css-nav -->\n""")
+
+
 def test_add_todo_comments_for_flags_template_replace():
     line = """          {% crispy form %}  {# todo B5: css-form-inline, css-nav #}\n"""
     flags = flag_crispy_forms_in_template(line)

--- a/corehq/apps/hqwebapp/utils/bootstrap/changes.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/changes.py
@@ -154,12 +154,14 @@ def make_template_dependency_renames(line, spec):
     return line, []
 
 
-def add_todo_comments_for_flags(flags, line, is_template):
+def add_todo_comments_for_flags(flags, line, is_template, is_submodule_app=False):
     if flags:
         line = line.rstrip('\n')
         flag_summary = [f[0] for f in flags]
-        open_comment = "{#" if is_template else "/*"
-        close_comment = "#}" if is_template else "*/"
+        template_flag_open = "<!--" if is_submodule_app else "{#"
+        template_flag_close = "-->" if is_submodule_app else "#}"
+        open_comment = template_flag_open if is_template else "/*"
+        close_comment = template_flag_close if is_template else "*/"
         comment = f"{open_comment} todo B5: {', '.join(flag_summary)} {close_comment}\n"
 
         todo_regex = _get_todo_regex(is_template)

--- a/corehq/apps/hqwebapp/utils/bootstrap/git.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/git.py
@@ -1,31 +1,44 @@
 import subprocess
 
+DEFAULT_GIT_PATH = "."
 
-def get_commit_command(message, as_string=False):
+
+def get_commit_command(message, as_string=False, path=None):
     message = message.replace('"', '\'')  # make sure there are no double-quotes
-    commit_command = ["git", "commit", "--no-verify", f"--message=\"Bootstrap 5 Migration - {message}\""]
+    commit_command = ["git"]
+    if path and path != DEFAULT_GIT_PATH:
+        commit_command.extend(["-C", path])
+    commit_command.extend(["commit", "--no-verify", f"--message=\"Bootstrap 5 Migration - {message}\""])
     if as_string:
         return " ".join(commit_command)
     return commit_command
 
 
-def get_commit_string(message):
-    return get_commit_command(message, as_string=True)
+def get_commit_string(message, path=None):
+    return get_commit_command(message, as_string=True, path=path)
 
 
-def apply_commit(message):
-    commit_command = get_commit_command(message)
+def apply_commit(message, path=None):
+    path = path or DEFAULT_GIT_PATH
+    commit_command = get_commit_command(message, path=path)
     subprocess.call([
-        "git", "add", ".",
+        "git", "-C", path, "add", ".",
     ])
     subprocess.call(commit_command)
 
 
-def has_pending_git_changes():
+def has_pending_git_changes(path=None):
+    path = path or DEFAULT_GIT_PATH
     status = subprocess.Popen(
-        ["git", "status"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ["git", "-C", path, "status"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
     return "nothing to commit" not in str(status.communicate()[0])
+
+
+def get_working_directory(app_name):
+    if app_name == "vellum":
+        return "./submodules/formdesigner"
+    return None
 
 
 def ensure_no_pending_changes_before_continuing():

--- a/corehq/apps/hqwebapp/utils/bootstrap/paths.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/paths.py
@@ -13,6 +13,9 @@ PARENT_PATHS = {
     "casexml": COREHQ_BASE_DIR / "ex-submodules/casexml/apps",
     "ex-submodules": COREHQ_BASE_DIR / "ex-submodules",
 }
+SUBMODULE_APPS = [
+    "vellum",
+]
 GRUNTFILE_PATH = COREHQ_BASE_DIR.parent / "Gruntfile.js"
 IGNORED_PATHS_BY_APP = {
     "hqwebapp": [
@@ -63,6 +66,8 @@ def is_mocha_path(path):
 
 
 def get_app_name_and_slug(app_name):
+    if app_name in SUBMODULE_APPS:
+        return app_name, app_name
     app_parts = app_name.split(".")
     if len(app_parts) == 2:
         return app_parts[0], app_parts[1]

--- a/corehq/apps/hqwebapp/utils/bootstrap/paths.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/paths.py
@@ -110,6 +110,8 @@ def get_app_static_folder_for_submodule(app_name, parent_path):
 
 
 def get_short_path(app_name, full_path, is_template):
+    if app_name in SUBMODULE_APPS:
+        return get_short_path_for_submodule(app_name, full_path, is_template)
     parent_path = get_parent_path(app_name)
     _, app_name = get_app_name_and_slug(app_name)
     if is_template:
@@ -120,6 +122,24 @@ def get_short_path(app_name, full_path, is_template):
         str(replace_path) + '/',
         ''
     )
+
+
+def get_short_path_for_submodule(app_name, full_path, is_template):
+    if app_name == "vellum":
+        if is_template:
+            parent_path = get_parent_path(app_name)
+            replace_path = parent_path / "templates"
+            return str(full_path).replace(
+                str(replace_path) + '/',
+                ''
+            )
+        else:
+            parent_path = get_parent_path(app_name)
+            return str(full_path).replace(
+                str(parent_path) + '/',
+                ''
+            )
+    raise ValueError(f"Unknown submodule app: {app_name}")
 
 
 def get_all_template_paths_for_app(app_name):

--- a/corehq/apps/hqwebapp/utils/bootstrap/paths.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/paths.py
@@ -84,13 +84,29 @@ def get_parent_path(app_name):
 def get_app_template_folder(app_name):
     parent_path = get_parent_path(app_name)
     _, app_name = get_app_name_and_slug(app_name)
+    if app_name in SUBMODULE_APPS:
+        return get_app_template_folder_for_submodule(app_name, parent_path)
     return parent_path / app_name / "templates" / app_name
+
+
+def get_app_template_folder_for_submodule(app_name, parent_path):
+    if app_name == "vellum":
+        return parent_path / "templates"
+    raise ValueError(f"Unknown submodule app: {app_name}")
 
 
 def get_app_static_folder(app_name):
     parent_path = get_parent_path(app_name)
     _, app_name = get_app_name_and_slug(app_name)
+    if app_name in SUBMODULE_APPS:
+        return get_app_static_folder_for_submodule(app_name, parent_path)
     return parent_path / app_name / "static" / app_name
+
+
+def get_app_static_folder_for_submodule(app_name, parent_path):
+    if app_name == "vellum":
+        return parent_path
+    raise ValueError(f"Unknown submodule app: {app_name}")
 
 
 def get_short_path(app_name, full_path, is_template):

--- a/corehq/apps/hqwebapp/utils/bootstrap/paths.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/paths.py
@@ -4,6 +4,7 @@ import corehq
 
 COREHQ_BASE_DIR = Path(corehq.__file__).resolve().parent
 CUSTOM_BASE_DIR = COREHQ_BASE_DIR.parent / "custom"
+SUBMODULES_BASE_DIR = COREHQ_BASE_DIR.parent / "submodules"
 TRACKED_JS_FOLDERS = ["js", "spec"]
 PARENT_PATHS = {
     "corehq": COREHQ_BASE_DIR,
@@ -12,6 +13,7 @@ PARENT_PATHS = {
     "motech": COREHQ_BASE_DIR / "motech",
     "casexml": COREHQ_BASE_DIR / "ex-submodules/casexml/apps",
     "ex-submodules": COREHQ_BASE_DIR / "ex-submodules",
+    "vellum": SUBMODULES_BASE_DIR / "formdesigner/src",
 }
 SUBMODULE_APPS = [
     "vellum",

--- a/corehq/apps/hqwebapp/utils/bootstrap/references.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/references.py
@@ -9,6 +9,9 @@ def update_and_get_references(app_name, old_reference, new_reference, is_templat
     if app_name == "vellum" and old_reference.endswith(".html"):
         old_reference = f"vellum/templates/{old_reference}"
         new_reference = f"vellum/templates/{new_reference}"
+    elif app_name == "vellum" and old_reference.endswith(".js"):
+        old_reference = f"vellum/{old_reference}"
+        new_reference = f"vellum/{new_reference}"
 
     references = []
     for file_path, filedata in get_references_data(app_name, old_reference, is_template):
@@ -24,7 +27,10 @@ def update_and_get_references(app_name, old_reference, new_reference, is_templat
     return references
 
 
-def get_requirejs_reference(short_path):
+def get_requirejs_reference(app_name, short_path):
+    if app_name == "vellum":
+        short_path = short_path.replace('.js', '')
+        return f"vellum/{short_path}"
     return short_path.replace('.js', '')
 
 

--- a/corehq/apps/hqwebapp/utils/bootstrap/references.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/references.py
@@ -2,12 +2,16 @@ from corehq.apps.hqwebapp.utils.bootstrap.changes import (
     file_contains_reference_to_path,
     replace_path_references,
 )
-from corehq.apps.hqwebapp.utils.bootstrap.paths import COREHQ_BASE_DIR, CUSTOM_BASE_DIR
+from corehq.apps.hqwebapp.utils.bootstrap.paths import COREHQ_BASE_DIR, CUSTOM_BASE_DIR, PARENT_PATHS
 
 
-def update_and_get_references(old_reference, new_reference, is_template=True):
+def update_and_get_references(app_name, old_reference, new_reference, is_template=True):
+    if app_name == "vellum" and old_reference.endswith(".html"):
+        old_reference = f"vellum/templates/{old_reference}"
+        new_reference = f"vellum/templates/{new_reference}"
+
     references = []
-    for file_path, filedata in get_references_data(old_reference, is_template):
+    for file_path, filedata in get_references_data(app_name, old_reference, is_template):
         references.append(str(file_path))
         with open(file_path, 'w') as file:
             use_bootstrap5_reference = "/bootstrap5/" in str(file_path)
@@ -24,16 +28,18 @@ def get_requirejs_reference(short_path):
     return short_path.replace('.js', '')
 
 
-def get_file_types(is_template=True):
+def get_file_types(app_name, is_template=True):
+    if app_name == "vellum":
+        return ["**/*.md", "**/*.html", "**/*.js"]
     file_types = ["**/*.py", "**/*.html", "**/*.md"]
     if not is_template:
         file_types.append("**/*.js")
     return file_types
 
 
-def get_references_data(reference, is_template=True):
-    for file_type in get_file_types(is_template):
-        for directory in [COREHQ_BASE_DIR, CUSTOM_BASE_DIR]:
+def get_references_data(app_name, reference, is_template=True):
+    for file_type in get_file_types(app_name, is_template):
+        for directory in _get_reference_directories_for_app(app_name):
             for file_path in directory.glob(file_type):
                 if not file_path.is_file():
                     continue
@@ -43,8 +49,14 @@ def get_references_data(reference, is_template=True):
                     yield file_path, filedata
 
 
-def get_references(reference, is_template):
+def _get_reference_directories_for_app(app_name):
+    if app_name == "vellum":
+        return [PARENT_PATHS.get(app_name)]
+    return [COREHQ_BASE_DIR, CUSTOM_BASE_DIR]
+
+
+def get_references(app_name, reference, is_template=True):
     references = []
-    for file_path, filedata in get_references_data(reference, is_template):
+    for file_path, filedata in get_references_data(app_name, reference, is_template):
         references.append(str(file_path))
     return references


### PR DESCRIPTION
## Technical Summary
Migrating vellum with our automated tools posed two challenges:
 - vellum has a different directory structure than our familiar django apps
 - vellum references template and javascript files differently
 - vellum has its own tests and build process

To address this, I've updated the migration script to adjust for vellum's directory structure so that it can migrate each file properly.

Additionally, while I experimented and succeeded with creating split files in vellum, I decided to prevent split files migrations for any submodules, as keeping the split files in sync poses too much complexity. Additionally, with vellum, it would mean splitting vellum's tests, build paths, references in the webpack build—not worth it.

My recommended approach for the app manager is as follows:

1. split `app_manager` and commit the split files
```
./manage.py migrate_app_to_bootstrap5 app_manager --skip-all
```

2. First, migrate the views that aren't hosting vellum, tackling each view one-by-one and marking templates and js files as "complete" where possible. This follows the standard recommendation for the split-files migration approach in the migration guide.

3. Create a "split" stylesheet for scss and begin the stylesheet migration (remember, you need to manually add stylesheets split [to the diff config](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/tests/data/bootstrap5_diff_config.json#L87-L102))

4. For the views that are hosting vellum:
- start two dev branches: one for hq and one for vellum
- enable bootstrap 5 on the view hosting vellum in hq
- kick off the in-place migration with vellum
```
./manage.py migrate_app_to_bootstrap5 vellum --no-split --skip-all
```
This will create a lot of commits that can be reviewed, with todo's sprinkled throughout which can be addressed one-by-one (or in groups) with followup commits.
- migrate any of the templates of the host view
- migrate the vellum stylesheets from less to scss

5. with vellum and its host view migrated, rebuild vellum, PR the HQ changes, update the submodule ref to vellum with the b5 changes, and commit + merge (after testing the vellum branch and HQ branch together on staging, of course! please don't forget that bit!)

6. After that, you can begin following the process to "unsplit" the app manager files and then complete the migration for app manager!

## Safety Assurance

### Safety story
This PR is safe, it just updates internal scripts which have been tested locally. no production workflows, views, templates, etc are affected.

### Automated test coverage
yes

### QA Plan
not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
