### PR TITLE
Revert tag change to IS_CONTRACTOR

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -853,7 +853,7 @@ GRAPH_CREATION = StaticToggle(
 IS_CONTRACTOR = StaticToggle(
     'is_contractor',
     'Is contractor',
-    TAG_DEPRECATED,
+    TAG_INTERNAL,
     description="Used to give non super-users access to select super-user features"
 )
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user facing change, just reverting a change to a feature flags tag back to internal instead of deprecated.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Following up to the [PR](https://github.com/dimagi/commcare-hq/pull/37193) where IS_CONTRACTOR was marked as deprecated but then was requested to be placed back as internal [here](https://docs.google.com/spreadsheets/d/1kE56g6cy3CRz4XncoNNW4riXts3HYTDdOKqw4CmdeDg/edit?disco=AAABugnmhnU)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
IS_CONTRACTOR

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
just a tag change, so its safe.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
