### PR TITLE
Styleguide Updates for KO migration, HTMX, and Alpine

### DIFF
--- a/corehq/apps/styleguide/context.py
+++ b/corehq/apps/styleguide/context.py
@@ -26,6 +26,7 @@ def get_navigation_context(current_page):
                     Page("Javascript Guide", 'styleguide_javascript_guide_b5'),
                     Page("HTML Guide", 'styleguide_html_guide_b5'),
                     Page("HTMX + Alpine.JS", 'styleguide_htmx_and_alpine_b5'),
+                    Page("Knockout to Alpine Migration", 'styleguide_knockout_to_alpine_guide_b5'),
                 ],
             ),
             NavigationGroup(

--- a/corehq/apps/styleguide/examples/bootstrap5/datepicker_alpine_crispy.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/datepicker_alpine_crispy.py
@@ -1,0 +1,46 @@
+import json
+
+from crispy_forms import bootstrap as twbscrispy
+from crispy_forms import layout as crispy
+from django import forms
+from django.utils.safestring import mark_safe
+
+from corehq.apps.hqwebapp import crispy as hqcrispy
+
+
+class DatepickerAlpineForm(forms.Form):
+    datepicker = forms.CharField(
+        label="Date",
+        required=False
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = hqcrispy.HQFormHelper()
+        self.helper.form_method = 'POST'
+        self.helper.form_action = '#'
+
+        alpine_data_model = {
+            'datepicker': self.fields['datepicker'].initial,
+        }
+
+        # Layout: Alpine is used to toggle visibility of the "value" field
+        # based on the selected match type.
+        self.helper.layout = crispy.Layout(
+            crispy.Div(
+                twbscrispy.AppendedText(
+                    'datepicker',
+                    mark_safe(  # nosec: no user input
+                        '<i class="fcc fcc-fd-datetime"></i>'
+                    ),
+                    x_datepicker=json.dumps(
+                        {
+                            'datetime': True,
+                            'useInputGroup': True,
+                        }
+                    ),
+                ),
+                # Bind the Alpine data model defined above to this wrapper <div>.
+                x_data=json.dumps(alpine_data_model),
+            ),
+        )

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_alpine_form_demo.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_alpine_form_demo.py
@@ -1,101 +1,100 @@
 import json
 
-from crispy_forms import bootstrap as twbscrispy, layout as crispy
+from crispy_forms import bootstrap as twbscrispy
+from crispy_forms import layout as crispy
 from crispy_forms.helper import FormHelper
-
 from django import forms
-from django.utils.translation import gettext_lazy, gettext as _
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 
 class MatchType:
-    EXACT = "exact"
-    IS_NOT = "is_not"
-    CONTAINS = "contains"
-    IS_EMPTY = "is_empty"
+    EXACT = 'exact'
+    IS_NOT = 'is_not'
+    CONTAINS = 'contains'
+    IS_EMPTY = 'is_empty'
 
     OPTIONS = (
-        (EXACT, gettext_lazy("is exactly")),
-        (IS_NOT, gettext_lazy("is not")),
-        (CONTAINS, gettext_lazy("contains")),
-        (IS_EMPTY, gettext_lazy("is empty")),
+        (EXACT, gettext_lazy('is exactly')),
+        (IS_NOT, gettext_lazy('is not')),
+        (CONTAINS, gettext_lazy('contains')),
+        (IS_EMPTY, gettext_lazy('is empty')),
     )
 
     MATCHES_WITH_VALUES = (
-        EXACT, IS_NOT, CONTAINS,
+        EXACT,
+        IS_NOT,
+        CONTAINS,
     )
 
 
 class FilterDemoForm(forms.Form):
     slug = forms.ChoiceField(
-        label=gettext_lazy("Column"),
+        label=gettext_lazy('Column'),
         choices=(
-            ('name', gettext_lazy("Name")),
-            ('color', gettext_lazy("Color")),
-            ('desc', gettext_lazy("Description")),
+            ('name', gettext_lazy('Name')),
+            ('color', gettext_lazy('Color')),
+            ('desc', gettext_lazy('Description')),
         ),
-        required=False
+        required=False,
     )
     match = forms.ChoiceField(
-        label=gettext_lazy("Match Type"),
+        label=gettext_lazy('Match Type'),
         choices=MatchType.OPTIONS,
         required=False,
-        help_text=gettext_lazy(
-            "Hint: select 'is empty' to watch the Value field below disappear"
-        )
+        help_text=gettext_lazy("Hint: select 'is empty' to watch the Value field below disappear"),
     )
-    value = forms.CharField(
-        label=gettext_lazy("Value"),
-        strip=False,
-        required=False
-    )
+    value = forms.CharField(label=gettext_lazy('Value'), strip=False, required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.helper = FormHelper()
 
-        # We defer to defining the <form> tag in the template as we will
-        # use HTMX to load and submit the form. Keeping the HTMX attributes
-        # local to the template is preferred to maintain context.
+        # We defer defining the <form> tag to the template, since we want
+        # full control over the HTMX attributes (hx-post, hq-hx-action, etc.)
+        # near the HTML they affect.
         self.helper.form_tag = False
 
-        # This form layout uses Alpine to toggle the visibility of
-        # the "value" field:
+        # Define the Alpine data model used by the layout below.
+        # Keeping this close to the layout makes the form behavior easier to follow.
+        alpine_data_model = {
+            'match': self.fields['match'].initial,
+            'valueMatches': MatchType.MATCHES_WITH_VALUES,
+        }
+
+        # Layout: Alpine is used to toggle visibility of the "value" field
+        # based on the selected match type.
         self.helper.layout = crispy.Layout(
             crispy.Div(
                 'slug',
                 crispy.Field(
                     'match',
-                    # We initialize the match value in the alpine
-                    # model defined below:
-                    x_init="match = $el.value",
-                    # and then two-way bind the alpine match
-                    # model variable to this input:
-                    x_model="match",
+                    # Initialize the Alpine "match" variable when the field is rendered...
+                    x_init='match = $el.value',
+                    # ...and keep it in sync with this input via two-way binding.
+                    x_model='match',
                 ),
                 crispy.Div(
                     'value',
-                    # This uses alpine to determine whether to
-                    # show the value field, based on the valueMatches
-                    # list defined in the alpine model below:
-                    x_show="valueMatches.includes(match)",
+                    # Only show the "value" field when the current match
+                    # requires a value (defined in valueMatches).
+                    x_show='valueMatches.includes(match)',
                 ),
                 twbscrispy.StrictButton(
-                    _("Add Filter"),
-                    type="submit",
-                    css_class="btn btn-primary",
+                    _('Add Filter'),
+                    type='submit',
+                    css_class='btn btn-primary',
                 ),
-                # The Alpine data model is easily bound to the form
-                # to control hiding/showing the value field:
-                x_data=json.dumps({
-                    "match": self.fields['match'].initial,
-                    "valueMatches": MatchType.MATCHES_WITH_VALUES,
-                }),
+                # Bind the Alpine data model defined above to this wrapper <div>.
+                x_data=json.dumps(alpine_data_model),
             ),
         )
 
     def clean(self):
-        match = self.cleaned_data['match']
-        value = self.cleaned_data['value']
+        cleaned_data = super().clean()
+        match = cleaned_data.get('match')
+        value = cleaned_data.get('value')
         if match in MatchType.MATCHES_WITH_VALUES and not value:
-            self.add_error('value', _("Please specify a value."))
+            self.add_error('value', _('Please specify a value.'))
+        return cleaned_data

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_alpine_form_views.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_alpine_form_views.py
@@ -1,68 +1,60 @@
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.views.generic import TemplateView
 
 from corehq.apps.domain.decorators import login_required
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.styleguide.examples.bootstrap5.htmx_alpine_form_demo import FilterDemoForm
+from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(use_bootstrap5, name='dispatch')
-class HtmxAlpineFormDemoView(BasePageView):
-    """
-    This view is just a basic page view which acts as the "container" for a separate
-    "FilterDemoFormView" that handles the interaction with the "FilterDemoForm".
-
-    This establishes the page as a `js_entry` point for HTMX + Alpine and loads the
-    form view below asynchronously in the page content.
-    """
-    urlname = "sg_htmx_alpine_form_demo"
-    template_name = "styleguide/htmx_alpine_crispy/main.html"
+class HtmxAlpineFormDemoView(HqHtmxActionMixin, BasePageView):
+    urlname = 'sg_htmx_alpine_form_demo'
+    template_name = 'styleguide/htmx_alpine_crispy/main.html'
+    form_template = 'styleguide/htmx_alpine_crispy/partial_form.html'
 
     @property
     def page_url(self):
         return reverse(self.urlname)
 
-    @property
-    def page_context(self):
+    def form_context(self, existing_form=None, show_success=False):
         return {
-            "filter_form_url": reverse(FilterDemoFormView.urlname),
+            'filter_form': existing_form or FilterDemoForm(),
+            'show_success': show_success,
         }
 
+    @hq_hx_action('get')
+    def load_form(self, request, *args, **kwargs):
+        """
+        HTMX action: load and render the initial form.
+        """
+        return self.render_htmx_partial_response(
+            request,
+            self.form_template,
+            self.form_context(),
+        )
 
-# don't forget to add the same security decorators as the "host" view above!
-@method_decorator(login_required, name='dispatch')
-# the use_bootstrap5 decorator is needed here for crispy forms to work properly
-@method_decorator(use_bootstrap5, name='dispatch')
-class FilterDemoFormView(TemplateView):
-    """
-    This view inherits from a simple `TemplateView` because the `template_name` is a
-    partial HTML template, so we don't need to extend any of the base HQ templates.
-    """
-    urlname = "sg_htmx_alpine_filter_form"
-    template_name = "styleguide/htmx_alpine_crispy/partial_form.html"
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        filter_form = kwargs.pop('filter_form') if 'filter_form' in kwargs else None
-        context.update({
-            "filter_form": filter_form or FilterDemoForm(),
-        })
-        return context
-
-    def post(self, request, *args, **kwargs):
+    @hq_hx_action('post')
+    def submit_form(self, request, *args, **kwargs):
+        """
+        HTMX action: handle form submission, validate, and
+        re-render the form partial (with errors or success).
+        """
         filter_form = FilterDemoForm(request.POST)
         show_success = False
         if filter_form.is_valid():
-            # do something with filter form data
+            # Do something with the form data here.
             show_success = True
+            # Reset the form after successful submission.
             filter_form = None
-        return super().get(
+
+        return self.render_htmx_partial_response(
             request,
-            filter_form=filter_form,
-            show_success=show_success,
-            *args,
-            **kwargs
+            self.form_template,
+            self.form_context(
+                existing_form=filter_form,
+                show_success=show_success,
+            ),
         )

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_complex_store.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_complex_store.py
@@ -1,0 +1,18 @@
+from corehq.apps.prototype.models.cache_store import CacheStore
+
+
+class KeyValuePairStore(CacheStore):
+    """
+    CacheStore is a helpful prototyping tool when you need to store
+    data on the server side for styleguide / demo HTMX views.
+
+    Caution: Please don't use this for real features. It isn't battle-tested yet.
+    """
+    slug = 'styleguide-key-value-pairs'
+    initial_value = [
+        {
+            "id": 1,
+            "key": "color",
+            "value": "Purple",
+        },
+    ]

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_debug_mixin_usage.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_debug_mixin_usage.py
@@ -1,0 +1,10 @@
+from corehq.apps.hqwebapp.views import BasePageView
+from corehq.util.htmx_action import HqHtmxActionMixin
+from corehq.util.htmx_debug import HqHtmxDebugMixin
+
+
+class TodoListDemoView(HqHtmxDebugMixin, HqHtmxActionMixin, BasePageView):
+    simulate_slow_response = True
+    slow_response_time = 3
+    simulate_flaky_gateway = False
+    ...  # The rest of the view implementation would go here

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_key_value_view.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_key_value_view.py
@@ -1,0 +1,130 @@
+from django.http import HttpResponse
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+
+from corehq.apps.domain.decorators import login_required
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.hqwebapp.views import BasePageView
+from corehq.apps.styleguide.examples.bootstrap5.htmx_complex_store import KeyValuePairStore
+from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
+
+
+@method_decorator(login_required, name='dispatch')
+@method_decorator(use_bootstrap5, name='dispatch')
+class HtmxKeyValuePairsDemoView(HqHtmxActionMixin, BasePageView):
+    """
+    A simple HTMX demo that manages key/value pairs on the server side
+    using a CacheStore instead of a client-side array.
+    """
+
+    urlname = 'sg_htmx_key_value_demo'
+    template_name = 'styleguide/htmx_key_values/main.html'
+    list_template = 'styleguide/htmx_key_values/partial.html'
+    error_value_template = 'styleguide/htmx_key_values/field_with_error.html'
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname)
+
+    def _store(self):
+        return KeyValuePairStore(self.request)
+
+    def get_pairs(self):
+        return self._store().get()
+
+    def save_pairs(self, pairs):
+        self._store().set(pairs)
+
+    def _next_id(self, pairs):
+        if not pairs:
+            return 1
+        return max(p['id'] for p in pairs) + 1
+
+    def render_pairs(self, request):
+        """
+        Helper to render the partial containing the list. We always target the
+        same container in the template and let HTMX replace it.
+        """
+        return self.render_htmx_partial_response(
+            request,
+            self.list_template,
+            {
+                'pairs': self.get_pairs(),
+            },
+        )
+
+    @hq_hx_action('get')
+    def load_pairs(self, request, *args, **kwargs):
+        """
+        Load the current list of key/value pairs.
+        """
+        return self.render_pairs(request)
+
+    @hq_hx_action('post')
+    def add_pair(self, request, *args, **kwargs):
+        """
+        Add a new, empty key/value row at the end of the list.
+        """
+        pairs = self.get_pairs()
+        pairs.append(
+            {
+                'id': self._next_id(pairs),
+                'key': '',
+                'value': '',
+            }
+        )
+        self.save_pairs(pairs)
+        return self.render_pairs(request)
+
+    @hq_hx_action('post')
+    def update_pair(self, request, *args, **kwargs):
+        """
+        Update a single field ('key' or 'value') for a specific row.
+        """
+        pair_id = int(request.POST['id'])
+        field = request.POST['field']  # "key" or "value"
+        new_value = request.POST.get(field, '')
+
+        pairs = self.get_pairs()
+        pair = next((p for p in pairs if p['id'] == pair_id), None)
+
+        if pair is None or field not in ('key', 'value'):
+            # Example of a generic error (could also raise HtmxResponseException)
+            response = HttpResponse('Invalid pair', status=400)
+            return response
+
+        pairs = self.get_pairs()
+        for pair in pairs:
+            if pair['id'] == pair_id and field in ('key', 'value'):
+                pair[field] = new_value
+                break
+
+        has_error = field == 'value' and not new_value.strip()
+        had_error = field == 'value' and 'error' in request.POST
+        if has_error or had_error:
+            # Render just the field-with-error fragment
+            context = {'pair': pair}
+            if has_error:
+                context['error'] = 'Value cannot be blank.'
+            response = self.render_htmx_partial_response(
+                request,
+                self.error_value_template,
+                context,
+            )
+            # Override hx-swap="none" and target a specific wrapper element
+            response['HX-Reswap'] = 'outerHTML'
+            response['HX-Retarget'] = f'#pair-{pair_id}-value'
+            return response
+
+        self.save_pairs(pairs)
+        return self.render_htmx_no_response(request)
+
+    @hq_hx_action('post')
+    def delete_pair(self, request, *args, **kwargs):
+        """
+        Remove a row entirely.
+        """
+        pair_id = int(request.POST['id'])
+        pairs = [p for p in self.get_pairs() if p['id'] != pair_id]
+        self.save_pairs(pairs)
+        return self.render_pairs(request)

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_next_action_simple_forms.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_next_action_simple_forms.py
@@ -1,0 +1,88 @@
+from crispy_forms import bootstrap as twbscrispy
+from crispy_forms import layout as crispy
+from django import forms
+
+from corehq.apps.hqwebapp import crispy as hqcrispy
+
+
+class ChooseFruitForm(forms.Form):
+    fruit = forms.ChoiceField(
+        label='Favorite fruit',
+        choices=(
+            ('apple', 'Apple'),
+            ('banana', 'Banana'),
+            ('orange', 'Orange'),
+        ),
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = hqcrispy.HQFormHelper()
+        self.helper.form_tag = False
+        self.helper.layout = crispy.Layout(
+            crispy.Field(
+                'fruit',
+            ),
+            hqcrispy.FormActions(
+                twbscrispy.StrictButton(
+                    'Next',
+                    type='submit',
+                    css_class='btn btn-primary',
+                ),
+                css_class='mb-0',
+            ),
+        )
+
+    def clean_fruit(self):
+        fruit = self.cleaned_data.get('fruit')
+        if not fruit:
+            raise forms.ValidationError('Please choose a fruit to continue.')
+        return fruit
+
+
+class ConfirmFruitChoiceForm(forms.Form):
+    fruit = forms.CharField(
+        widget=forms.HiddenInput,
+        required=False,
+    )
+    next_step = forms.ChoiceField(
+        label='What would you like to do?',
+        required=False,
+        widget=forms.RadioSelect,
+        choices=(
+            ('confirm', 'Yes, save this choice.'),
+            ('change', 'No, go back and change it.'),
+        ),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = hqcrispy.HQFormHelper()
+        self.helper.form_tag = False
+        self.helper.layout = crispy.Layout(
+            'fruit',
+            crispy.Field(
+                'next_step',
+            ),
+            hqcrispy.FormActions(
+                twbscrispy.StrictButton(
+                    'Next',
+                    type='submit',
+                    css_class='btn btn-primary',
+                ),
+                css_class='mb-0',
+            ),
+        )
+
+    def clean_fruit(self):
+        fruit = self.cleaned_data.get('fruit')
+        if not fruit:
+            raise forms.ValidationError('Missing fruit choice. Please go back and choose again.')
+        return fruit
+
+    def clean_next_step(self):
+        next_step = self.cleaned_data.get('next_step')
+        if not next_step:
+            raise forms.ValidationError('Please choose an option to continue.')
+        return next_step

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_next_action_simple_view.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_next_action_simple_view.py
@@ -1,0 +1,129 @@
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+
+from corehq.apps.domain.decorators import login_required
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.hqwebapp.views import BasePageView
+from corehq.apps.styleguide.examples.bootstrap5.htmx_next_action_simple_forms import (
+    ChooseFruitForm,
+    ConfirmFruitChoiceForm,
+)
+from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
+
+
+@method_decorator(login_required, name='dispatch')
+@method_decorator(use_bootstrap5, name='dispatch')
+class SimpleNextActionDemoView(HqHtmxActionMixin, BasePageView):
+    """
+    A minimal example of a multi-step flow using the `next_action` pattern.
+
+    Step 1: Choose a fruit.
+    Step 2: Confirm the choice or go back to change it.
+    """
+
+    urlname = 'sg_htmx_next_action_demo'
+    template_name = 'styleguide/htmx_next_action_simple/main.html'
+    form_template = 'styleguide/htmx_next_action_simple/next_step_with_message.html'
+    container_id = 'simple-next-action'
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname)
+
+    @property
+    def page_context(self):
+        # The initial full-page render (non-HTMX) doesn’t need the form;
+        # the container will fetch it via HTMX on load.
+        return {
+            'container_id': self.container_id,
+        }
+
+    def _step_context(self, form=None, next_action=None, message=None):
+        """
+        Shared context for all steps.
+        """
+        return {
+            'form': form or ChooseFruitForm(),
+            'container_id': self.container_id,
+            'next_action': next_action or 'validate_choice',
+            'message': message,
+        }
+
+    @hq_hx_action('get')
+    def load_first_step(self, request, *args, **kwargs):
+        """
+        HTMX action: load the initial "choose fruit" form.
+        """
+        return self.render_htmx_partial_response(
+            request,
+            self.form_template,
+            self._step_context(),
+        )
+
+    @hq_hx_action('post')
+    def validate_choice(self, request, *args, **kwargs):
+        """
+        HTMX action: validate the chosen fruit.
+
+        - If invalid: re-render the same step with errors.
+        - If valid: move to the "confirm or change" step.
+        """
+        form = ChooseFruitForm(request.POST)
+        if not form.is_valid():
+            return self.render_htmx_partial_response(
+                request,
+                self.form_template,
+                self._step_context(form=form, next_action='validate_choice'),
+            )
+
+        fruit = form.cleaned_data['fruit']
+        confirm_form = ConfirmFruitChoiceForm(initial={'fruit': fruit})
+        return self.render_htmx_partial_response(
+            request,
+            self.form_template,
+            self._step_context(
+                form=confirm_form,
+                next_action='confirm_or_change',
+            ),
+        )
+
+    @hq_hx_action('post')
+    def confirm_or_change(self, request, *args, **kwargs):
+        """
+        HTMX action: either finish the flow or go back to step 1.
+        """
+        form = ConfirmFruitChoiceForm(request.POST)
+        if not form.is_valid():
+            # Stay on confirm step and show errors
+            return self.render_htmx_partial_response(
+                request,
+                self.form_template,
+                self._step_context(form=form, next_action='confirm_or_change'),
+            )
+
+        fruit = form.cleaned_data['fruit']
+        next_step = form.cleaned_data['next_step']
+
+        if next_step == 'change':
+            # Go back to step 1, optionally pre-filling the previous choice
+            choose_form = ChooseFruitForm(initial={'fruit': fruit})
+            return self.render_htmx_partial_response(
+                request,
+                self.form_template,
+                self._step_context(
+                    form=choose_form,
+                    next_action='validate_choice',
+                ),
+            )
+
+        # next_step == "confirm": show a simple success message and reset to step 1
+        message = f'Saved your choice: {fruit}'
+        return self.render_htmx_partial_response(
+            request,
+            self.form_template,
+            self._step_context(
+                form=ChooseFruitForm(),
+                next_action='validate_choice',
+                message=message,
+            ),
+        )

--- a/corehq/apps/styleguide/examples/bootstrap5/htmx_todo_list.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/htmx_todo_list.py
@@ -13,10 +13,11 @@ from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 @method_decorator(use_bootstrap5, name='dispatch')
 class TodoListDemoView(HqHtmxActionMixin, BasePageView):
     """
-    This view demonstrates how we use HqHtmxActionMixin with a view to provide
-    HTMX responses when HTMX interacts with this view using the `hq-hx-action` attribute.
+    Demonstrates using HqHtmxActionMixin with a view to provide
+    HTMX responses for multiple actions via the `hq-hx-action` attribute.
     """
-    urlname = "sg_htmx_todo_list_example"
+
+    urlname = 'sg_htmx_todo_list_example'
     template_name = 'styleguide/htmx_todo/main.html'
 
     @property
@@ -25,8 +26,9 @@ class TodoListDemoView(HqHtmxActionMixin, BasePageView):
 
     @property
     def page_context(self):
+        # Initial page context: all items (done + not done)
         return {
-            "items": self.get_items(),
+            'items': self.get_items(),
         }
 
     def get_items(self):
@@ -36,31 +38,39 @@ class TodoListDemoView(HqHtmxActionMixin, BasePageView):
         TodoListStore(self.request).set(items)
 
     def update_item(self, item_id, name=None, is_done=None):
+        """
+        Update a single item by ID, optionally changing its name and/or done flag.
+        Returns the updated item.
+        """
         items = self.get_items()
         for item in items:
-            if item["id"] == item_id:
-                item["name"] = name if name is not None else item["name"]
-                item["is_done"] = is_done if is_done is not None else item["is_done"]
-                TodoListStore(self.request).set(items)
+            if item['id'] == item_id:
+                item['name'] = name if name is not None else item['name']
+                item['is_done'] = is_done if is_done is not None else item['is_done']
+                self.save_items(items)
                 return item
 
     def render_item_response(self, request, item):
-        template = ("styleguide/htmx_todo/item_done_oob_swap.html" if item["is_done"]
-                    else "styleguide/htmx_todo/item.html")
-        context = {
-            'item': item,
-        }
+        """
+        Return the appropriate partial template for a single item,
+        based on whether it's done or not.
+        """
+        template = (
+            'styleguide/htmx_todo/item_done_oob_swap.html' if item['is_done']
+            else 'styleguide/htmx_todo/item.html'
+        )
+        context = {'item': item}
         return self.render_htmx_partial_response(request, template, context)
 
-    # we can now reference `hq-hx-action="create_new_item"`
-    # alongside a `hx-post` to this view URL
+    # We can now reference `hq-hx-action="create_new_item"`
+    # alongside an `hx-post` to this view URL.
     @hq_hx_action('post')
     def create_new_item(self, request, *args, **kwargs):
         items = self.get_items()
         new_item = {
-            "id": len(items) + 1,
-            "name": _("New Item"),
-            "is_done": False,
+            'id': len(items) + 1,
+            'name': _('New Item'),
+            'is_done': False,
         }
         items.insert(0, new_item)
         self.save_items(items)
@@ -90,21 +100,22 @@ class TodoListStore(CacheStore):
 
     Caution: Please don't use this for real features.
     """
+
     slug = 'styleguide-todo-list'
     initial_value = [
         {
-            "id": 1,
-            "name": "get coat hangers",
-            "is_done": False,
+            'id': 1,
+            'name': 'get coat hangers',
+            'is_done': False,
         },
         {
-            "id": 2,
-            "name": "water plants",
-            "is_done": False,
+            'id': 2,
+            'name': 'water plants',
+            'is_done': False,
         },
         {
-            "id": 3,
-            "name": "Review PRs",
-            "is_done": False,
+            'id': 3,
+            'name': 'Review PRs',
+            'is_done': False,
         },
     ]

--- a/corehq/apps/styleguide/examples/bootstrap5/select2_alpine_crispy.py
+++ b/corehq/apps/styleguide/examples/bootstrap5/select2_alpine_crispy.py
@@ -1,0 +1,52 @@
+import json
+
+from crispy_forms import layout as crispy
+from django import forms
+
+from corehq.apps.hqwebapp import crispy as hqcrispy
+
+
+class Select2AlpineForm(forms.Form):
+    my_fav_color = forms.ChoiceField(
+        label='Colors',
+        choices=(
+            ('', 'Any'),
+            ('purple', 'Purple'),
+            ('blue', 'Blue'),
+            ('green', 'Green'),
+            ('red', 'Red'),
+        ),
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = hqcrispy.HQFormHelper()
+        self.helper.form_method = 'POST'
+        self.helper.form_action = '#'
+
+        alpine_data_model = {
+            'color': self.fields['my_fav_color'].initial,
+        }
+
+        # Layout: Alpine is used to toggle visibility of the "value" field
+        # based on the selected match type.
+        self.helper.layout = crispy.Layout(
+            crispy.Div(
+                crispy.Field(
+                    'my_fav_color',
+                    x_select2=json.dumps(
+                        {
+                            'placeholder': 'Select a Color',
+                        }
+                    ),
+                    **(
+                        {
+                            '@select2change': 'color = $event.detail',
+                        }
+                    ),
+                ),
+                # Bind the Alpine data model defined above to this wrapper <div>.
+                x_data=json.dumps(alpine_data_model),
+            ),
+        )

--- a/corehq/apps/styleguide/static/styleguide/js/dates_times.js
+++ b/corehq/apps/styleguide/static/styleguide/js/dates_times.js
@@ -6,3 +6,10 @@ import "styleguide/js/examples/date_range";
 import "styleguide/js/examples/tempus_dominus";
 import "styleguide/js/examples/time_only";
 import "styleguide/js/examples/time_only_24";
+
+import 'hqwebapp/js/htmx_base';
+
+import Alpine from 'alpinejs';
+import 'hqwebapp/js/alpinejs/directives/datepicker';
+
+Alpine.start();

--- a/corehq/apps/styleguide/static/styleguide/js/examples/ko_migration/alpine_complex.js
+++ b/corehq/apps/styleguide/static/styleguide/js/examples/ko_migration/alpine_complex.js
@@ -1,0 +1,17 @@
+import Alpine from 'alpinejs';
+
+Alpine.data('complexExample', (initialValue) => ({
+    keyValuePairs: initialValue.map(item => ({
+        key: item.key,
+        value: item.value,
+    })),
+    addKeyValuePair() {
+        this.keyValuePairs.push({ key: '', value: '' });
+    },
+    removeKeyValuePair(index) {
+        this.keyValuePairs.splice(index, 1);
+    },
+}));
+
+// If this was its own file, we would also start Alpine here:
+// Alpine.start();

--- a/corehq/apps/styleguide/static/styleguide/js/examples/ko_migration/alpine_complex_reusable.js
+++ b/corehq/apps/styleguide/static/styleguide/js/examples/ko_migration/alpine_complex_reusable.js
@@ -1,0 +1,12 @@
+export default (initialValue) => ({
+    keyValuePairs: initialValue.map(item => ({
+        key: item.key,
+        value: item.value,
+    })),
+    addKeyValuePair() {
+        this.keyValuePairs.push({ key: '', value: '' });
+    },
+    removeKeyValuePair(index) {
+        this.keyValuePairs.splice(index, 1);
+    },
+});

--- a/corehq/apps/styleguide/static/styleguide/js/examples/ko_migration/ko_complex.js
+++ b/corehq/apps/styleguide/static/styleguide/js/examples/ko_migration/ko_complex.js
@@ -1,0 +1,26 @@
+import $ from 'jquery';
+import ko from 'knockout';
+import initialPageData from 'hqwebapp/js/initial_page_data';
+
+$(function () {
+    var kvModel = function (key, value) {
+        let self = {};
+        self.key = ko.observable(key);
+        self.value = ko.observable(value);
+        return self;
+    };
+    var complexModel = function (initialData) {
+        let self = {};
+        self.keyValuePairs = ko.observableArray(initialData.map(function(item) {
+            return kvModel(item.key, item.value);
+        }));
+        self.addKeyValuePair = function () {
+            self.keyValuePairs.push(kvModel('', ''));
+        };
+        self.removeKeyValuePair = function (pair) {
+            self.keyValuePairs.remove(pair);
+        };
+        return self;
+    };
+    $("#complex-ko-start-example").koApplyBindings(complexModel(initialPageData.get("complex_initial_value")));
+});

--- a/corehq/apps/styleguide/static/styleguide/js/examples/ko_migration/ko_complex.js
+++ b/corehq/apps/styleguide/static/styleguide/js/examples/ko_migration/ko_complex.js
@@ -11,7 +11,7 @@ $(function () {
     };
     var complexModel = function (initialData) {
         let self = {};
-        self.keyValuePairs = ko.observableArray(initialData.map(function(item) {
+        self.keyValuePairs = ko.observableArray(initialData.map(function (item) {
             return kvModel(item.key, item.value);
         }));
         self.addKeyValuePair = function () {

--- a/corehq/apps/styleguide/static/styleguide/js/examples/ko_migration/ko_simple.js
+++ b/corehq/apps/styleguide/static/styleguide/js/examples/ko_migration/ko_simple.js
@@ -1,0 +1,23 @@
+import $ from 'jquery';
+import ko from 'knockout';
+import initialPageData from 'hqwebapp/js/initial_page_data';
+
+$(function () {
+    var simpleModel = function () {
+        let self = {};
+        self.name = ko.observable(initialPageData.get("ko_simple_name"));
+        self.count = ko.observable(0);
+        self.isVisible = ko.observable(false);
+        self.greeting = ko.computed(function () {
+            return 'Hello, ' + self.name() + '!';
+        });
+        self.incrementCount = function () {
+            self.count(self.count() + 1);
+        };
+        self.toggleVisibility = function () {
+            self.isVisible(!self.isVisible());
+        };
+        return self;
+    };
+    $("#simple-ko-start-example").koApplyBindings(simpleModel());
+});

--- a/corehq/apps/styleguide/static/styleguide/js/examples/ko_migration/use_alpine_complex_reusable.js
+++ b/corehq/apps/styleguide/static/styleguide/js/examples/ko_migration/use_alpine_complex_reusable.js
@@ -1,0 +1,10 @@
+import Alpine from 'alpinejs';
+
+import complexModel from "styleguide/js/examples/ko_migration/alpine_complex_reusable";
+Alpine.data('complexExample', complexModel);
+
+// Alternatively, you can load initial data from initialPageData here
+import initialPageData from 'hqwebapp/js/initial_page_data';
+Alpine.data('complexExample', () => complexModel(initialPageData.get("complex_initial_value")));
+
+Alpine.start();

--- a/corehq/apps/styleguide/static/styleguide/js/ko_migration.js
+++ b/corehq/apps/styleguide/static/styleguide/js/ko_migration.js
@@ -1,0 +1,12 @@
+import 'commcarehq';
+import 'styleguide/js/main';
+
+import "styleguide/js/examples/ko_migration/ko_simple";
+import "styleguide/js/examples/ko_migration/ko_complex";
+
+import 'hqwebapp/js/htmx_base';
+
+import "styleguide/js/examples/ko_migration/alpine_complex";
+
+import Alpine from 'alpinejs';
+Alpine.start();

--- a/corehq/apps/styleguide/static/styleguide/js/selections.js
+++ b/corehq/apps/styleguide/static/styleguide/js/selections.js
@@ -16,3 +16,10 @@ import "styleguide/js/examples/select2_manual";
 import "styleguide/js/examples/select2_manual_allow_clear";
 import "styleguide/js/examples/select2_manual_crispy";
 import "styleguide/js/examples/select2_static_ko_crispy";
+
+import 'hqwebapp/js/htmx_base';
+
+import Alpine from 'alpinejs';
+import 'hqwebapp/js/alpinejs/directives/select2';
+
+Alpine.start();

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/base.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/base.html
@@ -94,6 +94,15 @@
             <a href="https://getbootstrap.com/docs/5.3/getting-started/">Bootstrap 5 Docs</a>
           </li>
           <li>
+            <a href="https://alpinejs.dev/start-here">Alpine.js Docs</a>
+          </li>
+          <li>
+            <a href="https://htmx.org/docs/">HTMX Docs</a>
+          </li>
+          <li>
+            <a href="https://htmx.org/reference/">HTMX Reference</a>
+          </li>
+          <li>
             <a href="https://knockoutjs.com/documentation/introduction.html">Knockout.js Docs</a>
           </li>
           <li>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/datepicker_alpine_datetime.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/datepicker_alpine_datetime.html
@@ -1,0 +1,28 @@
+<div
+  class="card mb-3"
+  x-data="{
+    selectedDateTime: '',
+  }"
+>
+  <div class="card-body">
+    <label
+      for="alpine-datepicker-datetime"
+      class="form-label"
+    >
+      Date &amp; time picker (24-hour, yyyy-MM-dd H:mm:ss)
+    </label>
+    <input
+      id="alpine-datepicker-datetime"
+      type="text"
+      class="form-control w-auto"
+      x-model="selectedDateTime"
+      x-datepicker='{"datetime": true}'
+      placeholder="YYYY-MM-DD HH:MM:SS"
+      autocomplete="off"
+    />
+    <p class="mt-2 mb-0 small text-muted">
+      <strong>Selected date &amp; time:</strong>
+      <span x-text="selectedDateTime || '—'"></span>
+    </p>
+  </div>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/datepicker_alpine_simple.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/datepicker_alpine_simple.html
@@ -1,0 +1,28 @@
+<div
+  class="card mb-3"
+  x-data="{
+    selectedDate: '',
+  }"
+>
+  <div class="card-body">
+    <label
+      for="alpine-datepicker-simple"
+      class="form-label"
+    >
+      Simple date picker (YYYY-MM-DD)
+    </label>
+    <input
+      id="alpine-datepicker-simple"
+      type="text"
+      class="form-control w-auto"
+      x-model="selectedDate"
+      x-datepicker=""
+      placeholder="YYYY-MM-DD"
+      autocomplete="off"
+    />
+    <p class="mt-2 mb-0 small text-muted">
+      <strong>Selected date:</strong>
+      <span x-text="selectedDate || '—'"></span>
+    </p>
+  </div>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/alpine_complex.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/alpine_complex.html
@@ -1,0 +1,43 @@
+
+<!--
+  We can't use template tags in this file, but we would define
+  x-data in the <div> below as follows:
+  <div
+    x-data="complexExample({{ complex_initial_value|JSON }})"
+  >
+-->
+<div x-data="complexExample([{&quot;key&quot;: &quot;color&quot;, &quot;value&quot;: &quot;Purple&quot;}])">
+  <template x-for="(pair, index) in keyValuePairs">
+    <div class="d-flex">
+      <div class="flex-fill">
+        <input
+          type="text"
+          class="form-control"
+          x-model="pair.key"
+        />
+      </div>
+      <p class="py-1 px-3">&rarr;</p>
+      <div class="flex-fill">
+        <input
+          type="text"
+          class="form-control"
+          x-model="pair.value"
+        />
+      </div>
+      <p class="ps-3">
+        <button
+          type="button"
+          class="btn btn-outline-danger"
+          @click="removeKeyValuePair(index)"
+        ><i class="fa fa-remove"></i></button>
+      </p>
+    </div>
+  </template>
+  <p>
+    <button
+      type="button"
+      class="btn btn-primary"
+      @click="addKeyValuePair"
+    ><i class="fa fa-plus"></i> Add</button>
+  </p>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/alpine_simple.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/alpine_simple.html
@@ -1,0 +1,40 @@
+<div
+  x-data="{
+    name: 'Fred',
+    count: 0,
+    isVisible: false,
+    get greeting() {
+      return `Hello, ${this.name}!`;
+    },
+  }"
+>
+  <p>
+    Name:
+    <input
+      type="text"
+      class="form-control"
+      x-model="name"
+    />
+  </p>
+  <p x-text="greeting"></p>
+  <p>
+    <button
+      type="button"
+      class="btn btn-outline-primary"
+      @click="count++"
+    >Increment</button>
+  </p>
+  <p>
+    Count: <span class="badge bg-secondary" x-text="count"></span>
+  </p>
+  <p>
+    <button
+      type="button"
+      class="btn btn-outline-primary"
+      @click="isVisible = !isVisible"
+    >Toggle Message</button>
+  </p>
+  <div x-show="isVisible" x-cloak="">
+    Hello there!
+  </div>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/ko_complex.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/ko_complex.html
@@ -1,0 +1,40 @@
+<!--
+ We can't use template tags in this file, but we would include
+ the following tag on the same page for initial data:
+ {% initial_page_data "ko_complex_initial_value" complex_initial_value|JSON %}
+-->
+<div id="complex-ko-start-example" class="ko-template">
+  <!-- ko foreach: keyValuePairs -->
+    <div class="d-flex">
+      <div class="flex-fill">
+        <input
+          type="text"
+          class="form-control"
+          data-bind="textInput: key"
+        />
+      </div>
+      <p class="py-1 px-3">&rarr;</p>
+      <div class="flex-fill">
+        <input
+          type="text"
+          class="form-control"
+          data-bind="textInput: value"
+        />
+      </div>
+      <p class="ps-3">
+        <button
+          type="button"
+          class="btn btn-outline-danger"
+          data-bind="click: $root.removeKeyValuePair"
+        ><i class="fa fa-remove"></i></button>
+      </p>
+    </div>
+  <!-- /ko -->
+  <p>
+    <button
+      type="button"
+      class="btn btn-primary"
+      data-bind="click: addKeyValuePair"
+    ><i class="fa fa-plus"></i> Add</button>
+  </p>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/ko_simple.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/ko_simple.html
@@ -1,0 +1,31 @@
+<div id="simple-ko-start-example" class="ko-template">
+  <p>
+    Name:
+    <input
+      type="text"
+      class="form-control"
+      data-bind="textInput: name"
+    />
+  </p>
+  <p data-bind="text: greeting"></p>
+  <p>
+    <button
+      type="button"
+      class="btn btn-outline-primary"
+      data-bind="click: incrementCount"
+    >Increment</button>
+  </p>
+  <p>
+    Count: <span class="badge bg-secondary" data-bind="text: count"></span>
+  </p>
+  <p>
+    <button
+      type="button"
+      class="btn btn-outline-primary"
+      data-bind="click: toggleVisibility"
+    >Toggle Message</button>
+  </p>
+  <div data-bind="visible: isVisible">
+    Hello there!
+  </div>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/prompt_htmx_alpine.md
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/prompt_htmx_alpine.md
@@ -1,0 +1,43 @@
+Task:
+
+Help me migrate this Knockout-driven UI to a server-driven pattern using HTMX,
+with Alpine.js used only for small UI state (like inline-edit toggles).
+
+Project context:
+
+- Django + Bootstrap 5 app.
+- HTMX is available and we prefer HTML responses over JSON.
+- In this codebase we use a helper mixin, `HqHtmxActionMixin`, which:
+  - Is mixed into Django class-based views.
+  - Routes HTMX requests based on a custom header (e.g. `HQ-HX-Action`) to methods
+    decorated with `@hq_hx_action("get" | "post")`.
+  - In templates, we add `hq-hx-action="method_name"` to elements, alongside
+    `hx-get`/`hx-post` pointing at the view URL.
+
+Goals:
+
+- Move long-lived or business-critical state and validation into Django, using HTMX.
+- Use Alpine only for local UI state (e.g. `isEditing`, `isSubmitting`, toggles, etc.).
+- Replace Knockout bindings with:
+  - HTMX calls to server-side actions for data changes.
+  - Alpine for small interactive pieces that don't need server involvement.
+
+Constraints:
+
+- Keep user-visible behavior the same (no UX redesign).
+- Suggest a small set of HTMX actions (e.g. `load_items`, `add_item`, `update_item`, `delete_item`).
+- Use common HTMX attributes: `hx-get`, `hx-post`, `hx-target`, `hx-swap`, `hx-trigger`,
+  and `hx-disabled-elt`.
+- When inputs don't need new HTML on every change, consider using `hx-swap="none"` and a
+  “no content” response pattern.
+
+Output:
+
+1. A sketch of a Django view class using `HqHtmxActionMixin` with a few `@hq_hx_action` methods.
+2. A main template snippet showing a container that loads a partial with HTMX.
+3. A partial template snippet wiring forms/inputs/buttons to those HTMX actions.
+4. Any small Alpine snippets needed for purely UI concerns.
+
+Existing Knockout template + JS to migrate:
+
+<paste KO code here>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/prompt_modules.md
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/prompt_modules.md
@@ -1,0 +1,39 @@
+Task:
+
+Convert this Knockout view model into a reusable Alpine.js component defined in a separate JS module.
+
+Project context (so you don't have to guess):
+
+- Django + Bootstrap 5 app.
+- Alpine.js is our main front-end library for local UI state.
+- Initial values can be passed from the server via a global `initialPageData` helper or
+  similar mechanism.
+
+Constraints:
+
+- Preserve the behavior of the existing Knockout model (same fields, defaults, and events).
+- Define the Alpine model as a function that returns a data object, e.g.:
+
+  export default (initialValue) => ({
+      // properties and methods here
+  });
+
+- Show how to register it in a JS entry file with:
+
+  import Alpine from "alpinejs";
+  import myModel from "path/to/module";
+
+  Alpine.data("myModelName", () => myModel(initialValue));
+  Alpine.start();
+
+- Do NOT change backend logic or Django context variables.
+
+Output:
+
+1. A JS module exporting the Alpine model (`export default (initial) => ({ ... })`).
+2. A JS entry file snippet that imports it, registers `Alpine.data`, and calls `Alpine.start()`.
+3. If needed, an example HTML snippet showing `x-data="myModelName(...)"`.
+
+Existing Knockout code to migrate:
+
+<paste KO model + relevant HTML here, or reference files>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/prompt_one_liner.md
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/prompt_one_liner.md
@@ -1,0 +1,10 @@
+You have never seen this project before. It is a Django + Bootstrap 5 app
+that is migrating from Knockout.js to Alpine.js and HTMX.
+
+- Alpine is for light, local UI state.
+- HTMX is for server-driven interactions with HTML partials returned by Django.
+- We have a helper mixin called `HqHtmxActionMixin` that routes HTMX requests to
+  methods decorated with `@hq_hx_action`, called from templates via `hq-hx-action="..."`.
+
+Please keep behavior identical, avoid redesigning the UI, and prefer small,
+reviewable changes that follow these patterns.

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/prompt_review.md
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/prompt_review.md
@@ -1,0 +1,22 @@
+Task:
+
+Review this Knockout → Alpine (+HTMX) migration for correctness and small improvements.
+
+Context:
+
+- The old code used Knockout; the new code uses Alpine and/or HTMX.
+- The goal is to keep behavior identical while removing Knockout.
+- This is in the CommCare HQ codebase (Django, Bootstrap 5, Alpine, HTMX, `HqHtmxActionMixin`).
+
+Please:
+
+- Compare the Knockout version and the migrated version.
+- Point out any behavior that might have changed (validation, defaults, events, edge cases).
+- Check for:
+  - Lost accessibility attributes (`aria-*`, `role`, labels).
+  - Changes to required fields or default values.
+  - Event handlers that no longer fire (e.g. `change` vs `input`).
+  - Potential issues with focus/keyboard navigation (especially with HTMX swaps).
+- Suggest small, concrete fixes while keeping the diff as small as possible.
+
+Code to review (old Knockout first, then new Alpine/HTMX):

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/prompt_simple.md
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/prompt_simple.md
@@ -1,0 +1,29 @@
+Task:
+
+Translate this Knockout-based widget into Alpine.js, using inline Alpine in the template.
+
+Assume the following about the project:
+
+- It's a Django + Bootstrap 5 app.
+- Alpine.js is already loaded globally on the page.
+- We are slowly migrating away from Knockout.js, but we don't want to change server-side code.
+
+Constraints:
+
+- Keep the HTML structure, CSS classes, and behavior the same for the user.
+- Replace Knockout `data-bind` attributes with Alpine attributes like `x-model`, `x-text`,
+  `x-show`, `x-for`, and small methods declared in `x-data`.
+- Do NOT create a separate JavaScript file for this example; keep Alpine inline, e.g.:
+
+  <div x-data="{ ... }">...</div>
+
+- Do NOT change Django template tags or server-side logic.
+
+Output:
+
+1. The updated HTML snippet using Alpine.
+2. A brief explanation (1-3 bullet points) of what you changed and why.
+
+Code to migrate (Knockout template + JS):
+
+<paste Knockout code here>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/prompt_start.md
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/ko_migration/prompt_start.md
@@ -1,0 +1,35 @@
+Context about this project and what I'm doing:
+
+- This code is from a large Django + Bootstrap 5 web app.
+- Historically it used Knockout.js for client-side view models.
+- We are now migrating to:
+  - Alpine.js for lightweight interactivity and small, local UI state, and
+  - HTMX for server-coordinated interactions, where Django renders HTML partials.
+
+High-level goals:
+
+- Reduce JavaScript complexity and avoid duplicating server-side logic in the browser.
+- Rely on Django templates for most HTML and layout.
+- Use Alpine for light, local interactivity and UI-only state.
+- Use HTMX for forms, tables, filtering, pagination, and other server-backed actions.
+
+Codebase-specific detail:
+
+- We have a helper mixin called `HqHtmxActionMixin` in our codebase.
+- It's a Django class-based-view mixin that:
+  - Reads a custom request header like `HQ-HX-Action`.
+  - Routes the request to a method on the view whose name matches that action.
+  - Those methods are decorated with `@hq_hx_action("get" | "post" | "any_method")`.
+  - In templates, we call them via `hq-hx-action="method_name"` together with `hx-get`/`hx-post`.
+- You don't need to change the internals of `HqHtmxActionMixin`; just use it in examples.
+
+<note: if you can, include the htmx_action.py file for reference>
+
+Important constraints:
+
+- Preserve existing behavior and user-facing semantics.
+- Don't redesign the UI, just translate bindings / models.
+- Keep diffs small and reviewable.
+- Keep Django template logic and context variables intact where possible.
+
+I'll paste Knockout JS and related templates next. Please work within this context.

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/select2_alpine_basic.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/select2_alpine_basic.html
@@ -1,0 +1,18 @@
+<div x-data="{ color: null }">
+  <label for="color-select" class="form-label">Favorite color</label>
+  <select
+    id="color-select"
+    name="color"
+    x-select2
+  >
+    <option value=""></option>
+    <option value="purple">Purple</option>
+    <option value="red">Red</option>
+    <option value="green">Green</option>
+    <option value="blue">Blue</option>
+  </select>
+
+  <p class="mt-2 text-muted">
+    Selected: <span x-text="color || 'none'"></span>
+  </p>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/select2_alpine_select2change.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/select2_alpine_select2change.html
@@ -1,0 +1,20 @@
+<div x-data="{ color: null }">
+  <label for="color-select" class="form-label">Favorite color</label>
+  <select
+    name="color"
+    x-select2='{
+      "placeholder": "Select a color"
+    }'
+    @select2change="color = $event.detail"
+  >
+    <option value=""></option>
+    <option value="purple">Purple</option>
+    <option value="red">Red</option>
+    <option value="green">Green</option>
+    <option value="blue">Blue</option>
+  </select>
+
+  <p class="mt-2 text-muted">
+    Selected: <span x-text="color || 'none'"></span>
+  </p>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/select2_alpine_with_options.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/examples/select2_alpine_with_options.html
@@ -1,0 +1,21 @@
+<div x-data="{ color: null }">
+  <label for="color-select" class="form-label">Favorite color</label>
+  <select
+    name="color"
+    {# important: use proper JSON format (no trailing comma) #}
+    x-select2='{
+      "placeholder": "Select a color",
+      "allowClear": true
+    }'
+  >
+    <option value=""></option>
+    <option value="purple">Purple</option>
+    <option value="red">Red</option>
+    <option value="green">Green</option>
+    <option value="blue">Blue</option>
+  </select>
+
+  <p class="mt-2 text-muted">
+    Selected: <span x-text="color || 'none'"></span>
+  </p>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
@@ -666,7 +666,7 @@
       </a>
     </li>
     <li>
-      <a href="{% url "styleguide_b5_htmx_pagination_view" %}">
+      <a href="{% url "styleguide_b5_htmx_pagination_view" %}" target="_blank">
         Simple Pagination: HTMX + Django Tables2 (demo)
       </a>
     </li>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
@@ -382,7 +382,7 @@
       target="_blank"
     ><code>corehq.apps.data_cleaning</code></a>. The
     <a
-      href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/main.py#L60"
+      href="https://github.com/dimagi/commcare-hq/blob/5c8ae80653ab957525e91db0c9f48a7cfad9fd6d/corehq/apps/data_cleaning/views/main.py#L60"
       target="_blank"
     ><code>BulkEditCasesSessionView</code></a> acts as the host view for the page, and several
     section views handle individual areas of the UI.
@@ -391,7 +391,7 @@
   <p>
     In
     <a
-      href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/main.py#L104-L130"
+      href="https://github.com/dimagi/commcare-hq/blob/5c8ae80653ab957525e91db0c9f48a7cfad9fd6d/corehq/apps/data_cleaning/views/main.py#L104-L130"
       target="_blank"
     ><code>BulkEditCasesSessionView.page_context</code></a>, the host view exposes the URLs
     of its section views.
@@ -403,7 +403,7 @@
   <ul>
     <li>
       <a
-        href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/tables.py#L40"
+        href="https://github.com/dimagi/commcare-hq/blob/5c8ae80653ab957525e91db0c9f48a7cfad9fd6d/corehq/apps/data_cleaning/views/tables.py#L40"
         target="_blank"
       >
         <code>EditCasesTableView</code>
@@ -411,7 +411,7 @@
     </li>
     <li>
       <a
-        href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/filters.py#L27"
+        href="https://github.com/dimagi/commcare-hq/blob/5c8ae80653ab957525e91db0c9f48a7cfad9fd6d/corehq/apps/data_cleaning/views/filters.py#L27"
         target="_blank"
       >
         <code>ManagePinnedFiltersView</code>
@@ -419,7 +419,7 @@
     </li>
     <li>
       <a
-        href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/filters.py#L74"
+        href="https://github.com/dimagi/commcare-hq/blob/5c8ae80653ab957525e91db0c9f48a7cfad9fd6d/corehq/apps/data_cleaning/views/filters.py#L74"
         target="_blank"
       >
         <code>ManageFiltersView</code>
@@ -427,7 +427,7 @@
     </li>
     <li>
       <a
-        href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/columns.py#L23"
+        href="https://github.com/dimagi/commcare-hq/blob/5c8ae80653ab957525e91db0c9f48a7cfad9fd6d/corehq/apps/data_cleaning/views/columns.py#L23"
         target="_blank"
       >
         <code>ManageColumnsFormView</code>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
@@ -54,6 +54,7 @@
           <li><a href="#form-loading">Forms</a></li>
         </ul>
       </li>
+      <li><a href="#htmx-django-tables">Table Pagination with HTMX and Django Tables</a></li>
     </ul>
   </nav>
 {% endblock toc %}
@@ -642,4 +643,33 @@
   </p>
   {% include "styleguide/bootstrap5/code_display.html" with content=examples.loading_form %}
 
+  <h3 id="htmx-django-tables" class="pt-4">
+    Table Pagination with HTMX and Django Tables
+  </h3>
+  <p>
+    For paginated tables, HTMX pairs nicely with
+    <a href="https://django-tables2.readthedocs.io/en/latest/" target="_blank">django-tables2</a>:
+    Django renders each page of results as a partial, and HTMX swaps that partial into the page
+    as the user clicks through pages or changes page size.
+  </p>
+  <p>
+    We have a separate styleguide example that walks through this pattern end-to-end
+    (table definition, paginated view, and “host” HTMX view), plus a live demo:
+  </p>
+  <ul>
+    <li>
+      <a href="{% url "styleguide_molecules_pagination_b5" %}#using-pagination-htmx">
+        Pagination with HTMX and Django Tables (documentation)
+      </a>
+    </li>
+    <li>
+      <a href="{% url "styleguide_b5_htmx_pagination_view" %}">
+        Simple Pagination: HTMX + Django Tables2 (demo)
+      </a>
+    </li>
+  </ul>
+  <p>
+    If you're building or migrating any paginated tables, start there for concrete patterns you
+    can copy into your own views.
+  </p>
 {% endblock content %}

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
@@ -136,7 +136,7 @@
   </p>
   <p>
     The
-    <a href="{% url "styleguide_htmx_and_alpine_b5" %}#using-hqhtmxactionmixin" target="_blank">
+    <a href="https://github.com/dimagi/commcare-hq/blob/5c8ae80653ab957525e91db0c9f48a7cfad9fd6d/corehq/util/htmx_action.py" target="_blank">
       <code>HqHtmxActionMixin</code>
     </a>
     lets you treat a single view as a collection of named HTMX actions. Each action is a

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
@@ -216,21 +216,6 @@
   <h3 id="simple-form-example" class="pt-3">
     A Simple Form with HTMX and Alpine
   </h3>
-  <p>
-    <a href="{% url "sg_htmx_alpine_form_demo" %}" target="_blank">In this example</a>,
-    <strong>HTMX</strong> is used to asynchronously load a form and submit it back to the
-    same view. The form is posted to an <code>hq_hx_action</code> handler on that view,
-    which validates the data and either:
-  </p>
-  <ul>
-    <li>returns the form again with validation errors, or</li>
-    <li>shows a success message and resets the form.</li>
-  </ul>
-  <p>
-    <strong>Alpine</strong> provides a small layer of interactivity on top: it hides the
-    “Value” field when the “Match Type” is set to “is empty”. The Alpine model is defined
-    in the form layout itself, since that logic is specific to this form.
-  </p>
   <div class="alert alert-primary">
     <p class="mb-1">
       <strong>Tips:</strong>
@@ -252,6 +237,21 @@
       </li>
     </ul>
   </div>
+  <p>
+    <a href="{% url "sg_htmx_alpine_form_demo" %}" target="_blank">In this example</a>,
+    <strong>HTMX</strong> is used to asynchronously load a form and submit it back to the
+    same view. The form is posted to an <code>hq_hx_action</code> handler on that view,
+    which validates the data and either:
+  </p>
+  <ul>
+    <li>returns the form again with validation errors, or</li>
+    <li>shows a success message and resets the form.</li>
+  </ul>
+  <p>
+    <strong>Alpine</strong> provides a small layer of interactivity on top: it hides the
+    “Value” field when the “Match Type” is set to “is empty”. The Alpine model is defined
+    in the form layout itself, since that logic is specific to this form.
+  </p>
   <p>
     The <code>HtmxAlpineFormDemoView</code> uses <code>HqHtmxActionMixin</code> so that it
     can define two HTMX actions on the same URL using <code>hq-hx-action</code>:

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
@@ -216,6 +216,7 @@
   <h3 id="simple-form-example" class="pt-3">
     A Simple Form with HTMX and Alpine
   </h3>
+  {% include "styleguide/bootstrap5/partials/demo_callout.html" with urlname="sg_htmx_alpine_form_demo" %}
   <div class="alert alert-primary">
     <p class="mb-1">
       <strong>Tips:</strong>
@@ -305,6 +306,7 @@
   <h3 id="example-todo" class="pt-3">
     A Single View with Multiple HTMX Actions (To-Do List)
   </h3>
+  {% include "styleguide/bootstrap5/partials/demo_callout.html" with urlname="sg_htmx_todo_list_example" %}
   <p>
     The form demo showed a view with two HTMX actions (<code>load_form</code>,
     <code>submit_form</code>) on the same URL. The To-Do List demo takes the same idea
@@ -492,6 +494,7 @@
   <h3 id="multistep-next-action-example" class="mt-3">
     Example: Simple Two-Step “Choose &amp; Confirm” Flow
   </h3>
+  {% include "styleguide/bootstrap5/partials/demo_callout.html" with urlname="sg_htmx_next_action_demo" %}
   <p>
     <a
       href="{% url "sg_htmx_next_action_demo" %}"

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/htmx_and_alpine.html
@@ -1,4 +1,4 @@
-{% extends 'styleguide/bootstrap5/base.html' %}
+{% extends "styleguide/bootstrap5/base.html" %}
 {% load hq_shared_tags %}
 
 {% block intro %}
@@ -16,28 +16,42 @@
       <li>
         <a href="#overview">Overview</a>
         <ul>
-          <a href="#getting-started">Getting Started</a></li>
+          <li><a href="#getting-started">Getting Started</a></li>
+          <li><a href="#north-star-goals">North Star Goals</a></li>
         </ul>
       </li>
       <li>
-        <a href="#usage-forms">Usage with Forms</a>
+        <a href="#mixin"><code>HqHtmxActionMixin</code> to Simplify Usage</a>
         <ul>
-          <a href="#usage-forms-demo">Demo with Crispy Forms</a></li>
+          <li><a href="#mixin-how-it-works">How it works (high level)</a></li>
+        </ul>
+      </li>
+      <li>
+        <a href="#examples">Examples</a>
+        <ul>
+          <li><a href="#simple-form-example">Simple Form with HTMX and Alpine</a></li>
+          <li><a href="#example-todo">To-Do List (multiple HTMX actions)</a></li>
         </ul>
       </li>
       <li>
         <a href="#organization">Organization for Complex Pages</a>
         <ul>
-          <a href="#using-hqhtmxactionmixin">Using <code>HqHtmxActionMixin</code></a></li>
+          <li><a href="#bulk-edit-cases">Bulk Edit Cases (Host View + Section Views)</a></li>
+        </ul>
+      </li>
+      <li>
+        <a href="#multistep-next-action">Multi-Step Flows with <code>next_action</code></a>
+        <ul>
+          <li><a href="#multistep-next-action-example">Simple Two-Step “Choose &amp; Confirm” Flow</a></li>
         </ul>
       </li>
       <li><a href="#debugging">Debugging During Development</a></li>
       <li>
         <a href="#loading-indicators">Loading Indicators</a>
         <ul>
-          <a href="#button-loading">Buttons</a></li>
-          <a href="#checkbox-loading">Checkboxes</a></li>
-          <a href="#form-loading">Forms</a></li>
+          <li><a href="#button-loading">Buttons</a></li>
+          <li><a href="#checkbox-loading">Checkboxes</a></li>
+          <li><a href="#form-loading">Forms</a></li>
         </ul>
       </li>
     </ul>
@@ -49,240 +63,583 @@
     Overview
   </h2>
   <p>
-    <a href="https://htmx.org/" target="_blank">HTMX</a> and <a href="https://alpinejs.dev/" target="_blank">Alpine</a>
-    are two lightweight JavaScript libraries that work well together to add interactivity to a page without
-    needing to add a ton of custom javascript. They work through clever usage of HTML attributes.
+    <a href="https://htmx.org/" target="_blank">HTMX</a> and
+    <a href="https://alpinejs.dev/" target="_blank">Alpine</a>
+    are two lightweight JavaScript libraries that work well together to add interactivity
+    to a page without a lot of custom JavaScript. Both are driven primarily by HTML
+    attributes, which keeps most behavior close to the markup it affects.
   </p>
   <p>
-    HTMX is particularly suited for a Django environment like ours as it expects asynchronous responses to
-    be HTML (instead of JSON), meaning we can return partial templates as responses. This allows us to utilize
-    more of Django's backend power, rather than having to re-create a ton of logic in the front end.
+    HTMX is particularly well-suited to a Django environment like ours because it expects
+    asynchronous responses to be HTML (instead of JSON). That means our views can return
+    partial templates as responses, and HTMX will swap them into the page. We can lean on
+    Django for rendering and business logic, instead of re-implementing that logic in the
+    browser.
   </p>
+
   <h3 id="getting-started" class="pt-3">
     Getting Started
   </h3>
   <p>
-    If you want to quickly get started, you can use this <code>js_entry</code> point
-    <code>hqwebapp/js/htmx_and_alpine</code> (no additional configuration necessary) and
-    include <code>hqwebapp/htmx/error_modal.html</code> in the <code>modals</code> block of your page.
+    To quickly get started on a new page, you can:
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_get_started %}
+  <ul>
+    <li>
+      Use the <code>js_entry</code> point
+      <code>hqwebapp/js/htmx_and_alpine</code> (no additional configuration required), and
+    </li>
+    <li>
+      Include <code>hqwebapp/htmx/error_modal.html</code> in the
+      <code>modals</code> block of your page.
+    </li>
+  </ul>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_get_started %}
   <p>
-    Right now HTMX and Alpine are only available on pages using Webpack. If you don't know what this means,
-    please read the
-    <a href="https://commcare-hq.readthedocs.io/js-guide/static-files.html" target="_blank">Overview of Static Files
-    and JavaScript Bundlers</a>. If you don't know how to proceed after that, read further.
+    HTMX and Alpine are currently only available on pages using Bootstrap 5. This is
+    intentional: we want to encourage pages to migrate to Bootstrap 5 first, and then
+    add HTMX and Alpine on top.
   </p>
   <div class="alert alert-primary">
-    <strong>Important:</strong> HTMX and Alpine can only be included on pages using Webpack.
+   <h3 id="north-star-goals" class="pt-3">
+      North Star Goals
+    </h3>
+    <p>
+      These are our long-term <em>default</em> patterns when building or updating pages with
+      HTMX and Alpine. They are guidelines, not strict rules, especially when working in
+      legacy areas of the codebase:
+    </p>
+    <ul>
+      <li>Reduce JS complexity and avoid duplicating server-side logic in the browser</li>
+      <li>
+        Rely on Django templates for most HTML and layout
+      </li>
+      <li>
+        Take advantage of Django’s templating features&mdash;template inheritance, inclusion
+        tags, filters, and control flow&mdash;instead of re-creating loops and conditionals
+        in JavaScript.
+      </li>
+      <li>Use Alpine for light, local interactivity and UI-only state</li>
+      <li>Use HTMX for server-coordinated interactions (forms, tables, filtering, pagination)</li>
+    </ul>
   </div>
 
-  <h2 id="usage-forms" class="pt-4">
-    Usage with Forms
+  <h2 id="mixin" class="pt-4">
+    <code>HqHtmxActionMixin</code> to Simplify Usage
   </h2>
   <p>
-    HTMX and Alpine are well suited for sprinkling bits of interactivity into an otherwise very static form.
-    For instance, we want to hide or show a field depending on the value of a select input.
+    In practice, many HTMX pages need to send several different actions to the
+    same URL to modify state and/or return an updated partial. Without any structure,
+    each view ends up manually inspecting request headers and branching on different
+    actions, or we create many small views with separate URLs that are hard to keep
+    track of over time.
   </p>
   <p>
-    The in-page interactivity is handled by Alpine. HTMX is useful because it allows us to submit (and load)
-    the form asynchronously.
+    The
+    <a href="{% url "styleguide_htmx_and_alpine_b5" %}#using-hqhtmxactionmixin" target="_blank">
+      <code>HqHtmxActionMixin</code>
+    </a>
+    lets you treat a single view as a collection of named HTMX actions. Each action is a
+    small method on the view, instead of a separate endpoint or a big
+    <code>if...elif</code> block. Mentally, you can think of each
+    <code>@hq_hx_action</code> method as a “mini endpoint” hanging off the view, all
+    sharing the same URL and page context. It lets you:
   </p>
-  <h3 id="usage-forms-demo" class="pt-3">
-    Demo with Crispy Forms
+  <ul>
+    <li>Declare small handler methods (like <code>load_form</code>, <code>submit_form</code>, or <code>mark_item_done</code>)</li>
+    <li>Call them from HTML using <code>hq-hx-action="load_form"</code> and similar attributes</li>
+    <li>Enforce HTTP method checks and basic security via the <code>@hq_hx_action</code> decorator (e.g. <code>POST</code> only requests)</li>
+    <li>Use helper methods for partial responses, no-op responses, and redirects (and more).</li>
+  </ul>
+
+  <h3 id="mixin-how-it-works" class="mt-3">
+    How it works (high level)
   </h3>
   <p>
-    <a href="{% url "sg_htmx_alpine_form_demo" %}" target="_blank">Take a look at this simple demo</a> of how
-    we might use HTMX and Alpine with Crispy Forms. Tip: Make sure you are logged in.
+    When an HTMX request includes an <code>hq-hx-action</code> attribute on the triggering
+    element, HQ's
+    <a
+      href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/htmx_utils/hq_hx_action.js"
+      target="_blank"
+    >frontend code</a> also sends a <code>HQ-HX-Action</code> header with the same
+    value. <code>HqHtmxActionMixin</code> reads that header and routes the request to a
+    matching method on the view:
+  </p>
+  <ol>
+    <li>
+      Include <code>HqHtmxActionMixin</code> as a base class in your <code>TemplateView</code>
+    </li>
+    <li>
+      Where you use <code>hx-get</code> or <code>hx-post</code> in your code, include the
+      <code>hq-hx-action="some_action"</code> attribute.
+    </li>
+    <li>
+      In your view, you define a method with the same name
+      (<code>def some_action(...)</code>) and decorate it with
+      <code>@hq_hx_action()</code> (optionally passing an HTTP method like
+      <code>'post'</code>).
+    </li>
+    <li>
+      <code>HqHtmxActionMixin.dispatch()</code>:
+      <ul>
+        <li>Looks up <code>some_action</code> on the view</li>
+        <li>Checks that it's decorated with <code>@hq_hx_action</code></li>
+        <li>Verifies the HTTP method if one was specified</li>
+        <li>Calls the handler and returns its response</li>
+      </ul>
+    </li>
+  </ol>
+  <p>
+    If no <code>HQ-HX-Action</code> header is present, the mixin simply falls back to the
+    normal <code>dispatch</code> behavior (i.e., your view works like a regular
+    <code>TemplateView</code> for non-HTMX requests).
+  </p>
+
+  <h2 id="examples" class="pt-2">
+    Examples
+  </h2>
+
+  <p>
+    Below are two starter examples working with both HTMX and Alpine:
+  </p>
+  <ul>
+    <li>
+      A simple form demo-ing asynchronously loading, validating, and displaying
+      a success message (HTMX) and hiding/showing a field based on the value of another field (Alpine).
+    </li>
+    <li>
+      A more complex view using a todo-list to demo multiple different actions and partials with HTMX,
+      and triggering an inline-editing form with Alpine.
+    </li>
+  </ul>
+
+  <h3 id="simple-form-example" class="pt-3">
+    A Simple Form with HTMX and Alpine
+  </h3>
+  <p>
+    <a href="{% url "sg_htmx_alpine_form_demo" %}" target="_blank">In this example</a>,
+    <strong>HTMX</strong> is used to asynchronously load a form and submit it back to the
+    same view. The form is posted to an <code>hq_hx_action</code> handler on that view,
+    which validates the data and either:
+  </p>
+  <ul>
+    <li>returns the form again with validation errors, or</li>
+    <li>shows a success message and resets the form.</li>
+  </ul>
+  <p>
+    <strong>Alpine</strong> provides a small layer of interactivity on top: it hides the
+    “Value” field when the “Match Type” is set to “is empty”. The Alpine model is defined
+    in the form layout itself, since that logic is specific to this form.
+  </p>
+  <div class="alert alert-primary">
+    <p class="mb-1">
+      <strong>Tips:</strong>
+    </p>
+    <ul class="mb-0">
+      <li>
+        To <a href="{% url "sg_htmx_alpine_form_demo" %}" target="_blank">view this demo</a>,
+        make sure you are logged in.
+      </li>
+      <li>
+        Leave the “Value” field blank (with a match type that requires a value) to trigger
+        Django form validation via HTMX.
+      </li>
+      <li>
+        Set the “Match Type” field to “is empty” to hide the “Value” field (Alpine).
+      </li>
+      <li>
+        Submit the form with all fields filled out to trigger the success message (HTMX).
+      </li>
+    </ul>
+  </div>
+  <p>
+    The <code>HtmxAlpineFormDemoView</code> uses <code>HqHtmxActionMixin</code> so that it
+    can define two HTMX actions on the same URL using <code>hq-hx-action</code>:
+  </p>
+  <ul>
+    <li>
+      <code>load_form</code> &mdash; loads the initial empty form when the page first loads.
+    </li>
+    <li>
+      <code>submit_form</code> &mdash; handles the POSTed form data, validates it, and
+      returns either the form with errors or a success message with a fresh form.
+    </li>
+  </ul>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_alpine_form_views %}
+  <p>
+    <code>HtmxAlpineFormDemoView</code> references two templates:
+  </p>
+  <ul>
+    <li>
+      <code>main.html</code> &mdash; the full page template. It:
+      <ul>
+        <li>extends a core base template,</li>
+        <li>
+          uses the <code>hqwebapp/js/htmx_and_alpine</code> entry point (no extra JS
+          needed for this demo), and
+        </li>
+        <li>
+          sets up an HTMX <code>hx-trigger="load"</code> request to
+          <code>request.path_info</code> (the same URL serving the view),
+          which calls the <code>load_form</code> action.
+        </li>
+      </ul>
+      {% include "styleguide/bootstrap5/code_display.html" with content=examples.form_main_template %}
+    </li>
+    <li>
+      <code>partial_form.html</code> &mdash; the partial template returned by the two
+      <code>hq-hx-action</code> handlers. It renders the crispy form and, when
+      appropriate, a success message.
+      {% include "styleguide/bootstrap5/code_display.html" with content=examples.form_partial_template %}
+    </li>
+  </ul>
+
+  <p>
+    Lastly, the Django form <code>FilterDemoForm</code> uses crispy-forms to define the
+    layout. This layout also sets up the Alpine data model and <code>x-*</code> attributes
+    that drive the hide/show "Value" field behavior.
+  </p>
+
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_alpine_form %}
+
+  <h3 id="example-todo" class="pt-3">
+    A Single View with Multiple HTMX Actions (To-Do List)
+  </h3>
+  <p>
+    The form demo showed a view with two HTMX actions (<code>load_form</code>,
+    <code>submit_form</code>) on the same URL. The To-Do List demo takes the same idea
+    one step further: a single view with several HTMX actions for different interactions
+    (create, edit, mark done), plus some inline editing behavior powered by Alpine.
   </p>
   <p>
-    Below we have two template views, <code>HtmxAlpineFormDemoView</code> and <code>FilterDemoFormView</code>.
-    <code>HtmxAlpineFormDemoView</code> is the view that loads when visiting the URL above. It can be considered
-    the "host" view, and asynchronously loads the partial template content from the <code>FilterDemoFormView</code>
-    on page load. <code>FilterDemoFormView</code> then controls everything related to the <code>FilterDemoForm</code>.
+    In the
+    <a href="{% url "sg_htmx_todo_list_example" %}" target="_blank">To-Do List demo</a>,
+    <code>TodoListDemoView</code> mixes in <code>HqHtmxActionMixin</code>. Three methods
+    are decorated with <code>@hq_hx_action('post')</code>:
+    <code>create_new_item</code>, <code>edit_item</code>, and <code>mark_item_done</code>.
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_alpine_form_views %}
+
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_todo_list_view %}
+
   <p>
-    Take a look at the template for <code>HtmxAlpineFormDemoView</code>. You can see it uses a common
-    <code>js_entry</code> entry point <code>hqwebapp/js/htmx_and_alpine</code>, which is appropriate for
-    most common uses of HTMX and Alpine.
+    These methods act like small, named HTMX endpoints hanging off the same URL. The main
+    template wires them up with HTMX:
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.form_main_template %}
+
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_todo_main %}
+
   <p>
-    The template for <code>FilterDemoFormView</code> then looks like this&mdash;a very simple form partial!
-    The magic of what happens after the form is submitted is in the <code>hx-</code> attributes within
-    the <code>&lt;form&gt;</code> tag that control the HTMX interactions.
+    Each list item template then combines HTMX calls to those actions with a tiny Alpine
+    model for inline editing:
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.form_partial_template %}
+
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_todo_item %}
+
   <p>
-    The interaction within the form is then controlled by Alpine. Take a peek at <code>self.helper.layout</code>
-    in the code below. All the <code>x_</code> attributes define the Alpine model and interactions&mdash;no
-    external JavaScript file necessary!
+    When an item is marked as done, <code>render_item_response()</code> returns a different
+    partial that uses <code>hx-swap-oob</code> to move the item into the “Done” list:
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_alpine_form %}
+
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_todo_item_done_swap %}
+
+  <p>
+    This pattern (one view + several <code>@hq_hx_action</code> methods) works well for
+    medium-complexity pages that have a few related interactions but don’t yet need to be
+    split into multiple views.
+  </p>
 
   <h2 id="organization" class="pt-4">
     Organization for Complex Pages
   </h2>
   <p>
-    You can imagine that if a page needs to make a lot of different HTMX requests for multiple page interactions,
-    the view list needed to process each request might get pretty long. Additionally, it might be challenging to
-    properly identify these views as related to one main view.
+    For very complex pages, a single view with many HTMX actions can still become hard
+    to reason about. In those cases, it can be helpful to split the page into multiple
+    <strong>section views</strong>:
   </p>
+  <ul>
+    <li>
+      A single <strong>host view</strong> renders the overall page layout, navigation,
+      common context, and JavaScript entry point.
+    </li>
+    <li>
+      Several <strong>section views</strong> each manage one part of the page.
+      Each section view has its own URL and its own HTMX actions.
+    </li>
+  </ul>
   <p>
-    That is where <code>HqHtmxActionMixin</code> comes in! You can use this mixin with any <code>TemplateView</code>
-    (and common HQ subclasses, like <code>BasePageView</code>). Once mixed-in, any method on that view can be
-    decorated with <code>@hq_hx_action()</code> to make that method name directly available as an "action"
-    with any <code>hx-get</code>, <code>hx-post</code>, or related <code>hx-</code> request to that View's URL.
-    This association can be made with the <code>hq-hx-action</code> attribute in the same element that has the
-    <code>hx-</code> request tag.
+    The host view passes section view URLs into the template via context, and the
+    template uses those URLs as <code>hx-get</code>/<code>hx-post</code> targets for
+    different parts of the page.
   </p>
-  <p>
-    Not quite following? Yes, it's a bit complex. Let's check out a demo and hopefully that will clear up any
-    confusion...
-  </p>
-  <h3 id="using-hqhtmxactionmixin" class="pt-3">
-    Using <code>HqHtmxActionMixin</code>
+
+  <h3 id="bulk-edit-cases" class="pt-3">
+    Example: Bulk Edit Cases (Host View + Section Views)
   </h3>
   <p>
-    To illustrate the usage of <code>HqHtmxActionMixin</code>, here is a simple
-    <a href="{% url "sg_htmx_todo_list_example" %}" target="_blank">To-Do List</a> demo.
+    A concrete production example of this pattern is the bulk data editing UI in
+    <a
+      href="https://github.com/dimagi/commcare-hq/tree/master/corehq/apps/data_cleaning"
+      target="_blank"
+    ><code>corehq.apps.data_cleaning</code></a>. The
+    <a
+      href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/main.py#L60"
+      target="_blank"
+    ><code>BulkEditCasesSessionView</code></a> acts as the host view for the page, and several
+    section views handle individual areas of the UI.
+  </p>
+
+  <p>
+    In
+    <a
+      href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/main.py#L104-L130"
+      target="_blank"
+    ><code>BulkEditCasesSessionView.page_context</code></a>, the host view exposes the URLs
+    of its section views.
+  </p>
+
+  <p>
+    Each of these URLs points to a section view responsible for one part of the page:
+  </p>
+  <ul>
+    <li>
+      <a
+        href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/tables.py#L40"
+        target="_blank"
+      >
+        <code>EditCasesTableView</code>
+      </a> &mdash; main table of cases
+    </li>
+    <li>
+      <a
+        href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/filters.py#L27"
+        target="_blank"
+      >
+        <code>ManagePinnedFiltersView</code>
+      </a> &mdash; "pinned" / fixed filters
+    </li>
+    <li>
+      <a
+        href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/filters.py#L74"
+        target="_blank"
+      >
+        <code>ManageFiltersView</code>
+      </a> &mdash; user-definable filters
+    </li>
+    <li>
+      <a
+        href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/columns.py#L23"
+        target="_blank"
+      >
+        <code>ManageColumnsFormView</code>
+      </a> &mdash; column selection
+    </li>
+    <li>
+      <a
+        href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/bulk_edit.py"
+        target="_blank"
+      >
+        <code>EditSelectedRecordsFormView</code>
+      </a> &mdash; bulk edit form for selected rows
+    </li>
+    <li>
+      <a
+        href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/data_cleaning/views/status.py"
+        target="_blank"
+      >
+        <code>BulkEditSessionStatusView</code>
+      </a> &mdash; session progress / status when the edits are submitted
+    </li>
+  </ul>
+
+  <p>
+    Each section view follows the same patterns described earlier:
+    <code>TemplateView</code> + <code>HqHtmxActionMixin</code>, with one or more
+    <code>@hq_hx_action</code> methods to handle interactions for that section.
   </p>
   <p>
-    Let's first start with the <code>TodoListDemoView</code>, a subclass of <code>BasePageView</code> that mixes
-    in <code>HqHtmxActionMixin</code>. You can see that the <code>@hq_hx_action()</code> decorator is applied
-    to three methods in this view: <code>create_new_item</code>, <code>edit_item</code>, and
-    <code>mark_item_done</code>.
+    The end result is a page that feels like a single cohesive UI, but where each section
+    has its own view class, URL, and HTMX actions. This keeps each piece manageable and
+    testable, while still creating the feeling of a cohesive "full-page app" with the host
+    view tying everything together. You get a feeling of using React, but Django is actually at the core!
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_hq_hx_action %}
+
+  <h2 id="multistep-next-action" class="pt-4">
+    Multi-Step Flows with <code>next_action</code>
+  </h2>
   <p>
-    Looking at the main template for this view, we can scan the page for the first <code>hx-post</code>
-    attribute, which posts to <code>request.path_info</code>. This is URL of the page serving this
-    template: <code>TodoListDemoView</code>.
-  </p>
-  <p>
-    Below <code>hx-post</code> is the <code>hq-hx-action</code> attribute referencing the
-    <code>create_new_item</code> method of the <code>TodoListDemoView</code>. Remember, this was one
-    of the methods decorated with <code>@hq_hx_action()</code>. The rest of the attributes are specific to
-    HTMX, and you can read more about them on <a href="https://htmx.org/" target="_blank">htmx.org</a>.
+    Sometimes you need a short multi-step flow made of one or more forms:
+    pick something, confirm what to do with it, then either finish or go back.
+    You could model this as a single "wizard" form with a <code>step</code> field,
+    but often it's clearer to give each step its own form and handler.
   </p>
   <p>
-    If you scan the rest of the template, you will notice another <code>hq-hx-action</code> attribute which
-    references the method <code>does_not_exist</code>. As it is aptly named, this method does not exist in
-    <code>TodoListDemoView</code>. However, that's the point, as this attribute is attached to a button which
-    triggers the HTMX error modal. :)
+    With HTMX and <code>HqHtmxActionMixin</code>, you can keep this entirely
+    server-driven by using a simple <strong><code>next_action</code> pattern</strong>:
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_todo_main %}
+  <ul>
+    <li>One view class, with multiple <code>@hq_hx_action</code> methods.</li>
+    <li>A shared partial that posts to the same URL, but uses
+      <code>hq-hx-action="{{ next_action }}"</code>.
+    </li>
+    <li>Each handler validates its form and either:
+      <ul>
+        <li>returns a “next step” form with a new <code>next_action</code>, or</li>
+        <li>returns a final success / summary state.</li>
+      </ul>
+    </li>
+  </ul>
+
+  <h3 id="multistep-next-action-example" class="mt-3">
+    Example: Simple Two-Step “Choose &amp; Confirm” Flow
+  </h3>
   <p>
-    What about the other two actions, <code>edit_item</code> and <code>mark_item_done</code>? To examine the usage
-    for these, we need to look at the <code>item.html</code> template.
+    <a
+      href="{% url "sg_htmx_next_action_demo" %}"
+    >This demo</a> shows a tiny two-step flow:
   </p>
+  <ol>
+    <li>Choose a favorite fruit.</li>
+    <li>Confirm the choice or go back and change it.</li>
+  </ol>
   <p>
-    In this template, we see <code>hq_hx_action="mark_item_done"</code> applied to the <code>checkbox</code>
-    input. Scrolling down, we see <code>hq_hx_action="edit_item"</code> applied to the <code>form</code>
-    that contains the <code>input</code> with the edited form value.
+    The view <code>SimpleNextActionDemoView</code> uses three HTMX actions:
   </p>
+  <ul>
+    <li><code>load_first_step</code> &mdash; load the initial form on page load.</li>
+    <li><code>validate_choice</code> &mdash; validate the chosen fruit and move to the confirm step.</li>
+    <li><code>confirm_or_change</code> &mdash; either finish or go back to step 1.</li>
+  </ul>
+
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_next_action_simple_view %}
+
   <p>
-    However, how is the quick inline-edit interaction happening? That all comes from Alpine! Looking at the
-    attributes in the <code>li</code> element on that template, we see the simple Alpine model being defined,
-    setting up variables to track the <code>isEditing</code> and <code>isSubmitting</code> states. Additionally,
-    the <code>itemValue</code> is defined and initialized from the template variable <code>item.name</code>. This
-    <code>itemValue</code> is bound to the text <code>input</code> in the <code>edit_item</code> form below, with
-    Alpine's <code>x-model</code> attribute.
+    The main template sets up the HTMX + Alpine entry point and an empty container
+    that loads the first step via HTMX:
   </p>
+
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_next_action_simple_template %}
+
   <p>
-    The hide/show states of other elements are then controlled with Alpine's <code>x-show</code> attribute,
-    while other form elements are disabled using Alpine's <code>:disabled</code> shorthand attribute when the
-    <code>isEditing</code> or <code>isSubmitting</code> states change.
+    The partial template is intentionally generic, and based on an even simpler version reused elsewhere in HQ
+    (<a
+      href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/templates/hqwebapp/htmx/forms/next_action_form.html"
+      target="_blank"
+    >See it here</a>).
+    This template doesn't know about "fruits"
+    or a specific step...it just renders whatever <code>form</code> and
+    <code>next_action</code> the view provides. It does add a message alert in case one of the steps decides to display a message.
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_todo_item %}
+
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_next_action_simple_form_template %}
+
   <p>
-    From the code in <code>TodoListDemoView</code>, you can see that a request to the different
-    <code>@hq_hx_action()</code> methods returns <code>self.render_item_response</code>. This returns
-    <code>render_htmx_partial_response</code>, which is part of the <code>HqHtmxActionMixin</code>.
-    Looking at this <code>render_item_response</code> method, we see two partial templates being returned.
+    The two forms keep all validation and labels in Django:
   </p>
+
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_next_action_simple_forms %}
+
   <p>
-    The <code>item.html</code> template we've already examined above. However, when the item is marked as
-    <code>is_done</code>, the method returns the <code>item_done_oob_swap.html</code> partial. Let's take a
-    look at this template:
+    The end result is a small multi-step flow that:
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_todo_item_done_swap %}
+  <ul>
+    <li>stays entirely server-driven,</li>
+    <li>reuses one HTMX container and one partial template, and</li>
+    <li>keeps each step's logic in its own form + action method.</li>
+  </ul>
   <p>
-    As you can see, this template just adds a wrapper around the <code>item_done.html</code> template, but
-    it has a very interesting HTMX attribute in this wrapper, <code>hx-swap-oob</code>. This was included
-    to demonstrate a powerful feature of HTMX to do out-of-bounds swaps, which you can
-    <a href="https://htmx.org/attributes/hx-swap-oob/" target="_blank">read about here</a>.
-  </p>
-  <p>
-    Lastly, we have the <code>item_done.html</code> partial template. It's very simple:
-  </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_todo_item_done %}
-  <p>
-    That's it! Hopefully <code>HqHtmxActionMixin</code> seems less confusing now,
-    and you are inspired to use it. :)
+    The only thing the template needs to know is
+    <strong>which action name to call next</strong>.
   </p>
 
   <h2 id="debugging" class="pt-4">
     Debugging During Development
   </h2>
   <p>
-    During development of a page using <code>HTMX</code>, you might be interested in seeing how the page
-    looks like when requests take a long time to load, or when the server is a little flaky. Unfortunately,
-    when you try to use the browser dev tools to simulate page slowness, you are only delaying sending the
-    request to your local server, rather than simulating a slow server response. The distinction is important
-    with HTMX, especially when debugging timeout issues.
+    When developing an HTMX-powered page, it’s often useful to see how the UI behaves
+    when requests are slow or the server is flaky. Browser dev tools throttling only
+    delays the <em>request from the browser</em> to your local server&mdash;it does not
+    simulate a slow or unreliable <em>server response</em>. That distinction matters a lot
+    for HTMX, especially when you’re debugging spinners, timeouts, and retry behavior.
   </p>
   <p>
-    To enable some advanced debugging features on a view using the <code>HqHtmxActionMixin</code>, you
-    can also mix-in the <code>HqHtmxDebugMixin</code>. The <code>HqHtmxDebugMixin</code> allows you to
-    simulate slow server responses by setting <code>simulate_slow_response = True</code> on your view.
-    You can also simulate intermittent bad gateway errors with <code>simulate_flaky_gateway = True</code>.
+    To make this easier on views that use <code>HqHtmxActionMixin</code>, you can also mix in
+    <code>HqHtmxDebugMixin</code>. This mixin lets you:
+  </p>
+  <ul>
+    <li>
+      Simulate slow responses by setting
+      <code>simulate_slow_response = True</code> (and adjusting
+      <code>slow_response_time</code> in seconds).
+    </li>
+    <li>
+      Simulate intermittent 504 “gateway timeout” errors by setting
+      <code>simulate_flaky_gateway = True</code>.
+    </li>
+  </ul>
+  <p>
+    A typical usage looks like:
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_debug_mixin_usage %}
+  <p>
+    <strong>Important:</strong> mixin order matters. Make sure
+    <code>HqHtmxDebugMixin</code> appears <em>before</em>
+    <code>HqHtmxActionMixin</code> so its <code>dispatch()</code> runs first.
   </p>
   <p>
-    You can check out the <code>HqHtmxDebugMixin</code> directly for additional documentation and usage
-    guidance.
+    You can check out <code>HqHtmxDebugMixin</code> in the codebase for additional
+    documentation and implementation details.
   </p>
 
   <h2 id="loading-indicators" class="pt-4">
     Loading Indicators
   </h2>
   <p>
-    By default, if an element triggers an HTMX request, it will automatically get an <code>htmx-request</code>
-    CSS class applied to it. We've added custom styling to <code>_htmx.scss</code> to support the common states outlined
-    later in this section.
+    By default, when an element triggers an HTMX request, HTMX will automatically add the
+    <code>htmx-request</code> CSS class to that element for the duration of the request.
+    HQ defines some shared styles for this and related states in
+    <a
+      href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_htmx.scss"
+      target="_blank"
+    ><code>_htmx.scss</code></a>, which support the common patterns outlined later in this section.
   </p>
   <p>
-    If you want to create new types of loading indicators for non-standard elements, you can explore using
-    the <code>hx-indicator</code> attribute
+    If you want to create custom loading indicators for non-standard elements (for example, a spinner
+    elsewhere on the page rather than on the trigger itself), you can use the
+    <code>hx-indicator</code> attribute
     (<a href="https://htmx.org/attributes/hx-indicator/" target="_blank">see docs here</a>).
-  </p>
-  <p>
-    It's often a great idea to pair button requests with <code>hx-disabled-elt="this"</code>
-    (<a href="https://htmx.org/attributes/hx-disabled-elt/" target="_blank`">see docs for hx-disabled-elt</a>),
-    like the examples below, so that the requesting <code>button</code> is disabled during the request.
   </p>
   <h3 id="button-loading" class="pt-4">
     Buttons
   </h3>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.loading_button %}
+  <p>
+    It's often a good idea to pair button-triggered requests with
+    <code>hx-disabled-elt="this"</code>
+    (<a href="https://htmx.org/attributes/hx-disabled-elt/" target="_blank">see docs for hx-disabled-elt</a>),
+    as in the example below, so that the triggering <code>&lt;button&gt;</code> is disabled while the
+    request is in flight.
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.loading_button %}
 
   <h3 id="checkbox-loading" class="pt-4">
     Checkboxes
   </h3>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.loading_checkbox %}
+  <p>
+    You can also add <code>hx-disabled-elt="this"</code> to checkboxes to reveal the checkbox spinner
+    when a request is in flight.
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.loading_checkbox %}
 
   <h3 id="form-loading" class="pt-4">
     Forms
   </h3>
   <p>
-    In the example below, note that the <code>form</code> is the triggering element, so the
-    <code>hx-disabled-elt</code> value is set to <code>find button</code> to disable all button children
-    of that form during an HTMX request. Since <code>form</code> is the submitting element, by default
-    it has the <code>htmx-request</code> class applied. Our styles ensure that
-    <code>button type="submit"</code> elements of a submitting form show the loading indicator during
-    an HTMX request.
+    In the example below, the <code>&lt;form&gt;</code> element is the HTMX trigger, so
+    <code>hx-disabled-elt="find button"</code> is used to disable all of the form’s
+    <code>&lt;button&gt;</code> children while the request is in flight. Because the
+    form is the submitting element, HTMX automatically applies the
+    <code>htmx-request</code> class to it for the duration of the request.
+    Our styles then ensure that any <code>&lt;button type="submit"&gt;</code> inside a
+    submitting form shows a loading indicator during the HTMX request.
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.loading_form %}
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.loading_form %}
 
 {% endblock content %}

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/knockout_to_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/knockout_to_alpine.html
@@ -227,7 +227,7 @@
         <li>
           Send <code>hx-get</code> and <code>hx-post</code> actions to view methods
           using
-          <a href="{% url "styleguide_htmx_and_alpine_b5" %}#using-hqhtmxactionmixin" target="_blank">
+          <a href="{% url "styleguide_htmx_and_alpine_b5" %}#mixin" target="_blank">
             HqHtmxActionMixin
           </a>
           and <code>hq-hx-action</code>.
@@ -310,7 +310,7 @@
           <td>
             Django templates for base rendering.<br />
             HTMX endpoints (via
-            <a href="{% url "styleguide_htmx_and_alpine_b5" %}#using-hqhtmxactionmixin" target="_blank">
+            <a href="{% url "styleguide_htmx_and_alpine_b5" %}#mixin" target="_blank">
               HqHtmxActionMixin
             </a>)
             return partials for updates.

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/knockout_to_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/knockout_to_alpine.html
@@ -459,6 +459,7 @@
     array, the server stores the list of pairs and responds to HTMX requests when
     you add, edit, or delete a row.
   </p>
+  {% include "styleguide/bootstrap5/partials/demo_callout.html" with urlname="sg_htmx_key_value_demo" %}
   <p>
     <a href="{% url "sg_htmx_key_value_demo" %}">For this demo</a>, we use a
     small <code>CacheStore</code> (similar to the

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/knockout_to_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/knockout_to_alpine.html
@@ -1,0 +1,1097 @@
+{% extends "styleguide/bootstrap5/base.html" %}
+{% load hq_shared_tags %}
+
+{% js_entry "styleguide/js/ko_migration" %}
+
+{% block intro %}
+  <h1 class="sg-title mb-0" id="content">Migrating Knockout to Alpine (+HTMX)</h1>
+  <p class="sg-lead">
+    Some tips, examples, and strategies for how to migrate pages from Knockout to Alpine.js (+HTMX).
+  </p>
+{% endblock intro %}
+
+{% block toc %}
+  <h5 class="my-2 ms-3">On this page</h5>
+  <hr class="my-2 ms-3">
+  <nav id="TableOfContents">
+    <ul>
+      <li>
+        <a href="#overview">Overview</a>
+      </li>
+      <li>
+        <a href="#step-1">Step 1: Update Your Mental Model</a>
+        <ul>
+          <li><a href="#step-1-the-players">Meet the players</a></li>
+          <li><a href="#step-1-concept-mapping">Concept mapping: where things live now</a></li>
+        </ul>
+      </li>
+      <li>
+        <a href="#step-2">Step 2: Mapping Knockout Bindings to Alpine</a>
+        <ul>
+          <li><a href="#step-2-example-1">Example 1: Simple Model, Keep it Local</a></li>
+          <li><a href="#step-2-example-2">Example 2: Complex Model Approaches</a></li>
+          <li><a href="#step-2-example-2-knockout">Example 2: Knockout source</a></li>
+          <li><a href="#step-2-example-2-alpine">Example 2: Migration to Alpine</a></li>
+          <li><a href="#step-2-example-2-alpine-reusable">Example 2: Make it reusable</a></li>
+          <li><a href="#step-2-example-2-htmx">Migration to HTMX?</a></li>
+        </ul>
+      </li>
+      <li>
+        <a href="#step-3">Step 3: When to Stop at Alpine vs Move to HTMX</a>
+        <ul>
+          <li><a href="#step-3-when-alpine">Stay with Alpine when…</a></li>
+          <li><a href="#step-3-when-htmx">Reach for HTMX when…</a></li>
+        </ul>
+      </li>
+      <li>
+        <a href="#ai-assist">Using AI to Help with Migrations (Safely)</a>
+        <ul>
+          <li><a href="#ai-assist-where-helpful">Where AI is especially helpful</a></li>
+          <li><a href="#ai-assist-how-to-prompt">How to prompt in the HQ context</a></li>
+          <li><a href="#ai-assist-guardrails">Guardrails: things to watch out for</a></li>
+          <li><a href="#step-4-ai-snippets">Copy-paste prompt snippets</a>
+            <ul>
+              <li><a href="#step-4-ai-snippets-general">General HQ migration context</a></li>
+              <li><a href="#step-4-ai-snippets-inline-alpine">KO → inline Alpine</a></li>
+              <li><a href="#step-4-ai-snippets-alpine-module">KO → Alpine module</a></li>
+              <li><a href="#step-4-ai-snippets-htmx">KO → HTMX (+ Alpine)</a></li>
+              <li><a href="#step-4-ai-snippets-short">Super-short “one-liner” context</a></li>
+              <li><a href="#step-4-ai-snippets-review">Review this AI-generated migration</a></li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <a href="#step-5">Step 5: Before / After Checklists</a>
+        <ul>
+          <li><a href="#step-5-before-start">Before you start refactoring</a></li>
+          <li><a href="#step-5-before-merge">Before you merge: behavior &amp; UX checks</a></li>
+          <li><a href="#step-5-code-cleanup">Before you merge: code &amp; dependency cleanup</a></li>
+        </ul>
+      </li>
+      <li>
+        <a href="#example-commits">Commits from previous migrations</a>
+      </li>
+    </ul>
+  </nav>
+{% endblock toc %}
+
+{% block content %}
+  <h2 id="overview" class="pt-4">
+    Overview
+  </h2>
+  <p>
+    HQ is slowly moving away from
+    <a href="https://knockoutjs.com/" target="_blank">Knockout.js</a>. Knockout is largely
+    unmaintained, community support is dwindling, and we now have better options.
+    Going forward, we are standardizing on
+    <a href="https://alpinejs.dev/" target="_blank">Alpine.js</a> for lightweight interactivity
+    and <a href="https://htmx.org/" target="_blank">HTMX</a> to take better advantage of Django’s
+    server-side rendering.
+  </p>
+
+  <div class="alert alert-primary mt-3">
+    <p class="mb-1">
+      <strong>This is a living guide.</strong>
+    </p>
+    <p class="mb-0">
+      As we discover new migration patterns, refine prompts, and run into new edge cases,
+      this page will need updates. Whenever you learn something useful while working on a
+      Knockout → Alpine (+HTMX) migration, please add or adjust examples, notes, or links
+      here so the guide stays current and helpful for everyone.
+    </p>
+  </div>
+
+  <div class="alert alert-primary">
+    <a href="{% url "styleguide_htmx_and_alpine_b5" %}" target="_blank">
+      Read the HTMX + Alpine.js guide
+    </a>
+    for patterns and examples of using HTMX and Alpine in the HQ codebase.
+  </div>
+
+  <p>
+    At a high level, our long-term goals for JavaScript are:
+  </p>
+  <ul>
+    <li>Reduce JS complexity and avoid duplicating server-side logic in the browser</li>
+    <li>Rely on Django templates for most HTML and layout</li>
+    <li>Use Alpine for light, local interactivity</li>
+    <li>Use HTMX for server-coordinated interactions (forms, tables, filtering, pagination)</li>
+  </ul>
+
+  <p>
+    These are <strong>north star</strong> goals. Applying all of them everywhere during the
+    Knockout migration would make the migration take far too long. For existing pages,
+    it is acceptable to migrate in steps. For <em>new</em> JavaScript and new features,
+    we should follow these goals more strictly.
+  </p>
+
+  <div class="alert alert-primary">
+    <p class="mb-1">
+      For the Knockout → Alpine (+HTMX) migration, prefer a pragmatic approach:
+    </p>
+    <ul class="mb-0">
+      <li>
+        <strong>First priority:</strong> remove Knockout and replace it with Alpine in a
+        mostly one-to-one fashion, keeping existing behavior intact.
+      </li>
+      <li>
+        <strong>When it’s feasible (and worth the effort):</strong> move complex or
+        business-critical logic from JavaScript into Django, using templates and HTMX.
+        Treat the goals above as guidance, not a hard requirement for every migration.
+      </li>
+      <li>
+        Use this guide as a starting point when approaching a migration, and update it as
+        new patterns, shortcuts, or pitfalls are discovered.
+      </li>
+    </ul>
+  </div>
+
+  <h2 id="step-1" class="pt-4">
+    Step 1: Update Your Mental Model
+  </h2>
+  <p>
+    Before changing any code, it helps to update how you think about state and rendering
+    on HQ pages. In the Knockout era, most state lived in the browser. In the Alpine + HTMX
+    world we are moving toward, <strong>Django</strong> is the primary source of truth, and
+    the browser is mostly a thin layer of interactivity on top.
+  </p>
+
+  <div class="alert alert-primary">
+    You can think of <strong>HTMX as “data-binding to the server”</strong>.
+    Alpine handles small, local UI state. Django and HTMX work together to keep real data
+    and HTML in sync.
+  </div>
+
+  <h3 id="step-1-the-players" class="mt-3">
+    Meet the players
+  </h3>
+
+  <div class="card mt-2">
+    <div class="card-header">
+      Knockout (before)
+    </div>
+    <div class="card-body">
+      <p class="card-text mb-2">
+        Client-side MVVM. State lives in <code>ko.observable</code>s and
+        <code>ko.computed</code>s. HTML is generated or updated in the browser.
+      </p>
+      <ul class="mb-0">
+        <li>Browser owns most state</li>
+        <li><code>data-bind</code> everywhere</li>
+        <li>Templates often live in JS or inline script tags</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="card mt-2">
+    <div class="card-header">
+      Alpine (now)
+    </div>
+    <div class="card-body">
+      <p class="card-text mb-2">
+        Lightweight component state in <code>x-data</code>. Uses plain JS objects
+        and getters instead of observables.
+      </p>
+      <ul class="mb-0">
+        <li>Small, page-local state</li>
+        <li>
+          <a href="https://alpinejs.dev/directives/model" target="_blank"><code>x-model</code></a>,
+          <a href="https://alpinejs.dev/directives/show" target="_blank"><code>x-show</code></a>,
+          <a href="https://alpinejs.dev/directives/on#shorthand-syntax" target="_blank"><code>@click</code></a>
+        </li>
+        <li>
+          Primarily for transient UI behavior rather than core business logic
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="card mt-2">
+    <div class="card-header">
+      HTMX (now)
+    </div>
+    <div class="card-body">
+      <p class="card-text mb-2">
+        Server-driven updates. Django renders HTML; HTMX swaps it into the page
+        in response to user actions.
+      </p>
+      <ul class="mb-0">
+        <li>Django is the source of truth</li>
+        <li>
+          <a href="https://htmx.org/attributes/hx-get/" target="_blank"><code>hx-get</code></a>,
+          <a href="https://htmx.org/attributes/hx-post/" target="_blank"><code>hx-post</code></a>,
+          <a href="https://htmx.org/attributes/hx-target/" target="_blank"><code>hx-target</code></a>
+        </li>
+        <li>Great for tables, filters, forms, and actions</li>
+        <li>
+          Send <code>hx-get</code> and <code>hx-post</code> actions to view methods
+          using
+          <a href="{% url "styleguide_htmx_and_alpine_b5" %}#using-hqhtmxactionmixin" target="_blank">
+            HqHtmxActionMixin
+          </a>
+          and <code>hq-hx-action</code>.
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <h3 id="step-1-concept-mapping" class="mt-3">
+    Concept mapping: where things live now
+  </h3>
+  <p>
+    This table maps familiar Knockout ideas to the new Alpine + HTMX patterns. The main shift is that
+    business rules <em>ideally</em> move back into Django, while Alpine and HTMX focus on wiring up
+    interactions. During migration, it is fine for some logic to stay in JavaScript as an
+    intermediate step.
+  </p>
+
+  <div class="table-responsive">
+    <table class="table table-sm table-bordered align-middle">
+      <thead class="table-light">
+        <tr>
+          <th scope="col">Concept</th>
+          <th scope="col">Knockout</th>
+          <th scope="col">Alpine</th>
+          <th scope="col">HTMX / Django</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Source of truth</th>
+          <td>JS view model (objects with observables)</td>
+          <td>
+            Small JS objects inside
+            <a href="https://alpinejs.dev/directives/data" target="_blank"><code>x-data</code></a>
+          </td>
+          <td>
+            Django view + DB.<br />
+            Templates render HTML partials.
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Data model</th>
+          <td>
+            <code>ko.observable</code>, <code>ko.observableArray</code>, <code>ko.computed</code>
+          </td>
+          <td>
+            Plain properties and getters on the
+            <a href="https://alpinejs.dev/directives/data" target="_blank"><code>x-data</code></a>
+            object;
+            <a href="https://alpinejs.dev/magics/watch" target="_blank"><code>$watch</code></a>
+            for side effects
+          </td>
+          <td>
+            Context variables passed from Django to templates
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Bindings / templating</th>
+          <td>
+            <code>data-bind="text: name"</code>, KO templates
+            (<code>&lt;!-- ko if --&gt;</code>)
+          </td>
+          <td>
+            <a href="https://alpinejs.dev/directives/text" target="_blank"><code>x-text</code></a>,
+            <a href="https://alpinejs.dev/directives/model" target="_blank"><code>x-model</code></a>,
+            <a href="https://alpinejs.dev/directives/show" target="_blank"><code>x-show</code></a>,
+            <a href="https://alpinejs.dev/directives/for" target="_blank"><code>x-for</code></a>,
+            <a href="https://alpinejs.dev/directives/on#shorthand-syntax" target="_blank"><code>@click</code></a>,
+            and
+            <a href="https://alpinejs.dev/advanced/extending#custom-directives" target="_blank">
+              custom directives
+            </a>
+            like
+            <a href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/select2.js" target="_blank"><code>x-select2</code></a>
+            and
+            <a href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js" target="_blank"><code>x-datepicker</code></a>
+            (<a href="https://github.com/dimagi/commcare-hq/tree/master/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives" target="_blank">and more</a>).
+          </td>
+          <td>
+            Django templates for base rendering.<br />
+            HTMX endpoints (via
+            <a href="{% url "styleguide_htmx_and_alpine_b5" %}#using-hqhtmxactionmixin" target="_blank">
+              HqHtmxActionMixin
+            </a>)
+            return partials for updates.
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Where business logic lives</th>
+          <td>
+            Often inside the KO view model (JS)
+          </td>
+          <td>
+            Ideally: only light UI logic.<br />
+            In practice (for migration): it is fine for existing business logic to live in an
+            <a href="https://alpinejs.dev/globals/alpine-data" target="_blank"><code>Alpine.data</code></a>
+            model, especially for more complex or shared models in JS files.
+          </td>
+          <td>
+            Django views, forms, and template conditionals
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">How state changes</th>
+          <td>
+            Update observables<br />
+            → Knockout re-renders bindings
+          </td>
+          <td>
+            Update <a href="https://alpinejs.dev/directives/data" target="_blank"><code>x-data</code></a> properties<br />
+            → Alpine re-runs effects
+          </td>
+          <td>
+            User action triggers an HTMX request (e.g. <a href="https://htmx.org/attributes/hx-post/" target="_blank"><code>hx-post</code></a>)<br />
+            → Django returns new HTML<br />
+            → HTMX swaps it into the DOM
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Typical use cases</th>
+          <td>
+            Rich client-side apps, custom widgets, lots of in-browser logic
+          </td>
+          <td>
+            Small, local UI behavior and glue code:<br />
+            toggles, dialogs, complex form validation, “isLoading” flags,
+            simple multi-step forms, shared components/interactions.<br />
+            Alpine is fully capable of richer client-side interactions, but our default
+            pattern is to keep long-lived business state in Django.
+          </td>
+          <td>
+            Anything where the real state lives in the database/backend:<br />
+            tables/reports, search/filter forms, create/edit flows,
+            complex multi-step forms (taking advantage of Django form validation).
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2 id="step-2" class="pt-4">
+    Step 2: Mapping Knockout Bindings to Alpine
+  </h2>
+  <p>
+    This section shows a few different ways to translate a Knockout model into an
+    Alpine model, starting from the simplest case and building up.
+  </p>
+
+  <h3 id="step-2-example-1" class="pt-3">
+    Example 1: Simple Model, Keep it Local
+  </h3>
+  <p>
+    This example shows a very small model where the logic is simple enough that it
+    doesn't need its own JavaScript file. Everything can live directly in the HTML
+    via <code>x-data</code> and <code>x-model</code>.
+  </p>
+
+  <h4 id="step-2-example-1-knockout" class="pt-3">
+    Knockout Source
+  </h4>
+  {% initial_page_data "ko_simple_name" "Fred" %}{# this could come from template context #}
+  {% include "styleguide/bootstrap5/html_js_example.html" with content=examples.ko_simple %}
+
+  <h4 id="step-2-example-1-alpine" class="pt-3">
+    Migration to Alpine
+  </h4>
+  {% include "styleguide/bootstrap5/code_example.html" with content=examples.alpine_simple %}
+  <p>
+    All of the state that used to live in a Knockout view model now lives in a tiny
+    Alpine component attached directly to the markup.
+  </p>
+  <p>
+    Look, ma, no extra JavaScript file!
+  </p>
+
+  <h3 id="step-2-example-2" class="pt-3">
+    Example 2: Complex Model Approaches
+  </h3>
+  <p>
+    This example covers a slightly richer model where it's more reasonable to keep
+    the state and behavior in a JavaScript module instead of inline in the template.
+  </p>
+  <p>
+    The example is deliberately much simpler than real "complex" models in HQ. It's
+    mainly a placeholder to illustrate the core Alpine patterns involved in splitting
+    a model out into separate JavaScript files.
+  </p>
+
+  <h4 id="step-2-example-2-knockout" class="pt-3">
+    Knockout Source
+  </h4>
+  {% initial_page_data "complex_initial_value" complex_initial_value|JSON %}
+  {% include "styleguide/bootstrap5/html_js_example.html" with content=examples.ko_complex %}
+
+  <h4 id="step-2-example-2-alpine" class="pt-3">
+    Migration to Alpine
+  </h4>
+  {% include "styleguide/bootstrap5/html_js_example.html" with content=examples.alpine_complex %}
+
+  <h4 id="step-2-example-2-alpine-reusable" class="pt-3">
+    Migration to Alpine... but make it reusable!
+  </h4>
+  <p>
+    If we want to make the above model reusable, we first define a module like this:
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.alpine_complex_reusable %}
+  <p>
+    Then we can use it in one or more modules / <code>js_entry</code> points as follows:
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.use_alpine_complex_reusable %}
+  <p>
+    When using this model in a template, the HTML is the same as
+    <a href="#step-2-example-2-alpine">the Alpine example above</a>.
+  </p>
+
+  <h4 id="step-2-example-2-htmx" class="pt-3">
+    Migration to HTMX?
+  </h4>
+  <p>
+    The Alpine version keeps the key/value pairs entirely in the browser: the
+    <code>keyValuePairs</code> array lives in JavaScript, and changes are only
+    persisted when you explicitly save them somewhere. For some flows, that's
+    exactly what you want.
+  </p>
+  <p>
+    But if you'd rather have Django own the state — and immediately persist
+    changes — you can move this example to HTMX. Instead of maintaining a JS
+    array, the server stores the list of pairs and responds to HTMX requests when
+    you add, edit, or delete a row.
+  </p>
+  <p>
+    <a href="{% url "sg_htmx_key_value_demo" %}">For this demo</a>, we use a
+    small <code>CacheStore</code> (similar to the
+    <a href="{% url "styleguide_htmx_and_alpine_b5" %}#example-todo">
+      To-Do List example
+    </a>) to simulate server-side storage:
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_complex_store %}
+
+  <p>
+    The view, <code>HtmxKeyValuePairsDemoView</code>, mixes in
+    <code>HqHtmxActionMixin</code> and exposes four HTMX actions:
+  </p>
+  <ul>
+    <li><code>load_pairs</code> &mdash; load the current list of key/value pairs</li>
+    <li><code>add_pair</code> &mdash; append a new empty row</li>
+    <li><code>update_pair</code> &mdash; update the <code>key</code> or <code>value</code> of a row</li>
+    <li><code>delete_pair</code> &mdash; remove a row</li>
+  </ul>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_complex_view %}
+
+  <p>
+    The main template just sets up the JS entry point (the standard
+    <code>hqwebapp/js/htmx_and_alpine</code> entry is fine) and defines a
+    container that loads the list via HTMX:
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_complex_main %}
+
+  <p>
+    The partial template renders the list of pairs and wires each input and button
+    to one of the HTMX actions above:
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_complex_partial %}
+
+  <div class="alert alert-primary">
+    <p>
+      <strong>Pattern:</strong> inputs that are already showing the latest value don't
+      need new HTML on every change. In the key/value demo, each input uses
+      <code>hx-swap="none"</code> and the view's <code>update_pair</code> action
+      returns <code>render_htmx_no_response()</code>. This saves to the server
+      <em>without</em> replacing any DOM, so focus and keyboard navigation stay
+      exactly where the user left them.
+    </p>
+    <p>
+      Be careful if you need to handle input validation or if
+      <code>update_pair</code> can hit database errors. In those cases you have two
+      main options:
+    </p>
+    <ul>
+      <li>
+        Listen for
+        <a href="https://htmx.org/events/#htmx:afterRequest" target="_blank">
+          <code>htmx:afterRequest</code>
+        </a>
+        and show a global or inline error (for example, using the response status or
+        a custom header), or
+      </li>
+      <li>
+        Return a small error partial and override <code>hx-swap</code> /
+        <code>hx-target</code> for that response using the
+        <a href="https://htmx.org/reference/#response_headers" target="_blank">
+          <code>HX-Reswap</code>
+        </a>
+        and
+        <a href="https://htmx.org/reference/#response_headers" target="_blank">
+          <code>HX-Retarget</code>
+        </a>
+        response headers.<br />
+        <strong>Note:</strong> We do this in the example if you leave the field blank.
+        {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_complex_error %}
+      </li>
+    </ul>
+  </div>
+
+  <p>
+    Concretely, each input:
+  </p>
+  <ul>
+    <li>posts to the same view URL,</li>
+    <li>
+      sends the row <code>id</code> and which field changed
+      (<code>field="key"</code> or <code>"value"</code>) via <code>hx-vals</code>,
+    </li>
+    <li>triggers on <code>change</code>/<code>blur</code>, and</li>
+    <li>sets <code>hx-swap="none"</code> so HTMX never re-renders the input markup.</li>
+  </ul>
+
+  <p>
+    The <code>update_pair</code> handler then:
+  </p>
+  <ul>
+    <li>looks up the matching pair in the <code>CacheStore</code>,</li>
+    <li>updates just that one field on the server, and</li>
+    <li>returns <code>self.render_htmx_no_response()</code> (no HTML body).</li>
+  </ul>
+
+  <p>
+    Compared to the Alpine version:
+  </p>
+  <ul>
+    <li>There is no client-side array at all.</li>
+    <li>Each change (typing into a field, adding, deleting) immediately updates the
+      server-side list via HTMX.</li>
+    <li>The source of truth lives entirely in Django; the DOM is just a
+      reflection of that state.</li>
+    <li>
+      Because updates use <code>hx-swap="none"</code>, keyboard users can tab
+      between fields while requests are in flight without losing focus.
+    </li>
+  </ul>
+  <p>
+    This is a good fit when the "real" model is on the server and you want
+    instant saves without introducing extra JavaScript state or explicit "Save"
+    buttons.
+  </p>
+
+  <h2 id="step-3" class="pt-4">
+    Step 3: When to Stop at Alpine vs Move to HTMX
+  </h2>
+  <p>
+    Once you've translated a Knockout model into Alpine, the next question is:
+    <strong>do we stop here, or should this really live on the server with HTMX?</strong>
+  </p>
+  <p>
+    There isn't a single "right" answer, but there are some good rules of thumb that can
+    help keep both the migration and long-term maintenance sane.
+  </p>
+
+  <h3 id="step-3-when-alpine" class="pt-3">
+    Stay with Alpine when...
+  </h3>
+  <ul>
+    <li>
+      The state is <strong>purely UI-level</strong>:
+      show/hide, tabs, accordions, steps in a wizard, “isLoading” flags,
+      inline edit mode, etc.
+    </li>
+    <li>
+      The data is <strong>derived from what's already on the page</strong>:
+      filters that only affect what's rendered, client-side sort order, small
+      in-memory lists that don't need to sync to the server immediately.
+    </li>
+    <li>
+      The logic is <strong>simple and local</strong>:
+      one page, one small component, no other views need to know about it.
+    </li>
+    <li>
+      A brief delay to save is okay, or a single explicit “Save” button is fine.
+    </li>
+    <li>
+      You're doing a <strong>first-pass Knockout → Alpine migration</strong> and
+      just want to remove KO without reshaping the whole feature yet.
+    </li>
+  </ul>
+
+  <h3 id="step-3-when-htmx" class="pt-3">
+    Reach for HTMX when...
+  </h3>
+  <ul>
+    <li>
+      The <strong>real source of truth</strong> is in the database or external systems,
+      and you don't want to duplicate that model in JavaScript.
+    </li>
+    <li>
+      Multiple users or processes may change the data, so the browser needs to pull
+      fresh HTML from the server to stay in sync.
+    </li>
+    <li>
+      The logic involves <strong>permissions, complex validation, or side effects</strong>
+      (e.g. saving to multiple tables, enqueueing tasks, audit logs).
+    </li>
+    <li>
+      The Knockout code is already re-implementing a lot of Django logic
+      (form validation, choice lists, business rules) that you'd rather move back
+      to Django.
+    </li>
+    <li>
+      You want <strong>"instant save" semantics</strong>—each change should be persisted
+      immediately, not just when someone remembers to press "Save".
+    </li>
+  </ul>
+
+  <div class="alert alert-primary mt-3">
+    <p class="mb-1">
+      <strong>Migration-friendly rule of thumb:</strong>
+    </p>
+    <ul class="mb-0">
+      <li>
+        For existing Knockout pages, it's fine to <strong>stop at Alpine</strong> if the
+        logic is working and not clearly painful. You've already won by removing KO.
+      </li>
+      <li>
+        Reach for <strong>HTMX + Django</strong> when the Knockout code is clearly duplicating
+        backend rules, or when bugs keep appearing because the browser and server have
+        drifted apart.
+      </li>
+    </ul>
+  </div>
+
+  <p>
+    The <a href="#step-2-example-2-htmx">key/value example above</a> shows this spectrum
+    in practice:
+  </p>
+  <ul>
+    <li>
+      The Alpine version keeps a local <code>keyValuePairs</code> array in JavaScript and
+      only saves when you decide to.
+    </li>
+    <li>
+      The HTMX version drops the array entirely; the server owns the list, and each change
+      is persisted via HTMX calls (using <code>hx-swap="none"</code> so focus isn't lost).
+    </li>
+  </ul>
+  <p>
+    Both are valid patterns. The main question is where you want the <strong>long-lived
+    model</strong> to live: Alpine for small, local UI state; HTMX + Django for data that
+    really belongs on the server.
+  </p>
+
+  <h2 id="ai-assist" class="pt-4">
+    Using AI to Help with Migrations (Safely)
+  </h2>
+  <p>
+    Migrating Knockout to Alpine (+HTMX) is very pattern-heavy. That makes
+    it a great fit for code assistants / AI tools&mdash;as long as we keep
+    tight guardrails and review changes carefully.
+  </p>
+
+  <h3 id="ai-assist-where-helpful" class="pt-3">
+    Where AI is especially helpful
+  </h3>
+  <ul>
+    <li>
+      <strong>Mechanical translation of bindings:</strong> turning
+      <code>data-bind</code> expressions into <code>x-model</code>,
+      <code>x-text</code>, <code>x-show</code>, and small Alpine methods.
+    </li>
+    <li>
+      <strong>Creating Alpine skeletons:</strong> building out an
+      <code>x-data</code> model from an existing Knockout view model
+      (properties, computed values, event handlers).
+    </li>
+    <li>
+      <strong>HTMX wiring:</strong> stubbing out <code>hx-get</code> / <code>hx-post</code>
+      attributes, <code>hx-target</code> containers, and
+      <code>hq-hx-action</code> names for a view that uses
+      <code>HqHtmxActionMixin</code>.
+    </li>
+    <li>
+      <strong>Docs and comments:</strong> summarizing what a Knockout model
+      does and turning that into docstrings, inline comments, or
+      styleguide text (if you want to document some more adventures here).
+    </li>
+  </ul>
+
+  <h3 id="ai-assist-how-to-prompt" class="pt-3">
+    How to prompt in the HQ context
+  </h3>
+  <p>
+    When asking an AI tool to help with a migration, give it enough context
+    so it can follow HQ patterns:
+  </p>
+  <ul>
+    <li>
+      Include the <strong>Knockout JS</strong> and the relevant
+      <strong>template snippet</strong> together (bindings + markup).
+    </li>
+    <li>
+      Mention that you are using <strong>Alpine + HTMX + Django</strong>,
+      and that the page is on <strong>Bootstrap 5</strong>.
+    </li>
+    <li>
+      Be explicit about the target pattern, for example:
+      <ul>
+        <li>
+          “Translate these <code>data-bind</code> attributes to Alpine
+          (<code>x-model</code>, <code>x-text</code>, <code>x-show</code>).
+          Keep the HTML structure and CSS classes the same.”
+        </li>
+        <li>
+          “Create a <code>HqHtmxActionMixin</code>-based view and HTMX
+          attributes for these actions. Use <code>hq-hx-action</code>
+          names that match the method names.”
+        </li>
+      </ul>
+    </li>
+    <li>
+      Ask for <strong>small, focused changes</strong>:
+      “only migrate this one widget” or “just the bindings, no visual
+      redesign.”
+    </li>
+  </ul>
+
+  <h3 id="ai-assist-guardrails" class="pt-3">
+    Guardrails: things to watch out for
+  </h3>
+  <ul>
+    <li>
+      <strong>Behavior must stay the same.</strong> For migration work, treat
+      the AI output as a <em>proposal</em>. Review it like a PR from a new
+      teammate: does it really match the old behavior, including edge cases?
+    </li>
+    <li>
+      <strong>Don't accept giant rewrites.</strong> If an AI tool tries to
+      “modernize” the entire page (rename everything, split files, change
+      semantics), back up and ask for a smaller, narrower transformation.
+    </li>
+    <li>
+      <strong>Keep a tight diff:</strong> prefer migrations where the HTML
+      and structure stay mostly the same and only bindings / models change.
+      That makes it much easier to review and debug.
+    </li>
+    <li>
+      <strong>Run the tests (and the UI).</strong> After applying AI-generated
+      changes, run existing tests and click through the page with both
+      old and new flows in mind (including keyboard-only navigation).
+    </li>
+    <li>
+      <strong>Watch for subtle regressions:</strong> lost accessibility
+      attributes, missing <code>required</code> flags, changed defaults, or
+      behavior that depended on Knockout quirks.
+    </li>
+  </ul>
+
+  <div class="alert alert-primary">
+    <p class="mb-1">
+      <strong>Practical workflow:</strong>
+    </p>
+    <ul class="mb-0">
+      <li>
+        Pick one widget / panel / form at a time.
+      </li>
+      <li>
+        Paste the Knockout model + template into your code assistant and ask
+        for an Alpine (or HTMX) version that preserves behavior.
+      </li>
+      <li>
+        Review, trim, and adapt the suggestion to fit HQ patterns
+        (<code>js_entry</code> usage, <code>HqHtmxActionMixin</code>,
+        Bootstrap 5).
+      </li>
+      <li>
+        Test locally, then commit as a small, reviewable change.
+      </li>
+    </ul>
+  </div>
+
+  <h3 id="step-4-ai-snippets" class="pt-3">
+    Copy-paste prompt snippets
+  </h3>
+  <p>
+    You don't have to rewrite the same context every time you ask an AI tool for help.
+    Below are some "starter" snippets you can copy/paste into your prompts and then
+    follow with the specific code you're working on.
+  </p>
+
+  <h4 id="step-4-ai-snippets-general" class="pt-3">
+    General HQ migration context (use this in most prompts)
+  </h4>
+  <p>
+    Paste this once at the start of a conversation to set the scene:
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.prompt_start %}
+
+  <h4 id="step-4-ai-snippets-inline-alpine" class="pt-3">
+    KO → inline Alpine (simple widget, no extra JS file)
+  </h4>
+  <p>
+    Use this when you just want to move a small KO widget into inline Alpine:
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.prompt_simple %}
+
+  <h4 id="step-4-ai-snippets-alpine-module" class="pt-3">
+    KO → Alpine module (<code>Alpine.data</code>, reusable model)
+  </h4>
+  <p>
+    Use this for larger models that deserve their own JS module:
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.prompt_modules %}
+
+  <h4 id="step-4-ai-snippets-htmx" class="pt-3">
+    KO → HTMX (+ Alpine for small UI state)
+  </h4>
+  <p>
+    Use this when you want to move the “real” state to the server and keep Alpine just for UI sugar:
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.prompt_htmx_alpine %}
+
+  <h4 id="step-4-ai-snippets-short" class="pt-3">
+    Super-short “one-liner” context
+  </h4>
+  <p>
+    When you're in a hurry, prepend this to a quick question:
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.prompt_one_liner %}
+
+  <h4 id="step-4-ai-snippets-review" class="pt-3">
+    Review this AI-generated migration
+  </h4>
+  <p>
+    Use this when you already have a KO→Alpine/HTMX change (maybe generated by AI)
+    and want a second-pass sanity check.
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.prompt_review %}
+
+  <h2 id="step-5" class="pt-4">
+    Step 5: Before / After Checklists
+  </h2>
+  <p>
+    Before merging a Knockout → Alpine (+HTMX) migration, it helps to run through a few
+    quick sanity checks. The goal is simple: same behaviour, less complexity, no surprises.
+  </p>
+
+  <h3 id="step-5-before-start" class="pt-3">
+    Before you start refactoring
+  </h3>
+  <p>
+    These are lightweight prep steps that make the migration and review much easier:
+  </p>
+  <ul>
+    <li>
+      <strong>Capture current behaviour.</strong> Take short notes or screenshots/GIFs:
+      what does the page do today? What are the main interactions?
+    </li>
+    <li>
+      <strong>Find the Knockout entry points.</strong> Locate:
+      <ul>
+        <li>where <code>ko.applyBindings</code> is called, and</li>
+        <li>which templates use <code>data-bind</code> or KO comments
+          (<code>&lt;!-- ko if --&gt;</code>, etc.).
+        </li>
+      </ul>
+    </li>
+    <li>
+      <strong>Identify server-side helpers.</strong> Note which Django views, forms,
+      and template tags/filters the page already uses. These are often good candidates
+      for HTMX endpoints later.
+    </li>
+    <li>
+      <strong>Decide your scope.</strong> Are you doing a “KO → Alpine only” pass for now,
+      or are you also moving state/validation to HTMX in this PR?
+    </li>
+  </ul>
+
+  <h3 id="step-5-before-merge" class="pt-3">
+    Before you merge: behavior &amp; UX checks
+  </h3>
+  <p>
+    Once you've migrated the code, run through these checks to make sure the page still
+    behaves as expected.
+  </p>
+  <ul>
+    <li>
+      <strong>Basic interactions still work.</strong> Click through:
+      <ul>
+        <li>create / edit / delete flows,</li>
+        <li>filters, pagination, sorting, tab switches, dialogs, etc.</li>
+      </ul>
+    </li>
+    <li>
+      <strong>Edge cases still work.</strong> Try:
+      <ul>
+        <li>invalid input / required fields,</li>
+        <li>cancel / reset flows,</li>
+        <li>empty states and “no results” states.</li>
+      </ul>
+    </li>
+    <li>
+      <strong>Keyboard navigation feels sane.</strong> Check that:
+      <ul>
+        <li>
+          you can tab through interactive elements in a sensible order,
+        </li>
+        <li>
+          inline-edit widgets (like the key/value or to-do demos) don’t “lose” focus
+          when HTMX requests fire, and
+        </li>
+        <li>
+          buttons/checkboxes disable correctly while requests are in flight
+          (<code>hx-disabled-elt</code>).
+        </li>
+      </ul>
+    </li>
+    <li>
+      <strong>Loading and error states are clear.</strong>
+      <ul>
+        <li>Buttons show a spinner or disabled state when submitting (where appropriate).</li>
+        <li>
+          HTMX errors are surfaced via the shared error modal or a clear inline message
+          (no silent 500s).
+        </li>
+      </ul>
+    </li>
+    <li>
+      <strong>Translations and template tags survived.</strong>
+      <ul>
+        <li>No lost <code>{% verbatim %}{% trans %}{% endverbatim %}</code> /
+          <code>{% verbatim %}{% blocktrans %}{% endverbatim %}</code> blocks.</li>
+        <li>
+          Template tags, filters, and context variables are still used correctly in the
+          new markup.
+        </li>
+      </ul>
+    </li>
+    <li>
+      <strong>Analytics / tracking still fire (if present).</strong>
+      If the page has GTM events or other tracking, confirm they still fire on
+      the expected interactions.
+    </li>
+  </ul>
+
+  <h3 id="step-5-code-cleanup" class="pt-3">
+    Before you merge: code &amp; dependency cleanup
+  </h3>
+  <p>
+    These are the “don't leave crumbs behind” checks:
+  </p>
+  <ul>
+    <li>
+      <strong>No remaining Knockout bindings on this page.</strong>
+      <ul>
+        <li>No <code>data-bind</code> attributes.</li>
+        <li>No KO comment templates (<code>&lt;!-- ko ... --&gt;</code>).</li>
+        <li>No <code>ko.observable</code>, <code>ko.applyBindings</code>, or KO imports
+          in related JS files.</li>
+      </ul>
+    </li>
+    <li>
+      <strong>Alpine and/or HTMX wiring is clear.</strong>
+      <ul>
+        <li>
+          Inline Alpine: <code>x-data</code>, <code>x-model</code>, <code>x-show</code>,
+          <code>x-for</code>, etc., are small and local.
+        </li>
+        <li>
+          Reusable models: <code>Alpine.data("name", ...)</code> or a shared
+          <code>export default (initial) =&gt; ({ ... })</code> module is in place.
+        </li>
+        <li>
+          HTMX: <code>hx-get</code>/<code>hx-post</code>, <code>hx-target</code>,
+          <code>hx-swap</code>, and <code>hq-hx-action</code> all point to real
+          view methods.
+        </li>
+      </ul>
+    </li>
+    <li>
+      <strong>View and template structure is still sane.</strong>
+      <ul>
+        <li>
+          Class-based views still inherit from the expected base classes
+          (e.g. <code>BasePageView</code>, <code>TemplateView</code>).
+        </li>
+        <li>
+          If using <code>HqHtmxActionMixin</code>, HTMX handlers are small, focused
+          methods decorated with <code>@hq_hx_action</code>.
+        </li>
+      </ul>
+    </li>
+    <li>
+      <strong>Tests and linting pass.</strong>
+      <ul>
+        <li>Any existing tests for this page still pass.</li>
+        <li>
+          If you added new HTMX endpoints or forms, consider at least one small
+          view test or form test that exercises them.
+        </li>
+      </ul>
+    </li>
+    <li>
+      <strong>Dead code is gone.</strong>
+      <ul>
+        <li>
+          Old Knockout modules or RequireJS entries used only by this page are removed
+          or flagged for removal.
+        </li>
+        <li>
+          Inline scripts that only existed to bootstrap KO are gone.
+        </li>
+      </ul>
+    </li>
+  </ul>
+
+  <h2 id="example-commits" class="pt-4">
+    Commits from previous migrations
+  </h2>
+  <p>
+    Here is a starting list of migration commits you can refer to when planning or reviewing
+    your own Knockout → Alpine (+HTMX) work. As our patterns improve, please update this
+    section&mdash;add better examples, remove outdated ones, and keep the list focused on
+    migrations that reflect our current best practices.
+  </p>
+  <ul>
+    <li>
+      <a
+        href="https://github.com/dimagi/commcare-hq/pull/37040/commits/efa1c2bce56561582d679a180374909f50d0f45c"
+        target="_blank"
+      ><strong>Migrating the Stripe card manager</strong></a><br />
+      Shows a reusable <code>Alpine.data</code> model that wraps the Stripe JS API. Useful for:
+      <ul>
+        <li>Replacing a Knockout view model that talks to a third-party JS library</li>
+        <li>Keeping all Stripe-specific logic in a dedicated JS module instead of the template</li>
+        <li>Exposing a small, declarative API to the template via <code>x-data</code> / <code>@click</code></li>
+      </ul>
+    </li>
+    <li>
+      <a
+        href="https://github.com/dimagi/commcare-hq/pull/37055/commits/91b9c422e05dc208f0fcfbcb889455b77a9349d7"
+        target="_blank"
+      ><strong>Move autopay card management to HTMX + Alpine JS</strong></a><br />
+      Example of moving logic that used to live entirely in JavaScript back into Django views
+      and templates, with HTMX handling updates and Alpine handling light UI state. Patterns to
+      look for:
+      <ul>
+        <li>Using <code>HqHtmxActionMixin</code> + <code>hq-hx-action</code> instead of multiple KO
+          endpoints or big conditional blocks
+        </li>
+        <li>Returning small partials to refresh just the “select autopay card” UI</li>
+        <li>Letting Alpine manage only local concerns (toggling loaders, showing/hiding bits of UI)</li>
+      </ul>
+    </li>
+    <li>
+      <a
+        href="https://github.com/dimagi/commcare-hq/pull/37055/commits/cb1dcfbda2baffb93a1ff219870bb2b643f8ead3"
+        target="_blank"
+      ><strong>Introducing Alpine to the Billing Information form</strong></a><br />
+      Not really a Knockout to Alpine migration, but an example of layering Alpine on top of a Django
+      form to handle UI-only behavior. Helpful for:
+      <ul>
+        <li>Toggling informational messages / hints based on form field state</li>
+        <li>Using a small <code>Alpine.data</code> model alongside crispy-forms output</li>
+        <li>Keeping validation and business rules in Django while Alpine manages visibility and text</li>
+      </ul>
+    </li>
+  </ul>
+
+{% endblock content %}

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/knockout_to_alpine.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/knockout_to_alpine.html
@@ -33,7 +33,7 @@
           <li><a href="#step-2-example-2-knockout">Example 2: Knockout source</a></li>
           <li><a href="#step-2-example-2-alpine">Example 2: Migration to Alpine</a></li>
           <li><a href="#step-2-example-2-alpine-reusable">Example 2: Make it reusable</a></li>
-          <li><a href="#step-2-example-2-htmx">Migration to HTMX?</a></li>
+          <li><a href="#step-2-example-2-htmx">Example 2: Migration to HTMX?</a></li>
         </ul>
       </li>
       <li>
@@ -445,7 +445,7 @@
   </p>
 
   <h4 id="step-2-example-2-htmx" class="pt-3">
-    Migration to HTMX?
+    Example 2: Migration to HTMX?
   </h4>
   <p>
     The Alpine version keeps the key/value pairs entirely in the browser: the

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/dates_times.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/dates_times.html
@@ -62,7 +62,7 @@
     The <code>hqwebapp/js/bootstrap5/widgets</code> module when loaded to a page will look for <code>input</code> fields
     with the <code>date-picker</code> CSS class, and apply the Tempus Dominus plugin to that field.
   </p>
-  {% include 'styleguide/bootstrap5/code_example.html' with content=examples.datepicker_widget %}
+  {% include "styleguide/bootstrap5/code_example.html" with content=examples.datepicker_widget %}
 
   <h2 id="advanced-date-picker" class="pt-4">
     Advanced Date Picker
@@ -72,7 +72,7 @@
     the clock component. See the project's <a href="https://getdatepicker.com/6/options/" target="_blank">documentation</a>
     for additional guidance.
   </p>
-  {% include 'styleguide/bootstrap5/html_js_example.html' with content=examples.date_only %}
+  {% include "styleguide/bootstrap5/html_js_example.html" with content=examples.date_only %}
 
   <h2 id="date-and-time" class="pt-4">
     Date &amp; Time
@@ -82,7 +82,7 @@
     See the project's <a href="https://getdatepicker.com/6/options/" target="_blank">documentation</a>
     for additional guidance.
   </p>
-  {% include 'styleguide/bootstrap5/html_js_example.html' with content=examples.tempus_dominus %}
+  {% include "styleguide/bootstrap5/html_js_example.html" with content=examples.tempus_dominus %}
 
   <h2 id="time-only" class="pt-4">
     Time Only
@@ -97,11 +97,11 @@
     <code>bootstrap-timepicker</code> plugin. The example below should be a good starting point to use as a drop-in
     replacement for that widget.
   </div>
-  {% include 'styleguide/bootstrap5/html_js_example.html' with content=examples.time_only %}
+  {% include "styleguide/bootstrap5/html_js_example.html" with content=examples.time_only %}
   <p>
     If you want a time-picker in 24-hour format, the example below provides a good starting point.
   </p>
-  {% include 'styleguide/bootstrap5/html_js_example.html' with content=examples.time_only_24 %}
+  {% include "styleguide/bootstrap5/html_js_example.html" with content=examples.time_only_24 %}
 
   <h2 id="date-range" class="pt-4">
     Date Range
@@ -114,5 +114,5 @@
     For additional guidance, see the <a href="https://getdatepicker.com/6/options/" target="_blank">documentation</a>
     for Tempus Dominus.
   </p>
-  {% include 'styleguide/bootstrap5/html_js_example.html' with content=examples.date_range %}
+  {% include "styleguide/bootstrap5/html_js_example.html" with content=examples.date_range %}
 {% endblock content %}

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/dates_times.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/dates_times.html
@@ -21,6 +21,7 @@
       <li><a href="#date-and-time">Date &amp; Time</a></li>
       <li><a href="#time-only">Time Only</a></li>
       <li><a href="#date-range">Date Range</a></li>
+      <li><a href="#alpine-datepicker">Alpine <code>x-datepicker</code></a></li>
     </ul>
   </nav>
 {% endblock toc %}
@@ -115,4 +116,104 @@
     for Tempus Dominus.
   </p>
   {% include "styleguide/bootstrap5/html_js_example.html" with content=examples.date_range %}
+
+  <h2 id="alpine-datepicker" class="pt-4">
+    Using the <code>x-datepicker</code> Alpine directive
+  </h2>
+  <p>
+    In addition to CSS-class-based widgets, we provide an Alpine directive,
+    <a
+      href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js"
+      target="_blank"
+    ><code>x-datepicker</code></a>, that wraps Tempus Dominus with sensible defaults. This is useful
+    when you are already using Alpine for other page behavior.
+  </p>
+
+  <div class="alert alert-primary">
+    <p class="mb-1">
+      <strong>Important:</strong> to use <code>x-datepicker</code> on a page, make sure the
+      JavaScript entry file for that page imports the shared directive:
+    </p>
+    <pre class="mb-0 mt-2"><code>import "hqwebapp/js/alpinejs/directives/datepicker";</code></pre>
+  </div>
+
+  <p>
+    <a
+      href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js"
+      target="_blank"
+    >The directive is defined here.</a>
+  </p>
+
+  <p>
+    It supports a small JSON configuration object passed via the <code>x-datepicker</code> /
+    <code>x_datepicker</code> attribute:
+  </p>
+  <ul>
+    <li>
+      <code>datetime: true</code> &mdash; enable date <em>and</em> time selection, using a
+      24-hour clock and the format <code>yyyy-MM-dd H:mm:ss</code>.
+    </li>
+    <li>
+      <code>useInputGroup: true</code> &mdash; attach the picker to the surrounding
+      <code>.input-group</code> (for use with crispy <code>AppendedText</code> /
+      <code>PrependedText</code>). The input must be inside an <code>.input-group</code>.
+    </li>
+    <li>
+      <code>container: "#selector"</code> &mdash; render the popup inside a specific
+      DOM container (for example, an offcanvas or modal).
+    </li>
+  </ul>
+
+  <h3 id="alpine-datepicker-inline" class="pt-3">
+    Simple inline usage (date only)
+  </h3>
+  <p>
+    For a simple date-only picker rendered directly on the page, you can use
+    <code>x-datepicker</code> without any extra configuration:
+  </p>
+  {% include "styleguide/bootstrap5/code_example.html" with content=examples.datepicker_alpine_simple %}
+
+  <h3 id="alpine-datepicker-datetime" class="pt-3">
+    Date &amp; time with <code>x-datepicker</code>
+  </h3>
+  <p>
+    To capture both date and time (24-hour clock), pass <code>datetime: true</code> in the
+    configuration JSON:
+  </p>
+  {% include "styleguide/bootstrap5/code_example.html" with content=examples.datepicker_alpine_datetime %}
+
+  <h3 id="alpine-datepicker-crispy" class="pt-3">
+    Using <code>x_datepicker</code> in crispy forms
+  </h3>
+  <p>
+    When working with crispy forms, you typically pass the configuration as JSON into the
+    <code>x_datepicker</code> attribute on a <code>crispy.Field</code>. The directive will
+    automatically handle the Tempus Dominus initialization and cleanup.
+  </p>
+  <p>
+    Combine this pattern with <code>AppendedText</code> to add an icon, as shown in the example.
+  </p>
+  {% include "styleguide/bootstrap5/form_example.html" with content=examples.datepicker_alpine_crispy %}
+
+  <div class="alert alert-primary mt-3">
+    <p class="mb-1">
+      <strong>Behavior details:</strong>
+    </p>
+    <ul class="mb-0">
+      <li>
+        For date-only pickers, selecting a date is a single-click action; the directive
+        automatically hides the picker after a successful selection.
+      </li>
+      <li>
+        For date+time pickers (<code>datetime: true</code>), the widget shows a close button
+        and does <em>not</em> auto-hide, since picking both date and time is usually a
+        multi-step interaction.
+      </li>
+      <li>
+        If the input value cannot be parsed, the directive clears the Tempus Dominus value
+        and stops the error from bubbling further, preventing the widget from getting into
+        a broken state.
+      </li>
+    </ul>
+  </div>
 {% endblock content %}

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/feedback.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/feedback.html
@@ -27,6 +27,7 @@
 
 {% block content %}
   <h2 id="overview">Overview</h2>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     HQ has a custom feedback component that uses
     <a href="https://knockoutjs.com/documentation/component-overview.html"

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/inline_editing.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/inline_editing.html
@@ -29,6 +29,24 @@
 {% block content %}
   <h2 id="overview">Overview</h2>
   {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
+  <div class="alert alert-primary">
+    <strong>To see an Alpine + HTMX version of inline editing, please check out
+    the <a href="{% url "styleguide_htmx_and_alpine_b5" %}#example-todo">HTMX To-Do list example</a>.
+    </strong>
+    <p>
+      A nice item to add to that To-Do list is updating this
+      page to include a drop-in Alpine inline editing widget via an
+      <a
+        href="https://alpinejs.dev/advanced/extending#custom-directives"
+        target="_blank"
+      >Alpine directive</a> and/or reusable
+      <a
+        href="https://alpinejs.dev/globals/alpine-data"
+        target="_blank"
+      >Alpine.data model</a>.
+      What do you think? :)
+    </p>
+  </div>
   <p>
     HQ has a custom component for inline editing, based on
     <a href="https://knockoutjs.com/documentation/component-overview.html"

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/inline_editing.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/inline_editing.html
@@ -28,6 +28,7 @@
 
 {% block content %}
   <h2 id="overview">Overview</h2>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     HQ has a custom component for inline editing, based on
     <a href="https://knockoutjs.com/documentation/component-overview.html"

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/modals.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/modals.html
@@ -66,6 +66,7 @@
   <h3 id="ko-modal-binding" class="pt-3">
     Modal Knockout Binding
   </h3>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     It is also possible to control modals with Knockout using the <code>modal</code> knockout binding.
     This binding accepts an observable as an argument. If the value of the observable is
@@ -84,6 +85,7 @@
   <h3 id="ko-open-modal-binding" class="pt-3">
     OpenModal Knockout Binding
   </h3>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     This method quickly opens a modal using the <code>openModal</code> knockout binding, which takes a string value
     of the <code>id</code> of the knockout template supplying the HTML for this modal.
@@ -98,6 +100,7 @@
   <h3 id="ko-open-remote-modal-binding" class="pt-3">
     OpenRemoteModal Knockout Binding
   </h3>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     Another less frequently-used way of triggering a modal is to use the <code>openRemoteModal</code> Knockout Binding.
     This binding takes a URL to a view in HQ that renders the <code>modal-dialog</code> content of the modal, similar

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/pagination.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/pagination.html
@@ -65,6 +65,7 @@
   <h3 id="htmx-example" class="pt-3">
     An Example
   </h3>
+  {% include "styleguide/bootstrap5/partials/demo_callout.html" with urlname="styleguide_b5_htmx_pagination_view" %}
   <p>
     <a href="{% url "styleguide_b5_htmx_pagination_view" %}">Here is an example</a> of what this solution
     looks like in practice. We’ll go over its components in the sections below. Please also review the

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/pagination.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/pagination.html
@@ -52,12 +52,12 @@
     Pagination with HTMX and Django Tables
   </h2>
   <p>
-    As covered in the <a href="{% url "styleguide_htmx_and_alpine_b5" %}">HTMX + Alpine.JS</a> guide,
-    HTMX works by sending partial HTML responses to asynchronous requests triggered by special <code>hx-</code>
-    attributes added to buttons, forms, links, and other elements.
+    As covered in the <a href="{% url "styleguide_htmx_and_alpine_b5" %}">HTMX + Alpine.js</a> guide,
+    HTMX works by sending partial HTML responses to asynchronous requests triggered by special
+    <code>hx-</code> attributes added to buttons, forms, links, and other elements.
   </p>
   <p>
-    To assist with rendering this partial HTML template, we use
+    To assist with rendering these partial HTML responses, we use
     <a href="https://django-tables2.readthedocs.io/en/latest/" target="_blank">django-tables2</a> to paginate,
     sort, and format tabular data.
   </p>
@@ -67,66 +67,85 @@
   </h3>
   <p>
     <a href="{% url "styleguide_b5_htmx_pagination_view" %}">Here is an example</a> of what this solution
-    looks like. We will go over its components in the sections below. Please make sure to also review the
-    comments within the code.
+    looks like in practice. We’ll go over its components in the sections below. Please also review the
+    inline comments in the code examples.
   </p>
 
   <h4 id="htmx-pagination-definition" class="pt-3">
     Table Definition
   </h4>
   <p>
-    First, we begin with the Table Definition&mdash;<code>ExampleFakeDataTable</code> in this example.
-    It subclasses <code>BaseHtmxTable</code>, which inherits from <code>django-tables2</code>'s <code>Table</code>.
-    This object defines the table's visual style, template, and sets up the column structure and typing.
-    The template and default styling are already taken care of by <code>BaseHtmxTable.Meta</code>,
-    so most use cases just need to specify the columns when starting from <code>BaseHtmxTable</code>.
+    First, we begin with the table definition&mdash;<code>ExampleFakeDataTable</code> in this example.
+    It subclasses <code>BaseHtmxTable</code>, which itself inherits from
+    <code>django-tables2</code>'s <code>Table</code>.
+    This class defines the table's columns, their display names, and the template / styling used to render rows.
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_pagination_table %}
+  <p>
+    The column attribute names match the keys provided by
+    <code>generate_example_pagination_data()</code> (see below), and the
+    <code>verbose_name</code> specifies the label shown to the user.
+    The template and default styling are provided by <code>BaseHtmxTable.Meta</code>, so most
+    use cases only need to define columns when starting from <code>BaseHtmxTable</code>.
+  </p>
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_pagination_table %}
 
   <h4 id="htmx-pagination-table-view" class="pt-3">
     Table View
   </h4>
   <p>
-    Next we have the Table View, <code>ExamplePaginatedTableView</code> . This view renders a page of the
+    Next we have the table view, <code>ExamplePaginatedTableView</code>. This view renders a single page of
     <code>ExampleFakeDataTable</code> based on <code>GET</code> parameters and a <code>queryset</code>.
   </p>
   <p>
-    Since we are using HTMX, <code>ExamplePaginatedTableView</code> only returns a partial template response
-    that is just the table itself, page navigation, and page size selection&mdash;nothing else.
-    The <code>SelectablePaginatedTableView</code> parent class handles page size selection and saving that choice
-    in a cookie. It inherits from <code>django-tables2</code>'s classes and mixins, which handle pagination
-    within a given queryset.
+    Since we are using HTMX, <code>ExamplePaginatedTableView</code> only returns a partial template: the
+    table itself plus page navigation and page size selection&mdash;no outer layout or navigation.
+    The <code>SelectablePaginatedTableView</code> parent class handles page size selection and saving that
+    choice in a cookie. It inherits from <code>django-tables2</code>'s classes and mixins, which handle
+    pagination within a given queryset.
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_pagination_table_view %}
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_pagination_table_view %}
   <p>
-    The queryset in this example is just an in-memory list of dicts for simplicity (seen below).
-    However, <code>django-tables2</code> also has support for Django QuerySets. We will be adding
-    support for <code>elasticsearch</code> queries soon.
+    For this styleguide example, the queryset is just an in-memory list of dicts
+    (generated below). In a real project you would typically return a Django <code>QuerySet</code>
+    here instead.
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_pagination_data %}
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_pagination_data %}
 
   <h4 id="htmx-pagination-host" class="pt-3">
     Host View
   </h4>
   <p>
-    Lastly, we have the host view, <code>HtmxPaginationView</code>. This view "hosts" the partial template
-    HTML returned from HTMX requests to <code>ExamplePaginatedTableView</code>.
+    Lastly, we have the host view, <code>HtmxPaginationView</code>. This view renders the full page shell
+    (navigation, layout, scripts) and “hosts” the partial HTML returned by
+    <code>ExamplePaginatedTableView</code>.
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_pagination_host_view %}
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_pagination_host_view %}
   <p>
-    Its template (seen below) sets up the JavaScript context and inherits from the appropriate
-    CommCare HQ base template. A <code>div</code> makes the initial <code>hx-get</code> request to
+    Its template (shown below) sets up the JavaScript context and inherits from the appropriate
+    CommCare HQ base template. A <code>&lt;div&gt;</code> issues an initial <code>hx-get</code> request to
     <code>ExamplePaginatedTableView</code> on page load (<code>hx-trigger="load"</code>). Subsequent
-    requests are controlled by <code>hx-</code> attributes within the table's template.
+    requests (page links, page size, etc.) are driven by <code>hx-</code> attributes inside the table
+    template generated by <code>BaseHtmxTable</code>.
   </p>
-  {% include 'styleguide/bootstrap5/code_display.html' with content=examples.htmx_pagination_template %}
+  {% include "styleguide/bootstrap5/code_display.html" with content=examples.htmx_pagination_template %}
   <p>
-    The host view can also interact with the table from outside the original <code>div</code>
-    that contains the partial HTML responses from <code>ExamplePaginatedTableView</code>. This example demonstrates
-    sending a refresh event to the table using the <code>hq-hx-refresh-after</code> attribute placed
-    on a <code>button</code>. After this button's own HTMX request completes, the table is reloaded.
-    This example is very simple, but you can imagine chaining a refresh event to a <code>form</code>
-    (perhaps a column filter form) that triggers table refresh after submission.
+    The host view can also interact with the table from outside the original container
+    that receives partial HTML from <code>ExamplePaginatedTableView</code>. In this example, the
+    “Refresh Table After Request” button:
+  </p>
+  <ul>
+    <li>
+      performs its own HTMX <code>hx-get</code> to a separate URL, and
+    </li>
+    <li>
+      uses <code>hq-hx-refresh-after="#ExampleFakeDataTable"</code> to trigger an
+      <code>hqRefresh</code> event on the table after that request completes.
+    </li>
+  </ul>
+  <p>
+    The table listens for this event and reloads itself via HTMX. In a real page, you could use
+    the same pattern to refresh the table after submitting a filter form, applying bulk actions,
+    or changing configuration elsewhere on the page.
   </p>
 
   <h2 id="using-knockout-pagination" class="pt-4">

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/pagination.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/pagination.html
@@ -151,10 +151,7 @@
   <h2 id="using-knockout-pagination" class="pt-4">
     Using Knockout Pagination
   </h2>
-  <div class="alert alert-warning">
-    Note that these steps will be deprecated in 2025, and the section will be here for reference with older
-    code, until it is no longer needed.
-  </div>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     The best way to understand the different ways of using pagination is to see its use in HQ directly. The best
     sources for this are the Web Users and Mobile Workers pages.

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/searching.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/searching.html
@@ -75,6 +75,7 @@
   <h3 id="quick-example" class="pt-3">
     A Quick Example
   </h3>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     Here is a quick example simulating the search box usage. Ideally, this searching should be done asynchronously,
     as this widget is most useful for larger data sets, and it would likely be inefficient store the whole dataset in memory.
@@ -90,6 +91,7 @@
   <h3 id="client-side" class="pt-3">
     Client-Side Only Search
   </h3>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     In some cases we might only want to do client-side searches. This means that the entire data set is stored in browser
     memory, and we query that dataset without making additional calls to the server.

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/searching.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/searching.html
@@ -99,6 +99,7 @@
   <p>
     An example use case for this is the "Clean Case Data" modal that can be accessed from the Case Data
     page. In this page we use the search box widget to filter case properties.
+    <strong>Note:</strong> this is the legacy single case cleaning widget, not the "bulk edit case data" tool.
   </p>
   <p>
     Key points for this example are:

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/selections.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/selections.html
@@ -18,34 +18,34 @@
       <li><a href="#overview">Overview</a></li>
       <li><a href="#select-toggle">Select-Toggle</a>
           <ul>
-            <a href="#select-toggle-crispy">Usage in Crispy Forms</a></li>
+            <li><a href="#select-toggle-crispy">Usage in Crispy Forms</a></li>
           </ul>
         </li>
       <li><a href="#select2">Select2</a>
         <ul>
           <li><a href="#select2-manual">Manual Setup</a>
             <ul>
-              <a href="#select2-manual-crispy">With Crispy Forms</a></li>
+              <li><a href="#select2-manual-crispy">With Crispy Forms</a></li>
             </ul>
           </li>
           <li><a href="#select2-css-class">Referencing a CSS Class</a>
             <ul>
-              <a href="#select2-css-class-crispy">With Crispy Forms</a></li>
+              <li><a href="#select2-css-class-crispy">With Crispy Forms</a></li>
             </ul>
           </li>
           <li><a href="#select2-ko-dynamic">Dynamic Knockout Binding</a>
             <ul>
-              <a href="#select2-ko-dynamic-crispy">With Crispy Forms</a></li>
+              <li><a href="#select2-ko-dynamic-crispy">With Crispy Forms</a></li>
             </ul>
           </li>
           <li><a href="#select2-ko-static">Static Knockout Binding</a>
             <ul>
-              <a href="#select2-ko-static-crispy">With Crispy Forms</a></li>
+              <li><a href="#select2-ko-static-crispy">With Crispy Forms</a></li>
             </ul>
           </li>
           <li><a href="#select2-ko-autocomplete">Autocomplete Knockout Binding</a>
             <ul>
-              <a href="#select2-ko-autocomplete-crispy">With Crispy Forms</a></li>
+              <li><a href="#select2-ko-autocomplete-crispy">With Crispy Forms</a></li>
             </ul>
           </li>
           <li><a href="#select2-crispy-select2Ajax-widget">Crispy Forms Select2Ajax Widget</a></li>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/selections.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/selections.html
@@ -96,6 +96,7 @@
   <h2 id="select-toggle" class="pt-4">
     Select-Toggle
   </h2>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     On the occasions when a list is guaranteed to be short (2-5 items), consider displaying it as a toggle.
     This shows all options and only takes one click to select.
@@ -291,6 +292,7 @@
   <h3 id="select2-ko-dynamic" class="pt-3">
     Dynamic Knockout Binding
   </h3>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     We can also use the knockout binding <code>select2</code> to initialize a <code>select2</code>, with options
     provided by Knockout.
@@ -300,6 +302,7 @@
   <h4 id="select2-ko-dynamic-crispy" class="pt-2">
     Dynamic Knockout Binding with Crispy Forms
   </h4>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     This is similar to the HTML-based setups above, except that an external script applies <code>koApplyBindings</code>
     to the <code>&lt;form&gt; id</code> (<code>&lt;form&gt;</code> can also be wrapped with a <code>&lt;div&gt;</code> with the same
@@ -311,6 +314,7 @@
   <h3 id="select2-ko-static" class="pt-3">
     Static Knockout Binding
   </h3>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     We can also initialize a <code>select2</code> with the <code>staticSelect2</code> Knockout Binding, where the options
     are pulled from <code>HTML</code> instead of Knockout. This is useful for <code>select2s</code> that have
@@ -322,6 +326,7 @@
   <h4 id="select2-ko-static-crispy" class="pt-2">
     Static Knockout Binding with Crispy Forms
   </h4>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     This is similar to the HTML-based setups above, except that an external script applies <code>koApplyBindings</code>
     to the <code>&lt;form&gt; id</code> (<code>&lt;form&gt;</code> can also be wrapped with a <code>&lt;div&gt;</code> with the same
@@ -332,6 +337,7 @@
   <h3 id="select2-ko-autocomplete" class="pt-3">
     Autocomplete Knockout Binding
   </h3>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     To initialize a <code>select2</code> to autocomplete select suggestions, use the <code>autocompleteSelect2</code>
     Knockout binding. The difference between this binding and the original <code>select2</code>, is the ability to
@@ -342,6 +348,7 @@
   <h4 id="select2-ko-autocomplete-crispy" class="pt-2">
     Autocomplete Knockout Binding with Crispy Forms
   </h4>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     This is similar to the HTML-based setups above, except that an external script applies <code>koApplyBindings</code>
     to the <code>&lt;form&gt; id</code> (<code>&lt;form&gt;</code> can also be wrapped with a <code>&lt;div&gt;</code> with the same
@@ -366,6 +373,7 @@
   <h2 id="multiselect" class="pt-4">
     Multiselect
   </h2>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     This is a custom widget we built. It can be useful in situations where the user is adding and removing
     items from one list to another and wants to be able to see both the included and excluded items.
@@ -398,6 +406,7 @@
   <h4 id="multiselect-crispy" class="pt-2">
     Use in Crispy Forms
   </h4>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     This is similar to the manual setup above, but using crispy forms to provide the form HTML.
   </p>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/selections.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/molecules/selections.html
@@ -33,6 +33,12 @@
               <li><a href="#select2-css-class-crispy">With Crispy Forms</a></li>
             </ul>
           </li>
+          <li>
+            <a href="#select2-alpine">Alpine <code>x-select2</code> Directive</a>
+            <ul>
+              <li><a href="#select2-alpine-crispy">With Crispy Forms</a></li>
+            </ul>
+          </li>
           <li><a href="#select2-ko-dynamic">Dynamic Knockout Binding</a>
             <ul>
               <li><a href="#select2-ko-dynamic-crispy">With Crispy Forms</a></li>
@@ -137,8 +143,10 @@
     the <a href='https://select2.org/' target='_blank'>full documentation</a> for details.
   </p>
   <p>
-    We instantiate select2 in a number of different ways: manually with javascript, via knockout bindings,
-    and by using CSS classes that certain javascript modules search for.
+    We instantiate <code>select2</code> in a few different ways:
+    manually with JavaScript, via Knockout bindings, via an Alpine
+    directive (<code>x-select2</code>), and by using CSS classes that
+    certain JavaScript modules search for.
   </p>
   <p>
     We also have a <code>select2</code> options for common behaviors like validating email addresses and displaying form
@@ -187,6 +195,98 @@
     <code>crispy.Field</code>'s <code>css_class</code> argument instead.
   </p>
   {% include 'styleguide/bootstrap5/form_example.html' with content=examples.select2_css_class_crispy %}
+
+  <h3 id="select2-alpine" class="pt-3">
+    Alpine <code>x-select2</code> Directive
+  </h3>
+  <p>
+    On Bootstrap 5 pages using Alpine, the preferred way to initialize
+    <code>select2</code> is via the
+    <a
+      href="https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/select2.js"
+      target="_blank"
+    ><code>x-select2</code> Alpine directive</a>. This directive:
+  </p>
+  <ul>
+    <li>initializes <code>select2</code> on the <code>&lt;select&gt;</code>,</li>
+    <li>
+      accepts a JSON configuration object (same options you would pass
+      to <code>$(el).select2({...})</code>),
+    </li>
+    <li>
+      dispatches a custom <code>select2change</code> event when the value
+      changes so Alpine can react, and
+    </li>
+    <li>
+      cleans up <code>select2</code> when the element is removed (e.g., when
+      HTMX replaces a partial).
+    </li>
+  </ul>
+
+  <p>
+    At a minimum, you can add <code>x-select2</code> to any
+    <code>&lt;select&gt;</code>:
+  </p>
+  {% include "styleguide/bootstrap5/code_example.html" with content=examples.select2_alpine_basic %}
+
+  <p>
+    The directive expression is parsed as JSON, so you can pass
+    <code>select2</code> options directly. For example:
+  </p>
+  {% include "styleguide/bootstrap5/code_example.html" with content=examples.select2_alpine_with_options %}
+
+  <p>
+    The directive also dispatches a custom
+    <code>select2change</code> event whenever the value changes. In Alpine,
+    you can listen to that event with <code>@select2change</code>:
+  </p>
+  {% include "styleguide/bootstrap5/code_example.html" with content=examples.select2_alpine_select2change %}
+
+  <div class="alert alert-primary mt-3">
+    <p class="mb-1">
+      <strong>HTMX tip:</strong> <code>x-select2</code> plays nicely with
+      HTMX form submissions.
+    </p>
+    <p class="mb-0">
+      The directive listens for the
+      <code>htmx:afterSettle</code> event and re-applies the
+      <code>select2</code> styles and validation classes after a partial
+      is swapped back into the DOM. This prevents the “stacked native
+      &lt;select&gt; + select2” bug and keeps <code>is-valid</code> /
+      <code>is-invalid</code> in sync with the select2 container when
+      forms are re-rendered via HTMX.
+    </p>
+  </div>
+
+  <h4 id="select2-alpine-crispy" class="pt-2">
+    Alpine <code>x-select2</code> with Crispy Forms
+  </h4>
+  <p>
+    In crispy forms, you pass the directive via the <code>x_select2</code>
+    keyword argument on <code>crispy.Field</code>. The value should be
+    <code>json.dumps</code> of the <code>select2</code> config you want to use.
+    You can also attach Alpine event handlers like
+    <code>@select2change</code>.
+  </p>
+  {% include "styleguide/bootstrap5/form_example.html" with content=examples.select2_alpine_crispy %}
+  <p>
+    In this pattern:
+  </p>
+  <ul>
+    <li>
+      <code>x_select2</code> becomes the Alpine
+      <code>x-select2</code> directive on the rendered
+      <code>&lt;select&gt;</code>,
+    </li>
+    <li>
+      the config is parsed as JSON inside the directive and passed to
+      <code>$(el).select2(config)</code>, and
+    </li>
+    <li>
+      <code>@select2change</code> updates Alpine state using the new value
+      from <code>$event.detail</code>.
+    </li>
+  </ul>
 
   <h3 id="select2-ko-dynamic" class="pt-3">
     Dynamic Knockout Binding

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/organisms/forms.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/organisms/forms.html
@@ -135,6 +135,7 @@
   <h3 id="crispy-forms-knockout" class="pt-3">
     Using Knockout with Crispy Forms
   </h3>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     The example below demonstrates various ways Knockout Bindings can be applied within a Crispy Form. Please review the
     comments in python code for further details.
@@ -275,6 +276,7 @@
   <h3 id="ko-validation" class="pt-3">
     Knockout Validation
   </h3>
+  {% include "styleguide/bootstrap5/partials/ko_migration_alert.html" %}
   <p>
     <a href="https://github.com/Knockout-Contrib/Knockout-Validation" target="_blank">Knockout Validation</a>
     is an extension of Knockout that we use to do client-side validation of form fields.

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/organisms/tables.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/organisms/tables.html
@@ -38,7 +38,8 @@
           <li><a href="#datatables-simple">Simple Example</a></li>
         </ul>
       </li>
-      <li><a href="#paginated-table">Paginated Table</a></li>
+      <li><a href="#htmx-django-tables">Paginated Table (HTMX + Django Tables)</a></li>
+      <li><a href="#paginated-table">Paginated Table (Datatables)</a></li>
     </ul>
   </nav>
 {% endblock toc %}
@@ -238,8 +239,39 @@
   {% registerurl "styleguide_datatables_data" %}
   {% include 'styleguide/bootstrap5/html_js_example.html' with content=examples.datatables %}
 
+  <h3 id="htmx-django-tables" class="pt-4">
+    Paginated Table with HTMX and Django Tables
+  </h3>
+  <p>
+    For paginated tables, HTMX pairs nicely with
+    <a href="https://django-tables2.readthedocs.io/en/latest/" target="_blank">django-tables2</a>:
+    Django renders each page of results as a partial, and HTMX swaps that partial into the page
+    as the user clicks through pages or changes page size.
+  </p>
+  <p>
+    We have a separate styleguide example that walks through this pattern end-to-end
+    (table definition, paginated view, and “host” HTMX view), plus a live demo:
+  </p>
+  <ul>
+    <li>
+      <a href="{% url "styleguide_molecules_pagination_b5" %}#using-pagination-htmx">
+        Pagination with HTMX and Django Tables (documentation)
+      </a>
+    </li>
+    <li>
+      <a href="{% url "styleguide_b5_htmx_pagination_view" %}">
+        Simple Pagination: HTMX + Django Tables2 (demo)
+      </a>
+    </li>
+  </ul>
+  <p>
+    If you're building or migrating any paginated tables, start there for concrete patterns you
+    can copy into your own views. Hint: It might be an excellent alternative / replacement of
+    datatables, right? ;)
+  </p>
+
   <h2 id="paginated-table" class="pt-4">
-    Paginated Table
+    Paginated Table Using Datatables
   </h2>
   <p>
     Below is an example of a paginated table. As explained in the <a href="{% url "styleguide_molecules_pagination_b5" %}">Pagination</a> section of

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/partials/demo_callout.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/partials/demo_callout.html
@@ -1,0 +1,14 @@
+<div class="alert alert-primary d-flex flex-wrap align-items-center gap-2">
+  <strong class="text-primary">
+    {{ title|default:"See it in action" }}:
+  </strong>
+  <a
+    href="{% url urlname %}"
+    target="_blank"
+    rel="noopener"
+    class="btn btn-primary"
+  >
+    Open demo
+    <i class="fa fa-arrow-up-right-from-square ms-1"></i>
+  </a>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/bootstrap5/partials/ko_migration_alert.html
+++ b/corehq/apps/styleguide/templates/styleguide/bootstrap5/partials/ko_migration_alert.html
@@ -1,0 +1,9 @@
+<div class="alert alert-warning">
+  <p><strong>Legacy Knockout pattern — kept here for reference only.</strong></p>
+  Please <strong>do not write new code</strong>
+  like this. When you next work in this area, consider replacing this example with an equivalent
+  Alpine / HTMX pattern (if appropriate), following the
+  <a href="{% url 'styleguide_knockout_to_alpine_guide_b5' %}" target="_blank">
+    Knockout → Alpine (+HTMX) migration guide
+  </a>, or removing it when no longer needed.
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/htmx_alpine_crispy/main.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_alpine_crispy/main.html
@@ -2,24 +2,25 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{# use the `hqwebapp/js/htmx_and_alpine` entry point to get started with HTMX and Alpine without any extra javascript #}
+{# Use the `hqwebapp/js/htmx_and_alpine` entry point to enable HTMX + Alpine without adding any page-specific JavaScript. #}
 {% js_entry "hqwebapp/js/htmx_and_alpine" %}
 
 {% block content %}
   <div
-      class="container p-5"
-      {# loads FilterDemoFormView on load with hx-get #}
-      hx-trigger="load"
-      hx-get="{{ filter_form_url }}"
+    class="container p-5"
+    hx-trigger="load"
+    hx-get="{{ request.path_info }}"
+    hq-hx-action="load_form"
   >
+    {# Shown automatically while HTMX is waiting for the response. #}
     <div class="htmx-indicator">
       <i class="fa-solid fa-spinner fa-spin"></i> {% trans "Loading..." %}
     </div>
   </div>
-{% endblock %}
+{% endblock content %}
 
 {% block modals %}
-  {# you can either include this template or include an extension of this template to show HTMX errors to the user #}
+  {# Include a shared error modal for HTMX errors. You can override or extend this template in your own app if needed. #}
   {% include "hqwebapp/htmx/error_modal.html" %}
   {{ block.super }}
 {% endblock modals %}

--- a/corehq/apps/styleguide/templates/styleguide/htmx_alpine_crispy/partial_form.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_alpine_crispy/partial_form.html
@@ -4,27 +4,29 @@
 <div id="add-filter-form-container">
   {% if show_success %}
     <div
-        class="alert alert-success alert-dismissible fade show"
-        role="alert"
+      class="alert alert-success alert-dismissible fade show"
+      role="alert"
     >
       {% blocktrans %}
         Added filter!
       {% endblocktrans %}
       <button
-          type="button"
-          class="btn-close"
-          data-bs-dismiss="alert"
-          aria-label="{% trans "Close" %}"
+        type="button"
+        class="btn-close"
+        data-bs-dismiss="alert"
+        aria-label="{% trans "Close" %}"
       ></button>
     </div>
   {% endif %}
 
   <form
-      hx-post="{{ request.path_info }}"
-      hx-target="#add-filter-form-container"
-      hx-swap="outerHTML"
-      hx-disabled-elt="find button"
+    hx-post="{{ request.path_info }}"
+    hq-hx-action="submit_form"
+    hx-target="#add-filter-form-container"
+    hx-swap="outerHTML"
+    hx-disabled-elt="find button"
   >
+    {# Crispy Forms renders the fields and Alpine attributes defined in FilterDemoForm. #}
     {% crispy filter_form %}
   </form>
 </div>

--- a/corehq/apps/styleguide/templates/styleguide/htmx_key_values/field_with_error.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_key_values/field_with_error.html
@@ -1,0 +1,23 @@
+{% load hq_shared_tags %}
+<div id="pair-{{ pair.id }}-value">
+  <input
+    type="text"
+    name="value"
+    class="form-control {% if error %}is-invalid{% endif %}"
+    value="{{ pair.value }}"
+    hx-post="{{ request.path_info }}"
+    hq-hx-action="update_pair"
+    hx-vals='{
+      "id": "{{ pair.id }}",
+      "field": "value",
+      "error": {{ error|BOOL }}
+    }'
+    hx-trigger="change, blur"
+    hx-swap="none"
+  >
+  {% if error %}
+    <div class="invalid-feedback">
+      {{ error }}
+    </div>
+  {% endif %}
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/htmx_key_values/main.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_key_values/main.html
@@ -1,0 +1,38 @@
+{% extends "hqwebapp/bootstrap5/base_navigation.html" %}
+{% load hq_shared_tags %}
+
+{# No page-specific JS needed; use the shared HTMX + Alpine entry point #}
+{% js_entry "hqwebapp/js/htmx_and_alpine" %}
+
+{% block content %}
+  <div class="container py-4">
+    <h1 class="mb-3">
+      Key / Value Pairs (HTMX version)
+    </h1>
+    <p class="text-muted mb-2">
+      This example manages key/value pairs entirely on the server. HTMX sends
+      small requests when you add, edit, or delete a row, and the view returns
+      an updated HTML partial.
+    </p>
+    <p class="text-muted mb-4">
+      TIP: leave a value field blank to trigger an error response.
+    </p>
+
+    <div
+      id="kv-list-container"
+      hx-get="{{ request.path_info }}"
+      hq-hx-action="load_pairs"
+      hx-trigger="load"
+    >
+      <div class="htmx-indicator">
+        <i class="fa-solid fa-spinner fa-spin"></i> Loading...
+      </div>
+    </div>
+  </div>
+{% endblock content %}
+
+{% block modals %}
+  {# Standard HTMX error modal #}
+  {% include "hqwebapp/htmx/error_modal.html" %}
+  {{ block.super }}
+{% endblock modals %}

--- a/corehq/apps/styleguide/templates/styleguide/htmx_key_values/partial.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_key_values/partial.html
@@ -1,0 +1,85 @@
+<div
+  id="kv-list-container"
+  hx-swap="outerHTML"
+>
+  <div class="d-flex flex-column gap-2 mb-3">
+    {% for pair in pairs %}
+      <div class="d-flex align-items-center">
+        <div class="flex-fill me-2">
+          <input
+            type="text"
+            class="form-control"
+            name="key"
+            value="{{ pair.key }}"
+            hx-post="{{ request.path_info }}"
+            hq-hx-action="update_pair"
+            {# note: with hx-vals, make sure you don't have a trailing comma and use double quotes in the JSON #}
+            hx-vals='{
+              "id": "{{ pair.id }}",
+              "field": "key"
+            }'
+            hx-trigger="change, blur"
+            {# if we use outerHTML here, we loose state of where the keyboard is focused #}
+            hx-swap="none"
+            hx-disabled-elt="this"
+          />
+        </div>
+        <span class="px-2">&rarr;</span>
+        <div class="flex-fill me-2">
+          {# this id below will come in handy for validation #}
+          <div id="pair-{{ pair.id }}-value">
+            <input
+              type="text"
+              class="form-control"
+              name="value"
+              value="{{ pair.value }}"
+              hx-post="{{ request.path_info }}"
+              hq-hx-action="update_pair"
+              hx-vals='{
+                "id": "{{ pair.id }}",
+                "field": "value"
+              }'
+              hx-trigger="change, blur"
+              {# if we use outerHTML here, we loose state of where the keyboard is focused #}
+              hx-swap="none"
+              hx-disabled-elt="this"
+            />
+          </div>
+        </div>
+        <button
+          type="button"
+          class="btn btn-outline-danger"
+          hx-post="{{ request.path_info }}"
+          hq-hx-action="delete_pair"
+          hx-vals='{
+            "id": "{{ pair.id }}"
+          }'
+          hx-target="#kv-list-container"
+          hx-swap="outerHTML"
+          hx-disabled-elt="this"
+        >
+          <i class="fa fa-remove"></i>
+        </button>
+      </div>
+    {% empty %}
+      <p class="text-muted fst-italic mb-0">
+        No key/value pairs yet.
+      </p>
+    {% endfor %}
+  </div>
+
+  <p>
+    <button
+      type="button"
+      class="btn btn-primary"
+      hx-post="{{ request.path_info }}"
+      hq-hx-action="add_pair"
+      hx-target="#kv-list-container"
+      hx-swap="outerHTML"
+      hx-disabled-elt="this"
+    >
+      <i class="fa fa-plus"></i>
+      Add
+    </button>
+  </p>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/htmx_next_action_simple/main.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_next_action_simple/main.html
@@ -1,6 +1,4 @@
-{# styleguide/htmx_next_action_simple/main.html #}
 {% extends "hqwebapp/bootstrap5/base_navigation.html" %}
-{% load i18n %}
 {% load hq_shared_tags %}
 
 {# Use the standard HTMX + Alpine entry point; no extra JS is required. #}

--- a/corehq/apps/styleguide/templates/styleguide/htmx_next_action_simple/main.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_next_action_simple/main.html
@@ -1,0 +1,35 @@
+{# styleguide/htmx_next_action_simple/main.html #}
+{% extends "hqwebapp/bootstrap5/base_navigation.html" %}
+{% load i18n %}
+{% load hq_shared_tags %}
+
+{# Use the standard HTMX + Alpine entry point; no extra JS is required. #}
+{% js_entry "hqwebapp/js/htmx_and_alpine" %}
+
+{% block content %}
+  <div class="container py-4">
+    <h1 class="mb-3">
+      Favorite Fruit (Next Action Demo)
+    </h1>
+    <p class="text-muted">
+      This demo shows a small multi-step flow using a single view and the <code>next_action</code> pattern.
+    </p>
+
+    <div
+      id="{{ container_id }}"
+      hx-trigger="load"
+      hx-get="{{ request.path_info }}"
+      hq-hx-action="load_first_step"
+    >
+      <div class="htmx-indicator">
+        <i class="fa-solid fa-spinner fa-spin"></i>
+        Loading...
+      </div>
+    </div>
+  </div>
+{% endblock content %}
+
+{% block modals %}
+  {% include "hqwebapp/htmx/error_modal.html" %}
+  {{ block.super }}
+{% endblock modals %}

--- a/corehq/apps/styleguide/templates/styleguide/htmx_next_action_simple/next_step_with_message.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_next_action_simple/next_step_with_message.html
@@ -1,0 +1,29 @@
+{# styleguide/htmx_next_action_simple/next_action_form.html #}
+{% load i18n %}
+{% load crispy_forms_tags %}
+
+<div id="{{ container_id }}" hx-swap="outerHTML">
+  {% if message %}
+    <div
+      class="alert alert-success alert-dismissible fade show mb-3"
+      role="alert"
+    >
+      {{ message }}
+      <button
+        type="button"
+        class="btn-close"
+        data-bs-dismiss="alert"
+        aria-label="{% trans "Close" %}"
+      ></button>
+    </div>
+  {% endif %}
+
+  <form
+    hx-post="{{ request.path_info }}"
+    hx-target="#{{ container_id }}"
+    hx-disabled-elt="find button"
+    hq-hx-action="{{ next_action }}"
+  >
+    {% crispy form %}
+  </form>
+</div>

--- a/corehq/apps/styleguide/templates/styleguide/htmx_next_action_simple/next_step_with_message.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_next_action_simple/next_step_with_message.html
@@ -1,4 +1,3 @@
-{# styleguide/htmx_next_action_simple/next_action_form.html #}
 {% load i18n %}
 {% load crispy_forms_tags %}
 

--- a/corehq/apps/styleguide/templates/styleguide/htmx_todo/item.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_todo/item.html
@@ -1,48 +1,48 @@
 {% load i18n %}
 <li
-    id="item-{{ item.id }}"
-    class="list-group-item"
-    {# the x-data below is from Alpine, and sets up the model for inline editing #}
-    x-data='{
-      isEditing: false,
-      isSubmitting: false,
-      itemValue: "{{ item.name }}",
-    }'
+  id="item-{{ item.id }}"
+  class="list-group-item"
+  {# the x-data below is from Alpine, and sets up the model for inline editing #}
+  x-data='{
+    isEditing: false,
+    isSubmitting: false,
+    itemValue: "{{ item.name }}",
+  }'
 >
   <div class="d-flex align-items-center fs-4 p-1">
     <input
-        class="form-check-input me-3"
-        type="checkbox"
-        {# request.path_info is just the same URL for this view #}
-        {# an alternative would be {% url "sg_htmx_todo_list_example" %} #}
-        hx-post="{{ request.path_info }}"
-        {# hq-hx-action triggers the mark_item_done method in TodoListDemoView #}
-        hq-hx-action="mark_item_done"
-        {# hx-vals is a handy way to send extra JSON-formatted data with the request #}
-        hx-vals='{
-          "itemId": {{ item.id }}
-        }'
-        {# the next two lines say replace the entire content of the target in hx-target #}
-        hx-swap="outerHTML"
-        hx-target="#item-{{ item.id }}"
-        {# :disabled is shorthand for Alpine's x-bind:disabled #}
-        :disabled="isEditing || isSubmitting"
+      class="form-check-input me-3"
+      type="checkbox"
+      {# request.path_info is just the same URL for this view #}
+      {# an alternative would be {% url "sg_htmx_todo_list_example" %} #}
+      hx-post="{{ request.path_info }}"
+      {# hq-hx-action triggers the mark_item_done method in TodoListDemoView #}
+      hq-hx-action="mark_item_done"
+      {# hx-vals is a handy way to send extra JSON-formatted data with the request #}
+      hx-vals='{
+        "itemId": {{ item.id }}
+      }'
+      {# the next two lines say replace the entire content of the target in hx-target #}
+      hx-swap="outerHTML"
+      hx-target="#item-{{ item.id }}"
+      {# :disabled is shorthand for Alpine's x-bind:disabled #}
+      :disabled="isEditing || isSubmitting"
     >
 
     {# the element below defines what the text looks like when not in edit mode #}
     <div
-        class="pt-1"
-        {# here we react to the value of isEditing from the alpine model set up in the parent <li> element #}
-        x-show="!isEditing"
-        {# @dblclick is shorthand for Alpine's x-on:dblclick #}
-        @dblclick="isEditing = !isSubmitting"
+      class="pt-1"
+      {# here we react to the value of isEditing from the alpine model set up in the parent <li> element #}
+      x-show="!isEditing"
+      {# @dblclick is shorthand for Alpine's x-on:dblclick #}
+      @dblclick="isEditing = !isSubmitting"
     >
       <span>{{ item.name }}</span>
       <button
-          class="btn btn-link btn-sm inline-edit-action"
-          type="button"
-          @click="isEditing = true"
-          :disabled="isSubmitting"
+        class="btn btn-link btn-sm inline-edit-action"
+        type="button"
+        @click="isEditing = true"
+        :disabled="isSubmitting"
       >
         <i class="fa fa-pencil"></i>
         <span class="visually-hidden">
@@ -54,36 +54,36 @@
     {# the element below defines what the inline edit looks like in edit mode #}
     <div x-show="isEditing">
       <form
-          hx-post="{{ request.path_info }}"
-          hq-hx-action="edit_item"
-          hx-vals='{
-            "itemId": {{ item.id }}
-          }'
-          {# hx-disabled-elt ensures that all buttons related to this form are disabled on post #}
-          hx-disabled-elt="find button"
-          hx-swap="outerHTML"
-          hx-target="#item-{{ item.id }}"
+        hx-post="{{ request.path_info }}"
+        hq-hx-action="edit_item"
+        hx-vals='{
+          "itemId": {{ item.id }}
+        }'
+        {# hx-disabled-elt ensures that all buttons related to this form are disabled on post #}
+        hx-disabled-elt="find button"
+        hx-swap="outerHTML"
+        hx-target="#item-{{ item.id }}"
       >
         <div class="input-group">
           <input
-              type="text"
-              class="form-control"
-              name="newValue"
-              {# x-model creates a two-way binding for the value of itemValue in the alpine model with the value of the input #}
-              x-model="itemValue"
+            type="text"
+            class="form-control"
+            name="newValue"
+            {# x-model creates a two-way binding for the value of itemValue in the alpine model with the value of the input #}
+            x-model="itemValue"
           >
           <button
-              class="btn btn-primary"
-              type="submit"
-              @click="isSubmitting = true"
+            class="btn btn-primary"
+            type="submit"
+            @click="isSubmitting = true"
           >
             <i class="fa fa-check"></i>
           </button>
           <button
-              class="btn btn-outline-danger"
-              type="button"
-              :disabled="isSubmitting"
-              @click="isEditing = false"
+            class="btn btn-outline-danger"
+            type="button"
+            :disabled="isSubmitting"
+            @click="isEditing = false"
           >
             <i class="fa fa-close"></i>
           </button>
@@ -91,5 +91,4 @@
       </form>
     </div>
   </div>
-
 </li>

--- a/corehq/apps/styleguide/templates/styleguide/htmx_todo/item.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_todo/item.html
@@ -52,7 +52,11 @@
     </div>
 
     {# the element below defines what the inline edit looks like in edit mode #}
-    <div x-show="isEditing">
+    <div
+      x-show="isEditing"
+      {# x-cloak will hide the element until Alpine initializes on the page #}
+      x-cloak
+    >
       <form
         hx-post="{{ request.path_info }}"
         hq-hx-action="edit_item"

--- a/corehq/apps/styleguide/templates/styleguide/htmx_todo/item_done.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_todo/item_done.html
@@ -1,6 +1,6 @@
 <li
-    id="item-{{ item.id }}"
-    class="list-group-item"
+  id="item-{{ item.id }}"
+  class="list-group-item"
 >
   <div class="p-2 fs-5">
     <i class="fa-solid fa-circle-check text-success"></i>

--- a/corehq/apps/styleguide/templates/styleguide/htmx_todo/item_done_oob_swap.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_todo/item_done_oob_swap.html
@@ -1,4 +1,4 @@
 {# hx-swap-oob inserts the result of this element in the #done-items <ul> instead of the #todo-list <ul> #}
 <ul hx-swap-oob="afterbegin:#done-items">
-  {% include 'styleguide/htmx_todo/item_done.html' %}
+  {% include "styleguide/htmx_todo/item_done.html" %}
 </ul>

--- a/corehq/apps/styleguide/templates/styleguide/htmx_todo/main.html
+++ b/corehq/apps/styleguide/templates/styleguide/htmx_todo/main.html
@@ -2,35 +2,34 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{# use this entry point if you don't need to add any extra javascript to an HTMX + Alpine page #}
+{# Use this entry point if you don't need to add any extra JavaScript to an HTMX + Alpine page. #}
 {% js_entry "hqwebapp/js/htmx_and_alpine" %}
 
 {% block content %}
   <div class="container py-4">
-
     <h1>
       {% trans "To-Do" %}
       <button
-          class="btn btn-primary btn-sm"
-          {# request.path_info is just the same URL for this view #}
-          {# an alternative would be {% url "sg_htmx_todo_list_example" %} #}
-          hx-post="{{ request.path_info }}"
-          {# hq-hx-action triggers the create_new_item method in TodoListDemoView #}
-          hq-hx-action="create_new_item"
-          {# the next two lines tell HTMX to insert the returned HTML from the post at the beginning of the #todo-list <ul> below #}
-          hx-target="#todo-list"
-          hx-swap="afterbegin"
+        class="btn btn-primary btn-sm"
+        {# request.path_info is just the same URL for this view #}
+        hx-post="{{ request.path_info }}"
+        {# hq-hx-action triggers the create_new_item method in TodoListDemoView #}
+        hq-hx-action="create_new_item"
+        {# Insert the returned HTML at the beginning of the #todo-list <ul> #}
+        hx-target="#todo-list"
+        hx-swap="afterbegin"
       >
         <i class="fa-solid fa-plus"></i> {% trans "Add Item" %}
       </button>
     </h1>
+
     <ul
-        class="list-group"
-        id="todo-list"
+      class="list-group"
+      id="todo-list"
     >
       {% for item in items %}
         {% if not item.is_done %}
-          {% include 'styleguide/htmx_todo/item.html' %}
+          {% include "styleguide/htmx_todo/item.html" %}
         {% endif %}
       {% endfor %}
     </ul>
@@ -39,32 +38,32 @@
       {% trans "Done" %}
     </h2>
     <ul
-        class="list-group"
-        id="done-items"
+      class="list-group"
+      id="done-items"
     >
       {% for item in items %}
         {% if item.is_done %}
-          {% include 'styleguide/htmx_todo/item_done.html' %}
+          {% include "styleguide/htmx_todo/item_done.html" %}
         {% endif %}
       {% endfor %}
     </ul>
 
     <div class="py-5">
       <button
-          class="btn btn-outline-danger"
-          type="button"
-          {# this button posts to a non existent @hq_hx_action method in the view, purposely triggering the error modal #}
-          hx-post="{{ request.path_info }}"
-          hq-hx-action="does_not_exist"
+        class="btn btn-outline-danger"
+        type="button"
+        {# This posts to a non-existent @hq_hx_action method, intentionally triggering the HTMX error modal. #}
+        hx-post="{{ request.path_info }}"
+        hq-hx-action="does_not_exist"
       >
         {% trans "Trigger Error" %}
       </button>
     </div>
   </div>
-{% endblock %}
+{% endblock content %}
 
 {% block modals %}
-  {# you can either include this template or include an extension of this template to show HTMX errors to the user #}
+  {# You can include this template or an extension of it to show HTMX errors to the user. #}
   {% include "hqwebapp/htmx/error_modal.html" %}
   {{ block.super }}
 {% endblock modals %}

--- a/corehq/apps/styleguide/urls.py
+++ b/corehq/apps/styleguide/urls.py
@@ -78,6 +78,8 @@ urlpatterns = [
         name="styleguide_html_guide_b5"),
     url(r'^b5/htmx_alpine/$', bootstrap5.styleguide_htmx_and_alpine,
         name="styleguide_htmx_and_alpine_b5"),
+    url(r'^b5/ko_to_alpine/$', bootstrap5.styleguide_knockout_to_alpine_guide,
+        name="styleguide_knockout_to_alpine_guide_b5"),
     url(r'^b5/atoms/accessibility/$', bootstrap5.styleguide_atoms_accessibility,
         name="styleguide_atoms_accessibility_b5"),
     url(r'^b5/atoms/typography/$', bootstrap5.styleguide_atoms_typography,

--- a/corehq/apps/styleguide/urls.py
+++ b/corehq/apps/styleguide/urls.py
@@ -4,7 +4,7 @@ from corehq.apps.styleguide.examples.bootstrap5.example_urls import urlpatterns 
 from corehq.apps.styleguide.examples.bootstrap5.htmx_alpine_form_views import (
     HtmxAlpineFormDemoView,
 )
-from corehq.apps.styleguide.examples.bootstrap5.htmx_hq_hx_action import TodoListDemoView
+from corehq.apps.styleguide.examples.bootstrap5.htmx_todo_list import TodoListDemoView
 from corehq.apps.styleguide.examples.bootstrap5.htmx_pagination_host_view import HtmxPaginationView
 from corehq.apps.styleguide.examples.bootstrap5.htmx_pagination_table_view import ExamplePaginatedTableView
 from corehq.apps.styleguide.views import (

--- a/corehq/apps/styleguide/urls.py
+++ b/corehq/apps/styleguide/urls.py
@@ -4,6 +4,7 @@ from corehq.apps.styleguide.examples.bootstrap5.example_urls import urlpatterns 
 from corehq.apps.styleguide.examples.bootstrap5.htmx_alpine_form_views import (
     HtmxAlpineFormDemoView,
 )
+from corehq.apps.styleguide.examples.bootstrap5.htmx_key_value_view import HtmxKeyValuePairsDemoView
 from corehq.apps.styleguide.examples.bootstrap5.htmx_next_action_simple_view import SimpleNextActionDemoView
 from corehq.apps.styleguide.examples.bootstrap5.htmx_todo_list import TodoListDemoView
 from corehq.apps.styleguide.examples.bootstrap5.htmx_pagination_host_view import HtmxPaginationView
@@ -29,6 +30,7 @@ doc_urlpatterns = [
 advanced_demo_urlpatterns = [
     url(r'^htmx_todo/$', TodoListDemoView.as_view(), name=TodoListDemoView.urlname),
     url(r'^next_action/$', SimpleNextActionDemoView.as_view(), name=SimpleNextActionDemoView.urlname),
+    url(r'^key_value_demo/$', HtmxKeyValuePairsDemoView.as_view(), name=HtmxKeyValuePairsDemoView.urlname),
     url(r'^htmx_alpine_form/$', HtmxAlpineFormDemoView.as_view(), name=HtmxAlpineFormDemoView.urlname),
     url(r'^htmx_pagination/$', HtmxPaginationView.as_view(),
         name=HtmxPaginationView.urlname),

--- a/corehq/apps/styleguide/urls.py
+++ b/corehq/apps/styleguide/urls.py
@@ -4,6 +4,7 @@ from corehq.apps.styleguide.examples.bootstrap5.example_urls import urlpatterns 
 from corehq.apps.styleguide.examples.bootstrap5.htmx_alpine_form_views import (
     HtmxAlpineFormDemoView,
 )
+from corehq.apps.styleguide.examples.bootstrap5.htmx_next_action_simple_view import SimpleNextActionDemoView
 from corehq.apps.styleguide.examples.bootstrap5.htmx_todo_list import TodoListDemoView
 from corehq.apps.styleguide.examples.bootstrap5.htmx_pagination_host_view import HtmxPaginationView
 from corehq.apps.styleguide.examples.bootstrap5.htmx_pagination_table_view import ExamplePaginatedTableView
@@ -27,6 +28,7 @@ doc_urlpatterns = [
 
 advanced_demo_urlpatterns = [
     url(r'^htmx_todo/$', TodoListDemoView.as_view(), name=TodoListDemoView.urlname),
+    url(r'^next_action/$', SimpleNextActionDemoView.as_view(), name=SimpleNextActionDemoView.urlname),
     url(r'^htmx_alpine_form/$', HtmxAlpineFormDemoView.as_view(), name=HtmxAlpineFormDemoView.urlname),
     url(r'^htmx_pagination/$', HtmxPaginationView.as_view(),
         name=HtmxPaginationView.urlname),

--- a/corehq/apps/styleguide/urls.py
+++ b/corehq/apps/styleguide/urls.py
@@ -3,7 +3,6 @@ from django.urls import include, re_path as url
 from corehq.apps.styleguide.examples.bootstrap5.example_urls import urlpatterns as example_urlpatterns
 from corehq.apps.styleguide.examples.bootstrap5.htmx_alpine_form_views import (
     HtmxAlpineFormDemoView,
-    FilterDemoFormView,
 )
 from corehq.apps.styleguide.examples.bootstrap5.htmx_hq_hx_action import TodoListDemoView
 from corehq.apps.styleguide.examples.bootstrap5.htmx_pagination_host_view import HtmxPaginationView
@@ -29,7 +28,6 @@ doc_urlpatterns = [
 advanced_demo_urlpatterns = [
     url(r'^htmx_todo/$', TodoListDemoView.as_view(), name=TodoListDemoView.urlname),
     url(r'^htmx_alpine_form/$', HtmxAlpineFormDemoView.as_view(), name=HtmxAlpineFormDemoView.urlname),
-    url(r'^htmx_alpine_form/form/$', FilterDemoFormView.as_view(), name=FilterDemoFormView.urlname),
     url(r'^htmx_pagination/$', HtmxPaginationView.as_view(),
         name=HtmxPaginationView.urlname),
     url(r'^htmx_pagination/table/$', ExamplePaginatedTableView.as_view(),

--- a/corehq/apps/styleguide/views/bootstrap5.py
+++ b/corehq/apps/styleguide/views/bootstrap5.py
@@ -159,6 +159,10 @@ def styleguide_htmx_and_alpine(request):
                 code=get_example_context('styleguide/htmx_todo/item_done.html'),
                 language="Django",
             ),
+            'htmx_debug_mixin_usage': CodeForDisplay(
+                code=get_python_example_context('htmx_debug_mixin_usage.py'),
+                language="Python",
+            ),
             'loading_button': CodeForDisplayWithPartial(
                 code=get_example_context('styleguide/bootstrap5/examples/htmx_loading_button.html'),
                 partial="styleguide/bootstrap5/examples/htmx_loading_button.html",

--- a/corehq/apps/styleguide/views/bootstrap5.py
+++ b/corehq/apps/styleguide/views/bootstrap5.py
@@ -200,40 +200,6 @@ def styleguide_htmx_and_alpine(request):
 
 
 @use_bootstrap5
-def styleguide_knockout_to_alpine_guide(request):
-    context = get_navigation_context("styleguide_knockout_to_alpine_guide_b5")
-    context.update({
-        'examples': {
-            'ko_simple': HtmlWithJsDemo(
-                code_html=get_html_example_context('ko_migration/ko_simple.html'),
-                code_js=get_js_example_context('ko_migration/ko_simple.js'),
-            ),
-            'alpine_simple': get_html_example_context('ko_migration/alpine_simple.html'),
-            'ko_complex': HtmlWithJsDemo(
-                code_html=get_html_example_context('ko_migration/ko_complex.html'),
-                code_js=get_js_example_context('ko_migration/ko_complex.js'),
-            ),
-            'alpine_complex': HtmlWithJsDemo(
-                code_html=get_html_example_context('ko_migration/alpine_complex.html'),
-                code_js=get_js_example_context('ko_migration/alpine_complex.js'),
-            ),
-            'alpine_complex_reusable': CodeForDisplay(
-                code=get_js_example_context('ko_migration/alpine_complex_reusable.js'),
-                language='JS',
-            ),
-            'use_alpine_complex_reusable': CodeForDisplay(
-                code=get_js_example_context('ko_migration/use_alpine_complex_reusable.js'),
-                language='JS',
-            ),
-        },
-        'complex_initial_value': [
-            {'key': 'color', 'value': 'Purple'},
-        ],
-    })
-    return render(request, 'styleguide/bootstrap5/knockout_to_alpine.html', context)
-
-
-@use_bootstrap5
 def styleguide_atoms_accessibility(request):
     return render(request, 'styleguide/bootstrap5/atoms/accessibility.html',
                   get_navigation_context("styleguide_atoms_accessibility_b5"))

--- a/corehq/apps/styleguide/views/bootstrap5.py
+++ b/corehq/apps/styleguide/views/bootstrap5.py
@@ -139,8 +139,8 @@ def styleguide_htmx_and_alpine(request):
                 code=get_python_example_context('htmx_alpine_form_demo.py'),
                 language="Python",
             ),
-            'htmx_hq_hx_action': CodeForDisplay(
-                code=get_python_example_context('htmx_hq_hx_action.py'),
+            'htmx_todo_list_view': CodeForDisplay(
+                code=get_python_example_context('htmx_todo_list.py'),
                 language="Python",
             ),
             'htmx_todo_main': CodeForDisplay(
@@ -157,6 +157,22 @@ def styleguide_htmx_and_alpine(request):
             ),
             'htmx_todo_item_done': CodeForDisplay(
                 code=get_example_context('styleguide/htmx_todo/item_done.html'),
+                language="Django",
+            ),
+            'htmx_next_action_simple_forms': CodeForDisplay(
+                code=get_python_example_context('htmx_next_action_simple_forms.py'),
+                language="Python",
+            ),
+            'htmx_next_action_simple_view': CodeForDisplay(
+                code=get_python_example_context('htmx_next_action_simple_view.py'),
+                language="Python",
+            ),
+            'htmx_next_action_simple_template': CodeForDisplay(
+                code=get_example_context('styleguide/htmx_next_action_simple/main.html'),
+                language="Django",
+            ),
+            'htmx_next_action_simple_form_template': CodeForDisplay(
+                code=get_example_context('styleguide/htmx_next_action_simple/next_step_with_message.html'),
                 language="Django",
             ),
             'htmx_debug_mixin_usage': CodeForDisplay(
@@ -181,6 +197,40 @@ def styleguide_htmx_and_alpine(request):
         }
     })
     return render(request, 'styleguide/bootstrap5/htmx_and_alpine.html', context)
+
+
+@use_bootstrap5
+def styleguide_knockout_to_alpine_guide(request):
+    context = get_navigation_context("styleguide_knockout_to_alpine_guide_b5")
+    context.update({
+        'examples': {
+            'ko_simple': HtmlWithJsDemo(
+                code_html=get_html_example_context('ko_migration/ko_simple.html'),
+                code_js=get_js_example_context('ko_migration/ko_simple.js'),
+            ),
+            'alpine_simple': get_html_example_context('ko_migration/alpine_simple.html'),
+            'ko_complex': HtmlWithJsDemo(
+                code_html=get_html_example_context('ko_migration/ko_complex.html'),
+                code_js=get_js_example_context('ko_migration/ko_complex.js'),
+            ),
+            'alpine_complex': HtmlWithJsDemo(
+                code_html=get_html_example_context('ko_migration/alpine_complex.html'),
+                code_js=get_js_example_context('ko_migration/alpine_complex.js'),
+            ),
+            'alpine_complex_reusable': CodeForDisplay(
+                code=get_js_example_context('ko_migration/alpine_complex_reusable.js'),
+                language='JS',
+            ),
+            'use_alpine_complex_reusable': CodeForDisplay(
+                code=get_js_example_context('ko_migration/use_alpine_complex_reusable.js'),
+                language='JS',
+            ),
+        },
+        'complex_initial_value': [
+            {'key': 'color', 'value': 'Purple'},
+        ],
+    })
+    return render(request, 'styleguide/bootstrap5/knockout_to_alpine.html', context)
 
 
 @use_bootstrap5

--- a/corehq/apps/styleguide/views/bootstrap5.py
+++ b/corehq/apps/styleguide/views/bootstrap5.py
@@ -330,72 +330,78 @@ def styleguide_molecules_buttons(request):
 @use_bootstrap5
 def styleguide_molecules_selections(request):
     context = get_navigation_context("styleguide_molecules_selections_b5")
-    context.update({
-        'examples': {
-            'toggles': get_example_context('styleguide/bootstrap5/examples/toggles.html'),
-            'toggles_crispy': CrispyFormsDemo(
-                SelectToggleDemoForm(), get_python_example_context('select_toggle_form.py'),
-            ),
-            'select2_manual': HtmlWithJsDemo(
-                code_html=get_html_example_context('select2_manual.html'),
-                code_js=get_js_example_context('select2_manual.js'),
-            ),
-            'select2_manual_allow_clear': HtmlWithJsDemo(
-                code_html=get_html_example_context('select2_manual_allow_clear.html'),
-                code_js=get_js_example_context('select2_manual_allow_clear.js'),
-            ),
-            'select2_manual_crispy': CrispyFormsWithJsDemo(
-                form=Select2ManualDemoForm(),
-                code_python=get_python_example_context('select2_manual_form.py'),
-                code_js=get_js_example_context('select2_manual_crispy.js'),
-            ),
-            'select2_css_class': get_example_context('styleguide/bootstrap5/examples/select2_css_class.html'),
-            'select2_css_class_multiple': get_example_context(
-                'styleguide/bootstrap5/examples/select2_css_class_multiple.html'),
-            'select2_css_class_crispy': CrispyFormsDemo(
-                Select2CssClassDemoForm(), get_python_example_context('select2_css_class_form.py'),
-            ),
-            'select2_ko_dynamic': HtmlWithJsDemo(
-                code_html=get_html_example_context('select2_ko_dynamic.html'),
-                code_js=get_js_example_context('select2_ko_dynamic.js'),
-            ),
-            'select2_ko_dynamic_crispy': CrispyFormsWithJsDemo(
-                form=Select2DynamicKoForm(),
-                code_python=get_python_example_context('select2_dynamic_ko_form.py'),
-                code_js=get_js_example_context('select2_dynamic_ko_crispy.js'),
-            ),
-            'select2_ko_static': HtmlWithJsDemo(
-                code_html=get_html_example_context('select2_ko_static.html'),
-                code_js=get_js_example_context('select2_ko_static.js'),
-            ),
-            'select2_ko_static_crispy': CrispyFormsWithJsDemo(
-                form=Select2StaticKoForm(),
-                code_python=get_python_example_context('select2_static_ko_form.py'),
-                code_js=get_js_example_context('select2_static_ko_crispy.js'),
-            ),
-            'select2_ko_autocomplete': HtmlWithJsDemo(
-                code_html=get_html_example_context('select2_ko_autocomplete.html'),
-                code_js=get_js_example_context('select2_ko_autocomplete.js'),
-            ),
-            'select2_ko_autocomplete_crispy': CrispyFormsWithJsDemo(
-                form=Select2AutocompleteKoForm(),
-                code_python=get_python_example_context('select2_autocomplete_ko_form.py'),
-                code_js=get_js_example_context('select2_autocomplete_ko_crispy.js'),
-            ),
-            'multiselect': HtmlWithJsDemo(
-                code_html=get_html_example_context('multiselect.html'),
-                code_js=get_js_example_context('multiselect.js'),
-            ),
-            'multiselect_crispy': CrispyFormsWithJsDemo(
-                form=MultiselectDemoForm(),
-                code_python=get_python_example_context('multiselect_form.py'),
-                code_js=get_js_example_context('multiselect_crispy.js'),
-            ),
-            'select2_ajax_crispy': CrispyFormsDemo(
-                Select2AjaxDemoForm(), get_python_example_context('select2_ajax_form.py'),
-            ),
+    context.update(
+        {
+            'examples': {
+                'toggles': get_example_context('styleguide/bootstrap5/examples/toggles.html'),
+                'toggles_crispy': CrispyFormsDemo(
+                    SelectToggleDemoForm(),
+                    get_python_example_context('select_toggle_form.py'),
+                ),
+                'select2_manual': HtmlWithJsDemo(
+                    code_html=get_html_example_context('select2_manual.html'),
+                    code_js=get_js_example_context('select2_manual.js'),
+                ),
+                'select2_manual_allow_clear': HtmlWithJsDemo(
+                    code_html=get_html_example_context('select2_manual_allow_clear.html'),
+                    code_js=get_js_example_context('select2_manual_allow_clear.js'),
+                ),
+                'select2_manual_crispy': CrispyFormsWithJsDemo(
+                    form=Select2ManualDemoForm(),
+                    code_python=get_python_example_context('select2_manual_form.py'),
+                    code_js=get_js_example_context('select2_manual_crispy.js'),
+                ),
+                'select2_css_class': get_example_context('styleguide/bootstrap5/examples/select2_css_class.html'),
+                'select2_css_class_multiple': get_example_context(
+                    'styleguide/bootstrap5/examples/select2_css_class_multiple.html'
+                ),
+                'select2_css_class_crispy': CrispyFormsDemo(
+                    Select2CssClassDemoForm(),
+                    get_python_example_context('select2_css_class_form.py'),
+                ),
+                'select2_ko_dynamic': HtmlWithJsDemo(
+                    code_html=get_html_example_context('select2_ko_dynamic.html'),
+                    code_js=get_js_example_context('select2_ko_dynamic.js'),
+                ),
+                'select2_ko_dynamic_crispy': CrispyFormsWithJsDemo(
+                    form=Select2DynamicKoForm(),
+                    code_python=get_python_example_context('select2_dynamic_ko_form.py'),
+                    code_js=get_js_example_context('select2_dynamic_ko_crispy.js'),
+                ),
+                'select2_ko_static': HtmlWithJsDemo(
+                    code_html=get_html_example_context('select2_ko_static.html'),
+                    code_js=get_js_example_context('select2_ko_static.js'),
+                ),
+                'select2_ko_static_crispy': CrispyFormsWithJsDemo(
+                    form=Select2StaticKoForm(),
+                    code_python=get_python_example_context('select2_static_ko_form.py'),
+                    code_js=get_js_example_context('select2_static_ko_crispy.js'),
+                ),
+                'select2_ko_autocomplete': HtmlWithJsDemo(
+                    code_html=get_html_example_context('select2_ko_autocomplete.html'),
+                    code_js=get_js_example_context('select2_ko_autocomplete.js'),
+                ),
+                'select2_ko_autocomplete_crispy': CrispyFormsWithJsDemo(
+                    form=Select2AutocompleteKoForm(),
+                    code_python=get_python_example_context('select2_autocomplete_ko_form.py'),
+                    code_js=get_js_example_context('select2_autocomplete_ko_crispy.js'),
+                ),
+                'multiselect': HtmlWithJsDemo(
+                    code_html=get_html_example_context('multiselect.html'),
+                    code_js=get_js_example_context('multiselect.js'),
+                ),
+                'multiselect_crispy': CrispyFormsWithJsDemo(
+                    form=MultiselectDemoForm(),
+                    code_python=get_python_example_context('multiselect_form.py'),
+                    code_js=get_js_example_context('multiselect_crispy.js'),
+                ),
+                'select2_ajax_crispy': CrispyFormsDemo(
+                    Select2AjaxDemoForm(),
+                    get_python_example_context('select2_ajax_form.py'),
+                ),
+            }
         }
-    })
+    )
     return render(request, 'styleguide/bootstrap5/molecules/selections.html', context)
 
 

--- a/corehq/apps/styleguide/views/bootstrap5.py
+++ b/corehq/apps/styleguide/views/bootstrap5.py
@@ -200,6 +200,84 @@ def styleguide_htmx_and_alpine(request):
 
 
 @use_bootstrap5
+def styleguide_knockout_to_alpine_guide(request):
+    context = get_navigation_context("styleguide_knockout_to_alpine_guide_b5")
+    context.update({
+        'examples': {
+            'ko_simple': HtmlWithJsDemo(
+                code_html=get_html_example_context('ko_migration/ko_simple.html'),
+                code_js=get_js_example_context('ko_migration/ko_simple.js'),
+            ),
+            'alpine_simple': get_html_example_context('ko_migration/alpine_simple.html'),
+            'ko_complex': HtmlWithJsDemo(
+                code_html=get_html_example_context('ko_migration/ko_complex.html'),
+                code_js=get_js_example_context('ko_migration/ko_complex.js'),
+            ),
+            'alpine_complex': HtmlWithJsDemo(
+                code_html=get_html_example_context('ko_migration/alpine_complex.html'),
+                code_js=get_js_example_context('ko_migration/alpine_complex.js'),
+            ),
+            'alpine_complex_reusable': CodeForDisplay(
+                code=get_js_example_context('ko_migration/alpine_complex_reusable.js'),
+                language='JS',
+            ),
+            'use_alpine_complex_reusable': CodeForDisplay(
+                code=get_js_example_context('ko_migration/use_alpine_complex_reusable.js'),
+                language='JS',
+            ),
+            'htmx_complex_view': CodeForDisplay(
+                code=get_python_example_context('htmx_key_value_view.py'),
+                language="Python",
+            ),
+            'htmx_complex_store': CodeForDisplay(
+                code=get_python_example_context('htmx_complex_store.py'),
+                language="Python",
+            ),
+            'htmx_complex_partial': CodeForDisplay(
+                code=get_example_context('styleguide/htmx_key_values/partial.html'),
+                language='Django',
+            ),
+            'htmx_complex_main': CodeForDisplay(
+                code=get_example_context('styleguide/htmx_key_values/main.html'),
+                language='Django',
+            ),
+            'htmx_complex_error': CodeForDisplay(
+                code=get_example_context('styleguide/htmx_key_values/field_with_error.html'),
+                language='Django',
+            ),
+            'prompt_start': CodeForDisplay(
+                code=get_html_example_context('ko_migration/prompt_start.md'),
+                language='Markdown',
+            ),
+            'prompt_simple': CodeForDisplay(
+                code=get_html_example_context('ko_migration/prompt_simple.md'),
+                language='Markdown',
+            ),
+            'prompt_modules': CodeForDisplay(
+                code=get_html_example_context('ko_migration/prompt_modules.md'),
+                language='Markdown',
+            ),
+            'prompt_htmx_alpine': CodeForDisplay(
+                code=get_html_example_context('ko_migration/prompt_htmx_alpine.md'),
+                language='Markdown',
+            ),
+            'prompt_one_liner': CodeForDisplay(
+                code=get_html_example_context('ko_migration/prompt_one_liner.md'),
+                language='Markdown',
+            ),
+            'prompt_review': CodeForDisplay(
+                code=get_html_example_context('ko_migration/prompt_review.md'),
+                language='Markdown',
+            ),
+        },
+        'complex_initial_value': [
+            {'key': 'color', 'value': 'Purple'},
+        ],
+    })
+    return render(request, 'styleguide/bootstrap5/knockout_to_alpine.html', context)
+
+
+@use_bootstrap5
 def styleguide_atoms_accessibility(request):
     return render(request, 'styleguide/bootstrap5/atoms/accessibility.html',
                   get_navigation_context("styleguide_atoms_accessibility_b5"))

--- a/corehq/apps/styleguide/views/bootstrap5.py
+++ b/corehq/apps/styleguide/views/bootstrap5.py
@@ -28,6 +28,7 @@ from corehq.apps.styleguide.examples.bootstrap5.disabled_fields import DisabledF
 from corehq.apps.styleguide.examples.bootstrap5.multiselect_form import MultiselectDemoForm
 from corehq.apps.styleguide.examples.bootstrap5.placeholder_help_text import PlaceholderHelpTextExampleForm
 from corehq.apps.styleguide.examples.bootstrap5.select2_ajax_form import Select2AjaxDemoForm
+from corehq.apps.styleguide.examples.bootstrap5.select2_alpine_crispy import Select2AlpineForm
 from corehq.apps.styleguide.examples.bootstrap5.select2_autocomplete_ko_form import Select2AutocompleteKoForm
 from corehq.apps.styleguide.examples.bootstrap5.select2_css_class_form import Select2CssClassDemoForm
 from corehq.apps.styleguide.examples.bootstrap5.select2_dynamic_ko_form import Select2DynamicKoForm
@@ -352,6 +353,15 @@ def styleguide_molecules_selections(request):
                     code_js=get_js_example_context('select2_manual_crispy.js'),
                 ),
                 'select2_css_class': get_example_context('styleguide/bootstrap5/examples/select2_css_class.html'),
+                'select2_alpine_basic': get_example_context(
+                    'styleguide/bootstrap5/examples/select2_alpine_basic.html'
+                ),
+                'select2_alpine_with_options': get_example_context(
+                    'styleguide/bootstrap5/examples/select2_alpine_with_options.html'
+                ),
+                'select2_alpine_select2change': get_example_context(
+                    'styleguide/bootstrap5/examples/select2_alpine_select2change.html'
+                ),
                 'select2_css_class_multiple': get_example_context(
                     'styleguide/bootstrap5/examples/select2_css_class_multiple.html'
                 ),
@@ -398,6 +408,10 @@ def styleguide_molecules_selections(request):
                 'select2_ajax_crispy': CrispyFormsDemo(
                     Select2AjaxDemoForm(),
                     get_python_example_context('select2_ajax_form.py'),
+                ),
+                'select2_alpine_crispy': CrispyFormsDemo(
+                    Select2AlpineForm(),
+                    get_python_example_context('select2_alpine_crispy.py'),
                 ),
             }
         }

--- a/corehq/apps/styleguide/views/bootstrap5.py
+++ b/corehq/apps/styleguide/views/bootstrap5.py
@@ -352,19 +352,11 @@ def styleguide_molecules_selections(request):
                     code_python=get_python_example_context('select2_manual_form.py'),
                     code_js=get_js_example_context('select2_manual_crispy.js'),
                 ),
-                'select2_css_class': get_example_context('styleguide/bootstrap5/examples/select2_css_class.html'),
-                'select2_alpine_basic': get_example_context(
-                    'styleguide/bootstrap5/examples/select2_alpine_basic.html'
-                ),
-                'select2_alpine_with_options': get_example_context(
-                    'styleguide/bootstrap5/examples/select2_alpine_with_options.html'
-                ),
-                'select2_alpine_select2change': get_example_context(
-                    'styleguide/bootstrap5/examples/select2_alpine_select2change.html'
-                ),
-                'select2_css_class_multiple': get_example_context(
-                    'styleguide/bootstrap5/examples/select2_css_class_multiple.html'
-                ),
+                'select2_css_class': get_html_example_context('select2_css_class.html'),
+                'select2_alpine_basic': get_html_example_context('select2_alpine_basic.html'),
+                'select2_alpine_with_options': get_html_example_context('select2_alpine_with_options.html'),
+                'select2_alpine_select2change': get_html_example_context('select2_alpine_select2change.html'),
+                'select2_css_class_multiple': get_html_example_context('select2_css_class_multiple.html'),
                 'select2_css_class_crispy': CrispyFormsDemo(
                     Select2CssClassDemoForm(),
                     get_python_example_context('select2_css_class_form.py'),

--- a/corehq/apps/styleguide/views/bootstrap5.py
+++ b/corehq/apps/styleguide/views/bootstrap5.py
@@ -24,6 +24,7 @@ from corehq.apps.styleguide.examples.bootstrap5.crispy_forms_errors import Error
 from corehq.apps.styleguide.examples.bootstrap5.crispy_forms_knockout import KnockoutCrispyExampleForm
 from corehq.apps.styleguide.examples.bootstrap5.crispy_forms_knockout_validation import \
     KnockoutValidationCrispyExampleForm
+from corehq.apps.styleguide.examples.bootstrap5.datepicker_alpine_crispy import DatepickerAlpineForm
 from corehq.apps.styleguide.examples.bootstrap5.disabled_fields import DisabledFieldsExampleForm
 from corehq.apps.styleguide.examples.bootstrap5.multiselect_form import MultiselectDemoForm
 from corehq.apps.styleguide.examples.bootstrap5.placeholder_help_text import PlaceholderHelpTextExampleForm
@@ -572,6 +573,12 @@ def styleguide_molecules_dates_times(request):
             'time_only_24': HtmlWithJsDemo(
                 code_html=get_html_example_context('time_only_24.html'),
                 code_js=get_js_example_context('time_only_24.js'),
+            ),
+            'datepicker_alpine_simple': get_html_example_context('datepicker_alpine_simple.html'),
+            'datepicker_alpine_datetime': get_html_example_context('datepicker_alpine_datetime.html'),
+            'datepicker_alpine_crispy': CrispyFormsDemo(
+                DatepickerAlpineForm(),
+                get_python_example_context('datepicker_alpine_crispy.py'),
             ),
         }
     })

--- a/corehq/util/htmx_debug.py
+++ b/corehq/util/htmx_debug.py
@@ -7,19 +7,19 @@ from django.http import HttpResponse
 class HqHtmxDebugMixin:
     """
     Use this mixin alongside `HqHtmxActionMixin` to help simulate server
-    issues and slow requests locally (or on staging if you like) during
-    the development phase.
+    issues and slow requests locally (or on staging) during development.
 
-    Why a separate tool? Making the browser slow with dev tools throttling
-    just delays the request TO the server, rather than testing if the server
-    itself is slow.
+    Why a separate tool? Browser dev tools throttling slows the request
+    *to* the server, but doesn’t simulate a slow or flaky *server response*.
 
-    e.g.:
+    Example:
         class TodoListDemoView(HqHtmxDebugMixin, HqHtmxActionMixin, BasePageView):
-            ...
+            simulate_slow_response = True
+            slow_response_time = 3
+            simulate_flaky_gateway = True
 
-    Remember: Order matters when using mixins. make sure `HqHtmxDebugMixin` appears first
-    to have things work properly!
+    Remember: Order matters when using mixins. Make sure `HqHtmxDebugMixin`
+    appears first so its dispatch() logic runs before HqHtmxActionMixin.
     """
     # Simulate slow server responses by setting this to True and requests will wait
     # ``slow_response_time`` seconds with each request


### PR DESCRIPTION
## Technical Summary
This might very well be one of the last PRs I will be contributing for sometime to this codebase. 😿 

I hope to make it a good one and a useful starting point for working more with HTMX and Alpine in HQ, as well as providing a solid starting point for tackling the daunting Knockout to Alpine (+HTMX) migration. 💜 ✨ 

First, I've added a “Migrating Knockout to Alpine (+HTMX)” section ([view on staging](https://staging.commcarehq.org/styleguide/b5/ko_to_alpine/)) with:
- Mental model shift (KO → Alpine + HTMX) and a concept-mapping table
- Step-by-step examples
- Guidance on when to stop at Alpine vs move to HTMX
- AI-assist section with copy-pasteable prompt snippets and migration guardrails
- Before/after migration checklists
- A curated list of prior KO→Alpine/HTMX commits

I also updated the [HTMX + Django Tables](https://staging.commcarehq.org/styleguide/b5/ko_to_alpine/) pagination docs for improved clarity.

In the Selections docs, I added a section for using the [Alpine `x-select2` directive](https://staging.commcarehq.org/styleguide/b5/molecules/selections/#select2-alpine) that I introduced with the bulk data editing work. I also added some documentation for the [`x-datepicker` directive](https://staging.commcarehq.org/styleguide/b5/molecules/dates-times/#alpine-datepicker) as well.

For all the knockout-driven examples in the styleguide, I also added a [migration alert](https://staging.commcarehq.org/styleguide/b5/molecules/selections/), encouraging no more new usage of those patterns and future replacement with alpine (and/or HTMX) patterns.

And lastly, I made a big pass on the [HTMX and Alpine guide](https://staging.commcarehq.org/styleguide/b5/htmx_alpine/) to improve clarity, readability, and improved examples (and callouts to other examples in the styleguide).

## Safety Assurance

### Safety story
very safe, just updates styleguide docs and examples

### Automated test coverage
n/a

### QA Plan
not needed


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
