### PR TITLE
Ensure x-datepicker Alpine directive propagates change events back to input, updating x-model

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alpinejs/directives/datepicker.js
@@ -96,15 +96,24 @@ Alpine.directive('datepicker', (el, { expression }, { cleanup }) => {
         container: (config.container) ? document.querySelector(config.container) : undefined,
     });
 
-    if (!config.datetime) {
-        // Since picking a date is a single-click action, hide the picker on date selection
-        picker.subscribe('change.td',  () => {
+    // Helper: tell Alpine that the input changed so x-model can update.
+    const notifyAlpine = () => {
+        el.dispatchEvent(new Event('input'));
+    };
+
+    // Subscribe to Tempus Dominus change events
+    picker.subscribe('change.td', () => {
+        if (!config.datetime) {
+            // Since picking a date is a single-click action, hide the picker on date selection
             picker.hide();
-        });
-    }
+        }
+        // Make sure Alpine's x-model sees the new value
+        notifyAlpine();
+    });
 
     el.addEventListener('error.td', (event) => {
         picker.dates.setValue(null);
+        notifyAlpine();   // also sync the cleared value
         event.stopPropagation();
     });
 


### PR DESCRIPTION
## Technical Summary
This updates the `x-datepicker` Alpine directive to play more nicely with Alpine models. Previously, any `x-model` bound to the same input `x-datepicker` was applied to didn't update the data model properly. This PR ensures that datepicker changes are properly sent to the input element so that the model is updated when the datepicker is updated.

## Safety Assurance

### Safety story
this is a safe change I tested in the [styleguide changes](https://github.com/dimagi/commcare-hq/pull/37198) already. however, to be extra safe i'm pushing this branch to staging to test in the bulk data cleaning tool there.

### Automated test coverage
no

### QA Plan
not needed
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
