### PR TITLE
Don't import our own module

### DIFF
--- a/corehq/util/metrics/__init__.py
+++ b/corehq/util/metrics/__init__.py
@@ -198,7 +198,6 @@ def metrics_gauge_task(name, fn, run_every, multiprocess_mode=MPM_ALL):
     @periodic_task(queue='background_queue', run_every=run_every, acks_late=True, ignore_result=True)
     @wraps(fn)
     def inner():
-        from corehq.util.metrics import metrics_gauge
         metrics_gauge(name, fn(), multiprocess_mode=multiprocess_mode)
 
     return inner


### PR DESCRIPTION
## Technical Summary

This code moved from a different module in commit 9a49d2681e15ee96f9baf18a8763199588b7e3aa but this import was not removed.

## Safety Assurance

### Safety story

Tiny: Drops an unnecessary import.

### Automated test coverage

Not applicable.

### QA Plan

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
