### PR TITLE
Fix bug with one-time bulk payment via Stripe

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -237,9 +237,7 @@ var paymentMethodHandler = function (formId, opts) {
         self.serverErrorMsg('');
         self.newCard().reset();
         if (self.cardElementMounted) {
-            self.cardElementPromise.then(function (cardElement) {
-                cardElement.clear();
-            });
+            self.cardElementPromise();
         }
     };
 

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -130,7 +130,7 @@ var paymentMethodHandler = function (formId, opts) {
     // selections, so create stripe card elements as needed. This is called in a number
     // of places because several different observables affect the visiblity of the card UI.
     self.stripeKey = initialPageData.get("stripe_public_key");
-    self.resetStripeCardUI = function (shouldCreateElement) {
+    self.resetStripeCardUI = (shouldCreateElement) => {
         const stripeSelector = '#' + formId + ' .stripe-card-container';
         if (shouldCreateElement && $(stripeSelector).length) {
             getCardElementPromise(self.stripeKey).then(cardElement => {

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -127,14 +127,12 @@ var paymentMethodHandler = function (formId, opts) {
 
     // Stripe can't attach the card UI to the page until its container exists.
     // Its container is removed and re-added from the DOM depending on the user's
-    // selections, so mount and unmount it as needed. This is called in a number
+    // selections, so create stripe card elements as needed. This is called in a number
     // of places because several different observables affect the visiblity of the card UI.
-    self.cardElementPromise = function () {
-        return getCardElementPromise(initialPageData.get("stripe_public_key"));
-    };
-    self.showOrHideStripeUI = function (show) {
+    self.stripeKey = initialPageData.get("stripe_public_key");
+    self.resetStripeCardUI = function (show) {
         if (show) {
-            self.cardElementPromise().then(function (cardElement) {
+            getCardElementPromise(self.stripeKey).then(function (cardElement) {
                 const stripeSelector = '#' + formId + ' .stripe-card-container';
                 if ($(stripeSelector).length) {
                     cardElement.mount(stripeSelector);
@@ -145,7 +143,7 @@ var paymentMethodHandler = function (formId, opts) {
 
     self.savedCards = ko.observableArray();
     self.savedCards.subscribe(function (newValue) {
-        _.delay(function () { self.showOrHideStripeUI(newValue); });
+        _.delay(function () { self.resetStripeCardUI(newValue); });
     });
 
     self.selectedSavedCard = ko.observable();
@@ -161,7 +159,7 @@ var paymentMethodHandler = function (formId, opts) {
         return self.selectedCardType() === 'new';
     });
     self.isNewCard.subscribe(function (newValue) {
-        _.delay(function () { self.showOrHideStripeUI(newValue); });
+        _.delay(function () { self.resetStripeCardUI(newValue); });
     });
 
     self.newCard = ko.observable(stripeCardModel());
@@ -192,7 +190,7 @@ var paymentMethodHandler = function (formId, opts) {
     });
 
     self.mustCreateNewCard.subscribe(function (newValue) {
-        _.delay(function () { self.showOrHideStripeUI(newValue); });
+        _.delay(function () { self.resetStripeCardUI(newValue); });
     });
 
     self.canSelectCard = ko.computed(function () {
@@ -231,7 +229,7 @@ var paymentMethodHandler = function (formId, opts) {
         self.paymentIsComplete(false);
         self.serverErrorMsg('');
         self.newCard().reset();
-        self.showOrHideStripeUI();
+        self.resetStripeCardUI();
     };
 
     self.processPayment = function () {
@@ -278,7 +276,7 @@ var paymentMethodHandler = function (formId, opts) {
     };
 
     // Initial showing (or not) of Stripe UI
-    self.showOrHideStripeUI(self.mustCreateNewCard());
+    self.resetStripeCardUI(self.mustCreateNewCard());
 
     return self;
 };

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -229,6 +229,7 @@ var paymentMethodHandler = function (formId, opts) {
         self.paymentIsComplete(false);
         self.serverErrorMsg('');
         self.newCard().reset();
+        self.resetStripeCardUI(true);
     };
 
     self.processPayment = function () {

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -129,10 +129,12 @@ var paymentMethodHandler = function (formId, opts) {
     // Its container is removed and re-added from the DOM depending on the user's
     // selections, so mount and unmount it as needed. This is called in a number
     // of places because several different observables affect the visiblity of the card UI.
-    self.cardElementPromise = getCardElementPromise(initialPageData.get("stripe_public_key"));
+    self.cardElementPromise = function () {
+        return getCardElementPromise(initialPageData.get("stripe_public_key"));
+    };
     self.cardElementMounted = false;
     self.showOrHideStripeUI = function (show) {
-        self.cardElementPromise.then(function (cardElement) {
+        self.cardElementPromise().then(function (cardElement) {
             const stripeSelector = '#' + formId + ' .stripe-card-container';
             if (show) {
                 if ($(stripeSelector).length && !self.cardElementMounted) {

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -229,7 +229,6 @@ var paymentMethodHandler = function (formId, opts) {
         self.paymentIsComplete(false);
         self.serverErrorMsg('');
         self.newCard().reset();
-        self.resetStripeCardUI();
     };
 
     self.processPayment = function () {

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -130,13 +130,11 @@ var paymentMethodHandler = function (formId, opts) {
     // selections, so create stripe card elements as needed. This is called in a number
     // of places because several different observables affect the visiblity of the card UI.
     self.stripeKey = initialPageData.get("stripe_public_key");
-    self.resetStripeCardUI = function (show) {
-        if (show) {
-            getCardElementPromise(self.stripeKey).then(function (cardElement) {
-                const stripeSelector = '#' + formId + ' .stripe-card-container';
-                if ($(stripeSelector).length) {
-                    cardElement.mount(stripeSelector);
-                }
+    self.resetStripeCardUI = function (shouldCreateElement) {
+        const stripeSelector = '#' + formId + ' .stripe-card-container';
+        if (shouldCreateElement && $(stripeSelector).length) {
+            getCardElementPromise(self.stripeKey).then(cardElement => {
+                cardElement.mount(stripeSelector);
             });
         }
     };

--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -132,20 +132,15 @@ var paymentMethodHandler = function (formId, opts) {
     self.cardElementPromise = function () {
         return getCardElementPromise(initialPageData.get("stripe_public_key"));
     };
-    self.cardElementMounted = false;
     self.showOrHideStripeUI = function (show) {
-        self.cardElementPromise().then(function (cardElement) {
-            const stripeSelector = '#' + formId + ' .stripe-card-container';
-            if (show) {
-                if ($(stripeSelector).length && !self.cardElementMounted) {
+        if (show) {
+            self.cardElementPromise().then(function (cardElement) {
+                const stripeSelector = '#' + formId + ' .stripe-card-container';
+                if ($(stripeSelector).length) {
                     cardElement.mount(stripeSelector);
-                    self.cardElementMounted = true;
                 }
-            } else {
-                cardElement.unmount();
-                self.cardElementMounted = false;
-            }
-        });
+            });
+        }
     };
 
     self.savedCards = ko.observableArray();
@@ -236,9 +231,7 @@ var paymentMethodHandler = function (formId, opts) {
         self.paymentIsComplete(false);
         self.serverErrorMsg('');
         self.newCard().reset();
-        if (self.cardElementMounted) {
-            self.cardElementPromise();
-        }
+        self.showOrHideStripeUI();
     };
 
     self.processPayment = function () {

--- a/corehq/apps/accounting/static/accounting/js/stripe.js
+++ b/corehq/apps/accounting/static/accounting/js/stripe.js
@@ -11,6 +11,9 @@ function getCardElementPromise(key) {
         }
         self.stripePromise = self.stripePromise || loadStripe(key);
         self.stripePromise.then(function (stripe) {
+            if (self.cardElement) {
+                self.cardElement.unmount();
+            }
             self.cardElement = stripe.elements().create('card', {
                 hidePostalCode: true,
             });

--- a/corehq/apps/accounting/static/accounting/js/stripe.js
+++ b/corehq/apps/accounting/static/accounting/js/stripe.js
@@ -9,7 +9,7 @@ function getCardElementPromise(key) {
             console.warn("Cannot load Stripe, key not provided");
             return;
         }
-        self.stripePromise = loadStripe(key);
+        self.stripePromise = self.stripePromise || loadStripe(key);
         self.stripePromise.then(function (stripe) {
             self.cardElement = stripe.elements().create('card', {
                 hidePostalCode: true,

--- a/corehq/apps/domain/templates/domain/partials/bootstrap3/payment_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/bootstrap3/payment_modal.html
@@ -280,7 +280,7 @@
                            data: newCard,
                            name: 'select-new-stripe-card-template',
                            if: mustCreateNewCard,
-                           afterRender: showOrHideStripeUI,
+                           afterRender: resetStripeCardUI,
                        }"
           ></div>
 
@@ -289,7 +289,7 @@
                            data: $data,
                            name: 'select-stripe-card-template',
                            if: canSelectCard,
-                           afterRender: showOrHideStripeUI,
+                           afterRender: resetStripeCardUI,
                        }"
           ></div>
           <!-- /ko -->

--- a/corehq/apps/domain/templates/domain/partials/bootstrap5/payment_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/bootstrap5/payment_modal.html
@@ -280,7 +280,7 @@
                            data: newCard,
                            name: 'select-new-stripe-card-template',
                            if: mustCreateNewCard,
-                           afterRender: showOrHideStripeUI,
+                           afterRender: resetStripeCardUI,
                        }"
           ></div>
 
@@ -289,7 +289,7 @@
                            data: $data,
                            name: 'select-stripe-card-template',
                            if: canSelectCard,
-                           afterRender: showOrHideStripeUI,
+                           afterRender: resetStripeCardUI,
                        }"
           ></div>
           <!-- /ko -->


### PR DESCRIPTION
## Product Description
Fixes two related bugs where users could not make a bulk payment on the Billing Statements page with an unsaved card:
- when the customer had no saved cards, they would see a "Your card number is incorrect" error
- when the customer had any saved cards, they would see "Processing your payment..." forever

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19009
As noted in the existing javascript comment, `self.showOrHideStripeUI` is called several times on initializing the page... and more for each card the customer has saved. The `cardElement` is mounted and unmounted a few times during this process - while this ultimately gets to the correct visual appearance, Stripe doesn't actually allow re-using an element for data collection like this, which results in `IntegrationError: We could not retrieve data from the specified Element.` when attempting to pay with new card details.

This resolves that issue by creating a new `cardElement` and mounting it each time we reset the stripe card UI - and only doing so when there is a matching DOM element to mount, so as to try to avoid creating cardElements that get immediately thrown away. There is also a change to also avoid initializing Stripe more than once during this process, so we're not adding many new API calls on every page load. A more comprehensive solution here _would_ potentially include not attempting to update/reset the stripe card UI so many times on a page load, but I think that's out of scope for this bugfix.

This is small by volume. It can probably be reviewed as files changed.

## Safety Assurance

### Safety story
Tested locally and on staging. Because stripe is used in many places, also confirmed payment on the Current Subscription and enterprise Billing Statements pages still work using freshly entered card details or a saved card, in situations where the customer has and does not have any cards already saved.

### Automated test coverage
Likely not for this javascript component.

### QA Plan
Not planning it, but could see an argument if reviewers think necessary.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
