### PR TITLE
Ensure tableau group choices are populated on user invite

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1746,7 +1746,7 @@ class BaseTableauUserForm(forms.Form):
         label=gettext_noop("Groups"),
         choices=[],
         required=False,
-        widget=forms.CheckboxSelectMultiple()
+        widget=forms.CheckboxSelectMultiple(),
     )
 
     def __init__(self, *args, **kwargs):
@@ -1761,11 +1761,10 @@ class BaseTableauUserForm(forms.Form):
         self.allowed_tableau_groups = [
             TableauGroupTuple(group.name, group.id) for group in get_all_tableau_groups(self.domain)
             if group.name in get_allowed_tableau_groups_for_domain(self.domain)]
-        self.fields['groups'].choices = []
         self.fields['groups'].initial = []
-        for i, group in enumerate(self.allowed_tableau_groups):
-            # Add a choice for each tableau group on the server
-            self.fields['groups'].choices.append((i, group.name))
+        self.fields['groups'].choices = [
+            (i, group.name) for i, group in enumerate(self.allowed_tableau_groups)
+        ]
 
 
 class TableauUserForm(BaseTableauUserForm):


### PR DESCRIPTION
## Product Description
On the web user invite page, the Tableau Groups input shows up blank:

<img width="2088" height="425" alt="image" src="https://github.com/user-attachments/assets/1cf4d5df-003f-40bd-b913-3b50c863ddb2" />

This PR makes the results appear correctly

## Technical Summary
https://dimagi.atlassian.net/browse/USH-6382

Through some very tedious debugging (anti-shoutout to crispy forms) I found that choices were set on the field, but not on the widget.  Setting them on the widget solved the problem, but obviously you shouldn't have to set them twice.  Turns out setting it on the field also propagates it to the widget, because `field.choices` is a method with a getter and a setter, and the setter propagates the choices to the widget.  However, depending on what `choices` is, it might copy the value instead of setting a reference to it, so if it's a mutable that gets updated later, the updates might not be propagated.

## Feature Flag
Automatically sync HQ users with users on Tableau

## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
