### PR TITLE
Tag `split_screen_case_search` frozen

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1109,7 +1109,7 @@ SPLIT_SCREEN_CASE_SEARCH = StaticToggle(
     'split_screen_case_search',
     "Split screen case search: In case search, show the search filters in a sidebar on the left and the results"
     " on the right.",
-    TAG_DEPRECATED,
+    TAG_FROZEN,
     help_link='https://confluence.dimagi.com/display/USH/Split+Screen+Case+Search',
     namespaces=[NAMESPACE_DOMAIN],
     parent_toggles=[SYNC_SEARCH_CASE_CLAIM]


### PR DESCRIPTION
## Technical Summary

:t-rex: Jira: [SAAS-19013](https://dimagi.atlassian.net/browse/SAAS-19013)

This PR changes the tag for the `split_screen_case_search` feature flag from `TAG_DEPRECATED` to `TAG_FROZEN`.

## Feature Flag

`split_screen_case_search`

## Safety Assurance

### Safety story

Does not change behavior (just indicates the intent for the feature flag in the future).

### Automated test coverage

Not applicable

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19013]: https://dimagi.atlassian.net/browse/SAAS-19013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ