### PR TITLE
[B5] add app manager vellum build path to ignored paths

### DIFF
--- a/corehq/apps/hqwebapp/utils/bootstrap/paths.py
+++ b/corehq/apps/hqwebapp/utils/bootstrap/paths.py
@@ -38,7 +38,10 @@ IGNORED_PATHS_BY_APP = {
         "hqwebapp/crispy/multi_inline_field.html",
         "hqwebapp/crispy/field/hidden_with_errors.html",
         "hqwebapp/js/daterangepicker.config.js",  # Todo B5: delete me after migration
-    ]
+    ],
+    "app_manager": [
+        "app_manager/js/vellum",
+    ],
 }
 
 


### PR DESCRIPTION
## Technical Summary
This adds `app_manager/js/vellum` to the ignored paths list under `app_manager`. This should hopefully allow for a smooth `app_manager` split without breaking the webpack build.

- vellum will be migrated as a whole, separately
- these are build files...it makes no sense to split them

## Safety Assurance

### Safety story
safe change, just updates a config in an internal tool

### Automated test coverage
yes

### QA Plan
n/a

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
