### PR TITLE
Tag "CommCare Supply" feature flag as frozen

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1359,7 +1359,7 @@ def _commtrackify(domain_name, toggle_is_enabled):
 COMMTRACK = StaticToggle(
     'commtrack',
     "CommCare Supply",
-    TAG_DEPRECATED,
+    TAG_FROZEN,
     description=(
         '<a href="https://dimagi.atlassian.net/wiki/spaces/commtrack/overview">CommCare Supply</a> '
         "is a logistics and supply chain management module. It is designed "


### PR DESCRIPTION
## Technical Summary

🦖 Jira: [SAAS-19015](https://dimagi.atlassian.net/browse/SAAS-19015)

This PR changes the tag for the "CommCare Supply" feature flag from TAG_DEPRECATED to TAG_FROZEN.

## Feature Flag

"CommCare Supply" (`commtrack`)

## Safety Assurance

### Safety story

Does not change behavior (just indicates the intent for the feature flag in the future).

### Automated test coverage

Not applicable

### QA Plan

None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19015]: https://dimagi.atlassian.net/browse/SAAS-19015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ