### PR TITLE
Show next autopay date on Current Subscription page

### DIFF
--- a/corehq/apps/accounting/utils/invoicing.py
+++ b/corehq/apps/accounting/utils/invoicing.py
@@ -167,3 +167,24 @@ def get_prorated_software_plan_cost(date_start, date_end, monthly_fee):
     return total_cost.quantize(
         Decimal('0.01'), rounding=ROUND_HALF_UP,
     )
+
+
+def get_next_due_invoice(subscription, today):
+    return Invoice.objects.filter(
+        subscription=subscription,
+        is_hidden=False,
+        date_due__gte=today,
+        date_paid__isnull=True,
+    ).order_by('date_due').first()
+
+
+def get_next_due_customer_invoice(account, today, subscription=None):
+    current_invoices = CustomerInvoice.objects.filter(
+        account=account,
+        is_hidden=False,
+        date_due__gte=today,
+        date_paid__isnull=True,
+    )
+    if subscription:
+        current_invoices = current_invoices.filter(subscriptions__in=[subscription])
+    return current_invoices.order_by('date_due').first()

--- a/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
@@ -184,6 +184,13 @@
               {% endif %}
               (<a href="{{ manage_autopay_url }}#payment-methods">Manage</a>)
             </p>
+            {% if autopay_date %}
+              <p>
+                {% blocktrans %}
+                  Payment is scheduled for {{ autopay_date }}.
+                {% endblocktrans %}
+              </p>
+            {% endif %}
           </div>
         </div>
         {% if plan.next_subscription.exists and not plan.next_subscription.is_paused %}

--- a/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
@@ -180,6 +180,13 @@
               {% endif %}
               (<a href="{{ manage_autopay_url }}#payment-methods">Manage</a>)
             </p>
+            {% if autopay_date %}
+              <p>
+                {% blocktrans %}
+                  Payment is scheduled for {{ autopay_date }}.
+                {% endblocktrans %}
+              </p>
+            {% endif %}
           </div>
         </div>
         {% if plan.next_subscription.exists and not plan.next_subscription.is_paused %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
@@ -88,7 +88,7 @@
                    >
                      {% if plan.is_auto_renew %}
                        {% trans "Disable Auto Renewal" %}
-@@ -161,55 +157,55 @@
+@@ -161,26 +157,26 @@
              </div>
            {% endif %}
            <div data-bind="foreach: products">
@@ -122,6 +122,7 @@
                {% endif %}
                (<a href="{{ manage_autopay_url }}#payment-methods">Manage</a>)
              </p>
+@@ -194,29 +190,29 @@
            </div>
          </div>
          {% if plan.next_subscription.exists and not plan.next_subscription.is_paused %}
@@ -160,7 +161,7 @@
                <p class="form-control-text">
                  {{ plan.next_subscription.price }}
                </p>
-@@ -222,26 +218,26 @@
+@@ -229,26 +225,26 @@
          <div class="form form-horizontal">
            {% if plan.has_credits_in_non_general_credit_line %}
              <div data-bind="foreach: products">
@@ -193,7 +194,7 @@
                  <p class="form-control-text js-general-credit">
                    {{ plan.general_credit.amount }}
                  </p>
-@@ -249,29 +245,29 @@
+@@ -256,29 +252,29 @@
              </div>
            {% endif %}
            <div data-bind="with: prepayments">
@@ -231,7 +232,7 @@
                      <i class="fa fa-info-circle"></i>
                      {% trans "Not Billing Admin, Can't Add Credit" %}
                    </span>
-@@ -284,8 +280,8 @@
+@@ -291,8 +287,8 @@
            <legend>{% trans 'Account Credit' %}</legend>
            <div class="form form-horizontal">
              <div data-bind="foreach: products">
@@ -242,7 +243,7 @@
                    {% trans 'Plan Credit' %}
                    <div class="hq-help">
                      <a
-@@ -300,7 +296,7 @@
+@@ -307,7 +303,7 @@
                      </a>
                    </div>
                  </label>
@@ -251,7 +252,7 @@
                    <p
                      class="form-control-text"
                      data-bind="text: accountAmount"
-@@ -309,8 +305,8 @@
+@@ -316,8 +312,8 @@
                </div>
              </div>
              {% if plan.account_general_credit and plan.account_general_credit.is_visible %}
@@ -262,7 +263,7 @@
                    {% trans 'General Credit' %}
                    <div class="hq-help">
                      <a
-@@ -326,7 +322,7 @@
+@@ -333,7 +329,7 @@
                      </a>
                    </div>
                  </label>
@@ -271,7 +272,7 @@
                    <p class="form-control-text">
                      {{ plan.account_general_credit.amount }}
                    </p>
-@@ -396,8 +392,8 @@
+@@ -403,8 +399,8 @@
  
  {% block modals %}
    {{ block.super }}


### PR DESCRIPTION
## Product Description
Adds text showing the customer their next scheduled autopay date, when autopay is enabled and there is an invoice due in the future:
<img width="361" height="90" alt="image" src="https://github.com/user-attachments/assets/18bfb352-0f6f-4dd1-8e02-35c155751db3" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18574
Adds utils to get the next due Invoice or CustomerInvoice based on subscription or account and subscription, respectively. Gets the due date of this invoice in the DomainSubscriptionView and passes it as context to the template.

## Safety Assurance

### Safety story
Tested locally with and without autopay enabled, on single-project billing and customer billing accounts, with and without an invoice due soon. This has reasonable `None` checks for no invoice being returned and is a fairly small addition overall.

### Automated test coverage
None here, but could add if reviewers think needed for the queries.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
