### PR TITLE
Add new KYC Provider - Orange Cameroon

### DIFF
--- a/corehq/apps/integration/kyc/models.py
+++ b/corehq/apps/integration/kyc/models.py
@@ -112,7 +112,17 @@ class KycConfig(models.Model):
                 client_secret=kyc_settings['client_secret'],
                 token_url=kyc_settings['token_url'],
             )
-        # elif self.provider == KycProviders.NEW_PROVIDER_HERE: ...
+        elif self.provider == KycProviders.ORANGE_CAMEROON_KYC:
+            kyc_settings = settings.ORANGE_CAMEROON_CONNECTION_SETTINGS
+            return ConnectionSettings(
+                domain=self.domain,
+                name=KycProviders.ORANGE_CAMEROON_KYC.label,
+                url=kyc_settings['url'],
+                auth_type=OAUTH2_CLIENT,
+                client_id=kyc_settings['client_id'],
+                client_secret=kyc_settings['client_secret'],
+                token_url=kyc_settings['token_url'],
+            )
         else:
             raise ValueError(f'Unable to determine connection settings for KYC provider {self.provider!r}.')
 

--- a/corehq/apps/integration/kyc/models.py
+++ b/corehq/apps/integration/kyc/models.py
@@ -33,6 +33,7 @@ class KycProviders(models.TextChoices):
     # 2. Add it to `KycConfig.get_connections_settings()`
     # 3. Add required threshold fields to `KycProviderThresholdFields`
     MTN_KYC = 'mtn_kyc', _('MTN KYC')
+    ORANGE_CAMEROON_KYC = 'orange_cameroon_kyc', _('Orange Cameroon KYC')
 
 
 class KycProviderThresholdFields:
@@ -51,11 +52,17 @@ class KycProviderThresholdFields:
         'postCode',
         'country',
     ]
+    ORANGE_CAMEROON_KYC_REQUIRED_FIELDS = [
+        'firstName',
+        'lastName',
+    ]
 
     @classmethod
     def get_required_fields(cls, provider):
         if provider == KycProviders.MTN_KYC:
             return cls.MTN_KYC_REQUIRED_FIELDS
+        elif provider == KycProviders.ORANGE_CAMEROON_KYC:
+            return cls.ORANGE_CAMEROON_KYC_REQUIRED_FIELDS
         else:
             raise ValueError(f'Unable to determine required threshold fields for KYC provider {provider!r}.')
 

--- a/settings.py
+++ b/settings.py
@@ -1181,6 +1181,15 @@ MTN_KYC_CONNECTION_SETTINGS = {
     'client_id': 'test',
     'client_secret': 'password',
 }
+ORANGE_CAMEROON_CONNECTION_SETTINGS = {
+    'url': 'https://dev.api.chenosis.io/',
+    'token_url': 'https://dev.api.chenosis.io/oauth/client/accesstoken',
+    'client_id': 'test',
+    'client_secret': 'password',
+    'x-auth-token': 'test',
+    'channel_msisdn': 'test',
+    'channel_pin': '1234',
+}
 
 #### Chatbot configuration
 # Override in localsettings.py


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Adds a new KYC provider named 'Orange Cameroon'. It includes settings for Orange Cameroon.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/SC-4589)

Based to be changed to `main`, once the PR for `ay/threshold-kyc-verification` is merged.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
KYC_VERIFICATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Minor change.Behind an unused FF.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
