### PR TITLE
Disable Cancel and Subscribe to Plan buttons on submit

### DIFF
--- a/corehq/apps/domain/static/domain/js/confirm_billing_info.js
+++ b/corehq/apps/domain/static/domain/js/confirm_billing_info.js
@@ -28,6 +28,7 @@ Alpine.data('requiredBillingDetails', (isAutopayRequired) => ({
     emailList: [],
     isAutopayRequired: isAutopayRequired,
     hasAutopay: false,
+    isSubmitting: false,
     basicInfoComplete() {
         return (this.firstName
             && this.lastName && this.firstLine && this.city

--- a/corehq/apps/domain/templates/domain/confirm_billing_info.html
+++ b/corehq/apps/domain/templates/domain/confirm_billing_info.html
@@ -139,13 +139,18 @@
           </div>
 
           <div class="px-2 pt-2">
-            <a href="{{ cancel_url }}" class="btn btn-outline-primary">
+            <a
+              href="{{ cancel_url }}"
+              class="btn btn-outline-primary"
+              :class="{ 'disabled': isSubmitting }"
+            >
               {% trans "Cancel" %}
             </a>
             <button
               type="submit"
-              class="btn btn-primary"
+              class="btn btn-primary disable-on-submit"
               :disabled="isSubmitDisabled"
+              @click="isSubmitting = true"
             >
               {% trans "Subscribe to Plan" %}
             </button>


### PR DESCRIPTION
## Product Description
Disables Cancel and Subscribe to Plan buttons on submit when confirming signup for a new subscription:

https://github.com/user-attachments/assets/412e66b3-5d1e-4586-84d6-9fdd6d27845d



## Technical Summary
Disabling "Subscribe to Plan" prevents errors that can be caused if a customer clicks "Subscribe to Plan" more than once before the subscription change is complete. Disabling the "Cancel" button makes it clear the action is in progress and can no longer be canceled.

## Safety Assurance

### Safety story
Just a small change to UI. Tested locally that disabled attribute and class is applied correctly.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
