### PR TITLE
Add autopay_card to enterprise billing statements view

### DIFF
--- a/corehq/apps/enterprise/views.py
+++ b/corehq/apps/enterprise/views.py
@@ -40,8 +40,12 @@ from corehq.apps.accounting.models import (
     CustomerInvoice,
     CustomerBillingRecord,
 )
-from corehq.apps.accounting.utils.stripe import get_customer_cards
 from corehq.apps.accounting.utils import quantize_accounting_decimal, log_accounting_error
+from corehq.apps.accounting.utils.cards import (
+    get_autopay_card_and_owner_for_billing_account,
+    serialize_account_card,
+)
+from corehq.apps.accounting.utils.stripe import get_customer_cards
 from corehq.apps.domain.decorators import (
     login_and_domain_required,
     require_superuser,
@@ -368,6 +372,7 @@ class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedVie
     @property
     def page_context(self):
         pagination_context = self.pagination_context
+        autopay_card, autopay_owner = get_autopay_card_and_owner_for_billing_account(self.account)
         pagination_context.update({
             'stripe_public_key': settings.STRIPE_PUBLIC_KEY,
             'stripe_cards': self.stripe_cards,
@@ -389,6 +394,7 @@ class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedVie
             'total_balance': self.total_balance,
             'show_plan': False,
             'can_pay_by_wire': self.can_pay_by_wire,
+            'autopay_card': serialize_account_card(autopay_card, autopay_owner) if autopay_card else None,
         })
         return pagination_context
 


### PR DESCRIPTION
## Product Description
Fixes a bug where autopay card appears as undefined on the enterprise billing statements page, whether there is an autopay card set or not:
<img width="586" height="269" alt="image" src="https://github.com/user-attachments/assets/bf0fae50-e8b8-4fc7-b02a-63c84a577c4f" />


## Technical Summary
Adds the same context for `autopay_card` that is used in DomainBillingStatementsView.

## Safety Assurance

### Safety story
Mimics existing working code from elsewhere, a view that inherits from the same base view as this one (which is where `self.account` is defined). Tested locally that this fixes the issue - when there is an autopay card the details are shown, or when there is not the option is not available.

### Automated test coverage
Not likely.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
