### PR TITLE
Remove open form submission flag

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_auth.py
+++ b/corehq/apps/receiverwrapper/tests/test_auth.py
@@ -30,7 +30,6 @@ from corehq.apps.users.models import (
 from corehq.apps.users.util import normalize_username
 from corehq.form_processor.models import XFormInstance
 from corehq.form_processor.tests.utils import sharded
-from corehq.util.test_utils import flag_enabled
 
 
 class FakeFile(object):
@@ -464,11 +463,6 @@ class TestHasMobileAccess(TestCase):
         is_from_formplayer.return_value = True
         self.assertTrue(self._has_mobile_access(self.user_without_permission))
 
-    def test_no_permission_but_whitelisted(self, is_from_formplayer):
-        is_from_formplayer.return_value = False
-        with flag_enabled('OPEN_SUBMISSION_ENDPOINT'):
-            self.assertTrue(self._has_mobile_access(self.user_without_permission))
-
-    def test_no_permission_no_toggle(self, is_from_formplayer):
+    def test_no_permission(self, is_from_formplayer):
         is_from_formplayer.return_value = False
         self.assertFalse(self._has_mobile_access(self.user_without_permission))

--- a/corehq/apps/receiverwrapper/tests/test_auth.py
+++ b/corehq/apps/receiverwrapper/tests/test_auth.py
@@ -429,8 +429,6 @@ class TestAPIEndpoint(TestCase):
 
 
 @mock.patch('corehq.apps.receiverwrapper.views.is_from_formplayer')
-@mock.patch('corehq.apps.receiverwrapper.views.cache.get', mock.MagicMock(return_value=None))
-@mock.patch('corehq.apps.receiverwrapper.views.cache.set', mock.MagicMock)
 class TestHasMobileAccess(TestCase):
     domain = "test-has-mobile-access"
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1643,13 +1643,6 @@ DISABLE_MOBILE_ENDPOINTS = StaticToggle(
     )
 )
 
-OPEN_SUBMISSION_ENDPOINT = StaticToggle(
-    'open_submission_endpoint',
-    'Leave submission endpoint open to let old APIs keep working',
-    TAG_FROZEN,
-    [NAMESPACE_DOMAIN],
-)
-
 SORT_CALCULATION_IN_CASE_LIST = StaticToggle(
     'sort_calculation_in_case_list',
     'Configure a custom xpath calculation for Sort Property in Case Lists',


### PR DESCRIPTION
## Product Description
This was a deprecation path that is complete - no projects have it enabled anymore
https://docs.google.com/spreadsheets/d/1kE56g6cy3CRz4XncoNNW4riXts3HYTDdOKqw4CmdeDg/edit?gid=866038365#gid=866038365

## Technical Summary
https://dimagi.atlassian.net/browse/USH-6427

## Feature Flag
removes OPEN_SUBMISSION_ENDPOINT

## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
