### PR TITLE
Support shutting down celery workers in various broker migration states

### DIFF
--- a/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
+++ b/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         # broker than the one it is reading from
         check_worker_up = broker_conn is None
 
-        if check_worker_up and not self._is_worker_up(hostname, broker_conn):
+        if check_worker_up and not self._is_worker_up(hostname):
             print(f'{hostname} did not respond to ping. Aborted shutdown.')
             return False
 
@@ -56,7 +56,7 @@ class Command(BaseCommand):
             kwargs['connection'] = broker_conn
         self.celery.control.broadcast('shutdown', **kwargs)
 
-        if check_worker_up and self._is_worker_up(hostname, broker_conn):
+        if check_worker_up and self._is_worker_up(hostname):
             # if worker is still up, the shutdown likely did not succeed
             # or it is just a slow shutdown
             print(f'{hostname} responded to ping after initiating shutdown.')

--- a/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
+++ b/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
@@ -1,13 +1,12 @@
+from celery import Celery
 from django.conf import settings
 from django.core.management.base import BaseCommand
-
-from celery import Celery
 
 from corehq.apps.hqadmin.utils import parse_celery_pings
 
 
 class Command(BaseCommand):
-    help = "Gracefully shutsdown a celery worker"
+    help = "Gracefully shuts down a celery worker"
 
     def add_arguments(self, parser):
         parser.add_argument('hostname')
@@ -16,7 +15,9 @@ class Command(BaseCommand):
         celery = Celery()
         celery.config_from_object(settings)
         celery.control.broadcast('shutdown', destination=[hostname])
-        worker_responses = celery.control.ping(timeout=10, destination=[hostname])
+        worker_responses = celery.control.ping(
+            timeout=10, destination=[hostname]
+        )
         pings = parse_celery_pings(worker_responses)
         if hostname in pings:
             print('Did not shutdown worker')

--- a/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
+++ b/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
@@ -34,6 +34,7 @@ class Command(BaseCommand):
         for broker_url in [current_broker_url, old_broker_url]:
             broker_conn = Connection(broker_url)
             succeeded = self._shutdown(hostname, broker_conn)
+            broker_conn.release()
             if succeeded:
                 print(
                     '[Broker Migration In Progress] Initiated warm shutdown '

--- a/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
+++ b/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
@@ -46,18 +46,27 @@ class Command(BaseCommand):
         # broker than the one it is reading from
         check_worker_up = broker_conn is None
 
+        if check_worker_up and not self._is_worker_up(hostname, broker_conn):
+            print(f'{hostname} did not respond to ping. Aborted shutdown.')
+            return False
+
         kwargs = {'destination': [hostname]}
         if broker_conn is not None:
             # use a custom broker connection
             kwargs['connection'] = broker_conn
         self.celery.control.broadcast('shutdown', **kwargs)
 
-        if check_worker_up:
-            worker_responses = self.celery.control.ping(
-                timeout=10, destination=[hostname]
-            )
-            pings = parse_celery_pings(worker_responses)
-            if hostname in pings:
-                return False
-            return True
+        if check_worker_up and self._is_worker_up(hostname, broker_conn):
+            # if worker is still up, the shutdown likely did not succeed
+            # or it is just a slow shutdown
+            print(f'{hostname} responded to ping after initiating shutdown.')
+            return False
+
         return True
+
+    def _is_worker_up(self, hostname):
+        worker_responses = self.celery.control.ping(
+            timeout=10, destination=[hostname]
+        )
+        pings = parse_celery_pings(worker_responses)
+        return hostname in pings

--- a/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
+++ b/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
@@ -1,6 +1,7 @@
 from celery import Celery
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from kombu import Connection
 
 from corehq.apps.hqadmin.utils import parse_celery_pings
 
@@ -12,14 +13,51 @@ class Command(BaseCommand):
         parser.add_argument('hostname')
 
     def handle(self, hostname, **options):
-        celery = Celery()
-        celery.config_from_object(settings)
-        celery.control.broadcast('shutdown', destination=[hostname])
-        worker_responses = celery.control.ping(
-            timeout=10, destination=[hostname]
-        )
-        pings = parse_celery_pings(worker_responses)
-        if hostname in pings:
-            print('Did not shutdown worker')
+        self.celery = Celery()
+        self.celery.config_from_object(settings)
+
+        current_broker_url = getattr(settings, 'CELERY_BROKER_URL', None)
+        assert current_broker_url is not None, "CELERY_BROKER_URL is not set"
+
+        # as long as OLD_BROKER_URL is set, we are going to send shutdown
+        # broadcasts to both the old and new broker urls
+        old_broker_url = getattr(settings, 'OLD_BROKER_URL', None)
+        migration_in_progress = old_broker_url is not None
+
+        if not migration_in_progress:
+            succeeded = self._shutdown(hostname)
+            if succeeded:
+                print(f'Successfully initiated warm shutdown of {hostname}')
+                return
             exit(1)
-        print('Successfully initiated warm shutdown')
+
+        for broker_url in [current_broker_url, old_broker_url]:
+            broker_conn = Connection(broker_url)
+            succeeded = self._shutdown(hostname, broker_conn)
+            if succeeded:
+                print(
+                    '[Broker Migration In Progress] Initiated warm shutdown '
+                    f'of {hostname}'
+                )
+
+    def _shutdown(self, hostname, broker_conn=None):
+        # if using a custom broker connection, it is unlikely a ping will
+        # work properly since the worker might be writing to a different
+        # broker than the one it is reading from
+        check_worker_up = broker_conn is None
+
+        kwargs = {'destination': [hostname]}
+        if broker_conn is not None:
+            # use a custom broker connection
+            kwargs['connection'] = broker_conn
+        self.celery.control.broadcast('shutdown', **kwargs)
+
+        if check_worker_up:
+            worker_responses = self.celery.control.ping(
+                timeout=10, destination=[hostname]
+            )
+            pings = parse_celery_pings(worker_responses)
+            if hostname in pings:
+                return False
+            return True
+        return True


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19047

### How this command is used

We have a process that wraps celery worker processes, with the main goal of catching SIGTERM signals, calling this command on the underlying celery worker, and exiting to spin up a new celery worker while giving the old worker time to shutdown gracefully.

### The problem

The way this shutdown is communicated to the celery worker is via a "broadcast". In celery, broadcasts are sent via the celery broker, and the worker reads this message from that broker.

As part of a broker migration, some machines are configured as "bridges" where they read from the old broker and write to the new broker, and other machines are configured to read from and write to the new broker entirely.

This means this command needs to successfully broadcast the shutdown message to the right broker in various scenarios, or else the worker will never receive the signal to shutdown.

### Scenarios
In each of these scenarios we need to consider machines that act as the "bridge" and machines that don't.

#### Start of migration
At the start of a migration from broker A to broker B, `CELERY_BROKER_READ_URL` is updated to broker A on the bridge machine responsible for draining broker A, and `CELERY_BROKER_URL` is set to broker B on non-bridge machines.

On the bridge machine, settings will be updated to define `CELERY_BROKER_READ_URL` and `CELERY_BROKER_WRITE_URL`, the shutdown command will run with these updated settings while the celery worker is still running with `CELERY_BROKER_URL` set to broker A. This means this command needs to broadcast the shutdown to broker A.

On machines that do not act as the bridge between two brokers, `CELERY_BROKER_URL` will be set to broker A for existing workers, and the command to shutdown workers will run with this set to broker B. Similarly, this command needs to broadcast the shutdown to broker A.

#### Cut over
When we cut over to broker B, `CELERY_BROKER_URL` gets updated to broker B, and the READ and WRITE vars are removed because of how `rabbitmq_migration_bridge` works. This means the command will run with `CELERY_BROKER_URL` set to broker B, and will not communicate shutdowns to celery workers running with `CELERY_BROKER_READ_URL` set to broker A on bridge machines. Again, the solution is for this command to broadcast the shutdown to broker A.

For non-bridge machines, this is fine since the workers are already configured to read from and write to broker B.

#### Revert
The third scenario is unlikely, but still worth considering. After cutting over to broker B, if we decide we need to revert, ideally we would reset `CELERY_BROKER_READ_URL` to broker A, and keep `CELERY_BROKER_URL` set to broker B. In this case, on bridge machines the command will run with `CELERY_BROKER_READ_URL` set to broker A, but the existing celery workers will be running with `CELERY_BROKER_URL` set to broker B.

#### Solution
While we can come up with different solutions for each of these, ultimately the easiest solution is to depend on `OLD_BROKER_URL`. **As long as this is set, shutdowns should be communicated to both broker A and B**. This would mean there would be an imperative step at the end of the migration when cutting over, which is to leave `OLD_BROKER_URL` set even when removing `rabbitmq_migration_bridge` so that the shutdown command works properly. Once all workers are running against broker B, `OLD_BROKER_URL` can be removed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on staging. This command is very important as it is used to shutdown a celery worker whenever a SIGTERM is received by the supervisor process. If this fails, it means workers will not shutdown, and we will accumulate stale workers over time and run out of memory on the machine.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
