### PR TITLE
Implements the KYC API call for the Orange provider

### DIFF
--- a/corehq/apps/integration/kyc/models.py
+++ b/corehq/apps/integration/kyc/models.py
@@ -116,6 +116,9 @@ class KycConfig(models.Model):
         if self.provider == KycProviders.MTN_KYC:
             from corehq.apps.integration.kyc.services import mtn_kyc_verify
             return mtn_kyc_verify
+        elif self.provider == KycProviders.ORANGE_CAMEROON_KYC:
+            from corehq.apps.integration.kyc.services import orange_cameroon_kyc_verify
+            return orange_cameroon_kyc_verify
         else:
             raise ValueError(f'Unable to determine KYC API method for provider {self.provider!r}.')
 

--- a/corehq/apps/integration/kyc/models.py
+++ b/corehq/apps/integration/kyc/models.py
@@ -112,6 +112,13 @@ class KycConfig(models.Model):
         """
         return KycProviderThresholdFields.get_required_fields(self.provider)
 
+    def get_kyc_api_method(self):
+        if self.provider == KycProviders.MTN_KYC:
+            from corehq.apps.integration.kyc.services import mtn_kyc_verify
+            return mtn_kyc_verify
+        else:
+            raise ValueError(f'Unable to determine KYC API method for provider {self.provider!r}.')
+
     def get_kyc_users_query(self):
         if self.user_data_store == UserDataStore.CUSTOM_USER_DATA:
             return UserES().domain(self.domain).mobile_users()

--- a/corehq/apps/integration/kyc/models.py
+++ b/corehq/apps/integration/kyc/models.py
@@ -329,7 +329,7 @@ class KycUser:
                 device_id=device_id or f'{__name__}.update_status',
             )
             if isinstance(self._user_or_case_obj, CommCareCase):
-                self._user_or_case_obj.refresh_from_db()
+                self._user_or_case_obj = CommCareCase.objects.get_case(case_id, self.kyc_config.domain)
         self._user_data = None
 
 

--- a/corehq/apps/integration/kyc/models.py
+++ b/corehq/apps/integration/kyc/models.py
@@ -315,6 +315,8 @@ class KycUser:
             user_data_obj = self._user_or_case_obj.get_user_data(self.kyc_config.domain)
             user_data_obj.update(update)
             user_data_obj.save()
+            # Save the user to trigger ES update via couch_user_post_save signal
+            CommCareUser.get(self._user_or_case_obj.user_id).save()
         else:
             if isinstance(self._user_or_case_obj, CommCareUser):
                 case_id = self._user_or_case_obj.get_usercase().case_id

--- a/corehq/apps/integration/kyc/services.py
+++ b/corehq/apps/integration/kyc/services.py
@@ -45,7 +45,8 @@ def verify_user(kyc_user, config):
     verification_error = None
 
     try:
-        verification_status = _verify_user(kyc_user, config)
+        verify_method = config.get_kyc_api_method()
+        verification_status = verify_method(kyc_user, config)
         if verification_status == KycVerificationStatus.FAILED:
             verification_error = KycVerificationFailureCause.USER_INFORMATION_MISMATCH.value
 
@@ -64,7 +65,7 @@ def verify_user(kyc_user, config):
     return verification_status, verification_error
 
 
-def _verify_user(kyc_user, config):
+def mtn_kyc_verify(kyc_user, config):
     """
     Verify a user using the Chenosis MTN KYC API.
 

--- a/corehq/apps/integration/kyc/tests/test_services.py
+++ b/corehq/apps/integration/kyc/tests/test_services.py
@@ -11,6 +11,7 @@ from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.integration.kyc.models import (
     KycConfig,
+    KycProviders,
     KycUser,
     KycVerificationFailureCause,
     KycVerificationStatus,
@@ -213,13 +214,46 @@ class TestVerifyUser(BaseKycUserSetup):
     @patch('corehq.apps.integration.kyc.services._validate_schema', return_value=True)
     @patch('corehq.apps.integration.kyc.services.get_user_data_for_api', return_value={'phoneNumber': 1234})
     @patch('corehq.motech.requests.Requests.post')
-    def test_kyc_success(self, mock_post, *args):
+    def test_mtn_kyc_verify_success(self, mock_post, *args):
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = self._sample_response_json()
         mock_post.return_value = mock_response
 
         verification_status, error = verify_user(self.kyc_user, self.config)
+
+        assert verification_status == KycVerificationStatus.PASSED
+        assert error is None
+
+    @patch('corehq.apps.integration.kyc.services._validate_schema', return_value=True)
+    @patch('corehq.apps.integration.kyc.services.get_user_data_for_api',
+       return_value={'phoneNumber': 1234, 'firstName': 'abc', 'lastName': 'def'}
+    )
+    @patch('corehq.motech.requests.Requests.post')
+    def test_orange_cameroon_kyc_verify_success(self, mock_post, *args):
+        config = KycConfig.objects.create(
+            domain=self.domain,
+            user_data_store=UserDataStore.CUSTOM_USER_DATA,
+            provider=KycProviders.ORANGE_CAMEROON_KYC,
+            passing_threshold={
+                "firstName": 100,
+                "lastName": 100,
+            },
+        )
+        kyc_user = KycUser(config, self.user)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "message": "customer 1234567890 successfully retrieve full name.",
+            "data": {
+                "firstName": "abc",
+                "lastName": "def"
+            }
+        }
+        mock_post.return_value = mock_response
+
+        verification_status, error = verify_user(kyc_user, config)
 
         assert verification_status == KycVerificationStatus.PASSED
         assert error is None


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Implements the KYC API call for the Orange provider.

Additionally, a couple of minor fixes were made:

- Ensure that changes to the KYC status in user data are reflected in the Users ES.
- Correctly refresh the CommCare case object.


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/SC-4591)

Note that the Orange API returns the first name and last name, which need to be compared with the data in HQ.
For now, the data is compared directly; however, this will be updated in a follow-up PR to use a comparison algorithm that generates a score, based on which the KYC result will be marked as passed or failed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
KYC_VERIFICATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Small change behind an unused FF.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None. Single QA to be done at the end of feature completion.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
