### PR TITLE
Improve shutdown celery worker command

### DIFF
--- a/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
+++ b/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
@@ -14,11 +14,15 @@ class Command(BaseCommand):
     def handle(self, hostname, **options):
         self.celery = Celery()
         self.celery.config_from_object(settings)
+
         self.celery.control.broadcast('shutdown', destination=[hostname])
+
         if self._ping_worker(hostname):
-            print('Did not shutdown worker')
-            exit(1)
-        print('Successfully initiated warm shutdown')
+            print(
+                f'Sent shutdown to {hostname} but worker is still '
+                'responding to ping'
+            )
+        print(f'Successfully shutdown {hostname}')
 
     def _ping_worker(self, hostname):
         worker_responses = self.celery.control.ping(

--- a/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
+++ b/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
@@ -47,7 +47,9 @@ class Command(BaseCommand):
             print(f'Failed to ping {hostname} via broker at {conn.hostname}')
             return False
 
-        self.celery.control.broadcast('shutdown', destination=[hostname])
+        self.celery.control.broadcast(
+            'shutdown', destination=[hostname], connection=conn
+        )
 
         if self._ping_worker(hostname, conn):
             print(

--- a/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
+++ b/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
@@ -1,13 +1,12 @@
+from celery import Celery
 from django.conf import settings
 from django.core.management.base import BaseCommand
-
-from celery import Celery
 
 from corehq.apps.hqadmin.utils import parse_celery_pings
 
 
 class Command(BaseCommand):
-    help = "Gracefully shutsdown a celery worker"
+    help = "Gracefully shuts down a celery worker"
 
     def add_arguments(self, parser):
         parser.add_argument('hostname')
@@ -16,7 +15,9 @@ class Command(BaseCommand):
         celery = Celery()
         celery.config_from_object(settings)
         celery.control.broadcast('shutdown', destination=[hostname])
-        worker_responses = celery.control.ping(timeout=10, destination=[hostname])
+        worker_responses = celery.control.ping(
+            timeout=10, destination=[hostname]
+        )
         pings = parse_celery_pings(worker_responses)
         if hostname in pings:
             print('Did not shutdown worker')

--- a/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
+++ b/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
@@ -15,6 +15,10 @@ class Command(BaseCommand):
         self.celery = Celery()
         self.celery.config_from_object(settings)
 
+        if not self._ping_worker(hostname):
+            print(f'Failed to ping {hostname}. Aborting shutdown.')
+            exit(1)
+
         self.celery.control.broadcast('shutdown', destination=[hostname])
 
         if self._ping_worker(hostname):

--- a/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
+++ b/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
@@ -1,6 +1,9 @@
+from contextlib import contextmanager
+
 from celery import Celery
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from kombu import Connection
 
 from corehq.apps.hqadmin.utils import parse_celery_pings
 
@@ -15,22 +18,49 @@ class Command(BaseCommand):
         self.celery = Celery()
         self.celery.config_from_object(settings)
 
-        if not self._ping_worker(hostname):
-            print(f'Failed to ping {hostname}. Aborting shutdown.')
+        current_broker_url = getattr(settings, 'CELERY_BROKER_URL', None)
+        assert current_broker_url is not None, "CELERY_BROKER_URL is not set"
+        broker_urls = [current_broker_url]
+        if old_broker_url := getattr(settings, 'OLD_BROKER_URL', None):
+            broker_urls.append(old_broker_url)
+
+        success = False
+        for broker_url in broker_urls:
+            with self._connection(broker_url) as conn:
+                success = self._shutdown_worker(hostname, conn)
+            if success:
+                break
+
+        if not success:
+            print(f'Failed to shutdown {hostname}.')
             exit(1)
+
+    def _shutdown_worker(self, hostname, conn):
+        if not self._ping_worker(hostname, conn):
+            print(f'Failed to ping {hostname} via broker at {conn.hostname}')
+            return False
 
         self.celery.control.broadcast('shutdown', destination=[hostname])
 
-        if self._ping_worker(hostname):
+        if self._ping_worker(hostname, conn):
             print(
                 f'Sent shutdown to {hostname} but worker is still '
                 'responding to ping'
             )
         print(f'Successfully shutdown {hostname}')
+        return True
 
-    def _ping_worker(self, hostname):
+    def _ping_worker(self, hostname, conn):
         worker_responses = self.celery.control.ping(
-            timeout=10, destination=[hostname]
+            timeout=10, destination=[hostname], connection=conn
         )
         pings = parse_celery_pings(worker_responses)
         return hostname in pings
+
+    @contextmanager
+    def _connection(self, url):
+        conn = Connection(url)
+        try:
+            yield conn
+        finally:
+            conn.release()

--- a/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
+++ b/corehq/apps/hqadmin/management/commands/shutdown_celery_worker_by_hostname.py
@@ -9,6 +9,13 @@ from corehq.apps.hqadmin.utils import parse_celery_pings
 
 
 class Command(BaseCommand):
+    """
+    The complexity here is to accommodate migrating celery brokers
+    If in the future it becomes a challenge to support custom connections,
+    removing that logic here should be fine. The downside is that when
+    switching brokers, celery workers configured to read/write to the old
+    broker will not shutdown properly.
+    """
     help = "Gracefully shuts down a celery worker"
 
     def add_arguments(self, parser):


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19047

An attempt as a simpler followup to https://github.com/dimagi/commcare-hq/pull/37224, though the code is pretty similar.

This primarily adds support for sending shutdown broadcasts via the "old broker" if set, but also does the following:

- pings the worker first to see if it is even responsive (while it might be better to blindly send a shutdown, I think this method will allow us to look at logs in the cases where there are "zombie" celery processes to see if it wasn't responsive to the ping in the first place, effectively providing a better log trail then the current situation).
- no longer raises an exit(1) if the worker still responds to a ping _after_ a shutdown is sent, since it is very likely that the worker is still in the process of a warm shutdown. As discussed in https://github.com/dimagi/commcare-hq/pull/37224#discussion_r2658149733, this exit isn't significant since we don't do anything differently in the caller of this command based on the exit code.

While this is a good bit of code to be adding for a scenario we rarely find ourselves in (switching brokers), it will at least be useful for the upcoming migration and we can deem if it is worth keeping the additional complexity after that. The scenario I'm primarily thinking of is when initially changing `CELERY_BROKER_URL` to the new broker. The existing celery workers will still be running against the old broker, and when performing the restart to switch workers to the new broker, those old workers will not be shutdown unless these changes exist.

As discussed in the closed PR, once a celery worker is in the split state of reading from the old broker and writing to the new broker, we do not have the ability to successfully execute remote control commands, so this is not attempting to resolve that state.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on staging. This is an important command as it is used every time we restart celery services (deploys, manual restarts, etc), and needs to work or else zombie celery processes will live on and use up memory on the machine.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
