### PR TITLE
Replace deprecated auto_offset_reset values

### DIFF
--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -68,7 +68,7 @@ class KafkaChangeFeed(ChangeFeed):
         """
         timeout = MAX_TIMEOUT if forever else MIN_TIMEOUT
         start_from_latest = since is None
-        reset = 'largest' if start_from_latest else 'smallest'
+        reset = 'latest' if start_from_latest else 'earliest'
         self._init_consumer(timeout, auto_offset_reset=reset)
 
         since = self._filter_offsets(since)
@@ -137,7 +137,7 @@ class KafkaChangeFeed(ChangeFeed):
             return self._init_consumer()
         return self._consumer
 
-    def _init_consumer(self, timeout=MIN_TIMEOUT, auto_offset_reset='smallest'):
+    def _init_consumer(self, timeout=MIN_TIMEOUT, auto_offset_reset='earliest'):
         """Allow re-initing the consumer if necessary
         """
         config = {


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://kafka-python.readthedocs.io/en/master/changelog.html#id156

Happened to notice while looking at this code. While these values do appear to still [be supported](https://github.com/dpkp/kafka-python/blob/f8a91ec4d57caa5440d496c5dab937b7c4498e9a/kafka/consumer/group.py#L355-L360), I presume they will be removed at some point so just switching over to the non-deprecated values now.

> auto_offset_reset: previously values were ‘smallest’ or ‘largest’, now values are ‘earliest’ or ‘latest’


 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Very small change that should continue to function as normal.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
