### PR TITLE
B5 Migration: Events

### DIFF
--- a/corehq/apps/events/static/events/js/event_attendees.js
+++ b/corehq/apps/events/static/events/js/event_attendees.js
@@ -162,7 +162,7 @@ var newAttendeeCreationModel = function () {
     };
 
     self.submitNewAttendee = function () {
-        Modal.getInstance($("#new-attendee-modal")).hide();
+        Modal.getInstance("#new-attendee-modal").hide();
         //var newAttendee = ko.mapping.toJS(self.stagedAttendee);
         var newAttendee = attendeeModel(ko.mapping.toJS(self.stagedAttendee));
         self.newAttendees.push(newAttendee);

--- a/corehq/apps/events/static/events/js/event_attendees.js
+++ b/corehq/apps/events/static/events/js/event_attendees.js
@@ -2,6 +2,7 @@ import "commcarehq";
 import $ from "jquery";
 import ko from "knockout";
 import _ from "underscore";
+import { Modal } from "bootstrap5";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import RMI from "jquery.rmi/jquery.rmi";
 import locationsWidgets from "locations/js/widgets";
@@ -111,12 +112,12 @@ var mobileWorkerAttendees = function () {
         var button = document.getElementById("mobileWorkerAttendeeButton");
         if (self.mobileWorkerAttendeesEnabled()) {
             button.innerHTML = gettext("Disable Mobile Worker Attendees");
-            // Appending btn-danger will override btn-default
-            button.classList.add("btn-danger");
+            // Appending btn-outline-danger will override btn-outline-primary
+            button.classList.add("btn-outline-danger");
         } else {
             button.innerHTML = gettext("Enable Mobile Worker Attendees");
-            // Simply removing btn-danger will effectively enable btn-default
-            button.classList.remove("btn-danger");
+            // Simply removing btn-outline-danger will effectively enable btn-outline-primary
+            button.classList.remove("btn-outline-danger");
         }
     };
 
@@ -161,7 +162,7 @@ var newAttendeeCreationModel = function () {
     };
 
     self.submitNewAttendee = function () {
-        $("#new-attendee-modal").modal('hide');  /* todo B5: js-modal */
+        Modal.getInstance($("#new-attendee-modal")).hide();
         //var newAttendee = ko.mapping.toJS(self.stagedAttendee);
         var newAttendee = attendeeModel(ko.mapping.toJS(self.stagedAttendee));
         self.newAttendees.push(newAttendee);

--- a/corehq/apps/events/static/events/js/event_attendees.js
+++ b/corehq/apps/events/static/events/js/event_attendees.js
@@ -5,7 +5,7 @@ import _ from "underscore";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import RMI from "jquery.rmi/jquery.rmi";
 import locationsWidgets from "locations/js/widgets";
-import "hqwebapp/js/bootstrap3/widgets";
+import "hqwebapp/js/bootstrap5/widgets";
 import "hqwebapp/js/components/pagination";
 import "hqwebapp/js/components/search_box";
 
@@ -161,7 +161,7 @@ var newAttendeeCreationModel = function () {
     };
 
     self.submitNewAttendee = function () {
-        $("#new-attendee-modal").modal('hide');
+        $("#new-attendee-modal").modal('hide');  /* todo B5: js-modal */
         //var newAttendee = ko.mapping.toJS(self.stagedAttendee);
         var newAttendee = attendeeModel(ko.mapping.toJS(self.stagedAttendee));
         self.newAttendees.push(newAttendee);

--- a/corehq/apps/events/static/events/js/new_event.js
+++ b/corehq/apps/events/static/events/js/new_event.js
@@ -4,7 +4,7 @@ import ko from "knockout";
 import multiselectUtils from "hqwebapp/js/multiselect_utils";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import locationsWidgets from "locations/js/widgets";
-import "hqwebapp/js/bootstrap3/widgets";
+import "hqwebapp/js/bootstrap5/widgets";
 import "jquery-ui/ui/widgets/datepicker";
 import "jquery-ui-built-themes/redmond/jquery-ui.min.css";
 

--- a/corehq/apps/events/static/events/js/new_event.js
+++ b/corehq/apps/events/static/events/js/new_event.js
@@ -89,7 +89,7 @@ $(function () {
                     'location_id': newLocation,
                 },
                 success: function (data) {
-                    $("#attendance-list-error").addClass("hidden");
+                    $("#attendance-list-error").addClass("d-none");
 
                     rebuildList("id_expected_attendees", data.attendees);
                     rebuildList("id_attendance_takers", data.attendance_takers);
@@ -97,7 +97,7 @@ $(function () {
                     multiselectUtils.rebuildMultiselect('id_attendance_takers', ATTENDANCE_TAKER_PROPS);
                 },
                 error: function () {
-                    $("#attendance-list-error").removeClass("hidden");
+                    $("#attendance-list-error").removeClass("d-none");
                 },
             });
         });

--- a/corehq/apps/events/templates/events/edit_attendee.html
+++ b/corehq/apps/events/templates/events/edit_attendee.html
@@ -1,9 +1,7 @@
 {% extends 'hqwebapp/bootstrap5/base_section.html' %}
-
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 {% load i18n %}
-
 {% js_entry 'events/js/edit_attendee' %}
 
 {% block page_content %}
@@ -17,8 +15,9 @@
     {% if attendee_has_attended_events %}
       <div class="alert alert-warning">
         {% blocktrans %}
-          This attendee cannot be deleted as <strong>{{ attendee_name }}</strong> has been tracked as
-          having attended one or more events.
+          This attendee cannot be deleted as
+          <strong>{{ attendee_name }}</strong> has been tracked as having
+          attended one or more events.
         {% endblocktrans %}
       </div>
     {% endif %}
@@ -28,15 +27,17 @@
         <button type="submit" class="btn btn-primary disable-on-submit">
           {% trans 'Update Attendee' %}
         </button>
-        <a class="btn btn-outline-danger {% if attendee_has_attended_events %}disabled{% endif %}"
-            data-bs-toggle="modal" href="#delete_attendee_{{ attendee_id }}">
+        <a
+          class="btn btn-outline-danger {% if attendee_has_attended_events %}disabled{% endif %}"
+          data-bs-toggle="modal"
+          href="#delete_attendee_{{ attendee_id }}"
+        >
           <i class="fa-regular fa-trash-can"></i>
           {% trans "Delete Attendee" %}
         </a>
       </div>
     </div>
   </form>
-
 {% endblock %}
 {% block modals %}
   <div id="delete_attendee_{{ attendee_id }}" class="modal fade">
@@ -54,21 +55,25 @@
             aria-label="{% trans 'Close' %}"
           ></button>
         </div>
-        <form class="m-0 p-0"
-              action="{% url 'delete_attendee' domain attendee_id %}"
-              method="post"
-              data-bind="submit: submit">
+        <form
+          class="m-0 p-0"
+          action="{% url 'delete_attendee' domain attendee_id %}"
+          method="post"
+          data-bind="submit: submit"
+        >
           {% csrf_token %}
           <div class="modal-body">
             <p>
               {% blocktrans %}
-                Are you sure you want to permanently delete <strong>{{ attendee_name }}</strong>?
+                Are you sure you want to permanently delete
+                <strong>{{ attendee_name }}</strong>?
               {% endblocktrans %}
             </p>
             <p>
               {% blocktrans %}
-                This action will delete {{ attendee_name }} as a potential attendee and will remove them from all
-                future events that they are currently enlisted in.
+                This action will delete {{ attendee_name }} as a potential
+                attendee and will remove them from all future events that they
+                are currently enlisted in.
               {% endblocktrans %}
             </p>
             <div class="alert alert-warning">
@@ -79,7 +84,9 @@
             </div>
           </div>
           <div class="modal-footer">
-            <a href="#" data-bs-dismiss="modal" class="btn btn-outline-primary">{% trans "Cancel" %}</a>
+            <a href="#" data-bs-dismiss="modal" class="btn btn-outline-primary"
+              >{% trans "Cancel" %}</a
+            >
             <button type="submit" class="btn btn-outline-danger">
               {% trans "Delete Attendee" %}
             </button>

--- a/corehq/apps/events/templates/events/edit_attendee.html
+++ b/corehq/apps/events/templates/events/edit_attendee.html
@@ -1,10 +1,10 @@
-{% extends 'hqwebapp/bootstrap3/base_section.html' %}
+{% extends 'hqwebapp/bootstrap5/base_section.html' %}
 
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% js_entry_b3 'events/js/edit_attendee' %}
+{% js_entry 'events/js/edit_attendee' %}
 
 {% block page_content %}
   {% initial_page_data "attendee_id" attendee_id %}
@@ -12,7 +12,7 @@
     {% csrf_token %}
     <fieldset>
       <legend>{% trans 'Attendee' %}</legend>
-      {% crispy form %}
+      {% crispy form %}  {# todo B5: crispy #}
     </fieldset>
     {% if attendee_has_attended_events %}
       <div class="alert alert-warning">
@@ -26,12 +26,12 @@
     {% endif %}
 
     <div class="form-actions">
-      <div class="col-sm-offset-3 col-md-offset-2 col-sm-9 col-md-8 col-lg-6">
+      <div class="offset-md-3 offset-lg-2 col-md-9 col-lg-8 col-xl-6">
         <button type="submit" class="btn btn-primary disable-on-submit">
           {% trans 'Update Attendee' %}
         </button>
-        <a class="btn btn-danger {% if attendee_has_attended_events %}disabled{% endif %}"
-            data-toggle="modal" href="#delete_attendee_{{ attendee_id }}">
+        <a class="btn btn-outline-danger {% if attendee_has_attended_events %}disabled{% endif %}"
+            data-bs-toggle="modal" href="#delete_attendee_{{ attendee_id }}">
           <i class="fa-regular fa-trash-can"></i>
           {% trans "Delete Attendee" %}
         </a>
@@ -45,14 +45,14 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>  {# todo B5: css-close #}
           <h4 class="modal-title">
             {% trans "Delete Attendee" %} {{ attendee_name }}
             <small>Permanent Action</small>
           </h4>
         </div>
         <form class="form-horizontal"
-              style="margin: 0; padding: 0"
+              style="margin: 0; padding: 0"  {# todo B5: inline-style #}
               action="{% url 'delete_attendee' domain attendee_id %}"
               method="post"
               data-bind="submit: submit">
@@ -79,8 +79,8 @@
             </div>
           </div>
           <div class="modal-footer">
-            <a href="#" data-dismiss="modal" class="btn btn-default">{% trans "Cancel" %}</a>
-            <button type="submit" class="btn btn-danger">
+            <a href="#" data-bs-dismiss="modal" class="btn btn-outline-primary">{% trans "Cancel" %}</a>
+            <button type="submit" class="btn btn-outline-danger">
               {% trans "Delete Attendee" %}
             </button>
           </div>

--- a/corehq/apps/events/templates/events/edit_attendee.html
+++ b/corehq/apps/events/templates/events/edit_attendee.html
@@ -23,7 +23,7 @@
     {% endif %}
 
     <div class="form-actions">
-      <div class="offset-md-3 offset-lg-2 col-md-9 col-lg-8 col-xl-6">
+      <div class="offset-sm-3 offset-md-2 col-sm-9 col-md-8 col-lg-6 ps-1">
         <button type="submit" class="btn btn-primary disable-on-submit">
           {% trans 'Update Attendee' %}
         </button>

--- a/corehq/apps/events/templates/events/edit_attendee.html
+++ b/corehq/apps/events/templates/events/edit_attendee.html
@@ -8,20 +8,18 @@
 
 {% block page_content %}
   {% initial_page_data "attendee_id" attendee_id %}
-  <form id="attendee_form" class="form-horizontal" name="" method="post">
+  <form id="attendee_form" name="" method="post">
     {% csrf_token %}
     <fieldset>
       <legend>{% trans 'Attendee' %}</legend>
-      {% crispy form %}  {# todo B5: crispy #}
+      {% crispy form %}
     </fieldset>
     {% if attendee_has_attended_events %}
       <div class="alert alert-warning">
-        <p>
-          {% blocktrans %}
-            This attendee cannot be deleted as <strong>{{ attendee_name }}</strong> has been tracked as
-            having attended one or more events.
-          {% endblocktrans %}
-        </p>
+        {% blocktrans %}
+          This attendee cannot be deleted as <strong>{{ attendee_name }}</strong> has been tracked as
+          having attended one or more events.
+        {% endblocktrans %}
       </div>
     {% endif %}
 
@@ -45,14 +43,18 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>  {# todo B5: css-close #}
           <h4 class="modal-title">
             {% trans "Delete Attendee" %} {{ attendee_name }}
             <small>Permanent Action</small>
           </h4>
+          <button
+            type="button"
+            class="btn-close"
+            data-bs-dismiss="modal"
+            aria-label="{% trans 'Close' %}"
+          ></button>
         </div>
-        <form class="form-horizontal"
-              style="margin: 0; padding: 0"  {# todo B5: inline-style #}
+        <form class="m-0 p-0"
               action="{% url 'delete_attendee' domain attendee_id %}"
               method="post"
               data-bind="submit: submit">
@@ -70,12 +72,10 @@
               {% endblocktrans %}
             </p>
             <div class="alert alert-warning">
-              <p>
-                <i class="fa fa-warning"></i>
-                {% blocktrans %}
-                  This action cannot be undone.
-                {% endblocktrans %}
-              </p>
+              <i class="fa fa-warning"></i>
+              {% blocktrans %}
+                This action cannot be undone.
+              {% endblocktrans %}
             </div>
           </div>
           <div class="modal-footer">

--- a/corehq/apps/events/templates/events/event_attendees.html
+++ b/corehq/apps/events/templates/events/event_attendees.html
@@ -25,7 +25,7 @@
   <div class="btn-toolbar mb-2 ko-template" id="attendee-actions">
     <button
       type="button"
-      class="btn btn-primary me-2"
+      class="btn btn-primary me-1"
       data-bs-toggle="modal"
       data-bs-target="#new-attendee-modal"
       data-bind="click: initializeAttendee"

--- a/corehq/apps/events/templates/events/event_attendees.html
+++ b/corehq/apps/events/templates/events/event_attendees.html
@@ -15,7 +15,7 @@
   {% registerurl 'attendees_config' domain %}
   {% registerurl 'event_attendees' domain %}
   {% registerurl 'convert_mobile_workers' domain %}
-<p class="lead">
+
   <p>
     {% blocktrans %}
     Known potential attendees who can be invited to participate in Attendance
@@ -23,9 +23,9 @@
     {% endblocktrans %}
   </p>
 
-  <div class="btn-toolbar" id="attendee-actions" class="ko-template">
+  <div class="btn-toolbar mb-2 ko-template" id="attendee-actions">
       <button type="button"
-              class="btn btn-primary"
+              class="btn btn-primary me-2"
               data-bs-toggle="modal"
               data-bs-target="#new-attendee-modal"
               data-bind="click: initializeAttendee">
@@ -36,22 +36,23 @@
         <i class="fa"></i>{% trans "Enable Mobile Worker Attendees" %}
       </a>
   </div>
-</p>
 
   <div class="modal fade" id="new-attendee-modal">
     <div class="modal-dialog">
       <form novalidate data-bind="submit: submitNewAttendee">
         <div class="modal-content">
           <div class="modal-header">
-            <button type="button" class="btn-close" data-bs-dismiss="modal">  {# todo B5: css-close #}
-              <span aria-hidden="true">&times;</span>
-              <span class="sr-only">{% trans 'Close' %}</span>
-            </button>
             <h3 class="modal-title">{% trans "Create Potential Attendee" %}</h3>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="{% trans 'Close' %}"
+            ></button>
           </div>
           <div class="modal-body" data-bind="if: stagedAttendee">
-            <div class="form-horizontal" data-bind="with: stagedAttendee">
-              {% crispy new_attendee_form %}  {# todo B5: crispy #}
+            <div data-bind="with: stagedAttendee">
+              {% crispy new_attendee_form %}
             </div>
           </div>
           <div class="modal-footer">
@@ -67,13 +68,11 @@
     </div>
   </div>
 
-  <div class="card text-bg-info ko-template"  {# todo B5: css-panel #}
+  <div class="card border-info ko-template mb-3"
        id="new-attendees-list"
        data-bind="visible: newAttendees().length">
-    <div class="card-header">
-      <h3 class="card-title">
-        {% trans 'New Potential Attendees' %}
-      </h3>
+    <div class="card-header text-bg-info pt-3">
+      <h5 class="card-title">{% trans 'New Potential Attendees' %}</h5>
     </div>
     <div class="card-body">
       <table class="table table-striped">
@@ -84,38 +83,45 @@
         </tr>
         </thead>
         <tbody data-bind="foreach: newAttendees">
-        <tr>
-          <td data-bind="attr: {class: creationStatus}">
-            <i class="fa fa-user"></i> <strong data-bind="text: name"></strong>
-          </td>
-          <td data-bind="attr: {class: creationStatus}">
-            <div data-bind="visible: creationStatus() === $root.STATUS_CSS.PENDING">
-              <i class="fa fa-circle-notch fa-spin"></i>
-              {% trans 'Pending...' %}
-            </div>
-            <div data-bind="visible: creationStatus() === $root.STATUS_CSS.SUCCESS">
-              <span class="text-success">
-                <i class="fa fa-check"></i> {% trans 'NEW' %}
-              </span>
-            </div>
-            <div data-bind="visible: creationStatus() === $root.STATUS_CSS.ERROR">
-              <span class="text-danger">
-                <i class="fa-solid fa-triangle-exclamation"></i>
-                {% trans "ERROR" %}
-                <!-- ko text: creationError --><!--/ko-->
-              </span>
-            </div>
-          </td>
-        </tr>
+          <tr data-bind="attr: { class: 'table-'+ creationStatus() }">
+            <td>
+              <i class="fa fa-user"></i>
+              <strong data-bind="text: name"></strong>
+            </td>
+            <td>
+              <div
+                data-bind="visible: creationStatus() === $root.STATUS_CSS.PENDING"
+              >
+                <i class="fa fa-circle-notch fa-spin"></i>
+                {% trans 'Pending...' %}
+              </div>
+              <div
+                data-bind="visible: creationStatus() === $root.STATUS_CSS.SUCCESS"
+              >
+                <span class="text-success">
+                  <i class="fa fa-check"></i> {% trans 'NEW' %}
+                </span>
+              </div>
+              <div
+                data-bind="visible: creationStatus() === $root.STATUS_CSS.ERROR"
+              >
+                <span class="text-danger">
+                  <i class="fa-solid fa-triangle-exclamation"></i>
+                  {% trans "ERROR" %}
+                  <!-- ko text: creationError --><!--/ko-->
+                </span>
+              </div>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>
   </div>
 
   <div id="attendees-list" class="ko-template">
-    <div class="card ">  {# todo B5: css-panel #}
-      <div class="card-header">
-        <h3 class="card-title">{% trans 'Potential Attendees' %}</h3>
+    <div class="card mb-3">
+      <div class="card-header pt-3">
+        <h5 class="card-title">{% trans 'Potential Attendees' %}</h5>
       </div>
       <div class="card-body">
         <div class="row">
@@ -126,9 +132,10 @@
                                 placeholder: '{% trans_html_attr "Search attendees..." %}'"></search-box>
           </div>
         </div>
-        <table class="table table-striped table-responsive"
-               style="margin-bottom: 0;"  {# todo B5: inline-style #}
-               data-bind="visible: showTable">
+        <table
+          class="table table-striped table-responsive mb-0"
+          data-bind="visible: showTable"
+        >
           <thead>
           <tr>
             <th class="col-sm-12">{% trans "Name" %}</th>

--- a/corehq/apps/events/templates/events/event_attendees.html
+++ b/corehq/apps/events/templates/events/event_attendees.html
@@ -1,10 +1,10 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load compress %}
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
-{% js_entry_b3 'events/js/event_attendees' %}
+{% js_entry 'events/js/event_attendees' %}
 
 {% block page_title %}
   {{ current_page.title }}
@@ -26,13 +26,13 @@
   <div class="btn-toolbar" id="attendee-actions" class="ko-template">
       <button type="button"
               class="btn btn-primary"
-              data-toggle="modal"
-              data-target="#new-attendee-modal"
+              data-bs-toggle="modal"
+              data-bs-target="#new-attendee-modal"
               data-bind="click: initializeAttendee">
         <i class="fa fa-plus"></i> {% trans "Create Potential Attendee" %}
       </button>
 
-      <a id="mobileWorkerAttendeeButton" class="btn btn-default" href="{% url 'convert_mobile_workers' domain %}">
+      <a id="mobileWorkerAttendeeButton" class="btn btn-outline-primary" href="{% url 'convert_mobile_workers' domain %}">
         <i class="fa"></i>{% trans "Enable Mobile Worker Attendees" %}
       </a>
   </div>
@@ -43,7 +43,7 @@
       <form novalidate data-bind="submit: submitNewAttendee">
         <div class="modal-content">
           <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal">
+            <button type="button" class="btn-close" data-bs-dismiss="modal">  {# todo B5: css-close #}
               <span aria-hidden="true">&times;</span>
               <span class="sr-only">{% trans 'Close' %}</span>
             </button>
@@ -51,13 +51,13 @@
           </div>
           <div class="modal-body" data-bind="if: stagedAttendee">
             <div class="form-horizontal" data-bind="with: stagedAttendee">
-              {% crispy new_attendee_form %}
+              {% crispy new_attendee_form %}  {# todo B5: crispy #}
             </div>
           </div>
           <div class="modal-footer">
             <button type="button"
-                    class="btn btn-default"
-                    data-dismiss="modal">{% trans 'Cancel' %}</button>
+                    class="btn btn-outline-primary"
+                    data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
             <button type="submit"
                     class="btn btn-primary"
                     data-bind="enable: allowSubmit">{% trans "Create" %}</button>
@@ -67,20 +67,20 @@
     </div>
   </div>
 
-  <div class="panel panel-info ko-template"
+  <div class="card text-bg-info ko-template"  {# todo B5: css-panel #}
        id="new-attendees-list"
        data-bind="visible: newAttendees().length">
-    <div class="panel-heading">
-      <h3 class="panel-title">
+    <div class="card-header">
+      <h3 class="card-title">
         {% trans 'New Potential Attendees' %}
       </h3>
     </div>
-    <div class="panel-body">
+    <div class="card-body">
       <table class="table table-striped">
         <thead>
         <tr>
-            <th class="col-xs-9">{% trans "Name" %}</th>
-            <th class="col-xs-3">{% trans "Status" %}</th>
+            <th class="col-sm-9">{% trans "Name" %}</th>
+            <th class="col-sm-3">{% trans "Status" %}</th>
         </tr>
         </thead>
         <tbody data-bind="foreach: newAttendees">
@@ -113,13 +113,13 @@
   </div>
 
   <div id="attendees-list" class="ko-template">
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">{% trans 'Potential Attendees' %}</h3>
+    <div class="card ">  {# todo B5: css-panel #}
+      <div class="card-header">
+        <h3 class="card-title">{% trans 'Potential Attendees' %}</h3>
       </div>
-      <div class="panel-body">
+      <div class="card-body">
         <div class="row">
-          <div class="col-sm-6">
+          <div class="col-md-6">
             <search-box data-apply-bindings="false"
                         params="value: query,
                                 action: function() { goToPage(1); },
@@ -127,11 +127,11 @@
           </div>
         </div>
         <table class="table table-striped table-responsive"
-               style="margin-bottom: 0;"
+               style="margin-bottom: 0;"  {# todo B5: inline-style #}
                data-bind="visible: showTable">
           <thead>
           <tr>
-            <th class="col-xs-12">{% trans "Name" %}</th>
+            <th class="col-sm-12">{% trans "Name" %}</th>
           </tr>
           </thead>
           <tbody data-bind="foreach: attendees">
@@ -154,7 +154,7 @@
             <strong>There was an issue contacting the server.</strong>
             Please check your internet connection.
             If this issue continues, please
-            <a href="#modalReportIssue" data-toggle="modal">report an issue</a>.
+            <a href="#modalReportIssue" data-bs-toggle="modal">report an issue</a>.
           {% endblocktrans %}
         </div>
         <div class="alert alert-info" data-bind="visible: showProjectHasNoAttendees">

--- a/corehq/apps/events/templates/events/event_attendees.html
+++ b/corehq/apps/events/templates/events/event_attendees.html
@@ -3,7 +3,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
-
 {% js_entry 'events/js/event_attendees' %}
 
 {% block page_title %}
@@ -18,23 +17,29 @@
 
   <p>
     {% blocktrans %}
-    Known potential attendees who can be invited to participate in Attendance
-    Tracking Events.
+      Known potential attendees who can be invited to participate in Attendance
+      Tracking Events.
     {% endblocktrans %}
   </p>
 
   <div class="btn-toolbar mb-2 ko-template" id="attendee-actions">
-      <button type="button"
-              class="btn btn-primary me-2"
-              data-bs-toggle="modal"
-              data-bs-target="#new-attendee-modal"
-              data-bind="click: initializeAttendee">
-        <i class="fa fa-plus"></i> {% trans "Create Potential Attendee" %}
-      </button>
+    <button
+      type="button"
+      class="btn btn-primary me-2"
+      data-bs-toggle="modal"
+      data-bs-target="#new-attendee-modal"
+      data-bind="click: initializeAttendee"
+    >
+      <i class="fa fa-plus"></i> {% trans "Create Potential Attendee" %}
+    </button>
 
-      <a id="mobileWorkerAttendeeButton" class="btn btn-outline-primary" href="{% url 'convert_mobile_workers' domain %}">
-        <i class="fa"></i>{% trans "Enable Mobile Worker Attendees" %}
-      </a>
+    <a
+      id="mobileWorkerAttendeeButton"
+      class="btn btn-outline-primary"
+      href="{% url 'convert_mobile_workers' domain %}"
+    >
+      <i class="fa"></i>{% trans "Enable Mobile Worker Attendees" %}
+    </a>
   </div>
 
   <div class="modal fade" id="new-attendee-modal">
@@ -56,31 +61,41 @@
             </div>
           </div>
           <div class="modal-footer">
-            <button type="button"
-                    class="btn btn-outline-primary"
-                    data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
-            <button type="submit"
-                    class="btn btn-primary"
-                    data-bind="enable: allowSubmit">{% trans "Create" %}</button>
+            <button
+              type="button"
+              class="btn btn-outline-primary"
+              data-bs-dismiss="modal"
+            >
+              {% trans 'Cancel' %}
+            </button>
+            <button
+              type="submit"
+              class="btn btn-primary"
+              data-bind="enable: allowSubmit"
+            >
+              {% trans "Create" %}
+            </button>
           </div>
         </div>
       </form>
     </div>
   </div>
 
-  <div class="card border-info ko-template mb-3"
-       id="new-attendees-list"
-       data-bind="visible: newAttendees().length">
+  <div
+    class="card border-info ko-template mb-3"
+    id="new-attendees-list"
+    data-bind="visible: newAttendees().length"
+  >
     <div class="card-header text-bg-info pt-3">
       <h5 class="card-title">{% trans 'New Potential Attendees' %}</h5>
     </div>
     <div class="card-body">
       <table class="table table-striped">
         <thead>
-        <tr>
+          <tr>
             <th class="col-sm-9">{% trans "Name" %}</th>
             <th class="col-sm-3">{% trans "Status" %}</th>
-        </tr>
+          </tr>
         </thead>
         <tbody data-bind="foreach: newAttendees">
           <tr data-bind="attr: { class: 'table-'+ creationStatus() }">
@@ -126,10 +141,12 @@
       <div class="card-body">
         <div class="row">
           <div class="col-md-6">
-            <search-box data-apply-bindings="false"
-                        params="value: query,
-                                action: function() { goToPage(1); },
-                                placeholder: '{% trans_html_attr "Search attendees..." %}'"></search-box>
+            <search-box
+              data-apply-bindings="false"
+              params="value: query,
+                action: function() { goToPage(1); },
+                placeholder: '{% trans_html_attr "Search attendees..." %}'"
+            ></search-box>
           </div>
         </div>
         <table
@@ -137,34 +154,41 @@
           data-bind="visible: showTable"
         >
           <thead>
-          <tr>
-            <th class="col-sm-12">{% trans "Name" %}</th>
-          </tr>
+            <tr>
+              <th class="col-sm-12">{% trans "Name" %}</th>
+            </tr>
           </thead>
           <tbody data-bind="foreach: attendees">
-          <tr>
-            <td>
-              <a data-bind="attr: {href: case_id}">
-                <span data-bind="text: name"></span>
-              </a>
-            </td>
-          </tr>
+            <tr>
+              <td>
+                <a data-bind="attr: {href: case_id}">
+                  <span data-bind="text: name"></span>
+                </a>
+              </td>
+            </tr>
           </tbody>
         </table>
-        <div class="alert alert-info"
-             data-bind="visible: showLoadingSpinner() && !hasError()">
+        <div
+          class="alert alert-info"
+          data-bind="visible: showLoadingSpinner() && !hasError()"
+        >
           <i class="fa fa-spin fa-spinner"></i>
           {% trans "Loading potential attendees ..." %}
         </div>
         <div class="alert alert-danger" data-bind="visible: hasError">
           {% blocktrans %}
             <strong>There was an issue contacting the server.</strong>
-            Please check your internet connection.
-            If this issue continues, please
-            <a href="#modalReportIssue" data-bs-toggle="modal">report an issue</a>.
+            Please check your internet connection. If this issue continues,
+            please
+            <a href="#modalReportIssue" data-bs-toggle="modal"
+              >report an issue</a
+            >.
           {% endblocktrans %}
         </div>
-        <div class="alert alert-info" data-bind="visible: showProjectHasNoAttendees">
+        <div
+          class="alert alert-info"
+          data-bind="visible: showProjectHasNoAttendees"
+        >
           {% blocktrans %}
             You currently have no potential attendees.
           {% endblocktrans %}
@@ -174,14 +198,16 @@
             No matching potential attendees found.
           {% endblocktrans %}
         </div>
-        <pagination data-apply-bindings="false"
-                    data-bind="visible: showTable"
-                    params="goToPage: goToPage,
-                            slug: 'mobile-workers',
-                            perPage: itemsPerPage,
-                            totalItems: totalItems,
-                            onLoad: onPaginationLoad,
-                            showSpinner: showPaginationSpinner"></pagination>
+        <pagination
+          data-apply-bindings="false"
+          data-bind="visible: showTable"
+          params="goToPage: goToPage,
+            slug: 'mobile-workers',
+            perPage: itemsPerPage,
+            totalItems: totalItems,
+            onLoad: onPaginationLoad,
+            showSpinner: showPaginationSpinner"
+        ></pagination>
       </div>
     </div>
   </div>

--- a/corehq/apps/events/templates/events/events_list.html
+++ b/corehq/apps/events/templates/events/events_list.html
@@ -61,9 +61,13 @@
         <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">
-              <button type="button" class="btn-close" data-bs-dismiss="modal"><span aria-hidden="true">&times;</span>  {# todo B5: css-close #}
-                <span class="sr-only">Close</span></button>
               <h4 class="modal-title" data-bind="text: name"></h4>
+              <button
+                type="button"
+                class="btn-close"
+                data-bs-dismiss="modal"
+                aria-label="{% trans 'Close' %}"
+              ></button>
             </div>
             <div class="modal-body">
               <table class="table table-striped table-hover">

--- a/corehq/apps/events/templates/events/events_list.html
+++ b/corehq/apps/events/templates/events/events_list.html
@@ -1,7 +1,6 @@
 {% extends 'hqwebapp/bootstrap5/base_paginated_crud.html' %}
 {% load i18n %}
 {% load hq_shared_tags %}
-
 {% js_entry "hqwebapp/js/bootstrap5/crud_paginated_list_init" %}
 
 {% block page_title %}
@@ -13,7 +12,8 @@
     <div class="col-md-8">
       <p>
         {% blocktrans %}
-          Attendance tracking events can be used to track attendance of all the selected attendees.
+          Attendance tracking events can be used to track attendance of all the
+          selected attendees.
         {% endblocktrans %}
       </p>
     </div>
@@ -48,15 +48,16 @@
     <td data-bind="text: total_attendance_takers"></td>
     <td>
       <!-- ko if: show_attendance -->
-        <!-- ko if: total_attendance -->
-        <a data-bs-toggle="modal" data-bs-target="#attendee-details">
-          {% trans 'View Attendees' %}
-          (<span data-bind="text: total_attendance"> </span>)
-        </a>
-        <!-- /ko -->
-        <!-- ko ifnot: total_attendance -->
-          {% trans 'No Attendees Yet' %}
-        <!-- /ko -->
+      <!-- ko if: total_attendance -->
+      <a data-bs-toggle="modal" data-bs-target="#attendee-details">
+        {% trans 'View Attendees' %} (<span data-bind="text: total_attendance">
+        </span
+        >)
+      </a>
+      <!-- /ko -->
+      <!-- ko ifnot: total_attendance -->
+      {% trans 'No Attendees Yet' %}
+      <!-- /ko -->
       <div class="modal fade" id="attendee-details">
         <div class="modal-dialog">
           <div class="modal-content">
@@ -72,21 +73,25 @@
             <div class="modal-body">
               <table class="table table-striped table-hover">
                 <thead>
-                <tr>
-                  <th class="col-md-4">{% trans "Date Attended" %}</th>
-                  <th class="col-md-8">{% trans "Attendee Name" %}</th>
-                </tr>
+                  <tr>
+                    <th class="col-md-4">{% trans "Date Attended" %}</th>
+                    <th class="col-md-8">{% trans "Attendee Name" %}</th>
+                  </tr>
                 </thead>
                 <tbody data-bind="foreach: attendees">
                   <tr>
-                    <td data-bind='date'></td>
-                    <td data-bind='name'></td>
+                    <td data-bind="date"></td>
+                    <td data-bind="name"></td>
                   </tr>
                 </tbody>
-                </table>
+              </table>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">
+              <button
+                type="button"
+                class="btn btn-outline-primary"
+                data-bs-dismiss="modal"
+              >
                 Close
               </button>
             </div>

--- a/corehq/apps/events/templates/events/events_list.html
+++ b/corehq/apps/events/templates/events/events_list.html
@@ -1,8 +1,8 @@
-{% extends 'hqwebapp/bootstrap3/base_paginated_crud.html' %}
+{% extends 'hqwebapp/bootstrap5/base_paginated_crud.html' %}
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% js_entry_b3 "hqwebapp/js/bootstrap3/crud_paginated_list_init" %}
+{% js_entry "hqwebapp/js/bootstrap5/crud_paginated_list_init" %}
 
 {% block page_title %}
   {{ current_page.title }}
@@ -10,7 +10,7 @@
 
 {% block pagination_header %}
   <div class="row">
-    <div class="col-sm-8">
+    <div class="col-md-8">
       <p>
         {% blocktrans %}
           Attendance tracking events can be used to track attendance of all the selected attendees.
@@ -49,7 +49,7 @@
     <td>
       <!-- ko if: show_attendance -->
         <!-- ko if: total_attendance -->
-        <a data-toggle="modal" data-target="#attendee-details">
+        <a data-bs-toggle="modal" data-bs-target="#attendee-details">
           {% trans 'View Attendees' %}
           (<span data-bind="text: total_attendance"> </span>)
         </a>
@@ -61,7 +61,7 @@
         <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span>
+              <button type="button" class="btn-close" data-bs-dismiss="modal"><span aria-hidden="true">&times;</span>  {# todo B5: css-close #}
                 <span class="sr-only">Close</span></button>
               <h4 class="modal-title" data-bind="text: name"></h4>
             </div>
@@ -69,8 +69,8 @@
               <table class="table table-striped table-hover">
                 <thead>
                 <tr>
-                  <th class="col-sm-4">{% trans "Date Attended" %}</th>
-                  <th class="col-sm-8">{% trans "Attendee Name" %}</th>
+                  <th class="col-md-4">{% trans "Date Attended" %}</th>
+                  <th class="col-md-8">{% trans "Attendee Name" %}</th>
                 </tr>
                 </thead>
                 <tbody data-bind="foreach: attendees">
@@ -82,7 +82,7 @@
                 </table>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-default" data-dismiss="modal">
+              <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">
                 Close
               </button>
             </div>

--- a/corehq/apps/events/templates/events/new_event.html
+++ b/corehq/apps/events/templates/events/new_event.html
@@ -1,9 +1,9 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% js_entry_b3 'events/js/new_event' %}
+{% js_entry 'events/js/new_event' %}
 
 {% block page_content %}
   {% initial_page_data 'current_values' form.current_values %}
@@ -17,6 +17,6 @@
     </p>
   </div>
   <form id="tracking-event-form" class="form-horizontal disable-on-submit" method="post">
-    {% crispy form %}
+    {% crispy form %}  {# todo B5: crispy #}
   </form>
 {% endblock %}

--- a/corehq/apps/events/templates/events/new_event.html
+++ b/corehq/apps/events/templates/events/new_event.html
@@ -2,21 +2,19 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 {% load i18n %}
-
 {% js_entry 'events/js/new_event' %}
 
 {% block page_content %}
   {% initial_page_data 'current_values' form.current_values %}
   {% registerurl "get_attendees_and_attendance_takers" domain %}
 
-  <div id="attendance-list-error" class="alert alert-danger hidden">
-    <p>
-      {% blocktrans %}
-      There was a problem fetching the list of attendees and attendance takers. Please try again.
-      {% endblocktrans %}
-    </p>
+  <div id="attendance-list-error" class="alert alert-danger d-none">
+    {% blocktrans %}
+      There was a problem fetching the list of attendees and attendance takers.
+      Please try again.
+    {% endblocktrans %}
   </div>
-  <form id="tracking-event-form" class="form-horizontal disable-on-submit" method="post">
-    {% crispy form %}  {# todo B5: crispy #}
+  <form id="tracking-event-form" class="disable-on-submit" method="post">
+    {% crispy form %}
   </form>
 {% endblock %}

--- a/corehq/apps/events/templates/events/partials/attendee_conversion_status.html
+++ b/corehq/apps/events/templates/events/partials/attendee_conversion_status.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 {% block results %}
   <div class="alert alert-success">
-    <p>{{ on_complete_long }}</p>
+    {{ on_complete_long }}
   </div>
 {% endblock results %}

--- a/corehq/apps/events/templates/events/partials/attendee_conversion_status.html
+++ b/corehq/apps/events/templates/events/partials/attendee_conversion_status.html
@@ -1,7 +1,5 @@
 {% extends "hqwebapp/partials/download_status.html" %}
 {% load i18n %}
 {% block results %}
-  <div class="alert alert-success">
-    {{ on_complete_long }}
-  </div>
+  <div class="alert alert-success">{{ on_complete_long }}</div>
 {% endblock results %}

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -60,6 +60,7 @@ class BaseEventView(BaseDomainView):
         return reverse(BaseEventView.urlname, args=(self.domain,))
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 class EventsView(BaseEventView, CRUDPaginatedViewMixin):
     urlname = "events_page"
     template_name = 'events/events_list.html'

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -271,6 +271,7 @@ class EventEditView(EventCreateView):
         return HttpResponseRedirect(reverse(EventsView.urlname, args=(self.domain,)))
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 class AttendeesListView(JSONResponseMixin, BaseEventView):
     urlname = "event_attendees"
     template_name = 'events/event_attendees.html'

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -329,6 +329,7 @@ class AttendeesListView(JSONResponseMixin, BaseEventView):
         return {'error': _("Form validation failed: {}").format(err)}
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 class AttendeeEditView(BaseEventView):
     urlname = 'edit_attendee'
     template_name = "events/edit_attendee.html"

--- a/corehq/apps/events/views.py
+++ b/corehq/apps/events/views.py
@@ -1,13 +1,16 @@
 from django.http import Http404, HttpResponseRedirect, JsonResponse, HttpResponseServerError
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_GET
 from django.shortcuts import render
+
 
 from corehq import toggles
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqcase.case_helper import CaseHelper
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
@@ -151,6 +154,7 @@ class EventsView(BaseEventView, CRUDPaginatedViewMixin):
         }
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 class EventCreateView(BaseEventView):
     urlname = 'add_attendance_tracking_event'
     template_name = "events/new_event.html"
@@ -212,6 +216,7 @@ class EventCreateView(BaseEventView):
         return None
 
 
+@method_decorator(use_bootstrap5, name='dispatch')
 class EventEditView(EventCreateView):
     urlname = 'edit_attendance_tracking_event'
     template_name = "events/new_event.html"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_paginated_crud.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_paginated_crud.html
@@ -136,7 +136,7 @@
       <div class="row mt-3"
            data-bind="visible: isPaginationActive">
         <div class="col-lg-4">
-          <select class="form-control" id="pagination-limit" data-bind="event: {change: updateListLimit}">
+          <select class="form-select" id="pagination-limit" data-bind="event: {change: updateListLimit}">
             {% for limit in pagination.limit_options %}
               <option value="{{ limit }}">
                 {{ limit }} {{ pagination.text.limit }}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_paginated_crud.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_paginated_crud.html
@@ -135,8 +135,12 @@
 
       <div class="row mt-3"
            data-bind="visible: isPaginationActive">
-        <div class="col-lg-4">
-          <select class="form-select" id="pagination-limit" data-bind="event: {change: updateListLimit}">
+        <div class="col-md-4">
+          <select
+            class="form-select mb-2"
+            id="pagination-limit"
+            data-bind="event: {change: updateListLimit}"
+          >
             {% for limit in pagination.limit_options %}
               <option value="{{ limit }}">
                 {{ limit }} {{ pagination.text.limit }}
@@ -144,7 +148,7 @@
             {% endfor %}
           </select>
         </div>
-        <div class="col-lg-8">
+        <div class="col-md-8">
           {% include 'hqwebapp/partials/bootstrap5/pagination.html' %}
         </div>
       </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_paginated_crud.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_paginated_crud.html.diff.txt
@@ -92,7 +92,7 @@
 -            </select>
 -          </div>
 +        <div class="col-lg-4">
-+          <select class="form-control" id="pagination-limit" data-bind="event: {change: updateListLimit}">
++          <select class="form-select" id="pagination-limit" data-bind="event: {change: updateListLimit}">
 +            {% for limit in pagination.limit_options %}
 +              <option value="{{ limit }}">
 +                {{ limit }} {{ pagination.text.limit }}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_paginated_crud.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_paginated_crud.html.diff.txt
@@ -70,14 +70,14 @@
                    </td>
                  </tr>
  
-@@ -138,25 +133,19 @@
+@@ -138,25 +133,23 @@
  
        </div>
  
 -      <div class="row"
 +      <div class="row mt-3"
             data-bind="visible: isPaginationActive">
--        <div class="col-md-4">
+         <div class="col-md-4">
 -          <div class="form-inline"
 -               style="margin: 1.6em 0;">
 -            <label for="pagination-limit">
@@ -91,8 +91,11 @@
 -              {% endfor %}
 -            </select>
 -          </div>
-+        <div class="col-lg-4">
-+          <select class="form-select" id="pagination-limit" data-bind="event: {change: updateListLimit}">
++          <select
++            class="form-select mb-2"
++            id="pagination-limit"
++            data-bind="event: {change: updateListLimit}"
++          >
 +            {% for limit in pagination.limit_options %}
 +              <option value="{{ limit }}">
 +                {{ limit }} {{ pagination.text.limit }}
@@ -100,9 +103,8 @@
 +            {% endfor %}
 +          </select>
          </div>
--        <div class="col-md-8">
+         <div class="col-md-8">
 -          {% include 'hqwebapp/partials/bootstrap3/pagination.html' %}
-+        <div class="col-lg-8">
 +          {% include 'hqwebapp/partials/bootstrap5/pagination.html' %}
          </div>
        </div>

--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -116,6 +116,9 @@
   "enterprise": {
     "is_complete": true
   },
+  "events": {
+    "is_complete": true
+  },
   "export": {
     "is_complete": true
   },


### PR DESCRIPTION
## Product Description
Migrates "Events" / Attendance tracking app to Bootstrap 5. Main views shown with B3 top/left vs B5:

<img width="400" alt="events_b3" src="https://github.com/user-attachments/assets/499860f1-8f6b-4534-a8b9-07b1d5ae64b5" /> <img width="400" alt="image" src="https://github.com/user-attachments/assets/8681efcf-0646-4680-a364-39183fda6591" />

<img width="400" alt="add_event_b3" src="https://github.com/user-attachments/assets/21ffc6be-0737-46fb-8945-b9a00b67213a" /> <img width="400" alt="add_event_b5" src="https://github.com/user-attachments/assets/c191ca7b-ef9d-4690-8ba0-871683f5b764" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e9954314-03e2-43c7-b011-416ce98048c0" /> <img width="400" alt="image" src="https://github.com/user-attachments/assets/1948b18a-18dd-4d57-856d-6006cf270d2a" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/85af053e-7f7a-48d3-99c4-3ce671ecbd39" /> <img width="400" alt="image" src="https://github.com/user-attachments/assets/c3522a9e-b800-4be4-999e-7afe1e7fcb1e" />



## Technical Summary
Migrates the small "Events" django app to Bootstrap 5 using the no-split process. Most changes are small and fairly mechanical, with a bit of judgment given to margin/padding.

## Safety Assurance

### Safety story
These are all relatively minor stylistic and functional changes. Tested for appearance and functionality locally and on staging.

### Automated test coverage
For bootstrap migration/diffs.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
