### PR TITLE
Pass task id as string in durable task

### DIFF
--- a/corehq/apps/celery/durable.py
+++ b/corehq/apps/celery/durable.py
@@ -44,7 +44,10 @@ class DurableTask(Task):
             update_fields=list(defaults) if is_retry else None,
         )
         try:
-            return super().apply_async(args=args, kwargs=kwargs, task_id=record.task_id, **opts)
+            return super().apply_async(
+                # celery expects task_id to be a string
+                args=args, kwargs=kwargs, task_id=str(record.task_id), **opts
+            )
         except Exception as e:
             error = f"{type(e).__name__}: {e}"
             TaskRecord.objects.filter(task_id=record.task_id).update(error=error)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Between TaskRecord.id being a uuid4 and converting to a str here, this mimics how celery currently creates task ids via kombu

https://github.com/celery/kombu/blob/3a6f84f1d5061d38967beaa140961fa9c11efd4b/kombu/utils/uuid.py

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Minor change that is in line with celery behavior. Previously we were passing the raw uuid into `apply_async`, but celery expects task_id to be a string, so this mimics the exact behavior of celery's default task_id generation.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
