### PR TITLE
B5 Tweaks for Recently Migrated Pages

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/summary/models.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/models.js
@@ -89,7 +89,7 @@ var contentItemModel = function (options) {
 
     var basePopoverOptions = {
         "trigger": "hover",
-        "placement": "auto right",
+        "placement": "right",
         "container": "body",
         "html": true,
     };

--- a/corehq/apps/app_manager/templates/app_manager/bootstrap5/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/bootstrap5/app_view.html
@@ -38,7 +38,7 @@
 
 {% block form-view %}
   {% registerurl "edit_add_ons" domain app.id %}
-  <div class="appmanager-tabs-container">
+  <div class="mt-3">
     {% block app_view_tabs %}{% endblock app_view_tabs %}
   </div>
 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/bootstrap5/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/bootstrap5/form_view.html
@@ -113,7 +113,7 @@
   {% initial_page_data 'add_ons_privileges' add_ons_privileges %}
   {% registerurl "get_form_datums" domain app.id %}
 
-  <div class="tabbable appmanager-tabs-container">
+  <div class="tabbable mt-3">
     <ul class="nav nav-tabs sticky-tabs">  {# todo B5: css-nav #}
       {% if form.uses_cases %}
         <li>
@@ -162,7 +162,7 @@
 
     {% include 'app_manager/partials/forms/bootstrap5/case_config_ko_templates.html' %}
 
-    <div class="tab-content appmanager-tab-content">
+    <div class="tab-content mt-3">
       {% if form.uses_cases %}
         <div class="tab-pane" id="case-configuration">
           {% include "data_dictionary/partials/case_property_warning.html" %}

--- a/corehq/apps/app_manager/templates/app_manager/bootstrap5/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/bootstrap5/module_view.html
@@ -51,7 +51,7 @@
   {% registerurl "edit_module_detail_screens" domain app.id module.unique_id %}
   {% registerurl "validate_module_for_build" domain app.id module.unique_id %}
   {% registerurl "existing_case_types" domain %}
-  <div class="tabbable appmanager-tabs-container">
+  <div class="tabbable mt-3">
 
     {% if not module.is_surveys %}
       <ul class="nav nav-tabs sticky-tabs" id="module-view-tabs">  {# todo B5: css-nav #}

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/bootstrap5/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/bootstrap5/releases_deploy_modal.html
@@ -54,7 +54,7 @@
                         </a>
                       </li>
                     </ul>
-                    <div class="tab-content appmanager-tab-content">
+                    <div class="tab-content mt-3">
                       <div class="tab-pane active" id="online-install-tab">
                         <p>
                           {% trans "Download" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -218,7 +218,7 @@
       </li>
     {% endif %}
   </ul>
-  <div class="tab-content appmanager-tab-content">
+  <div class="tab-content mt-3">
     {% if is_linked_app %}
       <div class="tab-pane" id="linked-app">
         <div class="card">

--- a/corehq/apps/events/templates/events/event_attendees.html
+++ b/corehq/apps/events/templates/events/event_attendees.html
@@ -140,7 +140,7 @@
       </div>
       <div class="card-body">
         <div class="row">
-          <div class="col-md-6">
+          <div class="col-md-6 ps-0">
             <search-box
               data-apply-bindings="false"
               params="value: query,

--- a/corehq/apps/hqwebapp/static/app_manager/scss/app_manager-main.scss
+++ b/corehq/apps/hqwebapp/static/app_manager/scss/app_manager-main.scss
@@ -12,7 +12,6 @@
 @import "includes/content";
 @import "includes/case_tile_preview";
 @import "includes/popover";
-@import "includes/tabs";
 @import "includes/savebtn";
 @import "includes/panel";
 @import "includes/table";

--- a/corehq/apps/hqwebapp/static/app_manager/scss/includes/_content.scss
+++ b/corehq/apps/hqwebapp/static/app_manager/scss/includes/_content.scss
@@ -114,7 +114,7 @@
 }
 
 .appmanager-loading {
-  $dim: 4rem;
+  $dim: 2.5rem;
   display: block;
   position: absolute;
   font-size: $dim;
@@ -123,7 +123,7 @@
   left: calc(50% - $dim / 2);
   left: -moz-calc(50% - $dim / 2);
   left: -webkit-calc(50% - $dim / 2);
-  color: fadeOut($cc-text, 40);
+  color: rgba($cc-text, 0.6);
 }
 
 .appmanager-loading-nav {

--- a/corehq/apps/hqwebapp/static/app_manager/scss/includes/_tabs.scss
+++ b/corehq/apps/hqwebapp/static/app_manager/scss/includes/_tabs.scss
@@ -1,7 +1,0 @@
-.appmanager-tab-content {
-  margin-top: 2rem;
-}
-
-.appmanager-tabs-container {
-  margin-top: 2rem;
-}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diff_config.json
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diff_config.json
@@ -280,10 +280,6 @@
           "_tables.scss"
         ],
         [
-          "tabs.less",
-          "_tabs.scss"
-        ],
-        [
           "typography.less",
           "_type.scss"
         ],

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/app_view.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/app_view.html.diff.txt
@@ -26,7 +26,15 @@
      <inline-edit params="
          value: '{{ app.short_comment|escapejs }}',
          url: '{% url "edit_app_attr" domain app.id 'comment' %}',
-@@ -45,7 +45,7 @@
+@@ -38,14 +38,14 @@
+ 
+ {% block form-view %}
+   {% registerurl "edit_add_ons" domain app.id %}
+-  <div class="appmanager-tabs-container">
++  <div class="mt-3">
+     {% block app_view_tabs %}{% endblock app_view_tabs %}
+   </div>
+ {% endblock %}
  
  {% block modals %}{{ block.super }}
    {% for uploader in uploaders %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/form_view.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/form_view.html.diff.txt
@@ -28,11 +28,13 @@
        href="{% url "form_source" domain app.id form.unique_id %}"
      >
        <i class="fa fa-pencil"></i> {% trans "Edit Form" %}
-@@ -114,13 +114,13 @@
+@@ -113,14 +113,14 @@
+   {% initial_page_data 'add_ons_privileges' add_ons_privileges %}
    {% registerurl "get_form_datums" domain app.id %}
  
-   <div class="tabbable appmanager-tabs-container">
+-  <div class="tabbable appmanager-tabs-container">
 -    <ul class="nav nav-tabs sticky-tabs">
++  <div class="tabbable mt-3">
 +    <ul class="nav nav-tabs sticky-tabs">  {# todo B5: css-nav #}
        {% if form.uses_cases %}
          <li>
@@ -71,7 +73,7 @@
                {% trans "Visit Scheduler" %}
              </a>
            </li>
-@@ -155,12 +155,12 @@
+@@ -155,14 +155,14 @@
  
        {% if form.form_type != "shadow_form" %}
          <li>
@@ -82,10 +84,14 @@
      </ul>
  
 -    {% include 'app_manager/partials/forms/bootstrap3/case_config_ko_templates.html' %}
+-
+-    <div class="tab-content appmanager-tab-content">
 +    {% include 'app_manager/partials/forms/bootstrap5/case_config_ko_templates.html' %}
- 
-     <div class="tab-content appmanager-tab-content">
++
++    <div class="tab-content mt-3">
        {% if form.uses_cases %}
+         <div class="tab-pane" id="case-configuration">
+           {% include "data_dictionary/partials/case_property_warning.html" %}
 @@ -204,9 +204,9 @@
              <div class="casexml" id="casexml_home">
                {% if module.doc_type == 'AdvancedModule' %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/module_view.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/module_view.html.diff.txt
@@ -24,8 +24,12 @@
  {% endblock %}
  
  {% block form-view %}
-@@ -54,25 +54,25 @@
-   <div class="tabbable appmanager-tabs-container">
+@@ -51,28 +51,28 @@
+   {% registerurl "edit_module_detail_screens" domain app.id module.unique_id %}
+   {% registerurl "validate_module_for_build" domain app.id module.unique_id %}
+   {% registerurl "existing_case_types" domain %}
+-  <div class="tabbable appmanager-tabs-container">
++  <div class="tabbable mt-3">
  
      {% if not module.is_surveys %}
 -      <ul class="nav nav-tabs sticky-tabs" id="module-view-tabs">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/releases/releases_deploy_modal.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/releases/releases_deploy_modal.html.diff.txt
@@ -27,7 +27,7 @@
                    href="#panel-android"
                    aria-expanded="true"
                    aria-controls="panel-android"
-@@ -38,18 +38,18 @@
+@@ -38,23 +38,23 @@
                </h4>
              </div>
              <div class="panel-collapse in collapse" id="panel-android">
@@ -50,6 +50,12 @@
                            {% trans "Offline Install" %}
                          </a>
                        </li>
+                     </ul>
+-                    <div class="tab-content appmanager-tab-content">
++                    <div class="tab-content mt-3">
+                       <div class="tab-pane active" id="online-install-tab">
+                         <p>
+                           {% trans "Download" %}
 @@ -64,25 +64,25 @@
                            {% trans "to your Android device." %}
                          </p>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/app_manager-main.app_manager-main.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/app_manager-main.app_manager-main.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,19 +1,20 @@
+@@ -1,19 +1,19 @@
 -@import '../../hqwebapp/less/_hq/includes/variables.less';
 -@import '../../hqwebapp/less/_hq/includes/mixins.less';
 +@import "../../hqwebapp/scss/commcarehq/variables";
@@ -31,7 +31,6 @@
 +@import "includes/content";
 +@import "includes/case_tile_preview";
 +@import "includes/popover";
-+@import "includes/tabs";
 +@import "includes/savebtn";
 +@import "includes/panel";
 +@import "includes/table";

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/content._content.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/content._content.style.diff.txt
@@ -114,7 +114,7 @@
  
  .appmanager-loading {
 -  @dim: 4rem;
-+  $dim: 4rem;
++  $dim: 2.5rem;
    display: block;
    position: absolute;
 -  font-size: @dim;
@@ -130,7 +130,7 @@
 +  left: calc(50% - $dim / 2);
 +  left: -moz-calc(50% - $dim / 2);
 +  left: -webkit-calc(50% - $dim / 2);
-+  color: fadeOut($cc-text, 40);
++  color: rgba($cc-text, 0.6);
  }
  
  .appmanager-loading-nav {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/tabs._tabs.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/tabs._tabs.style.diff.txt
@@ -1,0 +1,10 @@
+--- 
++++ 
+@@ -1,7 +0,0 @@
+-.appmanager-tab-content {
+-  margin-top: 2rem;
+-}
+-
+-.appmanager-tabs-container {
+-  margin-top: 2rem;
+-}


### PR DESCRIPTION
## Product Description
Before (top/left) and after:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f4eda503-9993-40a7-9436-c0a1bb24fab9" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/a124ddc8-fb5b-4143-9f4c-74cc243ab550" />

<img alt="image" src="https://github.com/user-attachments/assets/0e573a18-75f5-48aa-86ba-030879de1b12" /> <img alt="image" src="https://github.com/user-attachments/assets/a0db7a51-39ae-4cde-b646-ae03b2f5c798" />


<img width="188" height="257" alt="image" src="https://github.com/user-attachments/assets/2c45d4fa-1573-4c86-ba36-d6e2c3ea50cc" /> <img width="390" height="237" alt="image" src="https://github.com/user-attachments/assets/1757af7c-dec0-4243-9680-29d31c890d42" />


<img width="300" alt="image" src="https://github.com/user-attachments/assets/05aa9361-fd00-41bd-afdc-b86cd4574302" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/b256e975-59e2-4141-9cc3-44486116518a" />


## Technical Summary
After revisiting and staring at some pages I recently migrated to B5, these are a few UI tweaks to add polish to those pages.

## Safety Assurance

### Safety story
These are all minor, safe UI-only changes.

### Automated test coverage
For bootstrap diffs where applicable.

### QA Plan
Not necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
