### PR TITLE
[Cleanup] Consolidate where celery task decorators live

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -46,7 +46,7 @@ from corehq.apps.analytics.utils.partner_analytics import (
     generate_monthly_web_user_statistics,
     send_partner_emails,
 )
-from corehq.apps.celery import periodic_task
+from corehq.apps.celery import analytics_task, periodic_task
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import get_domains_created_by_user
 from corehq.apps.es.forms import FormES
@@ -55,7 +55,6 @@ from corehq.apps.users.dbaccessors import get_all_user_rows
 from corehq.apps.users.models import WebUser
 from corehq.toggles import deterministic_random
 from corehq.util.dates import unix_time_in_micros
-from corehq.util.decorators import analytics_task
 from corehq.util.metrics import metrics_counter, metrics_gauge
 from corehq.util.metrics.const import MPM_LIVESUM, MPM_MAX
 from dimagi.utils.logging import notify_error

--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -1,7 +1,7 @@
 from django.http import Http404
 from django.utils.translation import gettext as _
 
-from corehq.apps.celery import task
+from corehq.apps.celery import serial_task, task
 from celery.utils.log import get_task_logger
 from collections import defaultdict
 
@@ -19,7 +19,6 @@ from corehq.apps.app_manager.exceptions import (
 from corehq.apps.users.dbaccessors import get_all_users_by_domain
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.toggles import VELLUM_SAVE_TO_CASE
-from corehq.util.decorators import serial_task
 from corehq.util.metrics import metrics_counter
 
 logger = get_task_logger(__name__)

--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -1,11 +1,10 @@
 from celery.schedules import crontab
-from corehq.apps.celery import task
+from corehq.apps.celery import serial_task, task
 
 from corehq.apps.hqadmin.tasks import (
     AbnormalUsageAlert,
     send_abnormal_usage_alert,
 )
-from corehq.util.decorators import serial_task
 from corehq.util.metrics import metrics_gauge_task
 from corehq.util.metrics.const import MPM_MAX
 from corehq.apps.data_dictionary.util import get_data_dict_deprecated_case_types

--- a/corehq/apps/celery/__init__.py
+++ b/corehq/apps/celery/__init__.py
@@ -10,6 +10,7 @@ from corehq.apps.celery.periodic import (  # noqa F401;
     periodic_task_when_true,
 )
 from corehq.apps.celery.shared_task import task  # noqa F401;
+from corehq.apps.celery.serial import serial_task  # noqa F401;
 
 
 class Config(AppConfig):

--- a/corehq/apps/celery/__init__.py
+++ b/corehq/apps/celery/__init__.py
@@ -1,9 +1,9 @@
-from django.apps import AppConfig
-
 from celery import Celery
 from celery.signals import setup_logging
+from django.apps import AppConfig
 
-from corehq.apps.celery.analytics import analytics_task # noqa F401;
+from corehq.apps.celery.analytics import analytics_task  # noqa F401;
+
 # Imported to give an idea of where decorators are defined and
 # we will be importing these decorators from this file in tasks
 from corehq.apps.celery.periodic import (  # noqa F401;
@@ -16,6 +16,7 @@ from corehq.apps.celery.shared_task import task  # noqa F401;
 
 class Config(AppConfig):
     """Configure global Celery app as part of Django setup"""
+
     name = 'corehq.apps.celery'
 
     def __init__(self, *args, **kw):
@@ -37,4 +38,5 @@ def config_loggers(*args, **kwargs):
     from logging.config import dictConfig
 
     from django.conf import settings
+
     dictConfig(settings.LOGGING)

--- a/corehq/apps/celery/__init__.py
+++ b/corehq/apps/celery/__init__.py
@@ -3,14 +3,15 @@ from django.apps import AppConfig
 from celery import Celery
 from celery.signals import setup_logging
 
+from corehq.apps.celery.analytics import analytics_task # noqa F401;
 # Imported to give an idea of where decorators are defined and
 # we will be importing these decorators from this file in tasks
 from corehq.apps.celery.periodic import (  # noqa F401;
     periodic_task,
     periodic_task_when_true,
 )
-from corehq.apps.celery.shared_task import task  # noqa F401;
 from corehq.apps.celery.serial import serial_task  # noqa F401;
+from corehq.apps.celery.shared_task import task  # noqa F401;
 
 
 class Config(AppConfig):

--- a/corehq/apps/celery/analytics.py
+++ b/corehq/apps/celery/analytics.py
@@ -1,0 +1,30 @@
+from functools import wraps
+
+import requests
+
+from corehq.apps.celery import task
+
+
+def analytics_task(default_retry_delay=10, max_retries=3, queue='analytics_queue', serializer='json'):
+    '''
+        defines a task that posts data to one of our analytics endpoints. It retries the task
+        up to 3 times if the post returns with a status code indicating an error with the post
+        that is not our fault.
+    '''
+    def decorator(func):
+        @task(bind=True, queue=queue, ignore_result=True, acks_late=True,
+              default_retry_delay=default_retry_delay, max_retries=max_retries, serializer=serializer)
+        @wraps(func)
+        def _inner(self, *args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except requests.exceptions.HTTPError as e:
+                # if its a bad request, raise the exception because it is our fault
+                res = e.response
+                status_code = res.status_code if isinstance(res, requests.models.Response) else res.status
+                if status_code == 400:
+                    raise
+                else:
+                    self.retry(exc=e)
+        return _inner
+    return decorator

--- a/corehq/apps/celery/analytics.py
+++ b/corehq/apps/celery/analytics.py
@@ -5,26 +5,45 @@ import requests
 from corehq.apps.celery import task
 
 
-def analytics_task(default_retry_delay=10, max_retries=3, queue='analytics_queue', serializer='json'):
-    '''
-        defines a task that posts data to one of our analytics endpoints. It retries the task
-        up to 3 times if the post returns with a status code indicating an error with the post
-        that is not our fault.
-    '''
+def analytics_task(
+    default_retry_delay=10,
+    max_retries=3,
+    queue='analytics_queue',
+    serializer='json',
+):
+    """
+    Defines a task that posts data to one of our analytics endpoints. It
+    retries the task up to 3 times if the post returns with a status code
+    indicating an error with the post that is not our fault.
+    """
+
     def decorator(func):
-        @task(bind=True, queue=queue, ignore_result=True, acks_late=True,
-              default_retry_delay=default_retry_delay, max_retries=max_retries, serializer=serializer)
+        @task(
+            bind=True,
+            queue=queue,
+            ignore_result=True,
+            acks_late=True,
+            default_retry_delay=default_retry_delay,
+            max_retries=max_retries,
+            serializer=serializer,
+        )
         @wraps(func)
         def _inner(self, *args, **kwargs):
             try:
                 return func(*args, **kwargs)
             except requests.exceptions.HTTPError as e:
-                # if its a bad request, raise the exception because it is our fault
+                # if bad request, raise exception because it is our fault
                 res = e.response
-                status_code = res.status_code if isinstance(res, requests.models.Response) else res.status
+                status_code = (
+                    res.status_code
+                    if isinstance(res, requests.models.Response)
+                    else res.status
+                )
                 if status_code == 400:
                     raise
                 else:
                     self.retry(exc=e)
+
         return _inner
+
     return decorator

--- a/corehq/apps/celery/analytics.py
+++ b/corehq/apps/celery/analytics.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 import requests
 
-from corehq.apps.celery import task
+from corehq.apps.celery.shared_task import task
 
 
 def analytics_task(

--- a/corehq/apps/celery/serial.py
+++ b/corehq/apps/celery/serial.py
@@ -3,7 +3,7 @@ from functools import wraps
 
 from django.conf import settings
 
-from corehq.apps.celery import task
+from corehq.apps.celery.shared_task import task
 
 
 def serial_task(

--- a/corehq/apps/celery/serial.py
+++ b/corehq/apps/celery/serial.py
@@ -1,0 +1,75 @@
+import inspect
+from functools import wraps
+
+from django.conf import settings
+
+from corehq.apps.celery import task
+
+
+def serial_task(unique_key, default_retry_delay=30, timeout=5 * 60, max_retries=3,
+                queue='background_queue', ignore_result=True, serializer=None):
+    """
+    Define a task to be executed one at a time.  If another serial_task with
+    the same unique_key is currently in process, this will retry after a delay.
+
+    :param unique_key: string used to lock the task.  There will be one lock
+        per unique value.  You may use any arguments that will be passed to the
+        function.  See example.
+    :param default_retry_delay: seconds to wait before retrying if a lock is
+        encountered
+    :param timeout: timeout on the lock (in seconds).  Normally the lock should
+        be released when the task completes, but you should also define a
+        timeout in case something goes wrong.  This must be greater than the
+        maximum length of the task.
+
+    Usage:
+        @serial_task("{user.username}-{from}", default_retry_delay=2)
+        def greet(user, from="Dimagi"):
+            ...
+
+        greet.delay(joeshmoe)
+        # Locking key used would be "greet-joeshmoe@test.commcarehq.org-Dimagi"
+    """
+
+    task_kwargs = {}
+    if serializer:
+        task_kwargs['serializer'] = serializer
+
+    def decorator(fn):
+        # register task with celery.  Note that this still happens on import
+        from dimagi.utils.couch import get_redis_lock, release_lock
+
+        @task(bind=True, queue=queue, ignore_result=ignore_result, default_retry_delay=default_retry_delay,
+              max_retries=max_retries, **task_kwargs)
+        @wraps(fn)
+        def _inner(self, *args, **kwargs):
+            if settings.UNIT_TESTING:  # Don't depend on redis
+                return fn(*args, **kwargs)
+
+            key = _get_unique_key(unique_key, fn, *args, **kwargs)
+            lock = get_redis_lock(key, timeout=timeout, name=fn.__name__)
+            if lock.acquire(blocking=False):
+                try:
+                    return fn(*args, **kwargs)
+                finally:
+                    release_lock(lock, True)
+            else:
+                msg = "Could not acquire lock '{}' for task '{}'.".format(
+                    key, fn.__name__)
+                self.retry(exc=CouldNotAcquireLock(msg))
+        return _inner
+    return decorator
+
+
+# Sorry this is so magic
+def _get_unique_key(format_str, fn, *args, **kwargs):
+    """
+    Lines args and kwargs up with those specified in the definition of fn and
+    passes the result to `format_str.format()`.
+    """
+    callargs = inspect.getcallargs(fn, *args, **kwargs)
+    return ("{}-" + format_str).format(fn.__name__, **callargs)
+
+
+class CouldNotAcquireLock(Exception):
+    pass

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -14,7 +14,7 @@ from soil import DownloadBase
 from soil.progress import set_task_progress
 
 from casexml.apps.case.mock import CaseBlock
-from corehq.apps.celery import periodic_task, task
+from corehq.apps.celery import periodic_task, serial_task, task
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
 from corehq.apps.hqcase.utils import AUTO_UPDATE_XMLNS
@@ -26,7 +26,6 @@ from corehq.motech.repeaters.models import RepeatRecord
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 from corehq.toggles import DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK
 from corehq.util.celery_utils import no_result_task
-from corehq.util.decorators import serial_task
 from corehq.util.log import send_HTML_email
 
 from .deduplication import backfill_deduplicate_rule, reset_deduplicate_rule

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -10,14 +10,13 @@ from soil import DownloadBase
 from soil.progress import get_task_status
 from soil.util import expose_blob_download, process_email_request
 
-from corehq.apps.celery import periodic_task, task
+from corehq.apps.celery import periodic_task, serial_task, task
 from corehq.apps.data_dictionary.util import add_properties_to_data_dictionary
 from corehq.apps.export.exceptions import RejectedStaleExport
 from corehq.apps.export.utils import get_export, get_default_export_settings_if_available
 from corehq.apps.users.models import CouchUser
 from corehq.blobs import CODES, get_blob_db
 from corehq.celery_monitoring.signals import get_task_time_to_start
-from corehq.util.decorators import serial_task
 from corehq.util.files import TransientTempfile, safe_filename_header
 from corehq.util.metrics import metrics_counter, metrics_track_errors
 from corehq.util.quickcache import quickcache

--- a/corehq/apps/locations/tasks.py
+++ b/corehq/apps/locations/tasks.py
@@ -6,7 +6,7 @@ from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.logging import notify_exception
 from soil import DownloadBase
 
-from corehq.apps.celery import task
+from corehq.apps.celery import serial_task, task
 from corehq.apps.commtrack.models import close_supply_point_case
 from corehq.apps.data_interfaces.models import LocationFilterDefinition
 from corehq.apps.fixtures.models import UserLookupTableStatus
@@ -22,7 +22,6 @@ from corehq.apps.userreports.dbaccessors import get_datasources_for_domain
 from corehq.apps.userreports.tasks import rebuild_indicators_in_place
 from corehq.apps.users.models import CouchUser
 from corehq.toggles import LOCATIONS_IN_UCR
-from corehq.util.decorators import serial_task
 from corehq.util.workbook_json.excel_importer import MultiExcelImporter
 
 

--- a/corehq/apps/saved_reports/tasks.py
+++ b/corehq/apps/saved_reports/tasks.py
@@ -14,7 +14,7 @@ from dimagi.utils.django.email import LARGE_FILE_SIZE_ERROR_CODES
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import json_request
 
-from corehq.apps.celery import periodic_task, task
+from corehq.apps.celery import periodic_task, serial_task, task
 from corehq.apps.reports.tasks import export_all_rows_task
 from corehq.apps.saved_reports.exceptions import (
     UnsupportedScheduledReportError,
@@ -25,7 +25,6 @@ from corehq.apps.saved_reports.scheduled import (
 )
 from corehq.apps.users.models import CouchUser
 from corehq.elastic import ESError
-from corehq.util.decorators import serial_task
 from corehq.util.log import send_HTML_email
 
 from .exceptions import ReportNotFound

--- a/corehq/apps/saved_reports/tasks.py
+++ b/corehq/apps/saved_reports/tasks.py
@@ -161,7 +161,7 @@ def send_email_report(self, recipient_emails, domain, report_slug, report_type,
                 'error': er,
             }
         )
-        if getattr(er, 'smtp_code', None) in LARGE_FILE_SIZE_ERROR_CODES or type(er) == ESError:
+        if getattr(er, 'smtp_code', None) in LARGE_FILE_SIZE_ERROR_CODES or isinstance(er, ESError):
             # If the email doesn't work because it is too large to fit in the HTML body,
             # send it as an excel attachment.
             report_state = {

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -22,7 +22,7 @@ from dimagi.utils.logging import notify_exception
 from pillowtop.dao.couch import ID_CHUNK_SIZE
 from soil.util import expose_download, get_download_file_path
 
-from corehq.apps.celery import periodic_task, task
+from corehq.apps.celery import periodic_task, serial_task, task
 from corehq.apps.change_feed.data_sources import (
     get_document_store_for_doc_type,
 )
@@ -30,7 +30,6 @@ from corehq.apps.export.const import MAX_DAILY_EXPORT_SIZE
 from corehq.apps.reports.util import send_report_download_email
 from corehq.elastic import ESError
 from corehq.util.context_managers import notify_someone
-from corehq.util.decorators import serial_task
 from corehq.util.es.elasticsearch import ConnectionTimeout
 from corehq.util.metrics import (
     metrics_counter,

--- a/corehq/form_processor/tasks.py
+++ b/corehq/form_processor/tasks.py
@@ -9,10 +9,9 @@ from couchforms.models import UnfinishedSubmissionStub
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.logging import notify_exception
 
-from corehq.apps.celery import periodic_task
+from corehq.apps.celery import periodic_task, serial_task
 from corehq.form_processor.reprocess import reprocess_unfinished_stub
 from corehq.util.celery_utils import no_result_task
-from corehq.util.decorators import serial_task
 from corehq.util.metrics import metrics_counter, metrics_gauge
 from corehq.util.metrics.const import MPM_MAX
 

--- a/corehq/pillows/tasks.py
+++ b/corehq/pillows/tasks.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from celery.schedules import crontab
 
-from corehq.apps.celery import periodic_task
+from corehq.apps.celery import periodic_task, serial_task
 from corehq.apps.es import FormES
 from corehq.apps.es.aggregations import CardinalityAggregation
 from corehq.form_processor.models import XFormInstance
@@ -11,7 +11,6 @@ from corehq.pillows.utils import (
     UNKNOWN_USER_TYPE,
     get_user_type_deep_cache_for_unknown_users,
 )
-from corehq.util.decorators import serial_task
 from corehq.util.metrics import metrics_gauge
 from corehq.util.metrics.const import MPM_MAX
 from corehq.util.quickcache import quickcache

--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -2,10 +2,9 @@ import logging
 
 from django.conf import settings
 
-from corehq.apps.celery import periodic_task
+from corehq.apps.celery import periodic_task, serial_task
 from corehq.preindex.accessors import get_preindex_designs, index_design_doc
 from corehq.util.celery_utils import deserialize_run_every_setting
-from corehq.util.decorators import serial_task
 
 logger = logging.getLogger(__name__)
 

--- a/corehq/util/decorators.py
+++ b/corehq/util/decorators.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 import warnings
 from contextlib import ContextDecorator, contextmanager
@@ -100,75 +99,6 @@ class require_debug_true(ContextDecorator):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
-
-
-class CouldNotAcquireLock(Exception):
-    pass
-
-
-# Sorry this is so magic
-def _get_unique_key(format_str, fn, *args, **kwargs):
-    """
-    Lines args and kwargs up with those specified in the definition of fn and
-    passes the result to `format_str.format()`.
-    """
-    callargs = inspect.getcallargs(fn, *args, **kwargs)
-    return ("{}-" + format_str).format(fn.__name__, **callargs)
-
-
-def serial_task(unique_key, default_retry_delay=30, timeout=5 * 60, max_retries=3,
-                queue='background_queue', ignore_result=True, serializer=None):
-    """
-    Define a task to be executed one at a time.  If another serial_task with
-    the same unique_key is currently in process, this will retry after a delay.
-
-    :param unique_key: string used to lock the task.  There will be one lock
-        per unique value.  You may use any arguments that will be passed to the
-        function.  See example.
-    :param default_retry_delay: seconds to wait before retrying if a lock is
-        encountered
-    :param timeout: timeout on the lock (in seconds).  Normally the lock should
-        be released when the task completes, but you should also define a
-        timeout in case something goes wrong.  This must be greater than the
-        maximum length of the task.
-
-    Usage:
-        @serial_task("{user.username}-{from}", default_retry_delay=2)
-        def greet(user, from="Dimagi"):
-            ...
-
-        greet.delay(joeshmoe)
-        # Locking key used would be "greet-joeshmoe@test.commcarehq.org-Dimagi"
-    """
-
-    task_kwargs = {}
-    if serializer:
-        task_kwargs['serializer'] = serializer
-
-    def decorator(fn):
-        # register task with celery.  Note that this still happens on import
-        from dimagi.utils.couch import get_redis_lock, release_lock
-
-        @task(bind=True, queue=queue, ignore_result=ignore_result, default_retry_delay=default_retry_delay,
-              max_retries=max_retries, **task_kwargs)
-        @wraps(fn)
-        def _inner(self, *args, **kwargs):
-            if settings.UNIT_TESTING:  # Don't depend on redis
-                return fn(*args, **kwargs)
-
-            key = _get_unique_key(unique_key, fn, *args, **kwargs)
-            lock = get_redis_lock(key, timeout=timeout, name=fn.__name__)
-            if lock.acquire(blocking=False):
-                try:
-                    return fn(*args, **kwargs)
-                finally:
-                    release_lock(lock, True)
-            else:
-                msg = "Could not acquire lock '{}' for task '{}'.".format(
-                    key, fn.__name__)
-                self.retry(exc=CouldNotAcquireLock(msg))
-        return _inner
-    return decorator
 
 
 def analytics_task(default_retry_delay=10, max_retries=3, queue='analytics_queue', serializer='json'):

--- a/corehq/util/decorators.py
+++ b/corehq/util/decorators.py
@@ -3,9 +3,8 @@ import warnings
 from contextlib import ContextDecorator, contextmanager
 from functools import wraps
 
-from django.conf import settings
-
 from dimagi.utils.logging import notify_exception
+from django.conf import settings
 
 from corehq.util.global_request import get_request
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Rather than have celery task decorators in a spaghetti utils/decorators file, I think we should move them into the celery app under their own respective file. I also did some linting as part of this, but everything should behave the same after this change.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Able to startup locally so no import issues. Will test on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
