### PR TITLE
Fix hyperlink rendering

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap3/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap3/app_manager.js
@@ -604,7 +604,7 @@ var _initNewModuleOptionClicks = function () {
 
                 function displayError(errorMsg) {
                     $formGroup.addClass('has-error');
-                    $error.text(errorMsg);
+                    $error.html(errorMsg);
                     $error.show();
                     $help.hide();
                     $createBtn.prop('disabled', true);

--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
@@ -604,7 +604,7 @@ var _initNewModuleOptionClicks = function () {
 
                 function displayError(errorMsg) {
                     $formGroup.addClass('has-error');
-                    $error.text(errorMsg);
+                    $error.html(errorMsg);
                     $error.show();
                     $help.hide();
                     $createBtn.prop('disabled', true);


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Before
<img width="758" height="331" alt="image" src="https://github.com/user-attachments/assets/f818a564-8507-4848-b05c-9035e799843d" />

After
<img width="602" height="298" alt="image" src="https://github.com/user-attachments/assets/a6901703-4a6b-49de-93fb-34a6e8c93dc9" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-18568

Changed `$error.text()` to `$error.html()` to allow HTML links in error messages to render properly. The reserved case type error message for 'commcare-user' contains an HTML anchor tag that was previously displayed as plain text.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
No

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe because we only pass `errorMsg` to `$error.html(errorMsg)`, and `errorMsg` is defined by us not user.
Tested locally. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
