### PR TITLE
Don't wrap wide table cells in web apps/app preview

### DIFF
--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/markdown-table.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/markdown-table.scss
@@ -1,35 +1,37 @@
 .webapp-markdown-output {
-    table {
-        word-break: normal !important;  // override .text-break on parent element
-        padding: 0;
-        tr {
-            background-color: white;
-            margin: 0;
-            padding: 0;
+  table {
+    word-break: normal !important; // override .text-break on parent element
+    padding: 0;
 
-            &:nth-child(2n) {
-                background-color: #f8f8f8;
-            }
+    tr {
+      background-color: white;
+      margin: 0;
+      padding: 0;
 
-            th, td {
-                border: 1px solid #ccc;
-                text-align: left;
-                margin: 0;
-                padding: 6px 13px;
-                &:first-child {
-                    margin-top: 0;
-                }
-                &:last-child {
-                    margin-bottom: 0;
-                }
-            }
+      &:nth-child(2n) {
+        background-color: #f8f8f8;
+      }
 
-            th {
-                font-weight: bold;
-                background-color: #ddd;     // override tr background color
-            }
+      th,
+      td {
+        border: 1px solid #ccc;
+        text-align: left;
+        margin: 0;
+        padding: 6px 13px;
+        &:first-child {
+          margin-top: 0;
         }
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+
+      th {
+        font-weight: bold;
+        background-color: #ddd; // override tr background color
+      }
     }
+  }
 }
 
 .text-center {

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/markdown-table.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/markdown-table.scss
@@ -1,5 +1,6 @@
 .webapp-markdown-output {
     table {
+        word-break: normal !important;  // override .text-break on parent element
         padding: 0;
         tr {
             background-color: white;


### PR DESCRIPTION
## Product Description
Makes markdown tables with many columns scroll instead of wrap. This does not prevent wrapping of table cells entirely - they will still break at appropriate locations between words.
Before:
<img width="442" height="181" alt="image" src="https://github.com/user-attachments/assets/4f330fb9-7755-4c27-8f19-f5932b0aa0fc" />


After:
<img width="443" height="179" alt="image" src="https://github.com/user-attachments/assets/7cbf8389-c2e3-47ff-a696-6f0a85548d34" />




## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18645


## Safety Assurance

### Safety story
This is just a tiny change to styling.

### Automated test coverage
Unlikely.

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
