### PR TITLE
Don't throw 500 on empty case ID

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -40,7 +40,11 @@ from corehq.apps.api.serializers import (
     CommCareCaseSerializer,
     XFormInstanceSerializer,
 )
-from corehq.apps.api.util import get_obj, get_object_or_not_exist
+from corehq.apps.api.util import (
+    get_obj,
+    get_object_or_not_exist,
+    object_does_not_exist,
+)
 from corehq.apps.app_manager.app_schemas.case_properties import (
     get_all_case_properties,
 )
@@ -214,8 +218,10 @@ class CommCareCaseResource(SimpleSortableResourceMixin, v0_3.CommCareCaseResourc
     closed_by = fields.CharField(attribute='closed_by', null=True)
 
     def obj_get(self, bundle, **kwargs):
-        case_id = kwargs['pk']
         domain = kwargs['domain']
+        case_id = kwargs['pk']
+        if not case_id:
+            raise object_does_not_exist('CommCareCase', '')
         return self.case_es(domain).get_document(case_id)
 
     class Meta(v0_3.CommCareCaseResource.Meta):

--- a/corehq/apps/api/tests/case_resources.py
+++ b/corehq/apps/api/tests/case_resources.py
@@ -76,6 +76,26 @@ class TestCommCareCaseResource(APIResourceTest):
         self.assertEqual(len(api_cases), 1)
         self.assertItemsEqual(api_cases[0]['case_id'], 'id1')
 
+    def test_get_by_case_id(self):
+        self._setup_case([('owner1', 'id1')])
+        url = f'{self.list_endpoint}id1/'
+        response = self._assert_auth_get_resource(url)
+        self.assertEqual(response.status_code, 200)
+        api_case = response.json()
+        self.assertEqual(api_case['case_id'], 'id1')
+
+    def test_get_by_missing_case_id(self):
+        url = f'{self.list_endpoint}missing-case-id/'
+        response = self._assert_auth_get_resource(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.content.decode(), '')
+
+    def test_get_by_empty_case_id(self):
+        url = f'{self.list_endpoint}/'
+        response = self._assert_auth_get_resource(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.content.decode(), '')
+
     def test_get_list_format(self):
         """
         Any case in the appropriate domain should be in the list from the API.


### PR DESCRIPTION
## Technical Summary

:lady_beetle: [SAAS-19076](https://dimagi.atlassian.net/browse/SAAS-19076)

The Case API v.1 throws a 500 error when called with an empty case ID. This change returns a 404 instead.

The added tests show that the response body is empty when a given case ID is not found. This change maintains that behavior.

## Safety Assurance

### Safety story

* Tested locally
* Fixes unexpected behavior, no other behavior change.

### Automated test coverage

Yes

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19076]: https://dimagi.atlassian.net/browse/SAAS-19076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ