### PR TITLE
Use @wraps in lock_locations decorator

### DIFF
--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -251,6 +251,9 @@ def _view_obj_is_safe(obj, request, *view_args, **view_kwargs):
 
 def is_location_safe(view_fn, request, view_args, view_kwargs):
     """
+    This decorator marks a view as safe to access for any user, including those
+    restricted to a specific location.
+
     Check if view_fn had the @location_safe decorator applied.
     request, view_args and kwargs are also needed because view_fn alone doesn't always
     contain enough information

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -193,7 +193,10 @@ def can_edit_form_location(domain, web_user, form):
 
 
 def location_safe(view):
-    """Decorator to apply to a view after making sure it's location-safe
+    """
+    This decorator marks a view as safe to access for any user, including those
+    restricted to a specific location, aka views that are "location safe".
+
     Supports view functions, class-based views, tastypie resources, and HQ reports.
     For classes, decorate the class, not the dispatch method.
     """
@@ -251,9 +254,6 @@ def _view_obj_is_safe(obj, request, *view_args, **view_kwargs):
 
 def is_location_safe(view_fn, request, view_args, view_kwargs):
     """
-    This decorator marks a view as safe to access for any user, including those
-    restricted to a specific location.
-
     Check if view_fn had the @location_safe decorator applied.
     request, view_args and kwargs are also needed because view_fn alone doesn't always
     contain enough information

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_lazy, gettext_noop
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods, require_POST
 
+from functools import wraps
 from memoized import memoized
 
 from dimagi.utils.couch import get_redis_lock, release_lock
@@ -90,6 +91,7 @@ def default(request, domain):
 
 def lock_locations(func):
     # Decorate a post/delete method of a view to ensure concurrent locations edits don't happen.
+    @wraps(func)
     def func_wrapper(request, *args, **kwargs):
         key = "import_locations_async-{domain}".format(domain=request.domain)
         lock = get_redis_lock(


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-12644

The `is_location_safe` attribute was being dropped on the `delete_location` function. While reordering the decorators so that `lock_locations` would be called first does work, this solution ensures order does not matter and is more desirable in preserving the underlying function that is being decorated (see below).

Before
```
In [1]: from corehq.apps.locations.views import delete_location

In [2]: delete_location
Out[2]: <function corehq.apps.locations.views.lock_locations.<locals>.func_wrapper(request, *args, **kwargs)>

In [3]: delete_location.is_location_safe
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[3], line 1
----> 1 delete_location.is_location_safe

AttributeError: 'function' object has no attribute 'is_location_safe'
```

After
```
In [1]: from corehq.apps.locations.views import delete_location

In [2]: delete_location
Out[2]: <function corehq.apps.locations.views.delete_location(request, domain, loc_id)>

In [3]: delete_location.is_location_safe
Out[3]: True
```
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally in a shell to see that the view behaves as expected as far as preserving attributes. Tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
