### PR TITLE
Add .caption to collapsible group header so .required-group styling gets applied

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/sub_group.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/sub_group.html
@@ -92,7 +92,7 @@
               ></i>
             </div>
             <span
-              class="webapp-markdown-output my-05em-for-hs flex-grow-1"
+              class="webapp-markdown-output caption my-05em-for-hs flex-grow-1"
               data-bind="html: caption_markdown() || caption(), attr: {id: captionId()}"
             ></span>
             <i


### PR DESCRIPTION
## Product Description

https://github.com/user-attachments/assets/07a39d9c-930b-4876-8d30-52b2b4d917f3



## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-17511
We have styles in place to add a required asterisk to collapsible group headers containing required questions, however the element needed the `.caption` class for the style to be applied correctly. 
https://github.com/dimagi/commcare-hq/blob/b12c0f44c5dd5708908a7e7651144f524b83f02c/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/webforms.scss#L80-L86

## Safety Assurance

### Safety story
Adds a single css class to apply intended styling. Tested locally in app preview and web apps.

### Automated test coverage
Not likely.

### QA Plan
No.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
