### PR TITLE
Fix date parsing in xform pillows 

### DIFF
--- a/corehq/pillows/tests/test_xform_date_formats.py
+++ b/corehq/pillows/tests/test_xform_date_formats.py
@@ -1,0 +1,44 @@
+import pytest
+
+from corehq.pillows.xform import is_valid_date, normalize_date_for_es
+
+
+class TestIsValidDate:
+
+    @pytest.mark.parametrize("date_str,expected", [
+        ("2025-01-13T16:05:01Z", True),
+        ("2025-01-13T16:05:01.123Z", True),
+        ("2025-01-13T16:05:01.123456Z", True),
+        ("2025-01-13T16:05:01.1234567Z", True),  # 7 digits, valid in Python
+        ("2025-01-13", True),
+        ("invalid-date", False),
+        ("", False),
+        (None, False),
+    ])
+    def test_is_valid_date(self, date_str, expected):
+        assert is_valid_date(date_str) == expected
+
+
+class TestNormalizeDateForEs:
+
+    @pytest.mark.parametrize("input_date,expected", [
+        # Dates with 7+ fractional digits should be truncated to 6
+        ("2026-01-19T07:23:45.1498543Z", "2026-01-19T07:23:45.149854Z"),
+        ("2025-01-13T16:05:01.0294562Z", "2025-01-13T16:05:01.029456Z"),
+        ("2025-01-13T16:05:01.1234567890Z", "2025-01-13T16:05:01.123456Z"),
+        # Dates with 6 or fewer fractional digits should pass through unchanged
+        ("2025-01-13T16:05:01.123456Z", "2025-01-13T16:05:01.123456Z"),
+        ("2025-01-13T16:05:01.123Z", "2025-01-13T16:05:01.123Z"),
+        ("2025-01-13T16:05:01Z", "2025-01-13T16:05:01Z"),
+        ("2025-01-13", "2025-01-13"),
+        # Dates with timezone offsets
+        ("2025-01-13T16:05:01.1234567+05:30", "2025-01-13T16:05:01.123456+05:30"),
+        ("2025-01-13T16:05:01.1234567-08:00", "2025-01-13T16:05:01.123456-08:00"),
+        # Edge cases
+        (None, None),
+        ("", ""),
+        # Dates with space separator instead of T
+        ("2025-01-13 16:05:01.1234567Z", "2025-01-13 16:05:01.123456Z"),
+    ])
+    def test_normalize_date_for_es(self, input_date, expected):
+        assert normalize_date_for_es(input_date) == expected


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
https://dimagi.atlassian.net/browse/SAAS-18612 
We saw these pillow errors in xform pillows - 

```
{'type': 'mapper_parsing_exception', 'reason': "failed to parse field [form.case.@date_modified] of type [date] in document with id <id>", 'caused_by': {'type': 'illegal_argument_exception', 'reason': 'Invalid format: "2026-01-19T07:23:45.1498543Z" is malformed at "3Z"'}}
```

```
{'type': 'mapper_parsing_exception', 'reason': "failed to parse field [form.meta.timeStart] of type [date] in document with id '<id>'", 'caused_by': {'type': 'illegal_argument_exception', 'reason': 'Invalid format: "2025-01-13T16:05:01.0294562Z" is malformed at "2Z"'}}
```

Elasticsearch's date mapping only supports up to 6 fractional second digits (microseconds). However, some form submissions contain timestamps with 7 or more fractional digits (e.g., 2026-01-19T07:23:45.1498543Z).                                                                                            
                                                                                                                                                                                                                                                                                 
When these dates are indexed into Elasticsearch, they fail to parse correctly because ES cannot handle the extra precision. 

I thought of updating the mappings file also and then I realised that ES6 only supports 6 digit precision. There is another `date_nanos` fieldtype which ES has introduced in newer versions https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/date_nanos 

I think the current approach that we are taking is better.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Have the relevant tests to ensure that existing things work fine.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->




### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
