### PR TITLE
DET Exports API documentation

### DIFF
--- a/docs/api/det-exports.rst
+++ b/docs/api/det-exports.rst
@@ -1,0 +1,84 @@
+DET Exports API
+===============
+
+Overview
+--------
+
+Purpose:
+    This API is intended for CommCare Data Pipeline to be able to list
+    the Case and Form Exports available to the Data Export Tool, a.k.a.
+    commcare-export, including the URL to download its config file.
+
+Request URL:
+    ``https://www.commcarehq.org/a/[domain]/api/det_export_instance/v1/``
+
+Permission Required:
+    View Reports
+
+
+Response Details
+----------------
+
+The API response has an "objects" field. Each object includes the
+following properties:
+
+name:
+    The name given by the user who created the export. For case
+    exports, this defaults to the case type and the date the export
+    was created.
+
+type:
+    "case" or "form"
+
+export_format:
+    The file format that the user chose to export data in. Most users
+    choose "xlsx" for modern versions of Microsoft Excel, or "csv" for
+    very large volumes of data.
+
+is_deidentified:
+    Whether personal ideintifiers are excluded from the export data.
+
+case_type:
+    (Case exports only) The case type of exported cases.
+
+xmlns:
+    (Form exports only) The XMLNS of exported forms.
+
+det_config_url:
+    The absolute URL where the Data Export Tool (DET) config file can be
+    downloaded.
+
+    This URL accepts API Key authentication, so the API client that is
+    using this DET Exports API endpoint can also fetch the DET config
+    file.
+
+
+Example Output
+~~~~~~~~~~~~~~
+
+.. code-block:: json
+
+    {
+      "objects": [
+        {
+          "id": "a1b2c3",
+          "name": "My Case Export",
+          "type": "case",
+          "export_format": "csv",
+          "is_deidentified": false,
+          "case_type": "stock",
+          "xmlns": null,
+          "det_config_url": "https://www.commcarehq.org/..."
+        },
+        {
+          "id": "d4e5f6",
+          "name": "My Form Export",
+          "type": "form",
+          "export_format": "xlsx",
+          "is_deidentified": false,
+          "case_type": null,
+          "xmlns": "http://example.com/form1",
+          "det_config_url": "https://www.commcarehq.org/..."
+        }
+      ]
+    }

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -57,6 +57,7 @@ please review CommCare's API Authentication Documentation:
     location-types
     fixture
     ota-api-restore
+    det-exports
 
 
 User APIs

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -2,12 +2,18 @@
 CommCare APIs
 =============
 
-CommCare APIs provide access to various system functionalities, including data retrieval, case and form submissions, and user management. This page describes different APIs available for integration.
+CommCare APIs provide access to various system functionalities,
+including data retrieval, case and form submissions, and user
+management. This page describes different APIs available for
+integration.
 
 .. note::
     This feature requires a **CommCare Software Plan**
 
-    This feature is only available to CommCare users with a **Standard Plan or above**. For more details, please see the `CommCare Pricing Overview <https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2420015134/CommCare+Pricing+Overview>`_
+    This feature is only available to CommCare users with a
+    **Standard Plan or above**. For more details, please see the
+    `CommCare Pricing Overview <https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2420015134/CommCare+Pricing+Overview>`_
+
 
 Table of contents
 -----------------
@@ -15,14 +21,21 @@ Table of contents
 Data APIs
 ~~~~~~~~~
 
-These APIs are intended for building project-specific applications and integrations, including:
+These APIs are intended for building project-specific applications and
+integrations, including:
 
 - Custom end-user applications that address project-specific needs.
-- Custom integrations with external back-end systems, such as an electronic patient record system.
 
-You can browse and test the Data APIs using the `CommCare API Explorer <https://commcare-api-explorer.dimagi.com/>`_.
+- Custom integrations with external back-end systems, such as an
+  electronic patient record system.
 
-**Implementation of URL Endpoints** - All URL endpoints should be utilized as part of a cURL authentication command. For more information, please review CommCare's API Authentication Documentation: `API Authentication <https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2279637003/CommCare+API+Overview#API-Authentication>`_.
+You can browse and test the Data APIs using the
+`CommCare API Explorer <https://commcare-api-explorer.dimagi.com/>`_.
+
+**Implementation of URL Endpoints** - All URL endpoints should be
+utilized as part of a cURL authentication command. For more information,
+please review CommCare's API Authentication Documentation:
+`API Authentication <https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2279637003/CommCare+API+Overview#API-Authentication>`_.
 
 .. toctree::
     :maxdepth: 1
@@ -48,7 +61,11 @@ You can browse and test the Data APIs using the `CommCare API Explorer <https://
 
 User APIs
 ~~~~~~~~~
-The User APIs provide endpoints for managing mobile and web users, including creation, editing, deletion, and authentication. These APIs also support group management, Single Sign-On, and user identity verification.
+
+The User APIs provide endpoints for managing mobile and web users,
+including creation, editing, deletion, and authentication. These APIs
+also support group management, Single Sign-On, and user identity
+verification.
 
 .. toctree::
     :maxdepth: 1
@@ -61,7 +78,9 @@ The User APIs provide endpoints for managing mobile and web users, including cre
 
 Form Submission API
 ~~~~~~~~~~~~~~~~~~~
-CommCare's Submission API implements the OpenRosa standard Form Submission API for submitting XForms over HTTP/S.
+
+CommCare's Submission API implements the OpenRosa standard Form
+Submission API for submitting XForms over HTTP/S.
 
 .. toctree::
     :maxdepth: 1
@@ -70,7 +89,12 @@ CommCare's Submission API implements the OpenRosa standard Form Submission API f
 
 SMS APIs
 ~~~~~~~~
-SMS APIs enable sending and receiving SMS messages through CommCare, allowing integration with external systems for automated messaging, notifications, and data collection. These APIs support message scheduling, two-way communication, and customization based on workflow needs.
+
+SMS APIs enable sending and receiving SMS messages through CommCare,
+allowing integration with external systems for automated messaging,
+notifications, and data collection. These APIs support message
+scheduling, two-way communication, and customization based on workflow
+needs.
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
## Product Description

Adds documentation for the new DET Exports API. The API was added for CommCare Data Pipeline, to be able to list the Case and Form Exports available, and to download their config files automatically.

This PR adds documentation for third-party users and organizations to use the API too.

## Technical Summary

:t-rex: [SAAS-19044](https://dimagi.atlassian.net/browse/SAAS-19044)

Documentation-only change

:tropical_fish: 

<img width="795" height="743" alt="image" src="https://github.com/user-attachments/assets/e7c48ca7-a273-48d0-9fea-96a6ab1b5ca8" />

## Safety Assurance

### Safety story

Built and checked documentation locally.

### Automated test coverage

Not applicable

### QA Plan

Not applicable

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19044]: https://dimagi.atlassian.net/browse/SAAS-19044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ