### PR TITLE
Support durable arg in other celery tasks

### DIFF
--- a/corehq/apps/celery/analytics.py
+++ b/corehq/apps/celery/analytics.py
@@ -10,6 +10,7 @@ def analytics_task(
     max_retries=3,
     queue='analytics_queue',
     serializer='json',
+    durable=False,
 ):
     """
     Defines a task that posts data to one of our analytics endpoints. It
@@ -26,6 +27,7 @@ def analytics_task(
             default_retry_delay=default_retry_delay,
             max_retries=max_retries,
             serializer=serializer,
+            durable=durable,
         )
         @wraps(func)
         def _inner(self, *args, **kwargs):

--- a/corehq/apps/celery/durable.py
+++ b/corehq/apps/celery/durable.py
@@ -3,8 +3,6 @@ from celery import Task
 from celery import states as celery_states
 from dimagi.utils.logging import notify_error
 
-from corehq.apps.celery.models import TaskRecord
-
 
 class DurableTask(Task):
     """
@@ -23,6 +21,8 @@ class DurableTask(Task):
             )
 
     def apply_async(self, args=None, kwargs=None, **opts):
+        from corehq.apps.celery.models import TaskRecord
+
         if not self.durable:
             return super().apply_async(args=args, kwargs=kwargs, **opts)
 
@@ -56,6 +56,8 @@ class DurableTask(Task):
 
 
 def delete_task_record(task_id, state):
+    from corehq.apps.celery.models import TaskRecord
+
     if state in [celery_states.SUCCESS, celery_states.FAILURE]:
         TaskRecord.objects.filter(task_id=task_id).delete()
     else:

--- a/corehq/apps/celery/periodic.py
+++ b/corehq/apps/celery/periodic.py
@@ -1,4 +1,4 @@
-from celery import Task
+from corehq.apps.celery.durable import DurableTask
 
 """
 @periodic_task has been removed from celery>=5.0.0.
@@ -10,7 +10,7 @@ See:
 """
 
 
-class PeriodicTask(Task):
+class PeriodicTask(DurableTask):
 
     @classmethod
     def on_bound(cls, app):

--- a/corehq/apps/celery/serial.py
+++ b/corehq/apps/celery/serial.py
@@ -14,6 +14,7 @@ def serial_task(
     queue='background_queue',
     ignore_result=True,
     serializer=None,
+    durable=False,
 ):
     """
     Define a task to be executed one at a time.  If another serial_task with
@@ -52,6 +53,7 @@ def serial_task(
             ignore_result=ignore_result,
             default_retry_delay=default_retry_delay,
             max_retries=max_retries,
+            durable=durable,
             **task_kwargs,
         )
         @wraps(fn)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19204

PeriodicTask needs to inherit from DurableTask to support actually doing something with the `durable` arg. The analytics_task and serial_task were much simpler, just needing to pass the durable arg through to the underlying @task decorator.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on staging to ensure periodic tasks still function and create TaskRecords as expected. Errors would be fairly obvious as we would see either a spike in errors in sentry or a lot more failing celery tasks, neither of which we've seen so far. As we add the durable arg to some periodic tasks, this will continue to be something I keep an eye on, but my test was positive.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
There are automated tests around the underlying durable task code, but nothing to do with the interaction of PeriodicTask inherting from DurableTask from what I can tell. I think this is ok.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
