### PR TITLE
Allow Web User/Mobile Worker "view" permission to download users

### DIFF
--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -75,7 +75,8 @@ from .views.mobile.users import (
     restore_commcare_user,
     toggle_demo_mode,
     update_user_groups,
-    user_download_job_poll,
+    commcare_user_download_job_poll,
+    web_user_download_job_poll,
     CommCareUserConfirmAccountViewByEmailView,
     send_confirmation_email,
     send_confirmation_sms,
@@ -127,6 +128,11 @@ urlpatterns = [
     url(r'^web/$', ListWebUsersView.as_view(), name=ListWebUsersView.urlname),
     url(r'^web/json/$', paginate_web_users, name='paginate_web_users'),
     url(r'^web/download/$', download_web_users, name='download_web_users'),
+    url(
+        r'^web/download/poll/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
+        web_user_download_job_poll,
+        name='web_user_download_job_poll'
+    ),
     url(
         r'^web/download/status/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
         DownloadWebUsersStatusView.as_view(),
@@ -239,8 +245,8 @@ urlpatterns = [
     ),
     url(
         r'^commcare/download/poll/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
-        user_download_job_poll,
-        name='user_download_job_poll'
+        commcare_user_download_job_poll,
+        name='commcare_user_download_job_poll'
     ),
     url(
         r'^commcare/confirm_charges/$',

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -622,7 +622,7 @@ class DownloadWebUsersStatusView(BaseUserSettingsView):
         context.update({
             'domain': self.domain,
             'download_id': kwargs['download_id'],
-            'poll_url': reverse('user_download_job_poll', args=[self.domain, kwargs['download_id']]),
+            'poll_url': reverse('web_user_download_job_poll', args=[self.domain, kwargs['download_id']]),
             'title': _("Download Web Users Status"),
             'progress_text': _("Preparing web user download."),
             'error_text': _("There was an unexpected error! Please try again or report an issue."),

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -894,12 +894,8 @@ def check_sso_trust(request, domain):
     return JsonResponse(response)
 
 
+@method_decorator([always_allow_project_access, require_can_edit_or_view_web_users], name='dispatch')
 class BaseManageWebUserView(BaseUserSettingsView):
-
-    @method_decorator(always_allow_project_access)
-    @method_decorator(require_can_edit_web_users)
-    def dispatch(self, request, *args, **kwargs):
-        return super(BaseManageWebUserView, self).dispatch(request, *args, **kwargs)
 
     @property
     def parent_pages(self):
@@ -910,6 +906,7 @@ class BaseManageWebUserView(BaseUserSettingsView):
 
 
 @location_safe
+@method_decorator(require_can_edit_web_users, name='dispatch')
 class InviteWebUserView(BaseManageWebUserView):
     template_name = "users/bootstrap3/invite_web_user.html"
     urlname = 'invite_web_user'
@@ -1291,6 +1288,7 @@ class UploadWebUsers(BaseUploadUser):
 
 
 @location_safe
+@method_decorator(require_can_edit_web_users, name='dispatch')
 class WebUserUploadStatusView(BaseManageWebUserView):
     urlname = 'web_user_upload_status'
     page_title = gettext_noop('Web User Upload Status')
@@ -1332,14 +1330,11 @@ class UserUploadJobPollView(BaseUserSettingsView):
 
 
 @location_safe
+@method_decorator(require_can_edit_web_users, name='dispatch')
 class WebUserUploadJobPollView(UserUploadJobPollView, BaseManageWebUserView):
     urlname = "web_user_upload_job_poll"
     on_complete_long = 'Web Worker upload has finished'
     user_type = 'web users'
-
-    @method_decorator(require_can_edit_web_users)
-    def dispatch(self, request, *args, **kwargs):
-        return super(WebUserUploadJobPollView, self).dispatch(request, *args, **kwargs)
 
 
 @require_POST

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1211,7 +1211,6 @@ class FilteredUserDownload(BaseUserSettingsView):
 
 
 @location_safe
-@method_decorator(require_can_edit_or_view_commcare_users, name='dispatch')
 class FilteredCommCareUserDownload(FilteredUserDownload, BaseManageCommCareUserView):
     page_title = gettext_noop('Filter and Download Mobile Workers')
     urlname = 'filter_and_download_commcare_users'
@@ -1220,7 +1219,7 @@ class FilteredCommCareUserDownload(FilteredUserDownload, BaseManageCommCareUserV
 
 
 @location_safe
-@method_decorator([require_can_use_filtered_user_download, require_can_edit_or_view_web_users], name='dispatch')
+@method_decorator(require_can_use_filtered_user_download, name='dispatch')
 class FilteredWebUserDownload(FilteredUserDownload, BaseManageWebUserView):
     page_title = gettext_noop('Filter and Download Users')
     urlname = 'filter_and_download_web_users'

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -102,7 +102,6 @@ from corehq.apps.users.dbaccessors import get_user_docs_by_username
 from corehq.apps.users.decorators import (
     require_can_edit_commcare_users,
     require_can_edit_or_view_commcare_users,
-    require_can_edit_web_users,
     require_can_edit_or_view_web_users,
     require_can_use_filtered_user_download,
 )
@@ -1221,16 +1220,12 @@ class FilteredCommCareUserDownload(FilteredUserDownload, BaseManageCommCareUserV
 
 
 @location_safe
-@method_decorator([require_can_use_filtered_user_download], name='dispatch')
+@method_decorator([require_can_use_filtered_user_download, require_can_edit_or_view_web_users], name='dispatch')
 class FilteredWebUserDownload(FilteredUserDownload, BaseManageWebUserView):
     page_title = gettext_noop('Filter and Download Users')
     urlname = 'filter_and_download_web_users'
     user_type = WEB_USER_TYPE
     count_view = 'count_web_users'
-
-    @method_decorator(require_can_edit_web_users)
-    def get(self, request, domain, *args, **kwargs):
-        return super().get(request, domain, *args, **kwargs)
 
 
 class UsernameUploadMixin(object):
@@ -1454,7 +1449,7 @@ def count_commcare_users(request, domain):
     return _count_users(request, domain, MOBILE_USER_TYPE)
 
 
-@require_can_edit_web_users
+@require_can_edit_or_view_web_users
 @require_can_use_filtered_user_download
 @location_safe
 def count_web_users(request, domain):

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -576,11 +576,8 @@ def toggle_demo_mode(request, domain, user_id):
     return HttpResponseRedirect(edit_user_url)
 
 
+@method_decorator(require_can_edit_or_view_commcare_users, name='dispatch')
 class BaseManageCommCareUserView(BaseUserSettingsView):
-
-    @method_decorator(require_can_edit_commcare_users)
-    def dispatch(self, request, *args, **kwargs):
-        return super(BaseManageCommCareUserView, self).dispatch(request, *args, **kwargs)
 
     @property
     def parent_pages(self):
@@ -590,6 +587,7 @@ class BaseManageCommCareUserView(BaseUserSettingsView):
         }]
 
 
+@method_decorator(require_can_edit_commcare_users, name='dispatch')
 class ConfirmTurnOffDemoModeView(BaseManageCommCareUserView):
     template_name = 'users/bootstrap3/confirm_turn_off_demo_mode.html'
     urlname = 'confirm_turn_off_demo_mode'
@@ -612,6 +610,7 @@ class ConfirmTurnOffDemoModeView(BaseManageCommCareUserView):
         return reverse(self.urlname, args=self.args, kwargs=self.kwargs)
 
 
+@method_decorator(require_can_edit_commcare_users, name='dispatch')
 class DemoRestoreStatusView(BaseManageCommCareUserView):
     urlname = 'demo_restore_status'
     page_title = gettext_noop('Demo User Status')
@@ -1103,6 +1102,7 @@ class UploadCommCareUsers(BaseUploadUser):
 
 
 @location_safe
+@method_decorator(require_can_edit_commcare_users, name='dispatch')
 class UserUploadStatusView(BaseManageCommCareUserView):
     urlname = 'user_upload_status'
     page_title = gettext_noop('Mobile Worker Upload Status')
@@ -1212,15 +1212,12 @@ class FilteredUserDownload(BaseUserSettingsView):
 
 
 @location_safe
+@method_decorator(require_can_edit_or_view_commcare_users, name='dispatch')
 class FilteredCommCareUserDownload(FilteredUserDownload, BaseManageCommCareUserView):
     page_title = gettext_noop('Filter and Download Mobile Workers')
     urlname = 'filter_and_download_commcare_users'
     user_type = MOBILE_USER_TYPE
     count_view = 'count_commcare_users'
-
-    @method_decorator(require_can_edit_commcare_users)
-    def get(self, request, domain, *args, **kwargs):
-        return super().get(request, domain, *args, **kwargs)
 
 
 @location_safe
@@ -1278,6 +1275,7 @@ class UsernameUploadMixin(object):
         return sheet
 
 
+@method_decorator(require_can_edit_commcare_users, name='dispatch')
 class DeleteCommCareUsers(BaseManageCommCareUserView, UsernameUploadMixin):
     urlname = 'delete_commcare_users'
     page_title = gettext_noop('Bulk Delete')
@@ -1405,6 +1403,7 @@ class ClearCommCareUsers(DeleteCommCareUsers):
         )
 
 
+@method_decorator(require_can_edit_commcare_users, name='dispatch')
 class CommCareUsersLookup(BaseManageCommCareUserView, UsernameUploadMixin):
     urlname = 'commcare_users_lookup'
     page_title = gettext_noop('Mobile Workers Bulk Lookup')
@@ -1449,7 +1448,7 @@ class CommCareUsersLookup(BaseManageCommCareUserView, UsernameUploadMixin):
         return outfile.getvalue()
 
 
-@require_can_edit_commcare_users
+@require_can_edit_or_view_commcare_users
 @location_safe
 def count_commcare_users(request, domain):
     return _count_users(request, domain, MOBILE_USER_TYPE)
@@ -1793,6 +1792,7 @@ class CommCareUserPasswordResetView(BaseManageCommCareUserView, FormView):
 
     @method_decorator(require_POST)
     @method_decorator(csrf_protect)
+    @method_decorator(require_can_edit_commcare_users)
     def dispatch(self, *args, **kwargs):
         if not user_can_access_other_user(self.domain, self.request.couch_user, self.editable_user):
             return HttpResponse(status=401)

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -103,6 +103,7 @@ from corehq.apps.users.decorators import (
     require_can_edit_commcare_users,
     require_can_edit_or_view_commcare_users,
     require_can_edit_web_users,
+    require_can_edit_or_view_web_users,
     require_can_use_filtered_user_download,
 )
 from corehq.apps.users.exceptions import (
@@ -1137,7 +1138,22 @@ class CommcareUserUploadJobPollView(UserUploadJobPollView):
 
 @require_can_edit_or_view_commcare_users
 @location_safe
-def user_download_job_poll(request, domain, download_id, template="hqwebapp/partials/shared_download_status.html"):
+def commcare_user_download_job_poll(
+    request, domain, download_id, template="hqwebapp/partials/shared_download_status.html"
+):
+    return _user_download_job_poll(request, domain, download_id, template)
+
+
+@require_can_edit_or_view_web_users
+@location_safe
+def web_user_download_job_poll(
+    request, domain, download_id, template="hqwebapp/partials/shared_download_status.html"
+):
+    return _user_download_job_poll(request, domain, download_id, template)
+
+
+@location_safe
+def _user_download_job_poll(request, domain, download_id, template):
     try:
         context = get_download_context(download_id, 'Preparing download')
         context.update({'link_text': _('Download Users')})
@@ -1167,7 +1183,7 @@ class DownloadUsersStatusView(BaseUserSettingsView):
         context.update({
             'domain': self.domain,
             'download_id': kwargs['download_id'],
-            'poll_url': reverse('user_download_job_poll', args=[self.domain, kwargs['download_id']]),
+            'poll_url': reverse('commcare_user_download_job_poll', args=[self.domain, kwargs['download_id']]),
             'title': _("Download Users Status"),
             'progress_text': _("Preparing user download."),
             'error_text': _("There was an unexpected error! Please try again or report an issue."),


### PR DESCRIPTION
## Product Description
- Gives "view" permission for web users or mobile workers the ability to download the corresponding list of users - previously those with just the "view" permission could see the Download button but would get a 403 on clicking it.
- Fixes a bug where the mobile worker permission was required in all cases to download web users.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19073
Updates permissions checks and inheritance on the various `download` users views and view classes used to filter and download web users and mobile workers, by relaxing the permission on the parent class to `edit_or_view` and specifying more strict checks on subclasses where needed.

## Safety Assurance

### Safety story
Tested locally and on staging that:
- View permission for mobile workers:
  - allows download of mobile workers
  - does not allow any access to web users pages
  - does not allow access to edit mobile workers
- View permission for web users:
  - allows download of web users
  - does not allow any access to mobile workers pages
  - does not allow access to edit web users

### Automated test coverage
It's unlikely we have much automated testing for view code, specifically the permissions checks used here.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
