### PR TITLE
Handle submit errors better in app preview

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/const.js
@@ -66,6 +66,7 @@ export default {
     NEXT_QUESTION: 'next_index',
     PREV_QUESTION: 'prev_index',
     SCROLLABLE_CONTENT_CONTAINER: '#content-plus-version-info-container',
+    APP_PREVIEW_FORM_CONTAINER: '.form-scrollable-container',
 
     // XForm Actions
     NEW_FORM: 'new-form',

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/form_ui.js
@@ -999,7 +999,10 @@ function Question(json, parent) {
             currentNode = parent;
         }
         var el = $("#" + self.entry.entryId + "-label");
-        const scrollContainer = $(constants.SCROLLABLE_CONTENT_CONTAINER);
+        let scrollContainer = $(constants.SCROLLABLE_CONTENT_CONTAINER);
+        if (!scrollContainer.length) {
+            scrollContainer = $(constants.APP_PREVIEW_FORM_CONTAINER);
+        }
         scrollContainer.animate({
             scrollTop: scrollContainer.scrollTop() + $(el).offset().top - 80,
         });

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/form.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/form.html
@@ -52,7 +52,7 @@
                   type="submit"
                   data-bind="enable: enableSubmitButton">
             <i class="fa fa-spin fa-refresh"
-               data-bind="visible: !enableSubmitButton(){% if environment == "web-apps" %} && erroredQuestions.length != 0{% endif %}"
+               data-bind="visible: !enableSubmitButton() && erroredQuestions.length != 0"
             ></i>
             <!-- ko text: submitText --><!-- /ko -->
           </button>

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/form.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/form.html
@@ -19,29 +19,27 @@
       <div class="question-container">
         <div class="mb-3" data-bind="template: { name: childTemplate, foreach: $data.children }"/>
       </div>
-      {% if environment == "web-apps" %}
-        <div class="row" data-bind="visible: erroredQuestions().length > 0">
-          <div class="alert alert-danger">
-            {% blocktrans %}
-              Please correct the answers below before submitting.
-              <br>
-              You can use the <strong><i class='fa fa-fast-forward'></i> Next Error</strong> button on the left-hand side of the screen to navigate between required fields.
-            {% endblocktrans %}
-            <ul data-bind="foreach: erroredQuestions">
-                <li>
-                    <a href="#" data-bind="click: navigateTo, html: caption_markdown() || caption() || question_id() || gettext('Unknown Question')"></a>
-                    <span data-bind="visible: serverError, text: serverError"></span>
-                    <span data-bind="if: error">
-                      <!-- ko text: error --><!-- /ko -->
-                    </span>
-                    <span data-bind="visible: !serverError() && !error()">
-                      {% trans "An answer is required." %}
-                    </span>
-                </li>
-            </ul>
-          </div>
+      <div class="row" data-bind="visible: erroredQuestions().length > 0">
+        <div class="alert alert-danger">
+          {% blocktrans %}
+            Please correct the answers below before submitting.
+            <br>
+            You can use the <strong><i class='fa fa-fast-forward'></i> Next Error</strong> button on the left-hand side of the screen to navigate between required fields.
+          {% endblocktrans %}
+          <ul data-bind="foreach: erroredQuestions">
+              <li>
+                  <a href="#" data-bind="click: navigateTo, html: caption_markdown() || caption() || question_id() || gettext('Unknown Question')"></a>
+                  <span data-bind="visible: serverError, text: serverError"></span>
+                  <span data-bind="if: error">
+                    <!-- ko text: error --><!-- /ko -->
+                  </span>
+                  <span data-bind="visible: !serverError() && !error()">
+                    {% trans "An answer is required." %}
+                  </span>
+              </li>
+          </ul>
         </div>
-      {% endif %}
+      </div>
       <div id="submit-button" class="form-actions noprint-sub-container"
            data-bind="
               visible: showSubmitButton,

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/form.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/form_entry/form.html
@@ -40,17 +40,23 @@
           </ul>
         </div>
       </div>
-      <div id="submit-button" class="form-actions noprint-sub-container"
-           data-bind="
-              visible: showSubmitButton,
-              css: { 'sticky-submit': isAnchoredSubmitStyle }"
+      <div
+        id="submit-button" class="form-actions noprint-sub-container"
+        data-bind="
+          visible: showSubmitButton,
+          css: {
+            'sticky-submit': isAnchoredSubmitStyle {% if environment == 'preview-app' %}&& !(erroredQuestions().length > 0){% endif %}
+          }"
       >
         <div class="col-12 text-center submit">
-          <button class="submit btn btn-primary"
-                  type="submit"
-                  data-bind="enable: enableSubmitButton">
-            <i class="fa fa-spin fa-refresh"
-               data-bind="visible: !enableSubmitButton() && erroredQuestions.length != 0"
+          <button 
+            class="submit btn btn-primary"
+            type="submit"
+            data-bind="enable: enableSubmitButton"
+          >
+            <i 
+              class="fa fa-spin fa-refresh"
+              data-bind="visible: !enableSubmitButton() && erroredQuestions.length != 0"
             ></i>
             <!-- ko text: submitText --><!-- /ko -->
           </button>

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/form.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-common/form.scss
@@ -47,6 +47,12 @@ legend {
   }
 }
 
+#next-error {
+  position: fixed;
+  bottom: 0px;
+  z-index: $zindex-next-error;
+}
+
 .sticky-submit {
     position: sticky;
     bottom: 0;

--- a/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/form.scss
+++ b/corehq/apps/hqwebapp/static/cloudcare/scss/formplayer-webapp/form.scss
@@ -218,9 +218,7 @@ $form-text-size: 16px; // If updating, update .checkbox, .radio margin-top to fi
 }
 
 #next-error {
-  position: fixed;
   bottom: 35px;
-  z-index: $zindex-next-error;
 }
 
 .my-05em-for-hs {


### PR DESCRIPTION
## Product Description
Before:
 - no overall error notification
 - 'next error' is always below the submit button and also it does not work
 - 'submit' spinner never disappears
<img width="450" height="644" alt="image" src="https://github.com/user-attachments/assets/a639ffab-d9df-4607-94d4-c83e0cdce685" /> <img width="250" height="444" alt="image" src="https://github.com/user-attachments/assets/5392ae20-cd00-4da8-85a0-beda51a4779b" />


After:
 - error alert is shown as in web apps
 - 'next error' is sticky at bottom of screen as in web apps and correctly jumps to question
 - 'submit' sits at bottom of content with no spinner when 'next error' is shown
<img width="450" height="644" alt="image" src="https://github.com/user-attachments/assets/288e9f0c-04e7-41f0-84f4-4a35d2941438" /> <img width="250" height="444" alt="image" src="https://github.com/user-attachments/assets/2dc702aa-a7fc-4227-9879-a2ca16dd43b6" />


Web Apps appearance is unchanged.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-15949

## Safety Assurance

### Safety story
Tested locally and (soon) on staging. These are small changes to the UI of app preview.

### Automated test coverage
Not for UI-only changes.

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
