### PR TITLE
Removes ability to verify all users at once

### DIFF
--- a/corehq/apps/integration/kyc/views.py
+++ b/corehq/apps/integration/kyc/views.py
@@ -170,11 +170,8 @@ class KycVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableView, 
 
     @hq_hx_action('post')
     def verify_rows(self, request, *args, **kwargs):
-        if request.POST.get('verify_all') == 'true':
-            kyc_users = list(self.kyc_config.get_all_kyc_users())
-        else:
-            selected_ids = request.POST.getlist('selected_ids')
-            kyc_users = list(self.kyc_config.get_kyc_users_by_ids(selected_ids))
+        selected_ids = request.POST.getlist('selected_ids')
+        kyc_users = list(self.kyc_config.get_kyc_users_by_ids(selected_ids))
         kyc_users = self._filter_valid_users(kyc_users)
 
         existing_failed_user_ids = self._get_existing_failed_users(kyc_users)

--- a/corehq/apps/integration/static/integration/js/kyc/kyc_verify.js
+++ b/corehq/apps/integration/static/integration/js/kyc/kyc_verify.js
@@ -7,19 +7,8 @@ import htmx from 'htmx.org';
 
 function updateVerifyButton(selectedIds) {
     const $verifyBtn = $('#verify-selected-btn');
-    const $verifyAll = $verifyBtn.find('span:first');
-    const $verifySelected = $verifyBtn.find('span:last');
 
     let verifyBtnVals = JSON.parse($verifyBtn.attr('hx-vals'));
-    if (selectedIds.length > 0) {
-        $verifyAll.addClass('d-none');
-        $verifySelected.removeClass('d-none');
-        verifyBtnVals['verify_all'] = false;
-    } else {
-        $verifyAll.removeClass('d-none');
-        $verifySelected.addClass('d-none');
-        verifyBtnVals['verify_all'] = true;
-    }
     verifyBtnVals['selected_ids'] = selectedIds;
     $verifyBtn.attr('hx-vals', JSON.stringify(verifyBtnVals));
 }

--- a/corehq/apps/integration/templates/kyc/kyc_verify_report.html
+++ b/corehq/apps/integration/templates/kyc/kyc_verify_report.html
@@ -38,12 +38,10 @@
             hx-target="#verify-alert"
             hq-hx-action="verify_rows"
             hx-vals='{
-                    "selected_ids": [],
-                    "verify_all": true
+                    "selected_ids": []
                 }'
           >
-            <span> {% trans "Verify All" %} </span>
-            <span class="d-none"> {% trans "Verify Selected" %} </span>
+            <span> {% trans "Verify Selected" %} </span>
           </button>
 
           <button


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Removes ability to verify all users at once

Verifying a large number of records is not feasible because:
- It requires significant time, as each record necessitates an API call, which blocks the UI while waiting.
- It may overload the external API provider and risk exceeding any API limits.

To address this, a decision was taken to remove the option to verify all users at once to prevent issues.
If this feature is necessary, we should consider a different approach, such as implementing a background job that respects API limits and sets a maximum number of records for processing.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/SC-4572)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
KYC_VERIFICATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on local. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
