### PR TITLE
Fix invalid case type names in Data Dictionary and Case Exports

### DIFF
--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -689,11 +689,11 @@ def show_outer_spaces(value):
     """Replace leading and/or trailing space with a bullet
 
     Convenient for disambiguating values like 'thing' and 'thing '.
-    The bullet character was chosen based on the convention of IDE's
-    that render spaces at the end of a line as a dot.
+    The "middle dot" character was chosen based on the convention of
+    IDE's that render spaces at the end of a line as a dot.
     """
     if value.startswith(" "):
-        value = '\u2022' + value[1:]
+        value = '\u00b7' + value[1:]
     if value.endswith(" "):
-        value = value[:-1] + '\u2022'
+        value = value[:-1] + '\u00b7'
     return value

--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -633,7 +633,7 @@ class ApplicationDataRMIHelper(object):
         all_case_type_names = get_case_types_for_domain(self.domain)
         all_case_type_objs = [RMIDataChoice(
             id=case_type,
-            text=case_type,
+            text=show_outer_spaces(case_type),
             data={
                 'unknown': True
             }
@@ -683,3 +683,17 @@ class ApplicationDataRMIHelper(object):
         response = self.get_form_rmi_response()
         response.update(self.get_case_rmi_response())
         return response
+
+
+def show_outer_spaces(value):
+    """Replace leading and/or trailing space with a bullet
+
+    Convenient for disambiguating values like 'thing' and 'thing '.
+    The bullet character was chosen based on the convention of IDE's
+    that render spaces at the end of a line as a dot.
+    """
+    if value.startswith(" "):
+        value = '\u2022' + value[1:]
+    if value.endswith(" "):
+        value = value[:-1] + '\u2022'
+    return value

--- a/corehq/apps/data_cleaning/forms/start_session.py
+++ b/corehq/apps/data_cleaning/forms/start_session.py
@@ -55,6 +55,7 @@ class ResumeOrRestartCaseSessionForm(forms.Form):
     case_type = forms.CharField(
         label=gettext_lazy('Case Type'),
         required=False,
+        strip=False,
     )
     next_step = forms.ChoiceField(
         label=gettext_lazy('Next Step'),

--- a/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
+++ b/corehq/apps/data_dictionary/static/data_dictionary/js/data_dictionary.js
@@ -28,12 +28,16 @@ var caseType = function (
     dataUrl,
 ) {
     var self = {};
-    self.name = name || gettext("No Name");
+    self.name = name;
+    self.displayName = name || gettext("No Name");
+    // bootstrap3TabSelector can probably be removed when migrating to bootstrap5
+    // Obviously also remove the 'data-target' attribute that uses it in base.html
+    self.bootstrap3TabSelector = "#" + $.escapeSelector(encodeURIComponent(name));
     self.deprecated = deprecated;
     self.appCount = moduleCount;  // The number of application modules using this case type
     self.propertyCount = propertyCount;
     self.deprecatedPropertyCount = deprecatedPropertyCount;
-    self.url = "#" + name;
+    self.url = "#" + encodeURIComponent(name);
     self.fhirResourceType = ko.observable(fhirResourceType);
     self.groups = ko.observableArray();
     self.geoCaseProp = geoCaseProp;
@@ -47,7 +51,7 @@ var caseType = function (
     self.loadCaseProperties = function (isLoading) {
         if (self.groups().length === 0) {
             isLoading(true);
-            const caseTypeUrl = self.dataUrl + self.name + '/';
+            const caseTypeUrl = self.dataUrl + encodeURIComponent(self.name) + '/';
             fetchCaseProperties(caseTypeUrl).then(() => {
                 self.groups.sort(sortGroupsFn);
                 self.resetSaveButton();
@@ -458,7 +462,7 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
 
     self.getHashNavigationCaseType = function () {
         const fullHash = window.location.hash.split('?')[0],
-            hash = fullHash.substring(1);
+            hash = decodeURIComponent(fullHash.substring(1));
         return _.find(self.caseTypes(), function (prop) {
             return prop.name === hash;
         });
@@ -511,7 +515,10 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
         activeCaseType.deprecated = shouldDeprecate;
         $("#case-type-error").hide();
         $.ajax({
-            url: initialPageData.reverse('deprecate_or_restore_case_type', activeCaseType.name),
+            url: initialPageData.reverse(
+                'deprecate_or_restore_case_type',
+                encodeURIComponent(activeCaseType.name),
+            ),
             method: 'POST',
             data: {
                 'is_deprecated': shouldDeprecate,
@@ -528,7 +535,10 @@ var dataDictionaryModel = function (dataUrl, casePropertyUrl, typeChoices, fhirR
     self.deleteCaseType = function () {
         $("#case-type-error").hide();
         $.ajax({
-            url: initialPageData.reverse('delete_case_type', self.getActiveCaseType().name),
+            url: initialPageData.reverse(
+                'delete_case_type',
+                encodeURIComponent(self.getActiveCaseType().name),
+            ),
             method: 'POST',
             success: function () {
                 window.location.href = initialPageData.reverse('data_dictionary');

--- a/corehq/apps/data_dictionary/templates/data_dictionary/base.html
+++ b/corehq/apps/data_dictionary/templates/data_dictionary/base.html
@@ -23,8 +23,8 @@
       <!-- ko foreach: caseTypes -->
       <li data-bind="css: { active: $data.name == $root.activeCaseType() }">
         {# navigation handle by URL hash #}
-        <a data-bind="attr: {href: $data.url}">
-          <span data-bind="text: $data.name" style="display: inline-block">
+        <a data-bind="attr: {href: $data.url, 'data-target': $data.bootstrap3TabSelector}">
+          <span data-bind="text: $data.displayName" style="display: inline-block">
           </span>
           <span
             data-bind="visible: $data.deprecated"
@@ -201,14 +201,14 @@
     {% if not request.is_view_only %}
       <div
         id="gtm-save-btn"
-        data-bind="saveButton: saveButton, visible: $root.activeCaseType()"
+        data-bind="saveButton: saveButton, visible: $root.getActiveCaseType()"
       ></div>
     {% endif %}
     <div class="row">
       <div class="col-xs-12">
         <div>
           <h3
-            data-bind="text: $root.activeCaseType()"
+            data-bind="text: $root.getActiveCaseType().displayName"
             style="display: inline-block;"
           ></h3>
           <span
@@ -291,7 +291,7 @@
             {% trans "Delete Case Type" %}
           </a>
         {% endif %}
-        <div data-bind="visible: $root.activeCaseType()">
+        <div data-bind="visible: $root.getActiveCaseType()">
           <button
             data-bind="click: $root.showDeprecated, visible: !showAll()"
             class="btn btn-default pull-right"

--- a/corehq/apps/data_dictionary/urls.py
+++ b/corehq/apps/data_dictionary/urls.py
@@ -17,12 +17,14 @@ from corehq.apps.hqwebapp.decorators import waf_allow
 
 urlpatterns = [
     path("json/", data_dictionary_json_case_types, name='data_dictionary_json_case_types'),
-    path("json/<slug:case_type_name>/", data_dictionary_json_case_properties,
-         name='data_dictionary_json_case_properties'),
+    # Due to lack of validation in some places, case_type_name may contain spaces
+    # and other special characters not normally allowed in case type names.
+    url(r"^json/(?P<case_type_name>.*)/$", data_dictionary_json_case_properties,
+        name='data_dictionary_json_case_properties'),
     url(r"^create_case_type/$", create_case_type, name='create_case_type'),
-    url(r"^deprecate_or_restore_case_type/(?P<case_type_name>[\w-]+)/$", deprecate_or_restore_case_type,
+    url(r"^deprecate_or_restore_case_type/(?P<case_type_name>.*)/$", deprecate_or_restore_case_type,
         name='deprecate_or_restore_case_type'),
-    url(r"^delete_case_type/(?P<case_type_name>[\w-]+)/$", delete_case_type, name='delete_case_type'),
+    url(r"^delete_case_type/(?P<case_type_name>.*)/$", delete_case_type, name='delete_case_type'),
     url(r"^update_case_property/$", update_case_property, name='update_case_property'),
     url(r"^update_case_property_description/$", update_case_property_description,
         name='update_property_description'),

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -82,7 +82,7 @@ class CreateExportTagForm(forms.Form):
     form = forms.CharField(required=False, widget=forms.Select(choices=[]))
 
     # Case export fields
-    case_type = forms.CharField(required=False, widget=forms.Select(choices=[]))
+    case_type = forms.CharField(required=False, widget=forms.Select(choices=[]), strip=False)
 
     def __init__(self, has_form_export_permissions, has_case_export_permissions, *args, **kwargs):
         self.has_form_export_permissions = has_form_export_permissions


### PR DESCRIPTION
Somehow case type names that contain spaces and other special characters have come into existence. Previously it was not possible to interact with them in the Data Dictionary. Empty case type names, which were partially accounted for, are also now supported.

Additionally, case exports can now be created for case type names with leading or trailing spaces. Case type names with leading and/or trailing spaces are disambiguated in the case export creation form.

<img width="517" height="323" alt="image" src="https://github.com/user-attachments/assets/519289a4-7a3c-4d2e-a546-817da3888592" />

https://dimagi.atlassian.net/browse/SAAS-19035

## Safety Assurance

### Safety story

 All changes were tested locally.

### Automated test coverage

No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations