### PR TITLE
Use time_machine instead of function kwarg

### DIFF
--- a/corehq/apps/saved_reports/scheduled.py
+++ b/corehq/apps/saved_reports/scheduled.py
@@ -63,8 +63,8 @@ def _make_all_notification_view_keys(period, target):
 
 
 @transaction.atomic
-def create_records_for_scheduled_reports(fake_now_for_tests=None):
-    end_datetime = fake_now_for_tests or datetime.utcnow()
+def create_records_for_scheduled_reports():
+    end_datetime = datetime.utcnow()
     last_checkpoint = ScheduledReportsCheckpoint.get_latest()
     if last_checkpoint:
         start_datetime = last_checkpoint.end_datetime

--- a/corehq/apps/saved_reports/tests/test_checkpointing.py
+++ b/corehq/apps/saved_reports/tests/test_checkpointing.py
@@ -1,5 +1,7 @@
 import datetime
 
+from time_machine import travel
+
 from django.test import TestCase
 
 from corehq.apps.saved_reports.models import (
@@ -24,12 +26,14 @@ class ScheduledReportsCheckpointTest(TestCase):
         point_2 = datetime.datetime(2019, 3, 22, 23, 1, 38, 363898)
         self.assertEqual(len(ScheduledReportsCheckpoint.objects.all()), 0)
 
-        create_records_for_scheduled_reports(fake_now_for_tests=point_1)
+        with travel(point_1, tick=False):
+            create_records_for_scheduled_reports()
         self.assertEqual(len(ScheduledReportsCheckpoint.objects.all()), 1)
         checkpoint_1 = ScheduledReportsCheckpoint.get_latest()
         self.assertEqual(checkpoint_1.end_datetime, point_1)
 
-        create_records_for_scheduled_reports(fake_now_for_tests=point_2)
+        with travel(point_2, tick=False):
+            create_records_for_scheduled_reports()
         self.assertEqual(len(ScheduledReportsCheckpoint.objects.all()), 2)
         checkpoint_2 = ScheduledReportsCheckpoint.get_latest()
         self.assertEqual(checkpoint_2.start_datetime, point_1)
@@ -58,12 +62,14 @@ class ScheduledReportsCheckpointTest(TestCase):
             ('monthly day off', False, ReportNotification(hour=22, minute=0, day=20, interval='monthly')),
         ]
 
-        create_records_for_scheduled_reports(fake_now_for_tests=point_1)
+        with travel(point_1, tick=False):
+            create_records_for_scheduled_reports()
 
         for _, _, report in test_cases:
             report.save()
 
-        report_ids = create_records_for_scheduled_reports(fake_now_for_tests=point_2)
+        with travel(point_2, tick=False):
+            report_ids = create_records_for_scheduled_reports()
 
         for description, should_fire, report in test_cases:
             if should_fire:

--- a/corehq/apps/saved_reports/tests/test_checkpointing.py
+++ b/corehq/apps/saved_reports/tests/test_checkpointing.py
@@ -16,9 +16,9 @@ from corehq.apps.saved_reports.tests.test_scheduled_reports import (
 
 
 class ScheduledReportsCheckpointTest(TestCase):
-    def tearDown(self):
-        delete_all_report_notifications()
-        ScheduledReportsCheckpoint.objects.all().delete()
+    def setUp(self):
+        self.addCleanup(delete_all_report_notifications)
+        self.addCleanup(ScheduledReportsCheckpoint.objects.all().delete)
 
     def test_checkpoint_created(self):
         point_1 = datetime.datetime(2019, 3, 22, 22, 46, 0, 439979)

--- a/corehq/apps/saved_reports/tests/test_checkpointing.py
+++ b/corehq/apps/saved_reports/tests/test_checkpointing.py
@@ -1,8 +1,7 @@
 import datetime
 
-from time_machine import travel
-
 from django.test import TestCase
+from time_machine import travel
 
 from corehq.apps.saved_reports.models import (
     ReportNotification,


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Just some simple cleanup to get rid of test code in production code.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tests still pass, and the removed kwarg was only used in tests.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
ScheduledReportsCheckpointTest

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
