### PR TITLE
Fix longstanding bug in subscription credit accounting

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2940,7 +2940,7 @@ class CustomerBillingRecord(BillingRecordBase):
             )
         )
         if subscription_credits or self._subscriptions_in_credit_adjustments(credit_adjustments):
-            credit_adjustments['subscription'].update({
+            credits['subscription'].update({
                 'product': {
                     'amount': quantize_accounting_decimal(subscription_credits)
                 }


### PR DESCRIPTION
## Product Description
Effectively no user-facing change—there's a bug fix, but the bug never seems to have been hit.

## Technical Summary
Found this when playing around with Claude Code.
Every other similar line updates credits and not credit_adjustments, and credit_adjustments is a QuerySet object that I don't even think makes any sense to do a key lookup on this way.

## Safety Assurance

### Safety story
Tests run well before and after, and the way it is right now really just doesn't make any logical sense.

### Automated test coverage

The accounting code has lots of tests, but clearly this line itself wasn't being tested fully, or else this bug wouldn't have been able to exist for so long.

### QA Plan

Nothing planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
