### PR TITLE
Form attachments layout improvements

### DIFF
--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/form/partials/single_form.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/reports/form/partials/single_form.html.diff.txt
@@ -1,6 +1,17 @@
 --- 
 +++ 
-@@ -85,7 +85,7 @@
+@@ -50,10 +50,6 @@
+     background-color: #fcf8e3;
+     text-align: center;
+   }
+-  .mb-2 {
+-    /* bootstrap5 forward-compatibility */
+-    margin-bottom: 0.5rem;
+-  }
+ </style>
+ 
+ {% if is_archived %}
+@@ -89,7 +85,7 @@
  {% endif %}
  
  <div class="clearfix">
@@ -9,7 +20,7 @@
      {% if auth_context.authenticated %}
        <i class="fa fa-lock" title="{% trans "Secure submission" %}"></i>
        {% if user_info.id != auth_user_info.id %}
-@@ -119,15 +119,15 @@
+@@ -123,15 +119,15 @@
      </ul>
    </div>
  </div>
@@ -28,7 +39,7 @@
          {% trans "Case Changes" %}
        </a>
      </li>
-@@ -135,7 +135,7 @@
+@@ -139,7 +135,7 @@
  
    {% if instance_history %}
      <li>
@@ -37,7 +48,7 @@
          {% trans "Form History" %}
        </a>
      </li>
-@@ -143,7 +143,7 @@
+@@ -147,7 +143,7 @@
  
    {% if form_meta_data %}
      <li>
@@ -46,7 +57,7 @@
          {% trans "Form Metadata" %}
        </a>
      </li>
-@@ -151,29 +151,29 @@
+@@ -155,29 +151,29 @@
  
    {% if instance.attachments %}
      <li>
@@ -81,7 +92,7 @@
              <i class="fa fa-shower"></i>
              {% trans 'Clean Form Submission' %}
            </button>
-@@ -185,9 +185,9 @@
+@@ -189,9 +185,9 @@
                    data-content="{% trans "Archived forms will no longer show up in reports and they will be removed from any relevant case histories. " %}"
                    data-placement="left"
              ></span>
@@ -93,7 +104,7 @@
              </button>
            </form>
          {% elif edit_info.was_edited %}
-@@ -197,9 +197,9 @@
+@@ -201,9 +197,9 @@
                    data-content="{% trans "Restoring an edited form will undo any later edits made. This operation is reversible." %}"
                    data-placement="left"
              ></span>
@@ -105,7 +116,7 @@
              </button>
            </form>
          {% endif %}
-@@ -211,9 +211,9 @@
+@@ -215,9 +211,9 @@
                    data-content="{% trans "Restoring this form will cause it to show up in reports again." %}"
                    data-placement="left"
              ></span>
@@ -117,7 +128,7 @@
              </button>
            </form>
          {% endif %}
-@@ -225,9 +225,9 @@
+@@ -229,9 +225,9 @@
                    data-content="{% trans "Resaving a form manually can cause it to be reincluded in reports if something went wrong during initial processing." %}"
                    data-placement="left"
              ></span>
@@ -129,7 +140,7 @@
              </button>
            </form>
          {% endif %}
-@@ -238,7 +238,7 @@
+@@ -242,7 +238,7 @@
                    data-content="{% trans "This is a permanent action that cannot be undone." %}"
                    data-placement="left"
              ></span>
@@ -138,7 +149,7 @@
                <i class="fa-regular fa-trash-can"></i>
                {% trans 'Delete this form' %}
              </button>
-@@ -247,20 +247,20 @@
+@@ -251,20 +247,20 @@
  
        {% endif %}
      </div>
@@ -165,7 +176,7 @@
                     href="#form-case-acc-{{ forloop.counter }}">
                    {% if case_data.valid_case and case_data.name %}
                      {{ case_data.name }}
-@@ -270,11 +270,11 @@
+@@ -274,11 +270,11 @@
                  </a>
  
                  {% if case_data.valid_case %}
@@ -180,7 +191,7 @@
                          {% trans "View" %}
                        </a>
                      {% endif %}
-@@ -282,11 +282,11 @@
+@@ -286,11 +282,11 @@
                  {% endif %}
                </h4>
              </div>
@@ -194,7 +205,7 @@
                </div>
              </div>
            </div>
-@@ -320,7 +320,7 @@
+@@ -324,7 +320,7 @@
  
    {% if form_meta_data %}
      <div class="tab-pane" id="form-metadata">
@@ -203,16 +214,16 @@
      </div>
    {% endif %}
  
-@@ -329,7 +329,7 @@
-       <table class="table table-striped table-hover">
-         {% for key, attachment in instance.attachments.items %}
-           <tr><td>
--            <dl class="dl-horizontal">
-+            <dl class="dl-horizontal">  {# todo B5: css:dl-horizontal #}
-               {% if not forloop.first %}<br>{% endif %}
-               <dt>{{ key }}</dt>
+@@ -341,7 +337,7 @@
+             <div class="mb-2">{{ key }}</div>
+             <div>
                {% if attachment.is_image %}
-@@ -345,10 +345,10 @@
+-                <img src="{% url "api_form_attachment" domain=domain instance_id=instance.form_id attachment_id=key %}" class="img-responsive">
++                <img src="{% url "api_form_attachment" domain=domain instance_id=instance.form_id attachment_id=key %}" class="img-fluid">
+               {% else %}
+                 <a href="{% url "api_form_attachment" domain instance.form_id key %}" download="{{ key }}">{% trans "Download" %}</a>
+               {% endif %}
+@@ -353,10 +349,10 @@
    {% endif %}
    <div class="tab-pane" id="form-xml">
      <p class="btn-group">
@@ -225,7 +236,7 @@
          <i class="fa-regular fa-files"></i>&nbsp;{% trans "Copy XML to clipboard" %}
        </button>
      </p>
-@@ -358,15 +358,15 @@
+@@ -366,15 +362,15 @@
  
  {% if show_edit_options %}
    {% if show_edit_submission %}
@@ -244,7 +255,7 @@
          <h4 class="modal-title">{% trans 'Permanently Delete Form' %}</h4>
        </div>
        <div class="modal-body">
-@@ -383,10 +383,10 @@
+@@ -391,10 +387,10 @@
              {% endblocktrans %}
            </p>
            <div class="modal-footer">

--- a/corehq/apps/reports/templates/reports/form/partials/bootstrap3/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/bootstrap3/single_form.html
@@ -333,7 +333,7 @@
               {% if not forloop.first %}<br>{% endif %}
               <dt>{{ key }}</dt>
               {% if attachment.is_image %}
-                <dd><img src="{% url "api_form_attachment" domain=domain instance_id=instance.form_id attachment_id=key %}"></dd>
+                <dd><img src="{% url "api_form_attachment" domain=domain instance_id=instance.form_id attachment_id=key %}" class="img-responsive"></dd>
               {% else %}
                 <dd><a href="{% url "api_form_attachment" domain instance.form_id key %}" download="{{ key }}">{% trans "Download" %}</a></dd>
               {% endif %}

--- a/corehq/apps/reports/templates/reports/form/partials/bootstrap3/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/bootstrap3/single_form.html
@@ -50,6 +50,10 @@
     background-color: #fcf8e3;
     text-align: center;
   }
+  .mb-2 {
+    /* bootstrap5 forward-compatibility */
+    margin-bottom: 0.5rem;
+  }
 </style>
 
 {% if is_archived %}
@@ -324,20 +328,24 @@
     </div>
   {% endif %}
 
-  {% if instance.attachments %}
+  {% if attachments %}
     <div class="tab-pane" id="form-attachments">
       <table class="table table-striped table-hover">
-        {% for key, attachment in instance.attachments.items %}
+        {% for key, attachment, question in attachments %}
           <tr><td>
-            <dl class="dl-horizontal">
-              {% if not forloop.first %}<br>{% endif %}
-              <dt>{{ key }}</dt>
+            {% if question %}
+            <div class="span6 mb-2" title="{{ question.value }}">
+              {% include 'reports/form/partials/single_form_label.html' %}
+            </div>
+            {% endif %}
+            <div class="mb-2">{{ key }}</div>
+            <div>
               {% if attachment.is_image %}
-                <dd><img src="{% url "api_form_attachment" domain=domain instance_id=instance.form_id attachment_id=key %}" class="img-responsive"></dd>
+                <img src="{% url "api_form_attachment" domain=domain instance_id=instance.form_id attachment_id=key %}" class="img-responsive">
               {% else %}
-                <dd><a href="{% url "api_form_attachment" domain instance.form_id key %}" download="{{ key }}">{% trans "Download" %}</a></dd>
+                <a href="{% url "api_form_attachment" domain instance.form_id key %}" download="{{ key }}">{% trans "Download" %}</a>
               {% endif %}
-            </dl>
+            </div>
           </td></tr>
         {% endfor %}
       </table>

--- a/corehq/apps/reports/templates/reports/form/partials/bootstrap3/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/bootstrap3/single_form.html
@@ -334,9 +334,9 @@
         {% for key, attachment, question in attachments %}
           <tr><td>
             {% if question %}
-            <div class="span6 mb-2" title="{{ question.value }}">
-              {% include 'reports/form/partials/single_form_label.html' %}
-            </div>
+              <div class="mb-2" title="{{ question.value }}">
+                {% include 'reports/form/partials/single_form_label.html' %}
+              </div>
             {% endif %}
             <div class="mb-2">{{ key }}</div>
             <div>

--- a/corehq/apps/reports/templates/reports/form/partials/bootstrap5/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/bootstrap5/single_form.html
@@ -324,20 +324,24 @@
     </div>
   {% endif %}
 
-  {% if instance.attachments %}
+  {% if attachments %}
     <div class="tab-pane" id="form-attachments">
       <table class="table table-striped table-hover">
-        {% for key, attachment in instance.attachments.items %}
+        {% for key, attachment, question in attachments %}
           <tr><td>
-            <dl class="dl-horizontal">  {# todo B5: css:dl-horizontal #}
-              {% if not forloop.first %}<br>{% endif %}
-              <dt>{{ key }}</dt>
+            {% if question %}
+            <div class="span6 mb-2" title="{{ question.value }}">
+              {% include 'reports/form/partials/single_form_label.html' %}
+            </div>
+            {% endif %}
+            <div class="mb-2">{{ key }}</div>
+            <div>
               {% if attachment.is_image %}
-                <dd><img src="{% url "api_form_attachment" domain=domain instance_id=instance.form_id attachment_id=key %}" class="img-fluid"></dd>
+                <img src="{% url "api_form_attachment" domain=domain instance_id=instance.form_id attachment_id=key %}" class="img-fluid">
               {% else %}
-                <dd><a href="{% url "api_form_attachment" domain instance.form_id key %}" download="{{ key }}">{% trans "Download" %}</a></dd>
+                <a href="{% url "api_form_attachment" domain instance.form_id key %}" download="{{ key }}">{% trans "Download" %}</a>
               {% endif %}
-            </dl>
+            </div>
           </td></tr>
         {% endfor %}
       </table>

--- a/corehq/apps/reports/templates/reports/form/partials/bootstrap5/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/bootstrap5/single_form.html
@@ -330,9 +330,9 @@
         {% for key, attachment, question in attachments %}
           <tr><td>
             {% if question %}
-            <div class="span6 mb-2" title="{{ question.value }}">
-              {% include 'reports/form/partials/single_form_label.html' %}
-            </div>
+              <div class="mb-2" title="{{ question.value }}">
+                {% include 'reports/form/partials/single_form_label.html' %}
+              </div>
             {% endif %}
             <div class="mb-2">{{ key }}</div>
             <div>

--- a/corehq/apps/reports/templates/reports/form/partials/bootstrap5/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/bootstrap5/single_form.html
@@ -333,7 +333,7 @@
               {% if not forloop.first %}<br>{% endif %}
               <dt>{{ key }}</dt>
               {% if attachment.is_image %}
-                <dd><img src="{% url "api_form_attachment" domain=domain instance_id=instance.form_id attachment_id=key %}"></dd>
+                <dd><img src="{% url "api_form_attachment" domain=domain instance_id=instance.form_id attachment_id=key %}" class="img-fluid"></dd>
               {% else %}
                 <dd><a href="{% url "api_form_attachment" domain instance.form_id key %}" download="{{ key }}">{% trans "Download" %}</a></dd>
               {% endif %}


### PR DESCRIPTION
Improve layout of the Attachments tab on Form Submission History pages:
- Label the image with the relevant form question type icon, label, and question ID (title tooltip) if available.
- Scale images to fit in the browser window rather than displaying them at their native resolution.

| Before | After |
|--------|--------|
| <img width="814" height="1064" alt="image" src="https://github.com/user-attachments/assets/d572953a-fa08-4709-a47e-a21f320140aa" /> | <img width="814" height="1064" alt="image" src="https://github.com/user-attachments/assets/fd8aad20-f86e-4fed-bdf6-d34335519305" /> |

## Safety Assurance

### Safety story

Adds a utility to map attachments to relevant questions via response. Small markup and styling changes to the Sumission History > Attachments tab.

### Automated test coverage

No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations