### PR TITLE
Make sure callback is called exactly once

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/google.js
+++ b/corehq/apps/analytics/static/analytix/js/google.js
@@ -83,7 +83,7 @@ define('analytix/js/google', [
      */
     var trackEvent = function (eventCategory, eventAction, eventLabel, eventValue, eventParameters, eventCallback) {
         var originalArgs = arguments;
-        const safeCallback = utils.createSafeCallback(eventCallback, 2000);
+        const safeCallback = utils.createSafeCallback(eventCallback);
         _ready.done(function () {
             var params = {
                 event_category: eventCategory,

--- a/corehq/apps/analytics/static/analytix/js/google.js
+++ b/corehq/apps/analytics/static/analytix/js/google.js
@@ -83,12 +83,13 @@ define('analytix/js/google', [
      */
     var trackEvent = function (eventCategory, eventAction, eventLabel, eventValue, eventParameters, eventCallback) {
         var originalArgs = arguments;
+        const safeCallback = utils.createSafeCallback(eventCallback, 2000);
         _ready.done(function () {
             var params = {
                 event_category: eventCategory,
                 event_label: eventLabel,
                 event_value: eventValue,
-                event_callback: eventCallback,
+                event_callback: safeCallback,
                 event_action: eventAction,
             };
             if (_.isObject(eventParameters)) {
@@ -97,8 +98,8 @@ define('analytix/js/google', [
             _logger.debug.log(_logger.fmt.labelArgs(["Category", "Action", "Label", "Value", "Parameters", "Callback"], originalArgs), "Event Recorded");
             _gtag('event', eventAction, params);
         }).fail(function () {
-            if (_.isFunction(eventCallback)) {
-                eventCallback();
+            if (_.isFunction(safeCallback)) {
+                safeCallback();
             }
         });
     };


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Before:
As shown in the video: https://www.loom.com/share/c69387f7d6774de282921fbfa8094647
The delete button will have 3 spinners
<img width="392" height="155" alt="image" src="https://github.com/user-attachments/assets/fc3307f0-8add-4773-9b11-7d8d46789d08" />

After:
<img width="393" height="156" alt="image" src="https://github.com/user-attachments/assets/02a131ea-a498-4669-b782-e10c78ccc741" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19156

By setup breakpoint, I find out `$deleteGroupModalForm.submit();` has been called 3 times, which will eventually call [addSpinnerToButton](https://github.com/dimagi/commcare-hq/blob/22210808c8e3dc5e356587104b24c680b8354948/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/hq.helpers.js#L100) 3 times.

A Tag Assistant trace confirmed that the site is running a multi-tag environment (GTM, Universal Analytics (GA3), and GA4 simultaneously). Calling `_gtag` will push the callback to `window.dataLayer` [here](https://github.com/dimagi/commcare-hq/blob/22210808c8e3dc5e356587104b24c680b8354948/corehq/apps/analytics/static/analytix/js/google.js#L36-L39), then each of these services independently processes dataLayer events, leading to the callback function being invoked three times.

I utilized the existing `utils.createSafeCallback` to make sure the callback is executed only once for better user experience.

This is not reproducible locally, so might due to how we setup GA on staging and prod.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on staging.
Just add a wrapper to make sure the callback is only called once.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
