### PR TITLE
B5: Various Todos in App Manager

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -5,7 +5,7 @@ import "commcarehq";
 import $ from "jquery";
 import ko from "knockout";
 import _ from "underscore";
-import { Modal, Tooltip } from "bootstrap5";
+import { Modal } from "bootstrap5";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import commcareSettings from "app_manager/js/settings/bootstrap5/commcare_settings";
 import supportedLanguages from "app_manager/js/bootstrap5/supported_languages";

--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -267,8 +267,4 @@ $(function () {
         saveButton.ui.appendTo($saveContainer);
         sectionChanger.attachToForm($saveContainer);
     })();
-
-    // Initialize tooltips
-    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
-    [...tooltipTriggerList].map((tooltipTriggerEl) => new Tooltip(tooltipTriggerEl));
 });

--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
@@ -2,6 +2,7 @@ import "commcarehq";
 import $ from "jquery";
 import ko from "knockout";
 import _ from "underscore";
+import { Modal, Popover } from "bootstrap5";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import hqLayout from "hqwebapp/js/layout";
 import toggles from "hqwebapp/js/toggles";
@@ -179,25 +180,30 @@ var _initCommcareVersion = function (args) {
  * @private
  */
 var _initAddItemPopovers = function () {
-    $('.js-add-new-item').popover({  /* todo B5: js-popover */
-        title: gettext("Add"),
-        container: 'body',
-        sanitize: false,
-        content: function () {
-            var template = $('.js-popover-template-add-item-content[data-slug="form"]').text();
-            return _.template(template)($(this).data());
-        },
-        html: true,
-        trigger: 'manual',
-        placement: 'right',
-        template: $('#js-popover-template-add-item').text(),
-    }).on('show.bs.popover', function () {
+    const $popoverEls = $('.js-add-new-item');
+    _.each($popoverEls, (el) => {
+        new Popover(el ,{
+            title: gettext("Add"),
+            container: 'body',
+            sanitize: false,
+            content: function () {
+                var template = $('.js-popover-template-add-item-content[data-slug="form"]').text();
+                return _.template(template)($(el).data());
+            },
+            html: true,
+            trigger: 'manual',
+            placement: 'right',
+            template: $('#js-popover-template-add-item').text(),
+        });
+    });
+    $popoverEls.on('show.bs.popover', function () {
         // Close any other open popover
-        $('.js-add-new-item').not($(this)).popover('hide');  /* todo B5: js-popover */
+        const $otherEls = $('.js-add-new-item').not($(this));
+        _.each($otherEls, (el) => Popover.getInstance(el).hide());
     }).one('shown.bs.popover', function () {
         var pop = this;
         $('.popover-additem').on('click', function (e) {
-            $(pop).popover('hide');  /* todo B5: js-popover */
+            Popover.getInstance(pop).hide();
             var dataType = $(e.target).closest('button').data('type'),
                 stopSubmit = $(e.target).closest('button').data('stopsubmit') === 'yes',
                 $form;
@@ -207,7 +213,7 @@ var _initAddItemPopovers = function () {
             }
 
             var caseAction =  $(e.target).closest('button').data('case-action'),
-                $popoverContent = $(e.target).closest(".popover-content > *"),
+                $popoverContent = $(e.target).closest(".popover-body > *"),
                 moduleId = $popoverContent.data("module-unique-id"),
                 $trigger = $('.js-add-new-item[data-module-unique-id="' + moduleId + '"]');
 
@@ -222,13 +228,13 @@ var _initAddItemPopovers = function () {
         });
     }).on('click', function (e) {
         e.preventDefault();
-        $(this).popover('show');  /* todo B5: js-popover */
+        Popover.getInstance(this).show();
     });
 
     // Close any open popover when user clicks elsewhere on the page
     $('body').click(function (event) {
         if (!($(event.target).hasClass('appnav-add') || $(event.target).hasClass('popover-additem-option') || $(event.target).hasClass('fa'))) {
-            $('.js-add-new-item').popover('hide');  /* todo B5: js-popover */
+            _.each($popoverEls, (el) => Popover.getInstance(el).hide());
         }
     });
 };
@@ -671,7 +677,7 @@ var _initNewModuleOptionClicks = function () {
     $('.new-module-option').each(function () {
         var type = $(this).data('type');
         if (hoverHelpTexts[type]) {
-            $(this).popover({  /* todo B5: js-popover */
+            new Popover(this, {
                 title: hoverHelpTexts[type].title,
                 content: hoverHelpTexts[type].content,
                 trigger: 'hover',

--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
@@ -2,7 +2,7 @@ import "commcarehq";
 import $ from "jquery";
 import ko from "knockout";
 import _ from "underscore";
-import { Modal, Popover } from "bootstrap5";
+import { Modal, Popover, Tooltip } from "bootstrap5";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import hqLayout from "hqwebapp/js/layout";
 import toggles from "hqwebapp/js/toggles";
@@ -349,7 +349,7 @@ var _initMenuItemSorting = function () {
         });
     }
     function promptToSaveOrdering() {
-        $("#reorder_modules_modal").modal('show');  /* todo B5: js-modal */
+        Modal.getOrCreateInstance("#reorder_modules_modal").show();
     }
     function initSortable($sortable) {
         var options = {
@@ -486,7 +486,9 @@ $(function () {
         }
     });
 
-    $('[data-toggle="tooltip"]').tooltip();  /* todo B5: js-tooltip */
+    _.each($('[data-bs-toggle="tooltip"]'), (el) => {
+        Tooltip.getOrCreateInstance(el);
+    });
 
     // https://github.com/twitter/bootstrap/issues/6122
     // this is necessary to get popovers to be able to extend
@@ -514,13 +516,17 @@ $(function () {
     });
 
     // Handling for popup displayed when accessing a deleted app
-    $('#deleted-app-modal').modal({  /* todo B5: js-modal */
-        backdrop: 'static',
-        keyboard: false,
-        show: true,
-    }).on('hide.bs.modal', function () {
-        window.location = initialPageData.reverse('dashboard_default');
-    });
+    const $deletedAppModalEl = $('#deleted-app-modal');
+    if ($deletedAppModalEl.length) {
+        new Modal($deletedAppModalEl, {
+            backdrop: 'static',
+            keyboard: false,
+            show: true,
+        });
+        $deletedAppModalEl.on('hide.bs.modal', function () {
+            window.location = initialPageData.reverse('dashboard_default');
+        });
+    }
 
     // Set up app preview
     previewApp.initPreviewWindow();

--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
@@ -536,15 +536,15 @@ var _initNewModuleOptionClicks = function () {
         var $form = $('#new-module-form');
 
         if (moduleType === "case") {
-            $('#add-new-module-modal').modal('hide');  /* todo B5: js-modal */
-            $('#define-case-type-modal').modal('show');  /* todo B5: js-modal */
+            Modal.getInstance('#add-new-module-modal').hide();
+            Modal.getOrCreateInstance('#define-case-type-modal').show();
         } else {
             if (moduleType === "survey") {
                 google.track.event("Added Surveys Menu");
                 noopMetrics.track.event("Added Surveys Menu");
             }
             $('.new-module-icon').removeClass().addClass("fa fa-refresh fa-spin");
-            $('#add-new-module-modal').modal('hide');  /* todo B5: js-modal */
+            Modal.getInstance('#add-new-module-modal').hide();
             $form.submit();
         }
     });
@@ -594,7 +594,7 @@ var _initNewModuleOptionClicks = function () {
                 // Reset error states
                 $formGroup.removeClass('has-error');
                 $help.show();
-                $error.hide();
+                $error.addClass('d-none');
                 $createBtn.prop('disabled', false);
 
                 if (!valueNoSpaces) {
@@ -605,7 +605,7 @@ var _initNewModuleOptionClicks = function () {
                 function displayError(errorMsg) {
                     $formGroup.addClass('has-error');
                     $error.html(errorMsg);
-                    $error.show();
+                    $error.removeClass('d-none');
                     $help.hide();
                     $createBtn.prop('disabled', true);
                 }
@@ -642,14 +642,14 @@ var _initNewModuleOptionClicks = function () {
         newCaseTypeHiddenInput.val(value);
 
         $('.new-module-icon').removeClass().addClass("fa fa-refresh fa-spin");
-        $('#define-case-type-modal').modal('hide');  /* todo B5: js-modal */
+        Modal.getInstance('#define-case-type-modal').hide();
         $form.submit();
     });
 
     // Handle "Go Back" button click
     $('#case-type-go-back-btn').on('click', function () {
-        $('#define-case-type-modal').modal('hide');  /* todo B5: js-modal */
-        $('#add-new-module-modal').modal('show');  /* todo B5: js-modal */
+        Modal.getInstance('#define-case-type-modal').hide();
+        Modal.getOrCreateInstance('#add-new-module-modal').show();
     });
 
     // Clear selection when modal is hidden

--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
@@ -598,13 +598,11 @@ var _initNewModuleOptionClicks = function () {
 
             $caseType.on('change', function () {
                 var valueNoSpaces = $(this).val();
-                var $formGroup = $(this).closest('.form-group');
                 var $help = $('#new-case-type-help');
                 var $error = $('#new-case-type-error');
                 var $createBtn = $('#case-type-create-btn');
 
                 // Reset error states
-                $formGroup.removeClass('has-error');
                 $help.show();
                 $error.addClass('d-none');
                 $createBtn.prop('disabled', false);
@@ -615,7 +613,6 @@ var _initNewModuleOptionClicks = function () {
                 }
 
                 function displayError(errorMsg) {
-                    $formGroup.addClass('has-error');
                     $error.html(errorMsg);
                     $error.removeClass('d-none');
                     $help.hide();

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/add_item_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/add_item_templates.html
@@ -2,9 +2,9 @@
 
 <script type="text/html" id="js-popover-template-add-item">
   <div class="popover popover-additem" role="tooltip">
-    <div class="arrow"></div>
-    <h3 class="popover-title"></h3>
-    <div class="popover-content"></div>
+    <div class="popover-arrow"></div>
+    <h3 class="popover-header"></h3>
+    <div class="popover-body"></div>
   </div>
 </script>
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/define_case_type_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/define_case_type_modal.html
@@ -51,7 +51,7 @@
                 <option value=""></option>
               </select>
               <div
-                class="help-block d-none"
+                class="help-block text-danger d-none"
                 id="new-case-type-error"
               ></div>
               <div class="help-block" id="new-case-type-help">

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/define_case_type_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/define_case_type_modal.html
@@ -8,7 +8,7 @@
   id="define-case-type-modal"
 >
   <div class="modal-dialog" role="document">
-    <div class="modal-content border-bottom border-secondary">
+    <div class="modal-content">
       <div class="modal-header">
         <h4 class="modal-title">
           <i class="fa-solid fa-list-check"></i> {% trans "Case List" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/define_case_type_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/define_case_type_modal.html
@@ -8,28 +8,25 @@
   id="define-case-type-modal"
 >
   <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <!-- B5 TODO: Replace inline styles with B5 utility classes -->
-      <div class="modal-header" style="border-bottom: 1px solid lightgray;">  {# todo B5: inline-style #}
-        <button
-          type="button"
-          class="btn-close"  {# todo B5: css-close #}
-          data-bs-dismiss="modal"
-          aria-label="{% trans 'Close' %}"
-        >
-          <span aria-hidden="true">&times;</span>
-        </button>
+    <div class="modal-content border-bottom border-secondary">
+      <div class="modal-header">
         <h4 class="modal-title">
           <i class="fa-solid fa-list-check"></i> {% trans "Case List" %}
         </h4>
+        <button
+          type="button"
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="{% trans 'Close' %}"
+        ></button>
       </div>
       <div class="modal-body">
         <p class="lead">
           {% trans "Please define a case type for your case list." %}
         </p>
-        <div class="form-horizontal" style="margin-top: 30px;">  {# todo B5: inline-style #}
-          <div class="form-group">  {# todo B5: css-form-group #}
-            <label class="form-label col-md-3">
+        <div class="mt-3">
+          <div class="row mb-3">
+            <label for="new-case-type-dropdown" class="col-form-label col-md-3">
               {% trans "Case Type" %}
               {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
                 <span
@@ -45,18 +42,17 @@
                 ></span>
               {% endif %}
             </label>
-            <div class="col-md-6">
-              <select  {# todo B5: css-select-form-control #}
-                class="form-control"
+            <div class="col-md">
+              <select
+                class="form-select"
                 id="new-case-type-dropdown"
                 name="new-case-type-dropdown"
               >
                 <option value=""></option>
               </select>
               <div
-                class="help-block"
+                class="help-block d-none"
                 id="new-case-type-error"
-                style="display: none;"  {# todo B5: inline-style #}
               ></div>
               <div class="help-block" id="new-case-type-help">
                 {% trans "* You can change the Case Type later by going to the menu settings page" %}

--- a/corehq/apps/hqwebapp/static/app_manager/scss/includes/_popover.scss
+++ b/corehq/apps/hqwebapp/static/app_manager/scss/includes/_popover.scss
@@ -4,14 +4,15 @@
   border-radius: 0;
   color: $cc-light-cool-accent-hi;
   border: 0;
+  border-color: $cc-light-cool-accent-low;
 
-  .popover-title {
+  .popover-header {
     background-color: transparent;
     text-transform: uppercase;
-    font-size: 1.2rem;
+    font-size: 0.75rem;
     border-bottom: 1px solid darken($cc-light-cool-accent-low, 2);
   }
-  &.right > .arrow:after {
+  &.bs-popover-auto > .popover-arrow::after {
     border-right-color: $cc-light-cool-accent-low;
   }
 }
@@ -30,7 +31,7 @@
   padding-bottom: 25px;
   text-align: center;
   transition: background 0.5s;
-  font-size: 1.2rem;
+  font-size: 0.75rem;
   &:focus {
     color: $cc-light-cool-accent-hi;
   }
@@ -43,7 +44,7 @@
 
   > [class*="fa-"],
   > .fcc {
-    font-size: 4.5rem;
+    font-size: 2.8125rem;
     display: block;
     text-align: center;
     width: 100%;
@@ -51,7 +52,7 @@
   }
 
   > .fcc {
-    font-size: 5.15rem;
+    font-size: 3.2188rem;
     margin-top: -5px;
   }
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/add_item_templates.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/add_item_templates.html.diff.txt
@@ -1,5 +1,18 @@
 --- 
 +++ 
+@@ -2,9 +2,9 @@
+ 
+ <script type="text/html" id="js-popover-template-add-item">
+   <div class="popover popover-additem" role="tooltip">
+-    <div class="arrow"></div>
+-    <h3 class="popover-title"></h3>
+-    <div class="popover-content"></div>
++    <div class="popover-arrow"></div>
++    <h3 class="popover-header"></h3>
++    <div class="popover-body"></div>
+   </div>
+ </script>
+ 
 @@ -15,7 +15,7 @@
  >
    <div data-module-unique-id="<%- moduleUniqueId %>">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/define_case_type_modal.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/define_case_type_modal.html.diff.txt
@@ -1,54 +1,68 @@
 --- 
 +++ 
-@@ -10,11 +10,11 @@
+@@ -8,28 +8,25 @@
+   id="define-case-type-modal"
+ >
    <div class="modal-dialog" role="document">
-     <div class="modal-content">
-       <!-- B5 TODO: Replace inline styles with B5 utility classes -->
+-    <div class="modal-content">
+-      <!-- B5 TODO: Replace inline styles with B5 utility classes -->
 -      <div class="modal-header" style="border-bottom: 1px solid lightgray;">
-+      <div class="modal-header" style="border-bottom: 1px solid lightgray;">  {# todo B5: inline-style #}
-         <button
-           type="button"
+-        <button
+-          type="button"
 -          class="close"
 -          data-dismiss="modal"
-+          class="btn-close"  {# todo B5: css-close #}
+-          aria-label="{% trans 'Close' %}"
+-        >
+-          <span aria-hidden="true">&times;</span>
+-        </button>
++    <div class="modal-content border-bottom border-secondary">
++      <div class="modal-header">
+         <h4 class="modal-title">
+           <i class="fa-solid fa-list-check"></i> {% trans "Case List" %}
+         </h4>
++        <button
++          type="button"
++          class="btn-close"
 +          data-bs-dismiss="modal"
-           aria-label="{% trans 'Close' %}"
-         >
-           <span aria-hidden="true">&times;</span>
-@@ -27,9 +27,9 @@
++          aria-label="{% trans 'Close' %}"
++        ></button>
+       </div>
+       <div class="modal-body">
          <p class="lead">
            {% trans "Please define a case type for your case list." %}
          </p>
 -        <div class="form-horizontal" style="margin-top: 30px;">
 -          <div class="form-group">
 -            <label class="control-label col-sm-3">
-+        <div class="form-horizontal" style="margin-top: 30px;">  {# todo B5: inline-style #}
-+          <div class="form-group">  {# todo B5: css-form-group #}
-+            <label class="form-label col-md-3">
++        <div class="mt-3">
++          <div class="row mb-3">
++            <label for="new-case-type-dropdown" class="col-form-label col-md-3">
                {% trans "Case Type" %}
                {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
                  <span
-@@ -45,8 +45,8 @@
+@@ -45,18 +42,17 @@
                  ></span>
                {% endif %}
              </label>
 -            <div class="col-sm-6">
--              <select
-+            <div class="col-md-6">
-+              <select  {# todo B5: css-select-form-control #}
-                 class="form-control"
++            <div class="col-md">
+               <select
+-                class="form-control"
++                class="form-select"
                  id="new-case-type-dropdown"
                  name="new-case-type-dropdown"
-@@ -56,7 +56,7 @@
+               >
+                 <option value=""></option>
+               </select>
                <div
-                 class="help-block"
+-                class="help-block"
++                class="help-block d-none"
                  id="new-case-type-error"
 -                style="display: none;"
-+                style="display: none;"  {# todo B5: inline-style #}
                ></div>
                <div class="help-block" id="new-case-type-help">
                  {% trans "* You can change the Case Type later by going to the menu settings page" %}
-@@ -68,8 +68,8 @@
+@@ -68,8 +64,8 @@
        <div class="modal-footer">
          <button
            type="button"

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/define_case_type_modal.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/define_case_type_modal.html.diff.txt
@@ -56,7 +56,7 @@
                </select>
                <div
 -                class="help-block"
-+                class="help-block d-none"
++                class="help-block text-danger d-none"
                  id="new-case-type-error"
 -                style="display: none;"
                ></div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/define_case_type_modal.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/define_case_type_modal.html.diff.txt
@@ -1,10 +1,9 @@
 --- 
 +++ 
-@@ -8,28 +8,25 @@
-   id="define-case-type-modal"
+@@ -9,27 +9,24 @@
  >
    <div class="modal-dialog" role="document">
--    <div class="modal-content">
+     <div class="modal-content">
 -      <!-- B5 TODO: Replace inline styles with B5 utility classes -->
 -      <div class="modal-header" style="border-bottom: 1px solid lightgray;">
 -        <button
@@ -15,7 +14,6 @@
 -        >
 -          <span aria-hidden="true">&times;</span>
 -        </button>
-+    <div class="modal-content border-bottom border-secondary">
 +      <div class="modal-header">
          <h4 class="modal-title">
            <i class="fa-solid fa-list-check"></i> {% trans "Case List" %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/app_manager.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/app_manager.js.diff.txt
@@ -1,6 +1,13 @@
 --- 
 +++ 
-@@ -8,10 +8,10 @@
+@@ -2,16 +2,17 @@
+ import $ from "jquery";
+ import ko from "knockout";
+ import _ from "underscore";
++import { Modal, Popover, Tooltip } from "bootstrap5";
+ import initialPageData from "hqwebapp/js/initial_page_data";
+ import hqLayout from "hqwebapp/js/layout";
+ import toggles from "hqwebapp/js/toggles";
  import uiElementLangcodeButton from "hqwebapp/js/ui_elements/ui-element-langcode-button";
  import google from "analytix/js/google";
  import noopMetrics from "analytix/js/noopMetrics";
@@ -14,80 +21,130 @@
  import sectionChanger from "app_manager/js/section_changer";
  import "hqwebapp/js/components/inline_edit";  // app, menu, and form names and comments all use these
  import "select2/dist/js/select2.full.min";
-@@ -179,7 +179,7 @@
+@@ -179,25 +180,30 @@
   * @private
   */
  var _initAddItemPopovers = function () {
 -    $('.js-add-new-item').popover({
-+    $('.js-add-new-item').popover({  /* todo B5: js-popover */
-         title: gettext("Add"),
-         container: 'body',
-         sanitize: false,
-@@ -193,11 +193,11 @@
-         template: $('#js-popover-template-add-item').text(),
-     }).on('show.bs.popover', function () {
+-        title: gettext("Add"),
+-        container: 'body',
+-        sanitize: false,
+-        content: function () {
+-            var template = $('.js-popover-template-add-item-content[data-slug="form"]').text();
+-            return _.template(template)($(this).data());
+-        },
+-        html: true,
+-        trigger: 'manual',
+-        placement: 'right',
+-        template: $('#js-popover-template-add-item').text(),
+-    }).on('show.bs.popover', function () {
++    const $popoverEls = $('.js-add-new-item');
++    _.each($popoverEls, (el) => {
++        new Popover(el ,{
++            title: gettext("Add"),
++            container: 'body',
++            sanitize: false,
++            content: function () {
++                var template = $('.js-popover-template-add-item-content[data-slug="form"]').text();
++                return _.template(template)($(el).data());
++            },
++            html: true,
++            trigger: 'manual',
++            placement: 'right',
++            template: $('#js-popover-template-add-item').text(),
++        });
++    });
++    $popoverEls.on('show.bs.popover', function () {
          // Close any other open popover
 -        $('.js-add-new-item').not($(this)).popover('hide');
-+        $('.js-add-new-item').not($(this)).popover('hide');  /* todo B5: js-popover */
++        const $otherEls = $('.js-add-new-item').not($(this));
++        _.each($otherEls, (el) => Popover.getInstance(el).hide());
      }).one('shown.bs.popover', function () {
          var pop = this;
          $('.popover-additem').on('click', function (e) {
 -            $(pop).popover('hide');
-+            $(pop).popover('hide');  /* todo B5: js-popover */
++            Popover.getInstance(pop).hide();
              var dataType = $(e.target).closest('button').data('type'),
                  stopSubmit = $(e.target).closest('button').data('stopsubmit') === 'yes',
                  $form;
-@@ -222,13 +222,13 @@
+@@ -207,7 +213,7 @@
+             }
+ 
+             var caseAction =  $(e.target).closest('button').data('case-action'),
+-                $popoverContent = $(e.target).closest(".popover-content > *"),
++                $popoverContent = $(e.target).closest(".popover-body > *"),
+                 moduleId = $popoverContent.data("module-unique-id"),
+                 $trigger = $('.js-add-new-item[data-module-unique-id="' + moduleId + '"]');
+ 
+@@ -222,13 +228,13 @@
          });
      }).on('click', function (e) {
          e.preventDefault();
 -        $(this).popover('show');
-+        $(this).popover('show');  /* todo B5: js-popover */
++        Popover.getInstance(this).show();
      });
  
      // Close any open popover when user clicks elsewhere on the page
      $('body').click(function (event) {
          if (!($(event.target).hasClass('appnav-add') || $(event.target).hasClass('popover-additem-option') || $(event.target).hasClass('fa'))) {
 -            $('.js-add-new-item').popover('hide');
-+            $('.js-add-new-item').popover('hide');  /* todo B5: js-popover */
++            _.each($popoverEls, (el) => Popover.getInstance(el).hide());
          }
      });
  };
-@@ -343,7 +343,7 @@
+@@ -343,7 +349,7 @@
          });
      }
      function promptToSaveOrdering() {
 -        $("#reorder_modules_modal").modal('show');
-+        $("#reorder_modules_modal").modal('show');  /* todo B5: js-modal */
++        Modal.getOrCreateInstance("#reorder_modules_modal").show();
      }
      function initSortable($sortable) {
          var options = {
-@@ -480,7 +480,7 @@
+@@ -480,7 +486,9 @@
          }
      });
  
 -    $('[data-toggle="tooltip"]').tooltip();
-+    $('[data-toggle="tooltip"]').tooltip();  /* todo B5: js-tooltip */
++    _.each($('[data-bs-toggle="tooltip"]'), (el) => {
++        Tooltip.getOrCreateInstance(el);
++    });
  
      // https://github.com/twitter/bootstrap/issues/6122
      // this is necessary to get popovers to be able to extend
-@@ -508,7 +508,7 @@
+@@ -508,13 +516,17 @@
      });
  
      // Handling for popup displayed when accessing a deleted app
 -    $('#deleted-app-modal').modal({
-+    $('#deleted-app-modal').modal({  /* todo B5: js-modal */
-         backdrop: 'static',
-         keyboard: false,
-         show: true,
-@@ -536,15 +536,15 @@
+-        backdrop: 'static',
+-        keyboard: false,
+-        show: true,
+-    }).on('hide.bs.modal', function () {
+-        window.location = initialPageData.reverse('dashboard_default');
+-    });
++    const $deletedAppModalEl = $('#deleted-app-modal');
++    if ($deletedAppModalEl.length) {
++        new Modal($deletedAppModalEl, {
++            backdrop: 'static',
++            keyboard: false,
++            show: true,
++        });
++        $deletedAppModalEl.on('hide.bs.modal', function () {
++            window.location = initialPageData.reverse('dashboard_default');
++        });
++    }
+ 
+     // Set up app preview
+     previewApp.initPreviewWindow();
+@@ -536,15 +548,15 @@
          var $form = $('#new-module-form');
  
          if (moduleType === "case") {
 -            $('#add-new-module-modal').modal('hide');
 -            $('#define-case-type-modal').modal('show');
-+            $('#add-new-module-modal').modal('hide');  /* todo B5: js-modal */
-+            $('#define-case-type-modal').modal('show');  /* todo B5: js-modal */
++            Modal.getInstance('#add-new-module-modal').hide();
++            Modal.getOrCreateInstance('#define-case-type-modal').show();
          } else {
              if (moduleType === "survey") {
                  google.track.event("Added Surveys Menu");
@@ -95,16 +152,34 @@
              }
              $('.new-module-icon').removeClass().addClass("fa fa-refresh fa-spin");
 -            $('#add-new-module-modal').modal('hide');
-+            $('#add-new-module-modal').modal('hide');  /* todo B5: js-modal */
++            Modal.getInstance('#add-new-module-modal').hide();
              $form.submit();
          }
      });
-@@ -642,14 +642,14 @@
+@@ -594,7 +606,7 @@
+                 // Reset error states
+                 $formGroup.removeClass('has-error');
+                 $help.show();
+-                $error.hide();
++                $error.addClass('d-none');
+                 $createBtn.prop('disabled', false);
+ 
+                 if (!valueNoSpaces) {
+@@ -605,7 +617,7 @@
+                 function displayError(errorMsg) {
+                     $formGroup.addClass('has-error');
+                     $error.html(errorMsg);
+-                    $error.show();
++                    $error.removeClass('d-none');
+                     $help.hide();
+                     $createBtn.prop('disabled', true);
+                 }
+@@ -642,14 +654,14 @@
          newCaseTypeHiddenInput.val(value);
  
          $('.new-module-icon').removeClass().addClass("fa fa-refresh fa-spin");
 -        $('#define-case-type-modal').modal('hide');
-+        $('#define-case-type-modal').modal('hide');  /* todo B5: js-modal */
++        Modal.getInstance('#define-case-type-modal').hide();
          $form.submit();
      });
  
@@ -112,17 +187,17 @@
      $('#case-type-go-back-btn').on('click', function () {
 -        $('#define-case-type-modal').modal('hide');
 -        $('#add-new-module-modal').modal('show');
-+        $('#define-case-type-modal').modal('hide');  /* todo B5: js-modal */
-+        $('#add-new-module-modal').modal('show');  /* todo B5: js-modal */
++        Modal.getInstance('#define-case-type-modal').hide();
++        Modal.getOrCreateInstance('#add-new-module-modal').show();
      });
  
      // Clear selection when modal is hidden
-@@ -671,7 +671,7 @@
+@@ -671,7 +683,7 @@
      $('.new-module-option').each(function () {
          var type = $(this).data('type');
          if (hoverHelpTexts[type]) {
 -            $(this).popover({
-+            $(this).popover({  /* todo B5: js-popover */
++            new Popover(this, {
                  title: hoverHelpTexts[type].title,
                  content: hoverHelpTexts[type].content,
                  trigger: 'hover',

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/app_manager.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/app_manager.js.diff.txt
@@ -156,25 +156,35 @@
              $form.submit();
          }
      });
-@@ -594,7 +606,7 @@
+@@ -586,15 +598,13 @@
+ 
+             $caseType.on('change', function () {
+                 var valueNoSpaces = $(this).val();
+-                var $formGroup = $(this).closest('.form-group');
+                 var $help = $('#new-case-type-help');
+                 var $error = $('#new-case-type-error');
+                 var $createBtn = $('#case-type-create-btn');
+ 
                  // Reset error states
-                 $formGroup.removeClass('has-error');
+-                $formGroup.removeClass('has-error');
                  $help.show();
 -                $error.hide();
 +                $error.addClass('d-none');
                  $createBtn.prop('disabled', false);
  
                  if (!valueNoSpaces) {
-@@ -605,7 +617,7 @@
+@@ -603,9 +613,8 @@
+                 }
+ 
                  function displayError(errorMsg) {
-                     $formGroup.addClass('has-error');
+-                    $formGroup.addClass('has-error');
                      $error.html(errorMsg);
 -                    $error.show();
 +                    $error.removeClass('d-none');
                      $help.hide();
                      $createBtn.prop('disabled', true);
                  }
-@@ -642,14 +654,14 @@
+@@ -642,14 +651,14 @@
          newCaseTypeHiddenInput.val(value);
  
          $('.new-module-icon').removeClass().addClass("fa fa-refresh fa-spin");
@@ -192,7 +202,7 @@
      });
  
      // Clear selection when modal is hidden
-@@ -671,7 +683,7 @@
+@@ -671,7 +680,7 @@
      $('.new-module-option').each(function () {
          var type = $(this).data('type');
          if (hoverHelpTexts[type]) {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/popover._popover.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/popover._popover.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,26 +1,25 @@
+@@ -1,26 +1,26 @@
  .popover-additem {
 -  background-color: @cc-light-cool-accent-low;
 +  background-color: $cc-light-cool-accent-low;
@@ -11,16 +11,20 @@
 +  border-radius: 0;
 +  color: $cc-light-cool-accent-hi;
    border: 0;
++  border-color: $cc-light-cool-accent-low;
  
-   .popover-title {
+-  .popover-title {
++  .popover-header {
      background-color: transparent;
      text-transform: uppercase;
-     font-size: 1.2rem;
+-    font-size: 1.2rem;
 -    border-bottom: 1px solid darken(@cc-light-cool-accent-low, 2);
++    font-size: 0.75rem;
 +    border-bottom: 1px solid darken($cc-light-cool-accent-low, 2);
    }
-   &.right > .arrow:after {
+-  &.right > .arrow:after {
 -    border-right-color: @cc-light-cool-accent-low;
++  &.bs-popover-auto > .popover-arrow::after {
 +    border-right-color: $cc-light-cool-accent-low;
    }
  }
@@ -33,13 +37,14 @@
    border: none;
    background-color: transparent;
    margin-bottom: 10px;
-@@ -30,19 +29,19 @@
+@@ -30,21 +30,21 @@
    padding-top: 25px;
    padding-bottom: 25px;
    text-align: center;
 -  .transition(background .5s);
+-  font-size: 1.2rem;
 +  transition: background 0.5s;
-   font-size: 1.2rem;
++  font-size: 0.75rem;
    &:focus {
 -    color: @cc-light-cool-accent-hi;
 +    color: $cc-light-cool-accent-hi;
@@ -56,5 +61,17 @@
 -  > [class*='fa-'],
 +  > [class*="fa-"],
    > .fcc {
-     font-size: 4.5rem;
+-    font-size: 4.5rem;
++    font-size: 2.8125rem;
      display: block;
+     text-align: center;
+     width: 100%;
+@@ -52,7 +52,7 @@
+   }
+ 
+   > .fcc {
+-    font-size: 5.15rem;
++    font-size: 3.2188rem;
+     margin-top: -5px;
+   }
+ 


### PR DESCRIPTION
## Product Description
On Bootstrap 5 pages, corrects the appearance of the New Menu > Case List modal
<img width="400" alt="image" src="https://github.com/user-attachments/assets/82beceac-3b7f-48e7-b731-66d5d5e8bb7e" /> <img width="400" alt="image" src="https://github.com/user-attachments/assets/9b6ba3d6-fe00-48c1-ae73-fcfe8bdbf3d0" />

Shows and styles the 'Add' nav popovers correctly, which were otherwise not visible on a B5 page.
<img width="281" height="200" alt="image" src="https://github.com/user-attachments/assets/8bbe89f0-31fe-4451-b339-a856809fbe15" />


## Technical Summary
Changes noted above as well as ensuring tooltips are initialized correctly (and only once) and that other javascript todos on the same page are addressed.

## Safety Assurance

### Safety story
UI-only JS/HTML changes only, tested locally and on staging.

### Automated test coverage
Not generally for UI.

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
