### PR TITLE
Form Builder case mappings

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -721,6 +721,33 @@ class FormActionsDiff(DocumentSchema):
     open_case = SchemaProperty(OpenCaseDiff)
     update_case = SchemaProperty(UpdateCaseDiff)
 
+    @classmethod
+    def from_json(cls, universal_diff_json, is_registration=False):
+        open_diff = OpenCaseDiff()
+        update_diff = UpdateCaseDiff(universal_diff_json)
+
+        if is_registration:
+            if 'name' in update_diff.add:
+                name_additions = update_diff.add['name']
+                open_diff.add = name_additions
+                del update_diff.add['name']
+
+            if 'name' in update_diff.update:
+                name_updates = update_diff.update['name']
+                open_diff.update = name_updates
+                del update_diff.update['name']
+
+            if 'name' in update_diff.delete:
+                name_deletions = update_diff.delete['name']
+                open_diff.delete = name_deletions
+                del update_diff.delete['name']
+
+        diff = FormActionsDiff()
+        diff.open_case = open_diff
+        diff.update_case = update_diff
+
+        return diff
+
 
 class FormActions(UpdateableDocument):
     open_case = SchemaProperty(OpenCaseAction)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -395,10 +395,13 @@ class UpdateCaseAction(FormAction):
             # because update_multi is meant to be exclusive with update, no items need to be moved
             return False
 
-        self.update_multi = {k: [v] for (k, v) in self.update.items()}
+        self.update_multi = self._multi_updates()
         self.update = {}
 
         return True
+
+    def _multi_updates(self):
+        return self.update_multi or {k: [v] for k, v in self.update.items()}
 
     def normalize_update(self):
         '''
@@ -548,6 +551,12 @@ class UpdateCaseAction(FormAction):
         if all_missing_mappings:
             raise MissingPropertyMapException(*all_missing_mappings)
 
+    def get_mappings(self):
+        return {
+            case_property: [_to_json_sans_doc_type(update) for update in updates]
+            for (case_property, updates) in self._multi_updates().items()
+        }
+
 
 class PreloadAction(FormAction):
 
@@ -656,6 +665,19 @@ class OpenCaseAction(FormAction):
 
     def _update_has_name(self, update):
         return bool(update.question_path)
+
+    def get_mappings(self):
+        updates = self.name_update_multi or [self.name_update]
+        return {
+            'name': [_to_json_sans_doc_type(update) for update in updates]
+        }
+
+
+def _to_json_sans_doc_type(obj):
+    json = obj.to_json()
+    if 'doc_type' in json:
+        del json['doc_type']
+    return json
 
 
 class OpenSubCaseAction(FormAction, IndexedSchema):
@@ -768,6 +790,14 @@ class FormActions(UpdateableDocument):
                 self.update_case.normalize_update()
             else:
                 self.update_case.make_single()
+
+    def get_mappings(self):
+        mappings = {}
+        if self.open_case:
+            mappings.update(self.open_case.get_mappings())
+        if self.update_case:
+            mappings.update(self.update_case.get_mappings())
+        return mappings
 
 
 class CaseIndex(DocumentSchema):

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -160,6 +160,19 @@ class OpenCaseActionTests(SimpleTestCase):
 
         self.assertFalse(action.has_name_update())
 
+    def test_get_mappings_serializes_name_updates(self):
+        action = OpenCaseAction({
+            'name_update_multi': [{'question_path': 'one'}, {'question_path': 'two'}]
+        })
+
+        json = action.get_mappings()
+        self.assertEqual(json, {
+            'name': [
+                {'question_path': 'one', 'update_mode': 'always'},
+                {'question_path': 'two', 'update_mode': 'always'}
+            ]
+        })
+
 
 class OpenCaseAction_ApplyUpdates_Tests(SimpleTestCase):
     def test_no_changes(self):
@@ -390,6 +403,37 @@ class UpdateCaseActionTests(SimpleTestCase):
         })
 
         self.assertEqual(action.get_property_names(), {'one'})
+
+    def test_get_mappings_serializes_updates(self):
+        action = UpdateCaseAction({
+            'update_multi': {
+                'one': [{'question_path': '/A/'}, {'question_path': '/B/'}],
+                'two': [{'question_path': '/C/'}],
+            }
+        })
+
+        json = action.get_mappings()
+
+        self.assertEqual(json, {
+            'one': [
+                {'question_path': '/A/', 'update_mode': 'always'},
+                {'question_path': '/B/', 'update_mode': 'always'}
+            ],
+            'two': [{'question_path': '/C/', 'update_mode': 'always'}]
+        })
+
+    def test_get_mappings_removes_doc_type(self):
+        action = UpdateCaseAction({
+            'update': {
+                'one': {'question_path': '/A/', 'update_mode': 'edit', 'doc_type': 'TestDoc'},
+            }
+        })
+
+        json = action.get_mappings()
+
+        self.assertEqual(json, {
+            'one': [{'question_path': '/A/', 'update_mode': 'edit'}]
+        })
 
 
 class UpdateCaseAction_ApplyUpdates_Tests(SimpleTestCase):

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -803,6 +803,54 @@ class FormActionsDiffTests(SimpleTestCase):
         assert diff.open_case.add[0].question_path == 'one'
         assert diff.update_case.delete['case_two'][0].question_path == 'two'
 
+    def test_from_json_creates_diff_object(self):
+        universal_json = {
+            'add': {
+                'prop1': [{'question_path': 'one'}]
+            },
+            'update': {
+                'prop2': [{'question_path': 'two'}]
+            },
+            'delete': {
+                'prop3': [{'question_path': 'three'}]
+            }
+        }
+
+        diff = FormActionsDiff.from_json(universal_json)
+
+        assert len(diff.update_case.add['prop1']) == 1
+        assert diff.update_case.add['prop1'][0].question_path == 'one'
+
+        assert len(diff.update_case.update['prop2']) == 1
+        assert diff.update_case.update['prop2'][0].question_path == 'two'
+
+        assert len(diff.update_case.delete['prop3']) == 1
+        assert diff.update_case.delete['prop3'][0].question_path == 'three'
+
+    def test_from_json_non_registration_name_stays_in_update(self):
+        universal_json = {
+            'add': {
+                'name': [{'question_path': 'one'}]
+            }
+        }
+
+        diff = FormActionsDiff.from_json(universal_json)
+
+        assert diff.update_case.add['name'][0].question_path == 'one'
+        assert 'name' not in diff.open_case.add
+
+    def test_from_json_registration_name_is_in_open_case(self):
+        universal_json = {
+            'add': {
+                'name': [{'question_path': 'one'}]
+            }
+        }
+
+        diff = FormActionsDiff.from_json(universal_json, is_registration=True)
+
+        assert diff.open_case.add[0].question_path == 'one'
+        assert 'name' not in diff.update_case.add
+
 
 class FormActionTests(SimpleTestCase):
     def test_get_action_properties_for_name_update(self):

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -151,7 +151,7 @@ def generate_xmlns():
     return str(uuid.uuid4()).upper()
 
 
-def save_xform(app, form, xml):
+def save_xform(app, form, xml, mapping_diff=None):
 
     def change_xmlns(xform, old_xmlns, new_xmlns):
         data = xform.data_node.render().decode('utf-8')
@@ -165,6 +165,9 @@ def save_xform(app, form, xml):
     except XFormException:
         pass
     else:
+        if mapping_diff:
+            form.actions = form.actions.with_updates({}, mapping_diff)
+
         GENERIC_XMLNS = "http://www.w3.org/2002/xforms"
         uid = generate_xmlns()
         tag_xmlns = xform.data_node.tag_xmlns

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -50,6 +50,7 @@ from corehq.apps.app_manager.views.utils import (
     set_lang_cookie,
 )
 from corehq.apps.cloudcare.utils import should_show_preview_app
+from corehq.apps.data_dictionary.util import get_case_properties
 from corehq.apps.domain.decorators import track_domain_request
 from corehq.apps.fixtures.fixturegenerators import item_lists_by_domain
 from corehq.apps.users.permissions import SUBMISSION_HISTORY_PERMISSION, has_permission_to_view_report
@@ -253,11 +254,9 @@ def _get_base_vellum_options(request, domain, form, displayLang):
     is_advanced_form = isinstance(form, AdvancedForm)
     case_type = form.get_module().case_type
     if case_type and has_vellum_case_mapping and not is_advanced_form:
-        # TODO get case properties from Data Dictionary
-        from corehq.apps.app_manager.app_schemas.case_properties import get_all_case_properties_for_case_type
         options['caseManagement'] = {
             'mappings': form.actions.get_mappings(),
-            'properties': get_all_case_properties_for_case_type(domain, case_type),
+            'properties': sorted(get_case_properties(domain, case_type).values_list('name', flat=True)),
             'view_form_url': reverse('view_form', args=[domain, app.id, form.unique_id]),
             'reserved_words': load_case_reserved_words(),
         }

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -33,7 +33,7 @@ from corehq.apps.app_manager.exceptions import (
     FormNotFoundException,
 )
 from corehq.apps.app_manager.helpers.validators import load_case_reserved_words
-from corehq.apps.app_manager.models import ModuleNotFoundException
+from corehq.apps.app_manager.models import ModuleNotFoundException, AdvancedForm
 from corehq.apps.app_manager.templatetags.xforms_extras import translate
 from corehq.apps.app_manager.util import (
     app_callout_templates,
@@ -250,8 +250,9 @@ def _get_base_vellum_options(request, domain, form, displayLang):
     }
 
     has_vellum_case_mapping = toggles.FORMBUILDER_SAVE_TO_CASE.enabled_for_request(request)
+    is_advanced_form = isinstance(form, AdvancedForm)
     case_type = form.get_module().case_type
-    if case_type and has_vellum_case_mapping:
+    if case_type and has_vellum_case_mapping and not is_advanced_form:
         # TODO get case properties from Data Dictionary
         from corehq.apps.app_manager.app_schemas.case_properties import get_all_case_properties_for_case_type
         options['caseManagement'] = {

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -149,7 +149,7 @@ def _get_form_designer_view(request, domain, app, module, form):
 
     vellum_options = _get_base_vellum_options(request, domain, form, context['lang'])
     vellum_options['core'] = _get_vellum_core_context(request, domain, app, module, form, context['lang'])
-    vellum_options['plugins'] = _get_vellum_plugins(domain, form, module)
+    vellum_options['plugins'] = _get_vellum_plugins(domain, form, module, vellum_options)
     vellum_options['features'] = _get_vellum_features(request, domain, app)
     context['vellum_options'] = vellum_options
 
@@ -306,7 +306,7 @@ def _get_vellum_core_context(request, domain, app, module, form, lang):
     return core
 
 
-def _get_vellum_plugins(domain, form, module):
+def _get_vellum_plugins(domain, form, module, options):
     """
     Returns a list of enabled vellum plugins based on the domain's
     privileges.
@@ -315,6 +315,8 @@ def _get_vellum_plugins(domain, form, module):
     if (toggles.COMMTRACK.enabled(domain)
             or toggles.NON_COMMTRACK_LEDGERS.enabled(domain)):
         vellum_plugins.append("commtrack")
+    if "caseManagement" in options:
+        vellum_plugins.append("caseManagement")
     if toggles.VELLUM_SAVE_TO_CASE.enabled(domain):
         vellum_plugins.append("saveToCase")
     if toggles.COMMCARE_CONNECT.enabled(domain):

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -32,6 +32,7 @@ from corehq.apps.app_manager.exceptions import (
     AppManagerException,
     FormNotFoundException,
 )
+from corehq.apps.app_manager.helpers.validators import load_case_reserved_words
 from corehq.apps.app_manager.models import ModuleNotFoundException
 from corehq.apps.app_manager.templatetags.xforms_extras import translate
 from corehq.apps.app_manager.util import (
@@ -257,6 +258,7 @@ def _get_base_vellum_options(request, domain, form, displayLang):
             'mappings': form.actions.get_mappings(),
             'properties': get_all_case_properties_for_case_type(domain, case_type),
             'view_form_url': reverse('view_form', args=[domain, app.id, form.unique_id]),
+            'reserved_words': load_case_reserved_words(),
         }
 
     return options

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -405,10 +405,17 @@ def is_case_property_unused(domain, case_type, case_property):
     return query.NOT(case_property_missing(case_property)).count() == 0
 
 
+def get_case_properties(domain, case_type_name):
+    return CaseProperty.objects.filter(
+        case_type__name=case_type_name,
+        case_type__domain=domain,
+        deprecated=False,
+        group__deprecated=False,
+    )
+
+
 def get_case_property_group_name_for_properties(domain, case_type_name):
-    return dict(CaseProperty.objects.filter(
-        case_type__name=case_type_name, case_type__domain=domain, deprecated=False, group__deprecated=False
-    ).values_list('name', 'group__name'))
+    return dict(get_case_properties(domain, case_type_name).values_list('name', 'group__name'))
 
 
 def update_url_query_params(url, params):


### PR DESCRIPTION
Redo of https://github.com/dimagi/commcare-hq/pull/37109 without XML-encoded case mappings, which were abandoned. The final commit (6c3361a6a469dd0de801b08f026bd0d547a984ff) addresses the TODO comment in the first commit (f5ee2f032b8c905c2c48d30014b6be56220d00f9): get case properties from Data Dictionary.

## Technical Summary

This is the HQ half of the Form Builder changes. This modifies the context we send down to Vellum so that Vellum's case management plugin has access to the current mappings and the case property suggestions.

## Feature Flag

All user-facing changes in this PR are gated by `FORMBUILDER_SAVE_TO_CASE`

## Safety Assurance

### Safety story

All changes are behind a feature flag. The original PR passed QA, and it will go through QA again before final release.

### Automated test coverage

Yes.

### QA Plan

TBD

### Rollback instructions

If this is rolled back it will disable case management features in the form builder.