### PR TITLE
More thoroughly validate autopay requirement on subscribing to plan

### DIFF
--- a/corehq/apps/domain/templates/domain/confirm_billing_info.html
+++ b/corehq/apps/domain/templates/domain/confirm_billing_info.html
@@ -151,6 +151,7 @@
               class="btn btn-primary disable-on-submit"
               :disabled="isSubmitDisabled"
               @click="isSubmitting = true"
+              disabled="disabled"
             >
               {% trans "Subscribe to Plan" %}
             </button>

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -292,7 +292,7 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
     def test_form_initial_values(self):
         plan_version = DefaultProductPlan.get_default_plan_version(SoftwarePlanEdition.STANDARD)
         form = self.create_form(plan_version)
-        self.assertEqual(form['plan_edition'].value(), plan_version.plan.edition)
+        assert form['plan_edition'].value() == plan_version.plan.edition
 
     def test_pay_monthly_subscription(self):
         new_plan_version = DefaultProductPlan.get_default_plan_version(
@@ -300,13 +300,13 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
         )
         form = self.create_form_for_submission(new_plan_version)
         form.save()
-        self.assertTrue(form.is_valid())
-        self.assertEqual(self.subscription.date_end, date.today())
+        assert form.is_valid()
+        assert self.subscription.date_end == date.today()
 
         new_subscription = Subscription.get_active_subscription_by_domain(self.domain)
-        self.assertEqual(new_subscription.plan_version, new_plan_version)
-        self.assertEqual(new_subscription.date_start, date.today())
-        self.assertIsNone(new_subscription.date_end)
+        assert new_subscription.plan_version == new_plan_version
+        assert new_subscription.date_start == date.today()
+        assert new_subscription.date_end is None
 
     def test_pay_annually_subscription(self):
         new_plan_version = DefaultProductPlan.get_default_plan_version(
@@ -314,13 +314,13 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
         )
         form = self.create_form_for_submission(new_plan_version)
         form.save()
-        self.assertTrue(form.is_valid())
-        self.assertEqual(self.subscription.date_end, date.today())
+        assert form.is_valid()
+        assert self.subscription.date_end == date.today()
 
         new_subscription = Subscription.get_active_subscription_by_domain(self.domain)
-        self.assertEqual(new_subscription.plan_version, new_plan_version)
-        self.assertEqual(new_subscription.date_start, date.today())
-        self.assertEqual(new_subscription.date_end, new_subscription.date_start + relativedelta(years=1))
+        assert new_subscription.plan_version == new_plan_version
+        assert new_subscription.date_start == date.today()
+        assert new_subscription.date_end == new_subscription.date_start + relativedelta(years=1)
 
     def test_pay_annually_creates_prepayment_invoice(self):
         new_plan_version = DefaultProductPlan.get_default_plan_version(
@@ -328,16 +328,15 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
         )
         form = self.create_form_for_submission(new_plan_version)
         form.save()
-        self.assertTrue(form.is_valid())
+        assert form.is_valid()
 
         prepayment_invoice = WirePrepaymentInvoice.objects.get(domain=self.domain.name)
         new_subscription = Subscription.get_active_subscription_by_domain(self.domain)
-        self.assertEqual(prepayment_invoice.date_start, new_subscription.date_start)
-        self.assertEqual(prepayment_invoice.date_end, new_subscription.date_end)
-        self.assertEqual(prepayment_invoice.date_due,
-                         date.today() + timedelta(days=SUBSCRIPTION_PREPAY_MIN_DAYS_UNTIL_DUE))
-        self.assertEqual(prepayment_invoice.balance,
-                         new_plan_version.product_rate.monthly_fee * PAY_ANNUALLY_SUBSCRIPTION_MONTHS)
+        assert prepayment_invoice.date_start == new_subscription.date_start
+        assert prepayment_invoice.date_end == new_subscription.date_end
+        assert prepayment_invoice.date_due == date.today() + timedelta(days=SUBSCRIPTION_PREPAY_MIN_DAYS_UNTIL_DUE)
+        assert (prepayment_invoice.balance
+                == new_plan_version.product_rate.monthly_fee * PAY_ANNUALLY_SUBSCRIPTION_MONTHS)
 
     def test_downgrade_minimum_subscription_length(self):
         self.subscription.delete()
@@ -350,12 +349,12 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
         new_plan_version = DefaultProductPlan.get_default_plan_version(SoftwarePlanEdition.STANDARD)
         form = self.create_form_for_submission(new_plan_version)
         form.save()
-        self.assertTrue(form.is_valid())
-        self.assertEqual(self.subscription.date_end, old_date_start + timedelta(days=30))
+        assert form.is_valid()
+        assert self.subscription.date_end == old_date_start + timedelta(days=30)
 
         next_subscription = self.subscription.next_subscription
-        self.assertEqual(next_subscription.plan_version, new_plan_version)
-        self.assertEqual(next_subscription.date_start, old_date_start + timedelta(days=30))
+        assert next_subscription.plan_version == new_plan_version
+        assert next_subscription.date_start == old_date_start + timedelta(days=30)
 
     def test_autopay_required_for_monthly_plan(self):
         new_plan_version = DefaultProductPlan.get_default_plan_version(


### PR DESCRIPTION
## Product Description
Adds this error message when subscribing to a plan if an autopay card is required and has not been added - and somehow frontend validation has been bypassed:
<img width="695" height="93" alt="image" src="https://github.com/user-attachments/assets/b9d64902-0d0f-4786-98de-15b23172f408" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19232
This adds backend form validation and tests that it is required for a customer to add an autopay method when subscribing to a monthly plan, or when require_auto_pay is True on the billing account.

Additionally, when subscribing to a new software plan, it was possible to unintentionally bypass frontend validation (especially on a slower internet connection) by clicking "Subscribe to Plan" before javascript had finished loading. This fixes that by adding a `disabled="disabled"` attribute to the button, which is the same format that Alpine applies or removes with `:disabled`.

## Safety Assurance

### Safety story
Confirmed locally that Subscribe to Plan button is disabled before JS loads or if JS is disabled, and becomes enabled once JS loads and form validation passes. Checked backend validation in UI by removing the `disabled` attribute from the Subscribe to Plan button and ensuring form submission is blocked and the validation message is shown - or succeeds when expected to.

### Automated test coverage
Adds test cases for backend form validation.

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
