### PR TITLE
Include domain in args for datadog tagging

### DIFF
--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -136,8 +136,8 @@ def rebuild_saved_export(export_instance_id, manual=False):
         return
 
     try:
-        export = ExportInstance.get(export_instance_id)
-        domain = export.domain
+        export_dict = ExportInstance.get_db().get(export_instance_id)
+        domain = export_dict.get('domain', None)
     except ResourceNotFound:
         domain = None
     # associate task with the export instance


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19056

I'd like to have domain info for this task to more easily trace this back in request logs. The logic for pulling domain from a task's args is [here](https://github.com/dimagi/commcare-hq/blob/f2da6a0bc0d15a2a92c2fe68d56eeff4e7524a16/corehq/celery_monitoring/signals.py#L84-L91).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
We do this in other places as well, and we only call this task in one place so it is a fairly straightforward change.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
