### PR TITLE
Log case search related queries

### DIFF
--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -146,6 +146,7 @@ def _get_helper(couch_user, domain, case_types, registry_slug):
             pass
         else:
             helper = RegistryQueryHelper(domain, couch_user, registry_helper)
+    helper.is_case_search = True
     return helper
 
 
@@ -153,6 +154,7 @@ class QueryHelper:
     def __init__(self, domain):
         self.domain = domain
         self.profiler = CaseSearchProfiler()
+        self.is_case_search = False
 
     def get_base_queryset(self, slug=None):
         # slug is only informational, used for profiling


### PR DESCRIPTION
## Product Description
No user-facing changes

## Technical Summary
Parts of both of these:
https://dimagi.atlassian.net/browse/USH-6469
https://dimagi.atlassian.net/browse/USH-6466

Logs `parent/myproperty`, `subcase-exists`, `subcase-count`, and `ancestor-exists` queries in sentry.  This is an informational step as we explore removing or limiting access to this functionality.  They result in secondary ES queries, which can be quite expensive.

## Feature Flag


## Safety Assurance


### Safety story
Added a test to verify the logging, though we'll also be QAing this with some other work on staging prior to release

### Automated test coverage
:+1: 

### QA Plan
TBD, but anticipated

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change