### PR TITLE
Momo Payments Bug fixes

### DIFF
--- a/corehq/apps/hqwebapp/tables/export.py
+++ b/corehq/apps/hqwebapp/tables/export.py
@@ -114,7 +114,7 @@ class TableExportMixin(TableExportConfig, SingleTableMixin):
         """
         Can be overridden to provide additional context for the export.
         """
-        return Context()
+        return Context({"exporting": True})
 
     def trigger_export(self, recipient_list=None, subject=None):
         self._validate_export_dependencies()

--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5.html
@@ -15,7 +15,9 @@
 
     {% block before_table %}{% endblock %}
 
-    {% block table %}{{ block.super }}{% endblock table %}
+    <div class="table-responsive">
+      {% block table %}{{ block.super }}{% endblock table %}
+    </div>
 
     {% if table.page.paginator.count == 0 %}
       {% block no_results_table %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/tables/bootstrap5.html
@@ -10,9 +10,9 @@
     {% if table.container_id %}
       id="{{ table.container_id }}"
     {% endif %}
-    {% block table-container-attrs %}{% endblock %}
+    {% block table-container-attrs %}
+    {% endblock %}
   >
-
     {% block before_table %}{% endblock %}
 
     <div class="table-responsive">
@@ -48,10 +48,11 @@
                 {% for p in table.paginator.paging_options %}
                   <option
                     value="{{ p }}"
-                    {% if p == table.paginator.per_page %} selected{% endif %}
+                    {% if p == table.paginator.per_page %}selected{% endif %}
                   >
                     {% blocktrans %}
-                      {{ p }} per page
+                      {{ p }}
+                      per page
                     {% endblocktrans %}
                   </option>
                 {% endfor %}
@@ -65,9 +66,10 @@
           {% if table.page and table.paginator.num_pages > 1 %}
             <nav aria-label="Table navigation">
               <ul class="pagination">
-
                 {% block pagination.previous %}
-                  <li class="previous page-item{% if not table.page.has_previous %} disabled{% endif %}">
+                  <li
+                    class="previous page-item{% if not table.page.has_previous %} disabled{% endif %}"
+                  >
                     <a
                       class="page-link"
                       {% if table.page.has_previous %}
@@ -84,7 +86,9 @@
                 {% if table.page.has_previous or table.page.has_next %}
                   {% block pagination.range %}
                     {% for p in table.page|table_page_range:table.paginator %}
-                      <li class="page-item{% if table.page.number == p %} active{% endif %}">
+                      <li
+                        class="page-item{% if table.page.number == p %} active{% endif %}"
+                      >
                         <a
                           class="page-link"
                           {% if p != '...' %}
@@ -99,7 +103,9 @@
                 {% endif %}
 
                 {% block pagination.next %}
-                  <li class="next page-item{% if not table.page.has_next %} disabled{% endif %}">
+                  <li
+                    class="next page-item{% if not table.page.has_next %} disabled{% endif %}"
+                  >
                     <a
                       class="page-link"
                       {% if table.page.has_next %}
@@ -112,7 +118,6 @@
                     </a>
                   </li>
                 {% endblock pagination.next %}
-
               </ul>
             </nav>
           {% endif %}
@@ -121,7 +126,6 @@
     </div>
 
     {% block after_table %}{% endblock %}
-
   </div>
 {% endblock table-wrapper %}
 

--- a/corehq/apps/integration/kyc/views.py
+++ b/corehq/apps/integration/kyc/views.py
@@ -21,7 +21,7 @@ from corehq.apps.es.users import (
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.tables.export import TableExportMixin
-from corehq.apps.hqwebapp.tables.pagination import SelectablePaginatedTableView
+from corehq.apps.hqwebapp.tables.pagination import SelectablePaginatedTableView, HtmxInvalidPageRedirectMixin
 from corehq.apps.integration.kyc.filters import KycVerificationStatusFilter, PhoneNumberFilter
 from corehq.apps.integration.kyc.forms import KycConfigureForm
 from corehq.apps.integration.kyc.models import (
@@ -110,11 +110,16 @@ class KycConfigurationView(HqHtmxActionMixin, BaseDomainView):
 @method_decorator(login_and_domain_required, name='dispatch')
 @method_decorator(toggles.KYC_VERIFICATION.required_decorator(), name='dispatch')
 @method_decorator(require_kyc_report_access, name='dispatch')
-class KycVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableView, TableExportMixin):
+class KycVerificationTableView(
+    HtmxInvalidPageRedirectMixin, HqHtmxActionMixin, SelectablePaginatedTableView, TableExportMixin
+):
     urlname = 'kyc_verify_table'
     table_class = KycVerifyTable
     report_title = _('KYC Report')
     exclude_columns_in_export = ('verify_select', 'verify_btn')
+
+    def get_host_url(self):
+        return reverse('kyc_verify', args=(self.request.domain,))
 
     @cached_property
     def kyc_config(self):

--- a/corehq/apps/integration/payments/tables.py
+++ b/corehq/apps/integration/payments/tables.py
@@ -116,6 +116,9 @@ class PaymentsVerifyTable(BaseHtmxTable, ElasticTable):
         except ValueError:
             label = _("Invalid Status")
 
+        if self.context.get('exporting'):
+            return label
+
         if value in (PaymentStatus.ERROR, PaymentStatus.FAILED, PaymentStatus.REQUEST_FAILED):
             badge_class = 'bg-danger'
         elif value == 'successful':

--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -15,7 +15,10 @@ from corehq.apps.geospatial.utils import get_celery_task_tracker
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.tables.export import TableExportMixin
-from corehq.apps.hqwebapp.tables.pagination import SelectablePaginatedTableView
+from corehq.apps.hqwebapp.tables.pagination import (
+    HtmxInvalidPageRedirectMixin,
+    SelectablePaginatedTableView,
+)
 from corehq.apps.integration.kyc.models import KycConfig
 from corehq.apps.integration.payments.const import (
     PaymentProperties,
@@ -117,7 +120,9 @@ class PaymentsVerificationReportView(BaseDomainView, PaymentsFiltersMixin):
 @method_decorator(login_and_domain_required, name='dispatch')
 @method_decorator(toggles.MTN_MOBILE_WORKER_VERIFICATION.required_decorator(), name='dispatch')
 @method_decorator(require_payments_report_access, name='dispatch')
-class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableView, TableExportMixin):
+class PaymentsVerificationTableView(
+    HtmxInvalidPageRedirectMixin, HqHtmxActionMixin, SelectablePaginatedTableView, TableExportMixin
+):
     urlname = 'payments_verify_table'
     table_class = PaymentsVerifyTable
     report_title = _('Payments Verification Report')
@@ -125,6 +130,9 @@ class PaymentsVerificationTableView(HqHtmxActionMixin, SelectablePaginatedTableV
 
     VERIFICATION_ROWS_LIMIT = 100
     REVERT_VERIFICATION_ROWS_LIMIT = 100
+
+    def get_host_url(self):
+        return reverse('payments_verify', args=(self.request.domain,))
 
     def get_queryset(self):
         query = CaseSearchES().domain(self.request.domain).case_type(MOMO_PAYMENT_CASE_TYPE)

--- a/corehq/apps/integration/templates/payments/payments_verify_report.html
+++ b/corehq/apps/integration/templates/payments/payments_verify_report.html
@@ -66,7 +66,6 @@
     id="payment-verify-table"
     hx-trigger="load"
     hx-get="{% url 'payments_verify_table' domain %}{% querystring %}"
-    class="table-responsive"
   >
     <div class="htmx-indicator">
       <i class="fa-solid fa-spinner fa-spin"></i> {% trans "Loading..." %}


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Fixes some minor bugs in MoMo Payments Verification Report.

- Renders the payment status column correctly during export. Earlier, it was appearing as an HTML string.
- Instead of making both the table and pagination bar scrollable, the table alone is now scrollable, with the pagination bar fixed at the bottom. This aligns with table behavior elsewhere in the application.
- In scenarios where pagination no longer has results—such as when a user selects a higher per-page value on the last page, making the page invalid—the view previously returned a 404 error. In such cases, it now falls back to the first page, aligning with other reports like the Case List report.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
[Ticket](https://dimagi.atlassian.net/browse/QA-8369)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
MTN_MOBILE_WORKER_VERIFICATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested on local.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Exists.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
