### PR TITLE
 Move the multiselect and autoselect checkboxes behind the advanced flag

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_list_module_overwrite.html
@@ -67,7 +67,7 @@
                     {% trans "Search and claim options" %}
                   </label><br>
                 {% endif %}
-                {% if request|toggle_enabled:'USH_CASE_LIST_MULTI_SELECT' %}
+                {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
                   <label for="multi_select">
                     <input type="checkbox" name="multi_select" id="multi_select"/>
                     {% trans "Multi-Select Case List Options" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_list_multi_select.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_list_multi_select.html
@@ -1,7 +1,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% if request|toggle_enabled:"USH_CASE_LIST_MULTI_SELECT" %}
+{% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
 
   <div class="panel panel-appmanager" data-bind="with: shortScreen">
     <div class="panel-heading">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_list_module_overwrite.html
@@ -67,7 +67,7 @@
                     {% trans "Search and claim options" %}
                   </label><br>
                 {% endif %}
-                {% if request|toggle_enabled:'USH_CASE_LIST_MULTI_SELECT' %}
+                {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
                   <label for="multi_select">
                     <input type="checkbox" name="multi_select" id="multi_select"/>  {# todo B5: css-checkbox #}
                     {% trans "Multi-Select Case List Options" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_list_multi_select.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_list_multi_select.html
@@ -1,7 +1,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% if request|toggle_enabled:"USH_CASE_LIST_MULTI_SELECT" %}
+{% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
 
   <div class="card panel-appmanager" data-bind="with: shortScreen">  {# todo B5: css-panel #}
     <div class="card-header">

--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -42,7 +42,6 @@ from .util import patch_validate_xform
 @patch('corehq.util.view_utils.get_url_base', new=lambda: "https://www.example.com")
 @patch_validate_xform()
 @patch_get_xform_resource_overrides()
-@flag_enabled('USH_CASE_LIST_MULTI_SELECT')
 class MultiSelectCaseListTests(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'suite', 'multi_select_case_list')
 
@@ -224,7 +223,6 @@ class MultiSelectCaseListTests(SimpleTestCase, TestXmlMixin):
 @patch('corehq.util.view_utils.get_url_base', new=lambda: "https://www.example.com")
 @patch_validate_xform()
 @patch_get_xform_resource_overrides()
-@flag_enabled('USH_CASE_LIST_MULTI_SELECT')
 class MultiSelectSelectParentFirstTests(SimpleTestCase, TestXmlMixin):
     def setUp(self):
         self.factory = AppFactory(domain="multiple-referrals")
@@ -348,7 +346,6 @@ class MultiSelectSelectParentFirstTests(SimpleTestCase, TestXmlMixin):
 @patch('corehq.util.view_utils.get_url_base', new=lambda: "https://www.example.com")
 @patch_validate_xform()
 @patch_get_xform_resource_overrides()
-@flag_enabled('USH_CASE_LIST_MULTI_SELECT')
 class MultiSelectChildModuleDatumIDTests(SimpleTestCase, SuiteMixin):
     MAIN_CASE_TYPE = 'beneficiary'
     OTHER_CASE_TYPE = 'household'
@@ -541,7 +538,6 @@ class MultiSelectChildModuleDatumIDTests(SimpleTestCase, SuiteMixin):
 @patch.object(Application, 'enable_practice_users', return_value=False)
 @patch_validate_xform()
 @patch_get_xform_resource_overrides()
-@flag_enabled('USH_CASE_LIST_MULTI_SELECT')
 class MultiSelectEndOfFormNavTests(SimpleTestCase, TestXmlMixin):
     CASE_TYPE = 'noun'
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_list_module_overwrite.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_list_module_overwrite.html.diff.txt
@@ -81,7 +81,7 @@
                      {% trans "Search and claim options" %}
                    </label><br>
                  {% endif %}
-                 {% if request|toggle_enabled:'USH_CASE_LIST_MULTI_SELECT' %}
+                 {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
                    <label for="multi_select">
 -                    <input type="checkbox" name="multi_select" id="multi_select"/>
 +                    <input type="checkbox" name="multi_select" id="multi_select"/>  {# todo B5: css-checkbox #}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_list_multi_select.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_list_multi_select.html.diff.txt
@@ -2,7 +2,7 @@
 +++ 
 @@ -3,29 +3,29 @@
  
- {% if request|toggle_enabled:"USH_CASE_LIST_MULTI_SELECT" %}
+ {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
  
 -  <div class="panel panel-appmanager" data-bind="with: shortScreen">
 -    <div class="panel-heading">


### PR DESCRIPTION
## Product Description
no user-facing changes

## Technical Summary
https://dimagi.atlassian.net/browse/USH-6481
Move the multiselect and autoselect checkboxes behind the advanced flag

## Feature Flag
USH_CASE_LIST_MULTI_SELECT > CASE_SEARCH_ADVANCED

## Safety Assurance


### Safety story
Affects only the config pages, and only those that use one of the two flags.  We're running a migration to enabled the advanced flag for relevant domains anyways.

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
