### PR TITLE
Remove unused python-imap dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ dependencies = [
     "psycopg2-binary>=2.9.10",
     "pycryptodome>=3.6.6", # security update
     "python-dateutil",
-    "python-imap",
     "pyphonetics",
     "python-magic",
     "pytz",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '4'",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '4'",
@@ -540,7 +540,6 @@ dependencies = [
     { name = "pyjwt" },
     { name = "pyphonetics" },
     { name = "python-dateutil" },
-    { name = "python-imap" },
     { name = "python-magic" },
     { name = "pytz" },
     { name = "pyyaml" },
@@ -714,7 +713,6 @@ requires-dist = [
     { name = "pyjwt" },
     { name = "pyphonetics" },
     { name = "python-dateutil" },
-    { name = "python-imap" },
     { name = "python-magic" },
     { name = "pytz" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -2753,12 +2751,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863, upload-time = "2024-01-23T06:32:58.246Z" },
 ]
-
-[[package]]
-name = "python-imap"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/57/4bda0520bf5cad16eba0078f55e4a8a09c8dd354e641de96b3ccd9c097ea/python-imap-1.0.0.tar.gz", hash = "sha256:c85dee177300c42e74004f2fbba1cff66edf9e97b49c3efbfed7b51427348de1", size = 763, upload-time = "2017-06-25T14:53:34.323Z" }
 
 [[package]]
 name = "python-magic"


### PR DESCRIPTION
## Product Description
No user-facing effects. Removes an unused Python dependency.

## Technical Summary
Remove `python-imap` from `pyproject.toml`. This package was added in #26353 (2020-01-07)
alongside the BouncedEmailManager feature, but the code only uses Python's built-in `imaplib`
module. The third-party `python-imap` package was never imported anywhere in the codebase.

## Feature Flag
N/A

## Safety Assurance

### Safety story
`python-imap` has zero imports anywhere in the codebase and never has had any. The only IMAP
usage is `import imaplib` in `corehq/util/bounced_email_manager.py`, which is a standard
library module.

### Automated test coverage
CI will confirm no code depends on this package.

### QA Plan
N/A — no code changes, only dependency removal.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change