### PR TITLE
Remove unused socketpool dependency

### DIFF
--- a/corehq/util/sentry.py
+++ b/corehq/util/sentry.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 RATE_LIMITED_EXCEPTIONS = {
     'dimagi.utils.couch.bulk.BulkFetchException': 'couchdb',
-    'socketpool.pool.MaxTriesError': 'couchdb',
 
     'corehq.elastic.ESError': 'elastic',
     'elasticsearch.exceptions.ConnectionTimeout': 'elastic',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ dependencies = [
     "simpleeval",
     "simplejson",
     "six",
-    "socketpool",
     "sqlagg",
     "SQLAlchemy",
     "stripe",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '4'",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '4'",
@@ -558,7 +558,6 @@ dependencies = [
     { name = "simpleeval" },
     { name = "simplejson" },
     { name = "six" },
-    { name = "socketpool" },
     { name = "sqlagg" },
     { name = "sqlalchemy" },
     { name = "stripe" },
@@ -732,7 +731,6 @@ requires-dist = [
     { name = "simpleeval" },
     { name = "simplejson" },
     { name = "six" },
-    { name = "socketpool" },
     { name = "sqlagg" },
     { name = "sqlalchemy" },
     { name = "stripe" },
@@ -3119,12 +3117,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274, upload-time = "2025-05-09T16:34:50.371Z" },
 ]
-
-[[package]]
-name = "socketpool"
-version = "0.5.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/39/fae99a735227234ffec389b252c6de2bc7816bf627f56b4c558dc46c85aa/socketpool-0.5.3.tar.gz", hash = "sha256:a06733434a56c4b60b8fcaa168102d2386253d36425804d55532a6bbbda6e2ec", size = 9793, upload-time = "2013-08-30T15:23:12.035Z" }
 
 [[package]]
 name = "soupsieve"


### PR DESCRIPTION
## Product Description
No user-facing effects. Removes an unused Python dependency.

## Technical Summary
- Remove `socketpool` from `pyproject.toml`
- Remove `socketpool.pool.MaxTriesError` from Sentry rate-limiting map in `corehq/util/sentry.py`

socketpool was a connection pooling library used with `restkit` for CouchDB connections:
- Added in 2012 (commit da55172) for the early pillowtop system
- Last import removed in 2013 (commit a456a5b) as unused
- Dependency has been unused for 12+ years, carried forward through every requirements migration

## Feature Flag
N/A

## Safety Assurance

### Safety story
`socketpool` has had zero imports for over 12 years. The only reference was a string in the
Sentry error categorization dict — the `MaxTriesError` exception cannot be raised since the
library is not used.

### Automated test coverage
CI will confirm no code depends on this package.

### QA Plan
N/A — minimal code change (one string removed from a dict).

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change