### PR TITLE
Remove APP_BUILDER_CUSTOM_PARENT_REF feature flag

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap3/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap3/case_config.html
@@ -280,15 +280,6 @@
                     <span class="help-block" data-bind="visible: !case_type()">
                       {% trans "Required" %}
                     </span>
-                    {% if show_custom_ref %}
-                      <label> {% trans "Override reference id: " %} </label>
-                      <input
-                        type="text"
-                        {% if not add_ons_privileges.subcases %}disabled="disabled"{% endif %}
-                        class="form-control"
-                        data-bind="value: reference_id"
-                      />
-                    {% endif %}
                   </span>
                 </div>
               </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap5/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap5/case_config.html
@@ -280,15 +280,6 @@
                     <span class="help-block" data-bind="visible: !case_type()">
                       {% trans "Required" %}
                     </span>
-                    {% if show_custom_ref %}
-                      <label> {% trans "Override reference id: " %} </label>
-                      <input
-                        type="text"
-                        {% if not add_ons_privileges.subcases %}disabled="disabled"{% endif %}
-                        class="form-control"
-                        data-bind="value: reference_id"
-                      />
-                    {% endif %}
                   </span>
                 </div>
               </div>

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -751,7 +751,7 @@ class TestViewGeneric(ViewsBase):
         'is_allowed_to_be_release_notes_form', 'custom_assertions', 'title_context_block', 'id',
         'secure_cookies', 'langs', 'None', 'CUSTOM_LOGO_URL', 'allow_form_copy', 'selected_form', 'slug',
         'env', 'False', 'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'allow_usercase',
-        'module_loads_registry_case', 'EULA_COMPLIANCE', 'sentry', 'show_shadow_modules', 'show_custom_ref',
+        'module_loads_registry_case', 'EULA_COMPLIANCE', 'sentry', 'show_shadow_modules',
         'block', 'IS_ANALYTICS_ENVIRONMENT', 'module_type', 'icon_class', 'case_property_warning',
         'form_submit_history_url', 'btn_style', 'ACCOUNTS_EMAIL', 'CHATBOT_ID', 'CHATBOT_TOKEN'
     }

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -51,10 +51,10 @@ from corehq.apps.app_manager.decorators import (
 from corehq.apps.app_manager.exceptions import (
     AppInDifferentDomainException,
     AppMisconfigurationError,
+    FormActionsDiffException,
     FormNotFoundException,
     ModuleNotFoundException,
     XFormValidationFailed,
-    FormActionsDiffException,
 )
 from corehq.apps.app_manager.helpers.validators import load_case_reserved_words
 from corehq.apps.app_manager.models import (
@@ -68,12 +68,12 @@ from corehq.apps.app_manager.models import (
     DeleteFormRecord,
     Form,
     FormActionCondition,
+    FormActionsDiff,
     FormDatum,
     FormLink,
     IncompatibleFormTypeException,
     OpenCaseAction,
     UpdateCaseAction,
-    FormActionsDiff,
 )
 from corehq.apps.app_manager.templatetags.xforms_extras import (
     clean_trans,
@@ -105,9 +105,9 @@ from corehq.apps.app_manager.xform import (
     XFormValidationError,
 )
 from corehq.apps.data_dictionary.util import (
+    get_case_property_count,
     get_case_property_deprecated_dict,
     get_case_property_description_dict,
-    get_case_property_count,
 )
 from corehq.apps.domain.decorators import (
     LoginAndDomainMixin,
@@ -119,7 +119,10 @@ from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.programs.models import Program
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
-from corehq.project_limits.const import CASE_PROP_LIMIT_PER_CASE_TYPE_KEY, DEFAULT_CASE_PROPS_PER_CASE_TYPE
+from corehq.project_limits.const import (
+    CASE_PROP_LIMIT_PER_CASE_TYPE_KEY,
+    DEFAULT_CASE_PROPS_PER_CASE_TYPE,
+)
 from corehq.project_limits.models import SystemLimit
 from corehq.util.view_utils import set_file_download
 
@@ -885,9 +888,6 @@ def get_form_view_context(
     else:
         # TODO: figure out a cleaner method
         form.actions.make_multi()
-        context.update({
-            'show_custom_ref': toggles.APP_BUILDER_CUSTOM_PARENT_REF.enabled_for_request(request),
-        })
         case_config_options.update({
             'actions': form.actions,
             'allowUsercase': allow_usercase,
@@ -1000,7 +1000,9 @@ def get_form_datums(request, domain, app_id):
 
 
 def _get_form_datums(domain, app_id, form_id):
-    from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
+    from corehq.apps.app_manager.suite_xml.sections.entries import (
+        EntriesHelper,
+    )
     try:
         app = get_app(domain, app_id)
     except AppInDifferentDomainException as e:

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/forms/case_config.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/forms/case_config.html.diff.txt
@@ -172,7 +172,7 @@
                        class="form-control"
                        {% if not add_ons_privileges.subcases %}disabled="disabled"{% endif %}
                        data-bind="options: $parent.caseTypes,
-@@ -297,7 +297,7 @@
+@@ -288,7 +288,7 @@
            </div>
          </div>
          {% if add_ons_privileges.subcases %}

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -647,13 +647,6 @@ def _ensure_valid_randomness(randomness):
         raise Exception('randomness must be between 0 and 1!')
 
 
-APP_BUILDER_CUSTOM_PARENT_REF = StaticToggle(
-    'custom-parent-ref',
-    'ICDS: Custom case parent reference',
-    TAG_DEPRECATED,
-    [NAMESPACE_DOMAIN],
-)
-
 LAZY_LOAD_MULTIMEDIA = StaticToggle(
     'optional-media',
     'ICDS: Lazy load multimedia files in Updates',


### PR DESCRIPTION
## Summary
- Remove the deprecated `APP_BUILDER_CUSTOM_PARENT_REF` (`custom-parent-ref`) toggle, which controlled the "Override reference id" UI in advanced module case config
- Remove toggle checks from application code (view, templates), update tests, and delete the toggle definition
- 5 files changed across 2 commits

## Test plan
- [x] `pytest corehq/apps/app_manager/tests/test_views.py` — 32 passed
- [x] `pytest corehq/toggles/` — 27 passed
- [x] Verified no remaining references to `APP_BUILDER_CUSTOM_PARENT_REF` or `show_custom_ref`

🤖 Generated with [Claude Code](https://claude.com/claude-code)