### PR TITLE
Remove ENABLE_INCLUDE_SMS_GATEWAY_CHARGING feature flag

### DIFF
--- a/corehq/apps/smsbillables/models.py
+++ b/corehq/apps/smsbillables/models.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 
 from django.db import models
 
-from corehq import toggles
 from corehq.apps.accounting import models as accounting
 from corehq.apps.accounting.const import EXCHANGE_RATE_DECIMAL_PLACES
 from corehq.apps.accounting.models import BillingAccount, Currency, Subscription
@@ -356,7 +355,6 @@ class SmsBillable(models.Model):
         is_gateway_billable = (
             backend_id is None
             or backend_instance.is_global
-            or toggles.ENABLE_INCLUDE_SMS_GATEWAY_CHARGING.enabled(domain)
         )
 
         direct_gateway_fee = gateway_fee = multipart_count = conversion_rate = None

--- a/corehq/apps/smsbillables/models.py
+++ b/corehq/apps/smsbillables/models.py
@@ -352,13 +352,9 @@ class SmsBillable(models.Model):
                 include_deleted=True,
             )
 
-        is_gateway_billable = (
-            backend_id is None
-            or backend_instance.is_global
-        )
-
         direct_gateway_fee = gateway_fee = multipart_count = conversion_rate = None
 
+        is_gateway_billable = backend_id is None or backend_instance.is_global
         if is_gateway_billable:
             if backend_instance and backend_instance.using_api_to_get_fees:
                 if backend_message_id:

--- a/corehq/apps/smsbillables/tests/test_gateway_charges.py
+++ b/corehq/apps/smsbillables/tests/test_gateway_charges.py
@@ -10,7 +10,6 @@ from corehq.apps.smsbillables.models import SmsBillable, SmsGatewayFee
 from corehq.apps.smsbillables.tests.utils import create_sms, long_text, short_text
 from corehq.messaging.smsbackends.test.models import SQLTestSMSBackend
 from corehq.messaging.smsbackends.twilio.models import SQLTwilioBackend
-from corehq.util.test_utils import flag_enabled
 
 
 class TestGatewayCharge(TestCase):
@@ -148,17 +147,6 @@ class TestGatewayCharge(TestCase):
         actual_gateway_charge = billable.gateway_charge
 
         self.assertEqual(Decimal('0.0'), actual_gateway_charge)
-
-    @flag_enabled('ENABLE_INCLUDE_SMS_GATEWAY_CHARGING')
-    def test_non_global_backend_is_charged_if_flag_enabled(self):
-        msg = create_sms(self.domain, self.non_global_backend, '+12223334444', OUTGOING, short_text)
-        SmsGatewayFee.create_new(self.non_global_backend.hq_api_id, msg.direction, Decimal('0.01'))
-        create_billable_for_sms(msg, delay=False)
-        billable = SmsBillable.objects.get(domain=self.domain, log_id=msg.couch_id)
-
-        actual_charge = billable.gateway_charge
-
-        self.assertEqual(Decimal('0.01'), actual_charge)
 
 
 class TestGetByCriteria(TestCase):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1437,12 +1437,12 @@ EXPORT_DATA_SOURCE_DATA = StaticToggle(
 )
 
 
-ENABLE_INCLUDE_SMS_GATEWAY_CHARGING = StaticToggle(
-    'enable_include_sms_gateway_charging',
-    'Enable include SMS gateway charging',
-    TAG_DEPRECATED,
-    [NAMESPACE_DOMAIN]
-)
+# ENABLE_INCLUDE_SMS_GATEWAY_CHARGING = StaticToggle(
+#     'enable_include_sms_gateway_charging',
+#     'Enable include SMS gateway charging',
+#     TAG_DEPRECATED,
+#     [NAMESPACE_DOMAIN]
+# )
 
 MESSAGE_LOG_METADATA = StaticToggle(
     'message_log_metadata',


### PR DESCRIPTION
## Product Description
No user-facing effects. This removes the deprecated `ENABLE_INCLUDE_SMS_GATEWAY_CHARGING` feature flag, which allowed non-global SMS backends to incur gateway charges. The flag is being deleted (evaluates to `False`).

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19311

- Removed the toggle check from `corehq/apps/smsbillables/models.py` — the `or toggles.ENABLE_INCLUDE_SMS_GATEWAY_CHARGING.enabled(domain)` clause was removed from the `is_gateway_billable` condition
- Removed the test that only exercised the flagged code path
- Commented out the toggle definition in `corehq/toggles/__init__.py`

## Feature Flag
`ENABLE_INCLUDE_SMS_GATEWAY_CHARGING` (`enable_include_sms_gateway_charging`) — TAG_DEPRECATED

## Safety Assurance

### Safety story
The flag is TAG_DEPRECATED. Removing it preserves the default behavior (non-global backends are not charged gateway fees). The change is minimal — one `or` clause removed from a boolean expression.

### Automated test coverage
`test_non_global_backend_charge_is_zero` in `test_gateway_charges.py` covers the default (non-flagged) behavior and remains in place.

### QA Plan
No

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change