### PR TITLE
Remove LOCALE_ID_INTEGRITY feature flag

### DIFF
--- a/corehq/apps/app_manager/tests/test_ccz.py
+++ b/corehq/apps/app_manager/tests/test_ccz.py
@@ -5,15 +5,10 @@ import zipfile
 
 from django.test import TestCase
 
-from unittest.mock import patch
-
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.xform_builder import XFormBuilder
 from corehq.apps.hqmedia.models import CommCareImage
-from corehq.apps.hqmedia.tasks import (
-    check_ccz_multimedia_integrity,
-    find_missing_locale_ids_in_ccz,
-)
+from corehq.apps.hqmedia.tasks import check_ccz_multimedia_integrity
 from corehq.apps.hqmedia.views import iter_media_files
 
 
@@ -35,19 +30,6 @@ class CCZTest(TestCase):
             self.image.add_domain(self.domain)
             self.image.save()
             self.addCleanup(self.image.delete)
-
-    @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
-    def test_missing_locale_ids(self, mock):
-        files = self.factory.app.create_all_files()
-        errors = find_missing_locale_ids_in_ccz(files)
-        self.assertEqual(len(errors), 0)
-
-        default_app_strings = files['default/app_strings.txt'].decode('utf-8').splitlines()
-        files['default/app_strings.txt'] = "\n".join([line for line in default_app_strings
-                                                      if not line.startswith("forms.m0f0")]).encode('utf-8')
-        errors = find_missing_locale_ids_in_ccz(files)
-        self.assertEqual(len(errors), 1)
-        self.assertIn('forms.m0f0', errors[0])
 
     def test_multimedia_integrity(self):
         icon_path = 'jr://file/commcare/icon.png'

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -274,30 +274,6 @@ def _expose_download_link(fpath, filename, compress_zip, download_id):
                                **common_kwargs)
 
 
-def find_missing_locale_ids_in_ccz(file_cache):
-    errors = [
-        _("Could not find {file_path} in CCZ").format(file_path=file_path)
-        for file_path in ('default/app_strings.txt', 'suite.xml') if file_path not in file_cache]
-    if errors:
-        return errors
-
-    # Each line of an app_strings.txt file is of the format "name.of.key=value of key"
-    # decode is necessary because Application._make_language_files calls .encode('utf-8')
-    app_strings_ids = {
-        line.decode("utf-8").split('=')[0]
-        for line in file_cache['default/app_strings.txt'].splitlines()
-    }
-
-    from corehq.apps.app_manager.xform import parse_xml
-    parsed = parse_xml(file_cache['suite.xml'])
-    suite_ids = {locale.get("id") for locale in parsed.iter("locale")}
-
-    return [
-        _("Locale ID {id} present in suite.xml but not in default app strings.").format(id=id)
-        for id in (suite_ids - app_strings_ids) if id
-    ]
-
-
 # Check that all media files present in media_suite.xml were added to the zip
 def check_ccz_multimedia_integrity(domain, fpath):
     errors = []

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -229,19 +229,9 @@ def create_files_for_ccz(build, build_profile_id, include_multimedia_files=True,
                 download_id, compress_zip, filename, download_targeted_version
             )
         with build.timing_context("_zip_files_for_ccz"):
-            file_cache = _zip_files_for_ccz(fpath, files, current_progress, file_progress,
-                                            file_count, compression, task)
+            _zip_files_for_ccz(fpath, files, current_progress, file_progress,
+                               file_count, compression, task)
 
-        if include_index_files and toggles.LOCALE_ID_INTEGRITY.enabled(build.domain):
-            with build.timing_context("find_missing_locale_ids_in_ccz"):
-                locale_errors = find_missing_locale_ids_in_ccz(file_cache)
-            if locale_errors:
-                errors.extend(locale_errors)
-                notify_exception(
-                    None,
-                    message="CCZ missing locale ids from default/app_strings.txt",
-                    details={'domain': build.domain, 'app_id': build.id, 'errors': locale_errors}
-                )
         if include_index_files and include_multimedia_files:
             with build.timing_context("check_ccz_multimedia_integrity"):
                 multimedia_errors = check_ccz_multimedia_integrity(build.domain, fpath)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1570,13 +1570,13 @@ CAUTIOUS_MULTIMEDIA = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-LOCALE_ID_INTEGRITY = StaticToggle(
-    'locale_id_integrity',
-    'Verify all locale ids in suite are present in app strings before allowing CCZ download',
-    TAG_DEPRECATED,
-    [NAMESPACE_DOMAIN],
-    notification_emails=['jschweers']
-)
+# LOCALE_ID_INTEGRITY = StaticToggle(
+#     'locale_id_integrity',
+#     'Verify all locale ids in suite are present in app strings before allowing CCZ download',
+#     TAG_DEPRECATED,
+#     [NAMESPACE_DOMAIN],
+#     notification_emails=['jschweers']
+# )
 
 BULK_UPDATE_MULTIMEDIA_PATHS = StaticToggle(
     'bulk_update_multimedia_paths',


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19305

Remove the deprecated `LOCALE_ID_INTEGRITY` feature flag and all associated code, including the locale ID integrity check during CCZ builds and its tests.

## Feature Flag
LOCALE_ID_INTEGRITY (slug: `locale_id_integrity`)

## Safety Assurance

### Safety story
This toggle was tagged `TAG_DEPRECATED`. The change removes code that was gated behind the flag, meaning the removed code paths were only reachable for domains with the flag enabled. After removal, the behavior is the same as for domains without the flag. Verified CCZ download on staging to confirm no regressions.

### Automated test coverage
The `test_missing_locale_ids` test was specific to the removed feature and has been deleted. The remaining `test_multimedia_integrity` test in `test_ccz.py` is unaffected.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change