### PR TITLE
Remove TWO_FACTOR_SUPERUSER_ROLLOUT feature flag

### DIFF
--- a/corehq/apps/api/odata/tests/test_auth.py
+++ b/corehq/apps/api/odata/tests/test_auth.py
@@ -1,13 +1,12 @@
-from django.test import TestCase
-from django.urls import reverse
-
 from unittest import mock
 
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
 from corehq.apps.domain.models import Domain
-from corehq.apps.es.tests.utils import es_test
 from corehq.apps.es.cases import case_adapter
+from corehq.apps.es.tests.utils import es_test
 from corehq.apps.export.models import CaseExportInstance, TableConfiguration
-from corehq.util.test_utils import flag_enabled
 
 from ..views import ODataCaseMetadataView
 from .utils import (
@@ -87,6 +86,10 @@ class TestOdataAuth(TestCase, CaseOdataTestMixin):
         response = self._execute_query(credentials)
         self.assertEqual(response.status_code, 200)
 
+    @override_settings(REQUIRE_TWO_FACTOR_FOR_SUPERUSERS=True)
     def test_success_with_two_factor_api_key(self):
-        with flag_enabled('TWO_FACTOR_SUPERUSER_ROLLOUT'):
+        self.web_user.is_superuser = True
+        try:
             self.test_success_with_api_key()
+        finally:
+            self.web_user.is_superuser = False

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -52,7 +52,6 @@ from corehq.toggles import (
     DATA_MIGRATION,
     DISABLE_MOBILE_ENDPOINTS,
     IS_CONTRACTOR,
-    TWO_FACTOR_SUPERUSER_ROLLOUT,
 )
 from corehq.util.soft_assert import soft_assert
 
@@ -548,7 +547,7 @@ def _two_factor_required(view_func, domain_obj, request):
         # For other policies requiring two factor auth,
         # allow the two_factor_disabled loophole for people who have lost their phones
         # and need time to set up two factor auth again.
-        (domain_obj.two_factor_auth or TWO_FACTOR_SUPERUSER_ROLLOUT.enabled(request.couch_user.username))
+        domain_obj.two_factor_auth
         and not request.couch_user.two_factor_disabled
     )
 

--- a/corehq/apps/domain/tests/test_two_factor_check.py
+++ b/corehq/apps/domain/tests/test_two_factor_check.py
@@ -55,14 +55,15 @@ class TestTwoFactorRequired(TestCase):
         )
         self.assertFalse(two_factor_required_bool)
 
-    @override_settings(REQUIRE_TWO_FACTOR_FOR_SUPERUSERS=False)
-    def test_two_factor_not_required_without_setting(self):
+    def test_two_factor_required_for_domain(self):
+        self.domain.two_factor_auth = True
+        self.domain.save()
         view_func = 'dummy_view_func'
         request = self.request
         two_factor_required_bool = _two_factor_required(
             view_func, self.domain, request
         )
-        self.assertFalse(two_factor_required_bool)
+        self.assertTrue(two_factor_required_bool)
 
 
 class TestTwoFactorCheck(TestCase):

--- a/corehq/apps/domain/tests/test_two_factor_check.py
+++ b/corehq/apps/domain/tests/test_two_factor_check.py
@@ -1,32 +1,26 @@
 import json
-
-from django.test import RequestFactory, TestCase
-
 from unittest.mock import Mock, patch
+
+from django.test import RequestFactory, TestCase, override_settings
 
 from corehq.apps.domain.decorators import (
     OTP_AUTH_FAIL_RESPONSE,
     _two_factor_required,
     two_factor_check,
 )
-from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.sso.tests.generator import create_request_session
 from corehq.apps.users.models import CouchUser
-from corehq.util.test_utils import flag_enabled
 
 
-class TestTwoFactorCheck(TestCase):
+class TestTwoFactorRequired(TestCase):
     domain_name = 'test_domain'
 
     def setUp(self):
-
         self.domain = create_domain(self.domain_name)
         self.domain.two_factor_auth = False
+        self.addCleanup(self.domain.delete)
         self.request = self.create_request(request_url='/account/')
-
-    def tearDown(self):
-        Domain.get_by_name(self.domain_name).delete()
 
     @classmethod
     def create_request(cls, request_url):
@@ -34,66 +28,97 @@ class TestTwoFactorCheck(TestCase):
         request.couch_user = CouchUser()
         return request
 
-    @flag_enabled('TWO_FACTOR_SUPERUSER_ROLLOUT')
-    def test_two_factor_required_with_feature_flag(self):
+    @override_settings(REQUIRE_TWO_FACTOR_FOR_SUPERUSERS=True)
+    def test_two_factor_required_for_superuser(self):
+        self.request.couch_user.is_superuser = True
         view_func = 'dummy_view_func'
-        request = self.request
         two_factor_required_bool = _two_factor_required(
-            view_func,
-            self.domain,
-            request
+            view_func, self.domain, self.request
         )
         self.assertTrue(two_factor_required_bool)
 
-    def test_two_factor_check_with_sso_request(self):
+    @override_settings(REQUIRE_TWO_FACTOR_FOR_SUPERUSERS=False)
+    def test_two_factor_not_required_for_superuser(self):
+        self.request.couch_user.is_superuser = True
+        view_func = 'dummy_view_func'
+        two_factor_required_bool = _two_factor_required(
+            view_func, self.domain, self.request
+        )
+        self.assertFalse(two_factor_required_bool)
+
+    def test_two_factor_not_required_with_sso_request(self):
         view_func = 'dummy_view_func'
         request = self.request
         create_request_session(request, use_saml_sso=True)
         two_factor_required_bool = _two_factor_required(
-            view_func,
-            self.domain,
-            request
+            view_func, self.domain, request
         )
         self.assertFalse(two_factor_required_bool)
 
-    def test_two_factor_required_without_feature_flag(self):
+    @override_settings(REQUIRE_TWO_FACTOR_FOR_SUPERUSERS=False)
+    def test_two_factor_not_required_without_setting(self):
         view_func = 'dummy_view_func'
         request = self.request
         two_factor_required_bool = _two_factor_required(
-            view_func,
-            self.domain,
-            request
+            view_func, self.domain, request
         )
         self.assertFalse(two_factor_required_bool)
 
-    @flag_enabled('TWO_FACTOR_SUPERUSER_ROLLOUT')
-    def test_two_factor_check_with_feature_flag(self):
-        mock_fn_to_call = Mock(return_value='Function was called!')
+
+class TestTwoFactorCheck(TestCase):
+    domain_name = 'test_domain'
+
+    def setUp(self):
+        self.domain = create_domain(self.domain_name)
+        self.domain.two_factor_auth = False
+        self.addCleanup(self.domain.delete)
+        self.request = self.create_request(request_url='/account/')
+
+    @classmethod
+    def create_request(cls, request_url):
+        request = RequestFactory().get(request_url)
+        request.couch_user = CouchUser()
+        return request
+
+    def test_successful_two_factor_check(self):
+        mock_fn_to_call = Mock(return_value="Function was called!")
         mock_fn_to_call.__name__ = 'test_name'
-        request = self.request
         api_key = None
         view_func = 'dummy_view_func'
         two_factor_check_fn = two_factor_check(view_func, api_key)
-        function_getting_checked_with_auth = two_factor_check_fn(mock_fn_to_call)
-        with patch('corehq.apps.domain.decorators._ensure_request_couch_user',
-                        return_value=request.couch_user):
-            response = function_getting_checked_with_auth(request, self.domain.name)
+        function_getting_checked_with_auth = two_factor_check_fn(
+            mock_fn_to_call
+        )
+        with patch(
+            'corehq.apps.domain.decorators._ensure_request_couch_user',
+            return_value=self.request.couch_user,
+        ):
+            response = function_getting_checked_with_auth(
+                self.request, self.domain.name
+            )
+            self.assertEqual(response, 'Function was called!')
+            mock_fn_to_call.assert_called_once()
+
+    @override_settings(REQUIRE_TWO_FACTOR_FOR_SUPERUSERS=True)
+    def test_failed_two_factor_check(self):
+        self.request.couch_user.is_superuser = True
+        mock_fn_to_call = Mock(return_value='Function was called!')
+        mock_fn_to_call.__name__ = 'test_name'
+        api_key = None
+        view_func = 'dummy_view_func'
+        two_factor_check_fn = two_factor_check(view_func, api_key)
+        function_getting_checked_with_auth = two_factor_check_fn(
+            mock_fn_to_call
+        )
+        with patch(
+            'corehq.apps.domain.decorators._ensure_request_couch_user',
+            return_value=self.request.couch_user,
+        ):
+            response = function_getting_checked_with_auth(
+                self.request, self.domain.name
+            )
             self.assertEqual(response.status_code, 401)
             mock_fn_to_call.assert_not_called()
 
             data = json.loads(response.content)
             self.assertDictEqual(data, OTP_AUTH_FAIL_RESPONSE)
-
-    def test_two_factor_check_without_feature_flag(self):
-        mock_fn_to_call = Mock(return_value="Function was called!")
-        mock_fn_to_call.__name__ = 'test_name'
-        request = self.request
-        api_key = None
-        view_func = 'dummy_view_func'
-        two_factor_check_fn = two_factor_check(view_func, api_key)
-        function_getting_checked_with_auth = two_factor_check_fn(mock_fn_to_call)
-        with patch('corehq.apps.domain.decorators._ensure_request_couch_user',
-                        return_value=request.couch_user):
-            response = function_getting_checked_with_auth(request, self.domain.name)
-            self.assertEqual(response, 'Function was called!')
-            mock_fn_to_call.assert_called_once()

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1659,12 +1659,12 @@ PREVENT_MOBILE_UCR_SYNC = StaticToggle(
     description='Prevents mobile UCRs from being generated or included in the sync payload',
 )
 
-TWO_FACTOR_SUPERUSER_ROLLOUT = StaticToggle(
-    'two_factor_superuser_rollout',
-    'Users in this list will be forced to have Two-Factor Auth enabled',
-    TAG_DEPRECATED,
-    [NAMESPACE_USER]
-)
+# TWO_FACTOR_SUPERUSER_ROLLOUT = StaticToggle(
+#     'two_factor_superuser_rollout',
+#     'Users in this list will be forced to have Two-Factor Auth enabled',
+#     TAG_DEPRECATED,
+#     [NAMESPACE_USER]
+# )
 
 CUSTOM_ICON_BADGES = FrozenPrivilegeToggle(
     privilege_slug=privileges.CUSTOM_ICON_BADGES,


### PR DESCRIPTION
## Product Description
No user-facing effects. This removes the deprecated `TWO_FACTOR_SUPERUSER_ROLLOUT` feature flag, which forced specific users to have Two-Factor Auth enabled. This functionality has been replaced by the `REQUIRE_TWO_FACTOR_FOR_SUPERUSERS` Django setting.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19293

- Removed the toggle check from `corehq/apps/domain/decorators.py` — the `or TWO_FACTOR_SUPERUSER_ROLLOUT.enabled(request.couch_user.username)` clause was removed from the `_two_factor_required` function
- Refactored tests in `corehq/apps/domain/tests/test_two_factor_check.py` and `corehq/apps/api/odata/tests/test_auth.py` to use `@override_settings(REQUIRE_TWO_FACTOR_FOR_SUPERUSERS=True)` instead of the feature flag
- Commented out the toggle definition in `corehq/toggles/__init__.py`
- Added a test for ensuring 2FA is required if the domain has `two_factor_auth` set to True.

## Feature Flag
`TWO_FACTOR_SUPERUSER_ROLLOUT` (`two_factor_superuser_rollout`) — TAG_DEPRECATED

## Safety Assurance

### Safety story
I confirmed that the users that have this flag enabled are dimagi or dimagi adjacent users.

The flag is TAG_DEPRECATED and its behavior has been replaced by the `REQUIRE_TWO_FACTOR_FOR_SUPERUSERS` setting. The two-factor enforcement logic for superusers remains intact through that setting. The change is minimal — one `or` clause removed from a boolean expression.

### Automated test coverage
Tests in `test_two_factor_check.py` have been refactored to verify both the enabled and disabled paths using the replacement setting. The odata auth test also verifies API key success with two-factor enforcement.

### QA Plan
None

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change