### PR TITLE
Remove SMS_USE_LATEST_DEV_APP feature flag

### DIFF
--- a/corehq/apps/sms/handlers/keyword.py
+++ b/corehq/apps/sms/handlers/keyword.py
@@ -1,9 +1,8 @@
 from functools import cmp_to_key
 
-from corehq import toggles
 from dimagi.utils.logging import notify_exception
 
-from corehq.apps.app_manager.dbaccessors import get_app, get_latest_released_app
+from corehq.apps.app_manager.dbaccessors import get_latest_released_app
 from corehq.apps.formplayer_api.smsforms.api import (
     FormplayerInterface,
     TouchformsError,
@@ -307,10 +306,7 @@ def get_app_module_form(domain, app_id, form_unique_id, logged_subevent=None):
     Returns (app, module, form, error, error_code)
     """
     try:
-        if toggles.SMS_USE_LATEST_DEV_APP.enabled(domain, toggles.NAMESPACE_DOMAIN):
-            app = get_app(domain, app_id)
-        else:
-            app = get_latest_released_app(domain, app_id)
+        app = get_latest_released_app(domain, app_id)
         form = app.get_form(form_unique_id)
         module = form.get_module()
         return app, module, form, False, None
@@ -509,10 +505,7 @@ def keyword_uses_form_that_requires_case(survey_keyword):
             KeywordAction.ACTION_STRUCTURED_SMS,
             KeywordAction.ACTION_CONNECT_SURVEY,
         ]:
-            if toggles.SMS_USE_LATEST_DEV_APP.enabled(survey_keyword.domain, toggles.NAMESPACE_DOMAIN):
-                app = get_app(survey_keyword.domain, action.app_id)
-            else:
-                app = get_latest_released_app(survey_keyword.domain, action.app_id)
+            app = get_latest_released_app(survey_keyword.domain, action.app_id)
             form = app.get_form(action.form_unique_id)
             if form.requires_case():
                 return True

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -7,10 +7,7 @@ from django.db import models, transaction
 from django.http import Http404
 
 from corehq import toggles
-from corehq.apps.app_manager.dbaccessors import (
-    get_app,
-    get_latest_released_app,
-)
+from corehq.apps.app_manager.dbaccessors import get_latest_released_app
 from corehq.apps.app_manager.exceptions import AppInDifferentDomainException, FormNotFoundException
 from corehq.apps.data_interfaces.utils import property_references_parent
 from corehq.apps.formplayer_api.smsforms.api import TouchformsError
@@ -578,10 +575,7 @@ class SurveyContent(Content):
     @memoized
     def get_memoized_app_module_form(self, domain):
         try:
-            if toggles.SMS_USE_LATEST_DEV_APP.enabled(domain, toggles.NAMESPACE_DOMAIN):
-                app = get_app(domain, self.app_id)
-            else:
-                app = get_latest_released_app(domain, self.app_id)
+            app = get_latest_released_app(domain, self.app_id)
             form = app.get_form(self.form_unique_id)
             module = form.get_module()
         except (Http404, FormNotFoundException, AppInDifferentDomainException):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2355,16 +2355,16 @@ TWO_STAGE_USER_PROVISIONING_BY_SMS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-SMS_USE_LATEST_DEV_APP = FeatureRelease(
-    'sms_use_latest_dev_app',
-    'Use latest development version of the app for SMS processing',
-    TAG_DEPRECATED,
-    namespaces=[NAMESPACE_DOMAIN],
-    owner='Simon Kelly',
-    description='This will revert the SMS processing to previous functionality of using the '
-                'development version of the app instead of the latest release. It should only'
-                'be used temporarily if a domain needs unreleased app changes to be used for SMS.',
-)
+# SMS_USE_LATEST_DEV_APP = FeatureRelease(
+#     'sms_use_latest_dev_app',
+#     'Use latest development version of the app for SMS processing',
+#     TAG_DEPRECATED,
+#     namespaces=[NAMESPACE_DOMAIN],
+#     owner='Simon Kelly',
+#     description='This will revert the SMS processing to previous functionality of using the '
+#                 'development version of the app instead of the latest release. It should only'
+#                 'be used temporarily if a domain needs unreleased app changes to be used for SMS.',
+# )
 
 VIEW_FORM_ATTACHMENT = StaticToggle(
     'view_form_attachments',


### PR DESCRIPTION
## Product Description
No user-facing effects. This removes the deprecated `SMS_USE_LATEST_DEV_APP` feature flag, which allowed domains to use the latest development version of an app for SMS processing instead of the latest released version.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19289

- Removed toggle checks from `corehq/messaging/scheduling/models/abstract.py` and `corehq/apps/sms/handlers/keyword.py` — all three `if/else` branches simplified to always use `get_latest_released_app()`
- Cleaned up unused `toggles`, `get_app` imports from modified files
- Commented out the toggle definition in `corehq/toggles/__init__.py`

## Feature Flag
`SMS_USE_LATEST_DEV_APP` (`sms_use_latest_dev_app`) — TAG_DEPRECATED, FeatureRelease

## Safety Assurance

### Safety story
The flag is TAG_DEPRECATED. Removing it preserves the default behavior — SMS processing always uses the latest released app version. The description explicitly states the flag "should only be used temporarily."

No projects or environments currently have this flag enabled.

### Automated test coverage
No tests were directly tied to this flag. The existing SMS and scheduling test suites cover the `get_latest_released_app` code path.

### QA Plan
None

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change