### PR TITLE
Remove CLEAN_OLD_FORMPLAYER_SYNCS feature flag

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -7,7 +7,6 @@ from datetime import datetime
 
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Q
 
 import architect
 import six
@@ -319,34 +318,9 @@ def delete_synclogs(current_synclog):
             user_id=current_synclog.user_id,
             date__lt=current_synclog.date,
         )
-        device_id_filter = Q(device_id=current_synclog.device_id)
-        if toggles.CLEAN_OLD_FORMPLAYER_SYNCS.enabled(
-                current_synclog.user_id,
-                toggles.NAMESPACE_OTHER
-        ):
-            # see comment in get_alt_device_id about the purpose of this short-lived code
-            alt_device_id = get_alt_device_id(current_synclog.device_id)
-            device_id_filter = device_id_filter | Q(device_id=alt_device_id)
-        query.filter(device_id_filter).delete()
+        query.filter(device_id=current_synclog.device_id).delete()
     elif current_synclog.previous_log_id:
         SyncLogSQL.objects.filter(synclog_id=current_synclog.previous_log_id).delete()
-
-
-def get_alt_device_id(device_id):
-    # this function and its usage can be deleted on or after March 31
-    # https://github.com/dimagi/formplayer/pull/808 changed the device_id format
-    # and this logic helps us purge both old and new format device_ids
-    try:
-        parts = device_id.split('*')
-        if len(parts) == 4:
-            return '*'.join([parts[0], parts[1].replace('.', '_'), parts[2], parts[3]])
-        else:
-            return device_id
-    # this is a short lived piece of code and an optimization
-    # and it's more important to us that it never causes an error
-    # than it is that it works
-    except Exception:
-        return device_id
 
 
 def synclog_to_sql_object(synclog_json_object):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_purge.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_purge.py
@@ -1,11 +1,8 @@
 import uuid
 
 from django.test import TestCase
-from testil import eq
-
 from casexml.apps.case.xml import V1
 from casexml.apps.phone.exceptions import MissingSyncLog
-from casexml.apps.phone.models import get_alt_device_id
 from casexml.apps.phone.tests.utils import create_restore_user
 from casexml.apps.phone.utils import MockDevice
 
@@ -103,8 +100,3 @@ class TestSyncPurge(TestCase):
         fourth_sync = device.sync()
         response = fourth_sync.config.get_response()
         self.assertEqual(response.status_code, 200)
-
-
-def test_get_alt_device_id():
-    eq(get_alt_device_id('WebAppsLogin*mr.snuggles@example.com*as*example.mr.snuggles'),
-                         'WebAppsLogin*mr_snuggles@example_com*as*example.mr.snuggles')

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2111,13 +2111,13 @@ BLOCKED_DOMAIN_EMAIL_SENDERS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-CLEAN_OLD_FORMPLAYER_SYNCS = DynamicallyPredictablyRandomToggle(
-    'clean_old_formplayer_syncs',
-    'Delete old formplayer syncs during submission processing',
-    TAG_DEPRECATED,
-    namespaces=[NAMESPACE_OTHER],
-    default_randomness=0.001
-)
+# CLEAN_OLD_FORMPLAYER_SYNCS = DynamicallyPredictablyRandomToggle(
+#     'clean_old_formplayer_syncs',
+#     'Delete old formplayer syncs during submission processing',
+#     TAG_DEPRECATED,
+#     namespaces=[NAMESPACE_OTHER],
+#     default_randomness=0.001
+# )
 
 PRIME_FORMPLAYER_DBS_BHA = StaticToggle(
     'prime_formplayer_dbs_bha',


### PR DESCRIPTION
## Product Description
No user-facing effects. This removes the deprecated `CLEAN_OLD_FORMPLAYER_SYNCS` feature flag, which enabled deletion of old formplayer syncs (including alternate device ID formats) during submission processing. This appears to have still been active on india (1.0), eu (0.001) and staging (1.0), but based on https://github.com/dimagi/commcare-hq/pull/29051, I believe this is very safe to remove at this point as we are well outside of the 9 week synclog retention window for when this PR was initially created.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19290

- Removed the toggle check from `corehq/ex-submodules/casexml/apps/phone/models.py` — simplified the formplayer synclog purge to filter only by the current device ID, without the alternate device ID logic
- Removed the now-dead `get_alt_device_id` helper function (which was explicitly marked as deletable "on or after March 31. 2021") and its test
- Cleaned up unused `Q` import
- Commented out the toggle definition in `corehq/toggles/__init__.py`

## Feature Flag
`CLEAN_OLD_FORMPLAYER_SYNCS` (`clean_old_formplayer_syncs`) — TAG_DEPRECATED, DynamicallyPredictablyRandomToggle

## Safety Assurance

### Safety story
The flag is TAG_DEPRECATED with a very low `default_randomness` of `0.001`. The `get_alt_device_id` function was explicitly marked as temporary code that could be deleted. The remaining synclog purge logic (filtering by current device ID) is preserved.

### Automated test coverage
`test_prune_formplayer_synclogs` in `test_sync_purge.py` covers the formplayer synclog purge behavior and remains in place.

### QA Plan
None

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change