### PR TITLE
Add shared AI assistant rules for PR and branch conventions

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,0 +1,1 @@
+ai_rules.txt

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+ai_rules.txt

--- a/ai_rules.txt
+++ b/ai_rules.txt
@@ -1,0 +1,8 @@
+When creating PRs, always create them as drafts and always use the GitHub PR template.
+
+When adding template descriptions, avoid verbally restating the code diff. Focus on useful context for the reviewer.
+
+When committing new changes, always commit on a branch.
+
+When creating a new branch, each author has a prefix they use. Use the prefix the author has used most
+on local git branches or else their initials (from `git config user.name`).


### PR DESCRIPTION
## Product Description

N/A — no user-facing effects.

## Technical Summary

Adds `ai_rules.txt` with shared conventions for AI coding assistants (PR templates, branch naming, commit workflow). `.clinerules` and `.cursorrules` are symlinks to `ai_rules.txt` so that Claude Code (formerly called Cline), Cursor, and other tools all read the same rules from a single source.

These complement the existing `CLAUDE.md` with rules that apply across all AI tools.

According to a conversation with Claude chat, the distinction between what goes in `CLAUDE.md`/`AGENTS.md` and what goes in `.clinerules`/`.cursorrules` is that documentation about the codebase and architecture goes in the former, and instructions for how you want the agent to behave goes in the latter. (I have to imagine in practice there are plenty of things that could go in either and it's not super clearcut, but at a high level that distinction makes sense to me.)

## Feature Flag

N/A

## Safety Assurance

### Safety story

Config files only — no code changes, no runtime impact.

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)