### PR TITLE
Remove SHOW_BUILD_PROFILE_IN_APPLICATION_STATUS feature flag

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -133,20 +133,9 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
     @property
     def headers(self):
         columns = self._columns
-        if self.show_build_profile:
-            columns.append(
-                DataTablesColumn(_("Build Profile"),
-                                 help_text=_("The build profile from the user's last hearbeat request."),
-                                 sortable=False,
-                                 use_bootstrap5=self.use_bootstrap5)
-            )
         headers = DataTablesHeader(*columns)
         headers.custom_sort = [[2, 'desc']]
         return headers
-
-    @cached_property
-    def show_build_profile(self):
-        return toggles.SHOW_BUILD_PROFILE_IN_APPLICATION_STATUS.enabled(self.domain)
 
     @property
     def default_sort(self):
@@ -287,7 +276,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         loc_names_dict = self._locations_names_dict(users)
         for user in users:
             last_build = last_seen = last_sub = last_sync = last_sync_date = app_name = commcare_version = None
-            last_build_profile_name = device = device_app_meta = num_unsent_forms = None
+            device = device_app_meta = num_unsent_forms = None
             is_commcare_user = user.get('doc_type') == 'CommCareUser'
             build_version = _("Unknown")
             devices = user.get('devices', None)
@@ -334,13 +323,6 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
                         app_name = self.get_app_name(last_build['app_id'])
                     except AppInDifferentDomainException:
                         continue
-                if self.show_build_profile:
-                    last_build_profile_id = last_build.get('build_profile_id')
-                    if last_build_profile_id:
-                        last_build_profile_name = _("Unknown")
-                        build_profiles = self._get_app_details(last_build['app_id']).get('build_profiles', {})
-                        if last_build_profile_id in build_profiles:
-                            last_build_profile_name = build_profiles[last_build_profile_id]
 
             row_data = [
                 user_display_string(user.get('username', ''),
@@ -351,8 +333,6 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
                 app_name or "---", build_version, commcare_version or '---',
                 num_unsent_forms if num_unsent_forms is not None else "---",
             ]
-            if self.show_build_profile:
-                row_data.append(last_build_profile_name)
 
             if self._include_primary_locations_hierarchy():
                 location_data = self._ordered_hierarchy(locations_hierarchy.get(user['location_id'], []))

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1976,12 +1976,12 @@ IP_ACCESS_CONTROLS = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-SHOW_BUILD_PROFILE_IN_APPLICATION_STATUS = StaticToggle(
-    'show_build_profile_in_app_status',
-    'Show build profile installed on phone tracked via heartbeat request in App Status Report',
-    TAG_DEPRECATED,
-    [NAMESPACE_DOMAIN]
-)
+# SHOW_BUILD_PROFILE_IN_APPLICATION_STATUS = StaticToggle(
+#     'show_build_profile_in_app_status',
+#     'Show build profile installed on phone tracked via heartbeat request in App Status Report',
+#     TAG_DEPRECATED,
+#     [NAMESPACE_DOMAIN]
+# )
 
 LIVEQUERY_READ_FROM_STANDBYS = DynamicallyPredictablyRandomToggle(
     'livequery_read_from_standbys',


### PR DESCRIPTION
## Product Description
Removes the "Build Profile" column from the App Status Report. This column showed the build profile installed on users' phones (tracked via heartbeat requests) and was gated behind the deprecated `SHOW_BUILD_PROFILE_IN_APPLICATION_STATUS` feature flag.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19301

- Removed the `show_build_profile` property and all conditional logic from `corehq/apps/reports/standard/deployments.py` — the "Build Profile" column header, the build profile lookup from heartbeat data, and the row data append
- Commented out the toggle definition in `corehq/toggles/__init__.py`

## Feature Flag
`SHOW_BUILD_PROFILE_IN_APPLICATION_STATUS` (`show_build_profile_in_app_status`) — TAG_DEPRECATED, StaticToggle

## Safety Assurance

### Safety story
The flag is TAG_DEPRECATED. Removing it preserves the default behavior — the App Status Report renders without the "Build Profile" column, which is what all domains without the flag already see.

### Automated test coverage
No tests were directly tied to this flag. The App Status Report's core functionality is unaffected.

### QA Plan
None

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change