### PR TITLE
Restore uv.lock revision to 3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '4'",


### PR DESCRIPTION
## Product Description
N/A - no user-facing effects.

## Technical Summary
A recently merged PR accidentally downgraded the `revision` field in `uv.lock` from 3 to 2. This restores it.

## Feature Flag
N/A

## Safety Assurance

### Safety story
This only changes the `revision` metadata field in `uv.lock`. No dependencies are added, removed, or changed.

### Automated test coverage
N/A

### QA Plan
N/A

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change