### PR TITLE
Remove partial_ui_translations feature flag

### DIFF
--- a/corehq/apps/translations/tests/test_updating_app_from_trans_dict.py
+++ b/corehq/apps/translations/tests/test_updating_app_from_trans_dict.py
@@ -2,8 +2,6 @@ from io import BytesIO
 
 from django.test import SimpleTestCase
 
-from unittest import mock
-
 from couchexport.export import export_raw
 
 from corehq.apps.app_manager.models import Application, LinkedApplication
@@ -14,7 +12,6 @@ from corehq.apps.app_manager.ui_translations import (
 from corehq.apps.translations.utils import (
     update_app_translations_from_trans_dict,
 )
-from corehq.util.test_utils import flag_enabled
 
 INITIAL_TRANSLATIONS = {
     'en': {
@@ -81,17 +78,6 @@ class TestBulkUiTranslation(SimpleTestCase):
         self.assertDictEqual(self.app.translations['en'], {'translation.always.upload': 'Miley'})
         self.assertDictEqual(self.app.translations['fra'], {'translation.always.upload': 'Cyrus'})
 
-    @flag_enabled('PARTIAL_UI_TRANSLATIONS')
-    def test_not_upload_all_properties_with_parital_ui_translations(self):
-        headers = (('translations', ('property', 'en', 'fra')),)
-        data = (('translation.always.upload', 'Miley', 'Cyrus'),)
-        f = self._build_translation_download_file(headers, data)
-
-        translations, error_properties, warnings = process_ui_translation_upload(self.app, f)
-        update_app_translations_from_trans_dict(self.app, translations)
-
-        self.assertDictEqual(self.app.translations, EXPECTED_TRANSLATIONS)
-
     def test_not_upload_all_languages(self):
         headers = (('translations', ('property', 'en')),)
         data = (
@@ -105,25 +91,6 @@ class TestBulkUiTranslation(SimpleTestCase):
         self.assertDictEqual(self.app.translations['en'], EXPECTED_TRANSLATIONS['en'])
         self.assertDictEqual(self.app.translations['fra'], INITIAL_TRANSLATIONS['fra'])
 
-    @flag_enabled('PARTIAL_UI_TRANSLATIONS')
-    def test_linked_app_not_upload_all_languages_with_partial_ui_translations(self):
-        headers = (('translations', ('property', 'en')),)
-        data = (
-            ('translation.always.upload', 'Miley'),
-            ('translation.sometimes.upload', 'Kanye'),
-        )
-        f = self._build_translation_download_file(headers, data)
-
-        translations, error_properties, warnings = process_ui_translation_upload(self.linked_app, f)
-        update_app_translations_from_trans_dict(self.linked_app, translations)
-        self.assertDictEqual(self.linked_app.translations['en'], EXPECTED_TRANSLATIONS['en'])
-        self.assertDictEqual(self.linked_app.translations['fra'], INITIAL_TRANSLATIONS['fra'])
-        self.assertDictEqual(self.linked_app.linked_app_translations['en'], EXPECTED_TRANSLATIONS['en'])
-
-        with mock.patch.object(LinkedApplication, 'save'):
-            self.linked_app.reapply_overrides()
-        self.assertDictEqual(self.linked_app.translations['en'], EXPECTED_TRANSLATIONS['en'])
-
     def test_partial_property_and_language(self):
         headers = (('translations', ('property', 'en')),)
         data = (('translation.always.upload', 'Miley'),)
@@ -133,16 +100,4 @@ class TestBulkUiTranslation(SimpleTestCase):
         update_app_translations_from_trans_dict(self.app, translations)
 
         self.assertDictEqual(self.app.translations['en'], {'translation.always.upload': 'Miley'})
-        self.assertDictEqual(self.app.translations['fra'], INITIAL_TRANSLATIONS['fra'])
-
-    @flag_enabled('PARTIAL_UI_TRANSLATIONS')
-    def test_partial_property_and_language_with_partial_ui_translations(self):
-        headers = (('translations', ('property', 'en')),)
-        data = (('translation.always.upload', 'Miley'),)
-        f = self._build_translation_download_file(headers, data)
-
-        translations, error_properties, warnings = process_ui_translation_upload(self.app, f)
-        update_app_translations_from_trans_dict(self.app, translations)
-
-        self.assertDictEqual(self.app.translations['en'], EXPECTED_TRANSLATIONS['en'])
         self.assertDictEqual(self.app.translations['fra'], INITIAL_TRANSLATIONS['fra'])

--- a/corehq/apps/translations/utils.py
+++ b/corehq/apps/translations/utils.py
@@ -1,6 +1,5 @@
 import tempfile
 
-from corehq import toggles
 from corehq.apps.app_manager.models import LinkedApplication
 
 
@@ -23,13 +22,5 @@ def update_app_translations_from_trans_dict(app, new_trans):
     else:
         current_trans_dicts = [app.translations]
 
-    if toggles.PARTIAL_UI_TRANSLATIONS.enabled(app.domain):
-        for lang in new_trans:
-            for current_translation_dict in current_trans_dicts:
-                if lang in current_translation_dict:
-                    current_translation_dict[lang].update(new_trans[lang])
-                else:
-                    current_translation_dict[lang] = new_trans[lang]
-    else:
-        for current_translation_dict in current_trans_dicts:
-            current_translation_dict.update(new_trans)
+    for current_translation_dict in current_trans_dicts:
+        current_translation_dict.update(new_trans)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1809,12 +1809,12 @@ DASHBOARD_REACH_REPORT = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-PARTIAL_UI_TRANSLATIONS = StaticToggle(
-    'partial_ui_translations',
-    'Enable uploading a subset of translations in the UI Translations Excel upload',
-    TAG_DEPRECATED,
-    [NAMESPACE_DOMAIN]
-)
+# PARTIAL_UI_TRANSLATIONS = StaticToggle(
+#     'partial_ui_translations',
+#     'Enable uploading a subset of translations in the UI Translations Excel upload',
+#     TAG_DEPRECATED,
+#     [NAMESPACE_DOMAIN]
+# )
 
 SKIP_ORM_FIXTURE_UPLOAD = StaticToggle(
     'skip_orm_fixture_upload',


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19304
Removes the PARTIAL_UI_TRANSLATIONS feature flag, the few lines of code gated by it, and tests for its functionality.

## Feature Flag
Removes PARTIAL_UI_TRANSLATIONS

## Safety Assurance

### Safety story
This is straightforward code removal for a technically very simple feature.

### Automated test coverage
Removes test cases that specifically used the PARTIAL_UI_TRANSLATIONS feature flag.

### QA Plan
Nope.



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
