### PR TITLE
Remove FCM_NOTIFICATION feature flag

### DIFF
--- a/corehq/apps/ota/tests/test_heartbeat.py
+++ b/corehq/apps/ota/tests/test_heartbeat.py
@@ -51,7 +51,7 @@ class HeartbeatTests(TestCase):
 
     def _do_request(self, user, device_id, app_id=None, app_version=1, last_sync='',
                     unsent_forms=0, quarantined_forms=0, cc_version='2.39', url=None,
-                    response_code=200, fcm_token=''):
+                    response_code=200):
         url = url or self.url
         resp = self.client.get(url, {
             'app_id': app_id or self.app.get_id,
@@ -61,7 +61,6 @@ class HeartbeatTests(TestCase):
             'num_unsent_forms': unsent_forms,
             'num_quarantined_forms': quarantined_forms,
             'cc_version': cc_version,
-            'fcm_token': fcm_token
         }, **self._auth_headers(user))
         self.assertEqual(resp.status_code, response_code)
         process_reporting_metadata_staging()
@@ -124,16 +123,6 @@ class HeartbeatTests(TestCase):
         # ensure the cache was wiped on delete
         device_log_request.delete()
         self.assertFalse(heartbeat_contains_force_logs())
-
-    def test_heartbeat_fcm_token_not_stored(self):
-        self._do_request(
-            self.user,
-            device_id='4',
-            fcm_token='token-101'
-        )
-        device = CommCareUser.get(self.user.get_id).get_device('4')
-        self.assertIsNone(device.fcm_token)
-        self.assertIsNone(device.fcm_token_timestamp)
 
     @patch("corehq.apps.ota.views.deterministic_random")
     def test_incude_user_for_integrity_reporting(self, deterministic_random_mock):

--- a/corehq/apps/ota/tests/test_heartbeat.py
+++ b/corehq/apps/ota/tests/test_heartbeat.py
@@ -11,7 +11,6 @@ from corehq.apps.app_manager.tests.util import patch_validate_xform, get_simple_
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.tasks import process_reporting_metadata_staging
-from corehq.util.test_utils import flag_enabled
 from ..models import DeviceLogRequest
 
 
@@ -64,9 +63,7 @@ class HeartbeatTests(TestCase):
         process_reporting_metadata_staging()
         return resp
 
-    @flag_enabled('FCM_NOTIFICATION')
     def test_heartbeat(self):
-        fcm_token = 'token-101'
         self._do_request(
             self.user,
             device_id='123123',
@@ -74,15 +71,12 @@ class HeartbeatTests(TestCase):
             last_sync=datetime.utcnow().isoformat(),
             unsent_forms=2,
             quarantined_forms=3,
-            fcm_token=fcm_token
         )
         device = CommCareUser.get(self.user.get_id).get_device('123123')
         self.assertEqual(device.device_id, '123123')
         self.assertIsNotNone(device.last_used)
         self.assertEqual(device.commcare_version, '2.39')
         self.assertEqual(1, len(device.app_meta))
-        self.assertEqual(device.fcm_token, fcm_token)
-        self.assertIsNotNone(device.fcm_token_timestamp)
 
         app_meta = device.app_meta[0]
         self.assertEqual(app_meta.app_id, self.app.get_id)
@@ -127,29 +121,7 @@ class HeartbeatTests(TestCase):
         device_log_request.delete()
         self.assertFalse(heartbeat_contains_force_logs())
 
-    @flag_enabled('FCM_NOTIFICATION')
-    def test_heartbeat_update_fcm_token(self):
-        self._do_request(
-            self.user,
-            device_id='3',
-            fcm_token='token-101'
-        )
-
-        device = CommCareUser.get(self.user.get_id).get_device('3')
-        self.assertEqual(device.fcm_token, 'token-101')
-
-        updated_fcm_token = 'token-102'
-        self._do_request(
-            self.user,
-            device_id='3',
-            fcm_token=updated_fcm_token
-        )
-        updated_device = CommCareUser.get(self.user.get_id).get_device('3')
-        self.assertEqual(updated_device.fcm_token, updated_fcm_token)
-        self.assertIsNotNone(updated_device.fcm_token_timestamp)
-        self.assertGreater(updated_device.fcm_token_timestamp, device.fcm_token_timestamp)
-
-    def test_heartbeat_update_fcm_token_disabled_domain(self):
+    def test_heartbeat_fcm_token_not_stored(self):
         self._do_request(
             self.user,
             device_id='4',

--- a/corehq/apps/ota/tests/test_heartbeat.py
+++ b/corehq/apps/ota/tests/test_heartbeat.py
@@ -1,16 +1,20 @@
 import base64
 from datetime import datetime
-from uuid import uuid4
 from unittest.mock import patch
+from uuid import uuid4
 
 from django.test import TestCase
 from django.urls.base import reverse
 
 from corehq.apps.app_manager.tests.app_factory import AppFactory
-from corehq.apps.app_manager.tests.util import patch_validate_xform, get_simple_form
+from corehq.apps.app_manager.tests.util import (
+    get_simple_form,
+    patch_validate_xform,
+)
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.tasks import process_reporting_metadata_staging
+
 from ..models import DeviceLogRequest
 
 

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -452,7 +452,6 @@ def update_user_reporting_data(app_build_id, app_id, build_profile_id, couch_use
     num_unsent_forms = _safe_int(request.GET.get('num_unsent_forms', ''))
     num_quarantined_forms = _safe_int(request.GET.get('num_quarantined_forms', ''))
     commcare_version = request.GET.get('cc_version', '')
-    fcm_token = ''
     # if mobile cannot determine app version it sends -1
     if app_version == -1:
         app_version = None
@@ -467,14 +466,14 @@ def update_user_reporting_data(app_build_id, app_id, build_profile_id, couch_use
     if settings.USER_REPORTING_METADATA_BATCH_ENABLED:
         UserReportingMetadataStaging.add_heartbeat(
             request.domain, couch_user._id, app_id, app_build_id, last_sync, device_id,
-            app_version, num_unsent_forms, num_quarantined_forms, commcare_version, build_profile_id, fcm_token
+            app_version, num_unsent_forms, num_quarantined_forms, commcare_version, build_profile_id,
         )
     else:
         record = UserReportingMetadataStaging(domain=request.domain, user_id=couch_user._id, app_id=app_id,
             build_id=app_build_id, sync_date=last_sync, device_id=device_id, app_version=app_version,
             num_unsent_forms=num_unsent_forms, num_quarantined_forms=num_quarantined_forms,
             commcare_version=commcare_version, build_profile_id=build_profile_id,
-            last_heartbeat=datetime.utcnow(), modified_on=datetime.utcnow(), fcm_token=fcm_token)
+            last_heartbeat=datetime.utcnow(), modified_on=datetime.utcnow())
         try:
             record.process_record(couch_user)
         except ResourceConflict:

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -37,7 +37,6 @@ from dimagi.utils.logging import notify_exception
 from dimagi.utils.parsing import string_to_utc_datetime
 
 from corehq import toggles
-from corehq.toggles import deterministic_random
 from corehq.apps.app_manager.dbaccessors import (
     get_app_cached,
     get_latest_released_app_version,
@@ -46,7 +45,10 @@ from corehq.apps.app_manager.models import GlobalAppConfig
 from corehq.apps.builds.utils import get_default_build_spec
 from corehq.apps.case_search.const import COMMCARE_PROJECT
 from corehq.apps.case_search.exceptions import CaseSearchUserError
-from corehq.apps.case_search.models import CASE_SEARCH_REGISTRY_ID_KEY, CASE_SEARCH_TAGS_MAPPING
+from corehq.apps.case_search.models import (
+    CASE_SEARCH_REGISTRY_ID_KEY,
+    CASE_SEARCH_TAGS_MAPPING,
+)
 from corehq.apps.case_search.utils import get_case_search_results_from_request
 from corehq.apps.domain.auth import formplayer_auth
 from corehq.apps.domain.decorators import check_domain_mobile_access
@@ -61,19 +63,28 @@ from corehq.apps.registry.exceptions import (
     RegistryNotFound,
 )
 from corehq.apps.registry.helper import DataRegistryHelper
-from corehq.apps.users.device_rate_limiter import device_rate_limiter, DEVICE_RATE_LIMIT_MESSAGE
+from corehq.apps.users.device_rate_limiter import (
+    DEVICE_RATE_LIMIT_MESSAGE,
+    device_rate_limiter,
+)
 from corehq.apps.users.models import CouchUser, UserReportingMetadataStaging
 from corehq.const import ONE_DAY, OPENROSA_VERSION_MAP
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.utils.xform import adjust_text_to_datetime
 from corehq.middleware import OPENROSA_VERSION_HEADER
-from corehq.util.metrics import limit_domains, metrics_histogram, limit_tags
+from corehq.toggles import deterministic_random
+from corehq.util.metrics import limit_domains, limit_tags, metrics_histogram
 from corehq.util.quickcache import quickcache
 from corehq.util.timer import set_request_duration_reporting_threshold
 
 from .case_restore import get_case_restore_response
-from .models import DeviceLogRequest, MobileRecoveryMeasure, SerialIdBucket, IntegritySamplePercentage
+from .models import (
+    DeviceLogRequest,
+    IntegritySamplePercentage,
+    MobileRecoveryMeasure,
+    SerialIdBucket,
+)
 from .rate_limiter import rate_limit_restore
 from .utils import (
     demo_user_restore_response,
@@ -303,8 +314,10 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     if user_id and user_id != couch_user.user_id:
         # sync with a user that has been deleted but a new
         # user was created with the same username and password
-        from couchforms.openrosa_response import get_simple_response_xml
-        from couchforms.openrosa_response import ResponseNature
+        from couchforms.openrosa_response import (
+            ResponseNature,
+            get_simple_response_xml,
+        )
         response = get_simple_response_xml(
             'Attempt to sync with invalid user.',
             ResponseNature.OTA_RESTORE_ERROR

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -440,8 +440,6 @@ def update_user_reporting_data(app_build_id, app_id, build_profile_id, couch_use
     num_quarantined_forms = _safe_int(request.GET.get('num_quarantined_forms', ''))
     commcare_version = request.GET.get('cc_version', '')
     fcm_token = ''
-    if toggles.FCM_NOTIFICATION.enabled(request.domain):
-        fcm_token = request.GET.get('fcm_token', '')
     # if mobile cannot determine app version it sends -1
     if app_version == -1:
         app_version = None

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -940,10 +940,6 @@ class DeviceIdLastUsed(DocumentSchema):
     def __eq__(self, other):
         return all(getattr(self, p) == getattr(other, p) for p in self.properties())
 
-    def update_fcm_token(self, fcm_token, fcm_token_timestamp):
-        self.fcm_token = fcm_token
-        self.fcm_token_timestamp = fcm_token_timestamp
-
 
 class LastSubmission(DocumentSchema):
     """Metadata for form sumbissions. This data is keyed by app_id"""
@@ -2366,8 +2362,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         case = self.get_usercase()
         return case.case_id if case else None
 
-    def update_device_id_last_used(self, device_id, when=None, commcare_version=None, device_app_meta=None,
-                                   fcm_token=None, fcm_token_timestamp=None):
+    def update_device_id_last_used(self, device_id, when=None, commcare_version=None, device_app_meta=None):
         """
         Sets the last_used date for the device to be the current time
         Does NOT save the user object.
@@ -2401,14 +2396,8 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                 meta = self.last_device.get_last_used_app_meta()
                 self.last_device.app_meta = [meta] if meta else []
                 save_user = True
-            if fcm_token and fcm_token_timestamp:
-                if not device.fcm_token_timestamp or fcm_token_timestamp > device.fcm_token_timestamp:
-                    device.update_fcm_token(fcm_token, fcm_token_timestamp)
-                    save_user = True
         else:
             device = DeviceIdLastUsed(device_id=device_id, last_used=when)
-            if fcm_token and fcm_token_timestamp:
-                device.update_fcm_token(fcm_token, fcm_token_timestamp)
             device.update_meta(commcare_version, device_app_meta)
             self.devices.append(device)
             self.last_device = device
@@ -2425,9 +2414,6 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         for device in self.devices:
             if device.device_id == device_id:
                 return device
-
-    def get_devices_fcm_tokens(self):
-        return [device.fcm_token for device in self.devices if device.fcm_token]
 
 
 class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
@@ -3075,7 +3061,7 @@ class UserReportingMetadataStaging(models.Model):
     @classmethod
     def add_heartbeat(cls, domain, user_id, app_id, build_id, sync_date, device_id,
                       app_version, num_unsent_forms, num_quarantined_forms,
-                      commcare_version, build_profile_id, fcm_token):
+                      commcare_version, build_profile_id):
         params = {
             'domain': domain,
             'user_id': user_id,
@@ -3088,7 +3074,6 @@ class UserReportingMetadataStaging(models.Model):
             'num_quarantined_forms': num_quarantined_forms,
             'commcare_version': commcare_version,
             'build_profile_id': build_profile_id,
-            'fcm_token': fcm_token
         }
         with connection.cursor() as cursor:
             cursor.execute(f"""
@@ -3097,13 +3082,13 @@ class UserReportingMetadataStaging(models.Model):
                     build_id,
                     sync_date, device_id,
                     app_version, num_unsent_forms, num_quarantined_forms,
-                    commcare_version, build_profile_id, last_heartbeat, fcm_token
+                    commcare_version, build_profile_id, last_heartbeat
                 ) VALUES (
                     %(domain)s, %(user_id)s, %(app_id)s, CLOCK_TIMESTAMP(), CLOCK_TIMESTAMP(),
                     %(build_id)s,
                     %(sync_date)s, %(device_id)s,
                     %(app_version)s, %(num_unsent_forms)s, %(num_quarantined_forms)s,
-                    %(commcare_version)s, %(build_profile_id)s, CLOCK_TIMESTAMP(), %(fcm_token)s
+                    %(commcare_version)s, %(build_profile_id)s, CLOCK_TIMESTAMP()
                 )
                 ON CONFLICT (domain, user_id, app_id)
                 DO UPDATE SET
@@ -3116,8 +3101,7 @@ class UserReportingMetadataStaging(models.Model):
                     num_quarantined_forms = EXCLUDED.num_quarantined_forms,
                     commcare_version = EXCLUDED.commcare_version,
                     build_profile_id = EXCLUDED.build_profile_id,
-                    last_heartbeat = CLOCK_TIMESTAMP(),
-                    fcm_token = EXCLUDED.fcm_token
+                    last_heartbeat = CLOCK_TIMESTAMP()
                 WHERE staging.last_heartbeat is NULL or EXCLUDED.last_heartbeat > staging.last_heartbeat
                 """, params)
 
@@ -3154,7 +3138,7 @@ class UserReportingMetadataStaging(models.Model):
                 self.domain, user, self.app_id, self.build_id,
                 self.sync_date, latest_build_date, self.device_id, device_app_meta,
                 commcare_version=self.commcare_version, build_profile_id=self.build_profile_id,
-                fcm_token=self.fcm_token, fcm_token_timestamp=self.last_heartbeat, save_user=False
+                save_user=False
             )
         if save:
             # update_django_user=False below is an optimization that allows us to update the CouchUser

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -21,7 +21,6 @@ from .views import (
     paginate_enterprise_users,
     paginate_web_users,
     reactivate_web_user,
-    register_fcm_device_token,
     remove_web_user,
     test_httpdigest,
     undo_remove_web_user,
@@ -159,11 +158,6 @@ urlpatterns = [
     url(r'^roles/new/$', EditRoleView.as_view(), name='create_role'),
     url(r'^roles/edit/(?P<role_id>[ \w-]+)', EditRoleView.as_view(), name=EditRoleView.urlname),
     url(r'^roles/delete/$', delete_user_role, name='delete_user_role'),
-    url(
-        r'^register_fcm_device_token/(?P<couch_user_id>[ \w-]+)/(?P<device_token>[ \w-]+)/$',
-        register_fcm_device_token,
-        name='register_fcm_device_token'
-    ),
     url(r'^httpdigest/?$', test_httpdigest, name='test_httpdigest'),
 ] + [
     url(r'^commcare/$', MobileWorkerListView.as_view(), name=MobileWorkerListView.urlname),

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -249,8 +249,7 @@ def user_location_data(location_ids):
     return ' '.join(location_ids)
 
 
-def update_device_meta(user, device_id, commcare_version=None, device_app_meta=None, fcm_token=None,
-                       fcm_token_timestamp=None, save=True):
+def update_device_meta(user, device_id, commcare_version=None, device_app_meta=None, save=True):
     from corehq.apps.users.models import CommCareUser
 
     updated = False
@@ -261,8 +260,6 @@ def update_device_meta(user, device_id, commcare_version=None, device_app_meta=N
                 device_id,
                 commcare_version=commcare_version,
                 device_app_meta=device_app_meta,
-                fcm_token=fcm_token,
-                fcm_token_timestamp=fcm_token_timestamp
             )
             if save and updated:
                 user.save(fire_signals=False)

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -36,7 +36,6 @@ from django.utils.translation import gettext as _, gettext_lazy, gettext_noop
 
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_GET, require_POST
 from django_digest.decorators import httpdigest
@@ -1485,14 +1484,3 @@ def change_password(request, domain, login_id):
 @login_and_domain_required
 def test_httpdigest(request, domain):
     return HttpResponse("ok")
-
-
-@always_allow_project_access
-@csrf_exempt
-@require_POST
-@require_superuser
-def register_fcm_device_token(request, domain, couch_user_id, device_token):
-    user = WebUser.get_by_user_id(couch_user_id)
-    user.fcm_device_token = device_token
-    user.save()
-    return HttpResponse()

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -19,7 +19,7 @@ from django.forms.widgets import (
     HiddenInput,
     Select,
     SelectMultiple,
-    Textarea
+    Textarea,
 )
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property
@@ -2699,7 +2699,9 @@ class ScheduleForm(Form):
             raise json_error()
 
         if self.cleaned_data.get("use_user_case_for_filter"):
-            from corehq.apps.data_dictionary.util import get_data_dict_props_by_case_type
+            from corehq.apps.data_dictionary.util import (
+                get_data_dict_props_by_case_type,
+            )
             user_case_properties = (
                 get_data_dict_props_by_case_type(self.domain, exclude_deprecated=True))[USERCASE_TYPE]
             invalid_keys = \

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -108,7 +108,6 @@ from corehq.messaging.scheduling.scheduling_partitioned.models import (
 from corehq.toggles import (
     COMMCARE_CONNECT,
     EXTENSION_CASES_SYNC_ENABLED,
-    FCM_NOTIFICATION,
     RICH_TEXT_EMAILS,
 )
 
@@ -3313,10 +3312,7 @@ class ConditionalAlertScheduleForm(ScheduleForm):
                 (self.CONTENT_CUSTOM_SMS, _("Custom SMS")),
             ]
 
-        if (
-            self.initial.get('content') == self.CONTENT_FCM_NOTIFICATION
-            or (FCM_NOTIFICATION.enabled(self.domain) and settings.FCM_CREDS)
-        ):
+        if self.initial.get('content') == self.CONTENT_FCM_NOTIFICATION:
             self.fields['content'].choices += [
                 (self.CONTENT_FCM_NOTIFICATION, _("Push Notification"))
             ]
@@ -3917,17 +3913,8 @@ class ConditionalAlertScheduleForm(ScheduleForm):
             if not settings.FCM_CREDS:
                 raise ValidationError(_("Push Notifications is no longer available on this environment."
                                         " Please contact Administrator."))
-            if not FCM_NOTIFICATION.enabled(self.domain):
-                raise ValidationError(_("Push Notifications is not available for your project."
-                                        " Please contact Administrator."))
-
-            recipient_types_choices = dict(self.fields['recipient_types'].choices)
-            unsupported_recipient_types = {str(recipient_types_choices[recipient_type])
-                                           for recipient_type in recipient_types
-                                           if recipient_type not in self.FCM_SUPPORTED_RECIPIENT_TYPES}
-            if unsupported_recipient_types:
-                raise ValidationError(_("'{}' recipient types are not supported for Push Notifications"
-                                        .format(', '.join(unsupported_recipient_types))))
+            raise ValidationError(_("Push Notifications is not available for your project."
+                                    " Please contact Administrator."))
 
     def distill_start_offset(self):
         send_frequency = self.cleaned_data.get('send_frequency')

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -89,7 +89,6 @@ from corehq.messaging.scheduling.models import (
     ConnectMessageSurveyContent,
     CustomContent,
     EmailContent,
-    FCMNotificationContent,
     ImmediateBroadcast,
     IVRSurveyContent,
     RandomTimedEvent,
@@ -175,15 +174,6 @@ class ContentForm(Form):
     # names in the HTML are prefixed with "content-"
     prefix = 'content'
 
-    FCM_SUBJECT_MAX_LENGTH = 255
-    FCM_MESSAGE_MAX_LENGTH = 2048
-
-    fcm_message_type = ChoiceField(
-        required=False,
-        choices=FCMNotificationContent.MESSAGE_TYPES,
-        initial=FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION,
-        label=''
-    )
     subject = CharField(
         required=False,
         widget=HiddenInput,
@@ -242,11 +232,6 @@ class ContentForm(Form):
         required=False,
         label=gettext_lazy("Intervals"),
     )
-    fcm_action = ChoiceField(
-        required=False,
-        label=gettext_lazy("Action on Notification"),
-        choices=FCMNotificationContent.ACTION_CHOICES,
-    )
 
     def __init__(self, *args, **kwargs):
         if 'schedule_form' not in kwargs:
@@ -268,11 +253,6 @@ class ContentForm(Form):
             }
 
     def clean_subject(self):
-        if (self.schedule_form.cleaned_data.get('content') == ScheduleForm.CONTENT_FCM_NOTIFICATION
-                and self.cleaned_data['fcm_message_type'] == FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION):
-            cleaned_value = self._clean_message_field('subject')
-            return self._validate_fcm_message_length(cleaned_value, self.FCM_SUBJECT_MAX_LENGTH)
-
         if self.schedule_form.cleaned_data.get('content') != ScheduleForm.CONTENT_EMAIL:
             return None
 
@@ -284,11 +264,6 @@ class ContentForm(Form):
                 and self.schedule_form.cleaned_data.get('content') == ScheduleForm.CONTENT_EMAIL
         ):
             return None
-        if (self.schedule_form.cleaned_data.get('content') == ScheduleForm.CONTENT_FCM_NOTIFICATION
-                and self.cleaned_data['fcm_message_type'] == FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION):
-            cleaned_value = self._clean_message_field('message')
-            return self._validate_fcm_message_length(cleaned_value, self.FCM_MESSAGE_MAX_LENGTH)
-
         if self.schedule_form.cleaned_data.get('content') not in (ScheduleForm.CONTENT_SMS,
                                                                   ScheduleForm.CONTENT_EMAIL,
                                                                   ScheduleForm.CONTENT_CONNECT_MESSAGE):
@@ -314,31 +289,6 @@ class ContentForm(Form):
             raise ValidationError(_("Please fill out at least one translation"))
 
         return cleaned_value
-
-    @staticmethod
-    def _validate_fcm_message_length(value, max_length):
-        for data in value.values():
-            if len(data) > max_length:
-                raise ValidationError(_('This field must not exceed {} characters'.format(max_length)))
-        return value
-
-    def clean_fcm_message_type(self):
-        if self.schedule_form.cleaned_data.get('content') != ScheduleForm.CONTENT_FCM_NOTIFICATION:
-            return None
-
-        value = self.cleaned_data.get('fcm_message_type')
-        if not value:
-            raise ValidationError(_("This field is required"))
-        return value
-
-    def clean_fcm_action(self):
-        if self.schedule_form.cleaned_data.get('content') != ScheduleForm.CONTENT_FCM_NOTIFICATION:
-            return None
-
-        value = self.cleaned_data.get('fcm_action')
-        if self.cleaned_data['fcm_message_type'] == FCMNotificationContent.MESSAGE_TYPE_DATA and not value:
-            raise ValidationError(_("This field is required"))
-        return value
 
     def clean_app_and_form_unique_id(self):
         if self.schedule_form.cleaned_data.get('content') not in (ScheduleForm.CONTENT_SMS_SURVEY,
@@ -456,13 +406,6 @@ class ContentForm(Form):
             return CustomContent(
                 custom_content_id=self.cleaned_data['custom_sms_content_id']
             )
-        elif self.schedule_form.cleaned_data['content'] == ScheduleForm.CONTENT_FCM_NOTIFICATION:
-            return FCMNotificationContent(
-                subject=self.cleaned_data['subject'],
-                message=self.cleaned_data['message'],
-                action=self.cleaned_data['fcm_action'],
-                message_type=self.cleaned_data['fcm_message_type'],
-            )
         elif self.schedule_form.cleaned_data['content'] == ScheduleForm.CONTENT_CONNECT_MESSAGE:
             return ConnectMessageContent(
                 message=self.cleaned_data['message'],
@@ -524,11 +467,7 @@ class ContentForm(Form):
                         crispy.Div(template='scheduling/partials/rich_text_message_configuration.html'),
                         data_bind='with: html_message',
                     ),
-                    data_bind=(
-                        f"visible: $root.content() === '{ScheduleForm.CONTENT_EMAIL}' || "
-                        f"($root.content() === '{ScheduleForm.CONTENT_FCM_NOTIFICATION}' && "
-                        f"fcm_message_type() === '{FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION}')"
-                    )
+                    data_bind=f"visible: $root.content() === '{ScheduleForm.CONTENT_EMAIL}'"
                 ),
                 hqcrispy.B3MultiField(
                     _("Message"),
@@ -543,9 +482,7 @@ class ContentForm(Form):
                     data_bind=(
                         f"visible: $root.content() === '{ScheduleForm.CONTENT_SMS}' || "
                         f"$root.content() === '{ScheduleForm.CONTENT_SMS_CALLBACK}' || "
-                        f"$root.content() === '{ScheduleForm.CONTENT_CONNECT_MESSAGE}' || "
-                        f"($root.content() === '{ScheduleForm.CONTENT_FCM_NOTIFICATION}' && "
-                        f"fcm_message_type() === '{FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION}')"
+                        f"$root.content() === '{ScheduleForm.CONTENT_CONNECT_MESSAGE}'"
                     ),
                 )
             ]
@@ -565,29 +502,12 @@ class ContentForm(Form):
                         f"visible: $root.content() === '{ScheduleForm.CONTENT_SMS}' || "
                         f"$root.content() === '{ScheduleForm.CONTENT_EMAIL}' || "
                         f"$root.content() === '{ScheduleForm.CONTENT_SMS_CALLBACK}' || "
-                        f"$root.content() === '{ScheduleForm.CONTENT_CONNECT_MESSAGE}' || "
-                        f"($root.content() === '{ScheduleForm.CONTENT_FCM_NOTIFICATION}' && "
-                        f"fcm_message_type() === '{FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION}')"
+                        f"$root.content() === '{ScheduleForm.CONTENT_CONNECT_MESSAGE}'"
                     ),
                 ),
             ]
 
         return [
-            hqcrispy.B3MultiField(
-                _('Message type'),
-                crispy.Field(
-                    'fcm_message_type',
-                    data_bind='value: fcm_message_type',
-                ),
-                data_bind=f"visible: $root.content() === '{ScheduleForm.CONTENT_FCM_NOTIFICATION}'"
-            ),
-            crispy.Div(
-                crispy.Field('fcm_action'),
-                data_bind=(
-                    f"visible: $root.content() === '{ScheduleForm.CONTENT_FCM_NOTIFICATION}' && "
-                    f"fcm_message_type() === '{FCMNotificationContent.MESSAGE_TYPE_DATA}'"
-                )
-            ),
             hqcrispy.B3MultiField(
                 _("Subject"),
                 crispy.Field(
@@ -598,11 +518,7 @@ class ContentForm(Form):
                     crispy.Div(template='scheduling/partials/message_configuration.html'),
                     data_bind='with: subject',
                 ),
-                data_bind=(
-                    f"visible: $root.content() === '{ScheduleForm.CONTENT_EMAIL}' || "
-                    f"($root.content() === '{ScheduleForm.CONTENT_FCM_NOTIFICATION}' && "
-                    f"fcm_message_type() === '{FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION}')"
-                )
+                data_bind=f"visible: $root.content() === '{ScheduleForm.CONTENT_EMAIL}'"
             ),
             *message_fields,
             crispy.Div(
@@ -715,11 +631,6 @@ class ContentForm(Form):
         elif isinstance(content, SMSCallbackContent):
             result['message'] = content.message
             result['sms_callback_intervals'] = ', '.join(str(i) for i in content.reminder_intervals)
-        elif isinstance(content, FCMNotificationContent):
-            result['subject'] = content.subject
-            result['message'] = content.message
-            result['fcm_action'] = content.action
-            result['fcm_message_type'] = content.message_type
         elif isinstance(content, ConnectMessageContent):
             result['message'] = content.message
         elif isinstance(content, ConnectMessageSurveyContent):
@@ -1212,7 +1123,6 @@ class ScheduleForm(Form):
     CONTENT_IVR_SURVEY = 'ivr_survey'
     CONTENT_SMS_CALLBACK = 'sms_callback'
     CONTENT_CUSTOM_SMS = 'custom_sms'
-    CONTENT_FCM_NOTIFICATION = 'fcm_notification'
     CONTENT_CONNECT_MESSAGE = 'connect_message'
     CONTENT_CONNECT_SURVEY = 'connect_survey'
 
@@ -1621,8 +1531,6 @@ class ScheduleForm(Form):
                 content.include_case_updates_in_partial_submissions
         elif isinstance(content, SMSCallbackContent):
             initial['content'] = self.CONTENT_SMS_CALLBACK
-        elif isinstance(content, FCMNotificationContent):
-            initial['content'] = self.CONTENT_FCM_NOTIFICATION
         elif isinstance(content, ConnectMessageContent):
             initial['content'] = self.CONTENT_CONNECT_MESSAGE
         elif isinstance(content, ConnectMessageSurveyContent):
@@ -3128,17 +3036,6 @@ class ConditionalAlertScheduleForm(ScheduleForm):
 
     use_case = 'conditional_alert'
 
-    FCM_SUPPORTED_RECIPIENT_TYPES = [
-        ScheduleInstance.RECIPIENT_TYPE_MOBILE_WORKER,
-        ScheduleInstance.RECIPIENT_TYPE_LOCATION,
-        ScheduleInstance.RECIPIENT_TYPE_USER_GROUP,
-        CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER,
-        CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER,
-        CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USERNAME,
-        CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER_ID,
-        CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
-    ]
-
     # start_date is defined on the superclass but cleaning it in this subclass
     # depends on start_date_type, which depends on send_frequency
     field_order = [
@@ -3312,11 +3209,6 @@ class ConditionalAlertScheduleForm(ScheduleForm):
         ):
             self.fields['content'].choices += [
                 (self.CONTENT_CUSTOM_SMS, _("Custom SMS")),
-            ]
-
-        if self.initial.get('content') == self.CONTENT_FCM_NOTIFICATION:
-            self.fields['content'].choices += [
-                (self.CONTENT_FCM_NOTIFICATION, _("Push Notification"))
             ]
 
     @property
@@ -3910,13 +3802,6 @@ class ConditionalAlertScheduleForm(ScheduleForm):
         if CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL in recipient_types:
             if self.cleaned_data.get('content') != self.CONTENT_EMAIL:
                 raise ValidationError(_("Email case property can only be used with Email content"))
-
-        if self.cleaned_data.get('content') == self.CONTENT_FCM_NOTIFICATION:
-            if not settings.FCM_CREDS:
-                raise ValidationError(_("Push Notifications is no longer available on this environment."
-                                        " Please contact Administrator."))
-            raise ValidationError(_("Push Notifications is not available for your project."
-                                    " Please contact Administrator."))
 
     def distill_start_offset(self):
         send_frequency = self.cleaned_data.get('send_frequency')

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
@@ -109,7 +109,6 @@ var ContentViewModel = function (initialValues) {
     );
 
     self.survey_reminder_intervals_enabled = ko.observable(initialValues.survey_reminder_intervals_enabled);
-    self.fcm_message_type = ko.observable(initialValues.fcm_message_type);
 
 };
 

--- a/corehq/pillows/synclog.py
+++ b/corehq/pillows/synclog.py
@@ -120,8 +120,7 @@ class UserSyncHistoryProcessor(PillowProcessor):
 
 
 def mark_last_synclog(domain, user, app_id, build_id, sync_date, latest_build_date, device_id,
-                      device_app_meta, commcare_version=None, build_profile_id=None, fcm_token=None,
-                      fcm_token_timestamp=None, save_user=True):
+                      device_app_meta, commcare_version=None, build_profile_id=None, save_user=True):
     version = None
     if build_id:
         version = get_version_from_build_id(domain, build_id)
@@ -136,8 +135,7 @@ def mark_last_synclog(domain, user, app_id, build_id, sync_date, latest_build_da
 
     if device_id:
         local_save |= update_device_meta(user, device_id, commcare_version=commcare_version,
-                                         device_app_meta=device_app_meta, fcm_token=fcm_token,
-                                         fcm_token_timestamp=fcm_token_timestamp, save=False)
+                                         device_app_meta=device_app_meta, save=False)
     if local_save and save_user:
         user.save(fire_signals=False)
     return local_save

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2480,14 +2480,14 @@ COMMCARE_CONNECT = StaticToggle(
     description='More details to come',
 )
 
-FCM_NOTIFICATION = StaticToggle(
-    'fcm_notification',
-    'FCM Push Notifications - no longer functional',
-    TAG_DEPRECATED,
-    namespaces=[NAMESPACE_DOMAIN],
-    description='Push Notification option will be available in content for '
-                'Conditional Alerts in Messaging.'
-)
+# FCM_NOTIFICATION = StaticToggle(
+#     'fcm_notification',
+#     'FCM Push Notifications - no longer functional',
+#     TAG_DEPRECATED,
+#     namespaces=[NAMESPACE_DOMAIN],
+#     description='Push Notification option will be available in content for '
+#                 'Conditional Alerts in Messaging.'
+# )
 
 SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER_TOGGLE = StaticToggle(
     'show_owner_location_property_in_report_builder',

--- a/docs/messaging/schedules.rst
+++ b/docs/messaging/schedules.rst
@@ -136,7 +136,5 @@ be configured to send includes:
 * SMS
 * SMS Survey
 * Emails
-* Push Notifications
-
 In the case of SMS SurveysSessions, the survey content is defined using a form in an app which is then
 played to the recipients over SMS or Whatsapp.

--- a/settings.py
+++ b/settings.py
@@ -1152,9 +1152,6 @@ IGNORE_ALL_DEMO_USER_SUBMISSIONS = False
 USE_PHONE_ENTRIES = True
 COMMCARE_ANALYTICS_HOST = ""
 
-# FCM Server creds used for sending FCM Push Notifications
-FCM_CREDS = None
-
 CONNECTID_USERINFO_URL = 'http://localhost:8080/o/userinfo'
 CONNECTID_CLIENT_ID = ''
 CONNECTID_SECRET_KEY = ''

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -173,7 +173,7 @@ class XFormPillowTest(TestCase):
         UserReportingMetadataStaging.add_heartbeat(
             self.domain, self.user._id, self.metadata.app_id,
             '123', sync_date, 'heartbeat_device_id',
-            230, 2, 10, 'CommCare 2.28', 'en', 'acegi'
+            230, 2, 10, 'CommCare 2.28', 'en',
         )
 
         self.assertEqual(UserReportingMetadataStaging.objects.count(), 1)
@@ -188,7 +188,6 @@ class XFormPillowTest(TestCase):
         self.assertEqual(ccuser.reporting_metadata.last_syncs[0].sync_date, sync_date)
         self.assertEqual(ccuser.reporting_metadata.last_sync_for_user.sync_date, sync_date)
         self.assertEqual(ccuser.last_device.device_id, 'heartbeat_device_id')
-        self.assertEqual(ccuser.last_device.fcm_token, 'acegi')
         app_meta = ccuser.last_device.get_last_used_app_meta()
         self.assertEqual(app_meta.num_unsent_forms, 2)
         self.assertEqual(app_meta.num_quarantined_forms, 10)


### PR DESCRIPTION
## Product Description

No user-facing effects. The `FCM_NOTIFICATION` toggle was already tagged as `TAG_DEPRECATED` with the label "FCM Push Notifications - no longer functional". This PR removes the toggle checks so the feature is fully disabled. Existing schedules with FCM notification content will still display in the UI but cannot be saved (validation error).

## Technical Summary

Removes the `FCM_NOTIFICATION` (`fcm_notification`) feature flag from the codebase:

- **`corehq/apps/ota/views.py`**: Removed toggle-gated FCM token reading from heartbeat requests. `fcm_token` is now always `''`.
- **`corehq/messaging/scheduling/forms.py`**: Removed toggle import and simplified the content choice visibility (only shown for existing FCM schedules) and validation (always rejects new FCM content).
- **`corehq/apps/ota/tests/test_heartbeat.py`**: Removed `@flag_enabled('FCM_NOTIFICATION')` decorators. Deleted `test_heartbeat_update_fcm_token` (tested only the flagged feature). Renamed `test_heartbeat_update_fcm_token_disabled_domain` to `test_heartbeat_fcm_token_not_stored`.
- **`corehq/toggles/__init__.py`**: Commented out the `FCM_NOTIFICATION` toggle definition.

## Feature Flag

`FCM_NOTIFICATION` (slug: `fcm_notification`), `TAG_DEPRECATED`, `StaticToggle`

## Safety Assurance

### Safety story

This toggle was already tagged as `TAG_DEPRECATED` with the label "no longer functional". Removing it preserves the default (disabled) behavior — no domains will lose functionality since the feature was already non-functional. The form validation already had a "no longer available" error message in place.

### Automated test coverage

`corehq/apps/ota/tests/test_heartbeat.py` — 6 tests pass, covering heartbeat functionality including verification that FCM tokens are not stored.

### QA Plan

Verify no domains have the flag enabled:
```
cchq production django-manage list_ff_domains fcm_notification
cchq staging django-manage list_ff_domains fcm_notification
cchq india django-manage list_ff_domains fcm_notification
cchq eu django-manage list_ff_domains fcm_notification
```

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change