### PR TITLE
Remove EXPORTS_APPS_USE_ELASTICSEARCH feature flag

### DIFF
--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -424,15 +424,14 @@ class ApplicationDataRMIHelper(object):
         forms = []
         unknown_forms = []
 
-        for f in get_exports_by_form(self.domain, use_es=self.domain_object.exports_use_elasticsearch):
+        for f in get_exports_by_form(self.domain):
             form = f['value']
             if form.get('app_deleted') and not form.get('submissions'):
                 continue
             if 'app' in form:
                 form['has_app'] = True
                 forms.append(form)
-            elif not self.domain_object.exports_use_elasticsearch:
-                # If the elasticsearch toggle is on, we don't care about forms without apps
+            else:
                 app_id = f['key'][1] or ''
                 form['app'] = {
                     'id': app_id

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -7,12 +7,6 @@ import re
 import urllib.parse
 import uuid
 
-from captcha.fields import ReCaptchaField
-from crispy_forms import bootstrap as twbscrispy
-from crispy_forms import layout as crispy
-from crispy_forms.bootstrap import StrictButton
-from crispy_forms.layout import Layout, Submit
-from dateutil.relativedelta import relativedelta
 from django import forms
 from django.conf import settings
 from django.contrib import messages
@@ -44,6 +38,13 @@ from django.utils.http import urlsafe_base64_encode
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy, gettext_noop
+
+from captcha.fields import ReCaptchaField
+from crispy_forms import bootstrap as twbscrispy
+from crispy_forms import layout as crispy
+from crispy_forms.bootstrap import StrictButton
+from crispy_forms.layout import Layout, Submit
+from dateutil.relativedelta import relativedelta
 from django_countries.data import COUNTRIES
 from memoized import memoized
 from PIL import Image

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -137,7 +137,6 @@ from corehq.apps.users.models import CouchUser, WebUser
 from corehq.apps.users.util import generate_mobile_username
 from corehq.toggles import (
     COMMCARE_CONNECT,
-    EXPORTS_APPS_USE_ELASTICSEARCH,
     HIPAA_COMPLIANCE_CHECKBOX,
     MOBILE_UCR,
     SECURE_SESSION_TIMEOUT,
@@ -597,16 +596,6 @@ class DomainGlobalSettingsForm(forms.Form):
         )
     )
 
-    exports_use_elasticsearch = BooleanField(
-        label=gettext_lazy("Use elasticsearch when fetching apps for exports"),
-        required=False,
-        help_text=gettext_lazy(
-            """
-            (Internal) Fetches apps using elasticsearch instead of couch in exports
-            """
-        )
-    )
-
     connect_messaging_channel_name = CharField(
         label=gettext_lazy("Connect Messaging Channel Name"),
         required=False,
@@ -666,11 +655,6 @@ class DomainGlobalSettingsForm(forms.Form):
         self._handle_orphan_case_alerts_setting_value()
         self._handle_opt_out_of_data_sharing_setting_value()
 
-        if not EXPORTS_APPS_USE_ELASTICSEARCH.enabled(self.domain):
-            del self.fields['exports_use_elasticsearch']
-        else:
-            self._handle_exports_use_elasticsearch_setting_value()
-
         checkbox_fields = [
             hqcrispy.CheckboxField('release_mode_visibility'),
         ]
@@ -720,8 +704,6 @@ class DomainGlobalSettingsForm(forms.Form):
             ])
         if MOBILE_UCR.enabled(self.domain):
             extra_fields.append('mobile_ucr_sync_interval')
-        if EXPORTS_APPS_USE_ELASTICSEARCH.enabled(self.domain):
-            extra_fields.append('exports_use_elasticsearch')
         if COMMCARE_CONNECT.enabled(self.domain):
             extra_fields.append('connect_messaging_channel_name')
         return extra_fields
@@ -766,9 +748,6 @@ class DomainGlobalSettingsForm(forms.Form):
 
     def _handle_orphan_case_alerts_setting_value(self):
         self.fields['orphan_case_alerts_warning'].initial = self.project.orphan_case_alerts_warning
-
-    def _handle_exports_use_elasticsearch_setting_value(self):
-        self.fields['exports_use_elasticsearch'].initial = self.project.exports_use_elasticsearch
 
     def _handle_opt_out_of_data_sharing_setting_value(self):
         self.fields['opt_out_of_data_sharing'].initial = not self.project.internal.can_use_data
@@ -941,9 +920,6 @@ class DomainGlobalSettingsForm(forms.Form):
     def _save_opt_out_of_data_sharing_setting(self, domain):
         domain.update_internal(can_use_data=not self.cleaned_data.get("opt_out_of_data_sharing"))
 
-    def _save_exports_use_elasticsearch(self, domain):
-        domain.exports_use_elasticsearch = self.cleaned_data.get("exports_use_elasticsearch", True)
-
     def save(self, request, domain):
         domain.hr_name = self.cleaned_data['hr_name']
         domain.project_description = self.cleaned_data['project_description']
@@ -967,8 +943,6 @@ class DomainGlobalSettingsForm(forms.Form):
         self._save_enable_all_add_ons_setting(domain)
         self._save_orphan_case_alerts_setting(domain)
         self._save_opt_out_of_data_sharing_setting(domain)
-        if EXPORTS_APPS_USE_ELASTICSEARCH.enabled(self.domain):
-            self._save_exports_use_elasticsearch(domain)
         domain.save()
         return True
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -456,7 +456,6 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
 
     ga_opt_out = BooleanProperty(default=False)
     orphan_case_alerts_warning = BooleanProperty(default=False)
-    exports_use_elasticsearch = BooleanProperty(default=False)
 
     # For domains that have been migrated to a different environment
     redirect_url = StringProperty()

--- a/corehq/ex-submodules/couchforms/analytics.py
+++ b/corehq/ex-submodules/couchforms/analytics.py
@@ -1,19 +1,11 @@
 import datetime
 
-from corehq.apps.es import AppES, FormES
+from corehq.apps.es import FormES
 from corehq.apps.es.aggregations import TermsAggregation
-from corehq.apps.experiments import ES_FOR_EXPORTS, Experiment
 from corehq.const import MISSING_APP_ID
 from corehq.util.couch import stale_ok
 from corehq.util.dates import iso_string_to_datetime
 from corehq.util.quickcache import quickcache
-
-experiment = Experiment(
-    campaign=ES_FOR_EXPORTS,
-    old_args={},
-    new_args={'use_es': True},
-    is_equal=lambda a, b: True,
-)
 
 
 @quickcache(['domain'], timeout=10 * 60)
@@ -138,13 +130,8 @@ def get_form_analytics_metadata(domain, app_id, xmlns):
         return None
 
 
-def get_exports_by_form(domain, use_es=False):
-    if use_es:
-        # if use_es is True here, the "export_apps_use_elasticsearch" ff is enabled for
-        # this domain so just return es results without the experiment
-        rows = _get_export_forms_by_app_es(domain)
-    else:
-        rows = _experiment_get_export_forms(domain)
+def get_exports_by_form(domain):
+    rows = _get_export_forms(domain)
     form_count_breakdown = get_form_count_breakdown_for_domain(domain)
 
     for row in rows:
@@ -159,40 +146,15 @@ def get_exports_by_form(domain, use_es=False):
     return rows
 
 
-@experiment
-def _experiment_get_export_forms(domain, use_es=False):
+def _get_export_forms(domain):
     from corehq.apps.app_manager.models import Application
-    if use_es:
-        rows = _get_export_forms_by_app_es(domain)
-    else:
-        rows = Application.get_db().view(
-            'exports_forms_by_app/view',
-            startkey=[domain],
-            endkey=[domain, {}],
-            group=True,
-            stale=stale_ok()
-        ).all()
-    return rows
-
-
-def _get_export_forms_by_app_es(domain):
-    rows = []
-    apps = AppES().domain(domain).is_build(False).run().hits
-    for app in apps:
-        for module_id, module in enumerate(app.get("modules", [])):
-            for form_id, form in enumerate(module.get("forms", [])):
-                rows.append({
-                    "key": [app['domain'], app['_id'], form["xmlns"]],
-                    "value": {
-                        "xmlns": form["xmlns"],
-                        "app": {"name": app["name"], "langs": app["langs"], "id": app["_id"]},
-                        "module": {"name": module["name"], "id": module_id},
-                        "form": {"name": form["name"], "id": form_id},
-                        "app_deleted": app["doc_type"] in ["Application-Deleted", "LinkedApplication-Deleted"],
-                    }
-                })
-
-    return rows
+    return Application.get_db().view(
+        'exports_forms_by_app/view',
+        startkey=[domain],
+        endkey=[domain, {}],
+        group=True,
+        stale=stale_ok()
+    ).all()
 
 
 def get_form_count_breakdown_for_domain(domain):

--- a/corehq/ex-submodules/couchforms/tests/test_analytics.py
+++ b/corehq/ex-submodules/couchforms/tests/test_analytics.py
@@ -139,33 +139,6 @@ class ExportsFormsAnalyticsTest(TestCase, DocTestMixin):
                     'my://crazy.xmlns/deleted-app']
         }])
 
-    def test_get_exports_by_form_es(self):
-        self.assertEqual(get_exports_by_form(self.domain, use_es=True), [{
-            'value': {'xmlns': 'my://crazy.xmlns/', 'submissions': 2},
-            'key': ['exports_forms_analytics_domain', self.app_id_1,
-                    'my://crazy.xmlns/']
-        }, {
-            'value': {
-                'xmlns': 'my://crazy.xmlns/app',
-                'form': {'name': {}, 'id': 0},
-                'app': {'langs': [], 'name': None, 'id': self.app_id_2},
-                'module': {'name': {}, 'id': 0},
-                'app_deleted': False, 'submissions': 1},
-            'key': ['exports_forms_analytics_domain', self.app_id_2,
-                    'my://crazy.xmlns/app']
-        }, {
-            'value': {
-                'xmlns': 'my://crazy.xmlns/deleted-app',
-                'submissions': 1,
-                'form': {'name': {}, 'id': 0},
-                'app': {'langs': [], 'name': None, 'id': self.app_id_3},
-                'module': {'name': {}, 'id': 0},
-                'app_deleted': True
-            },
-            'key': ['exports_forms_analytics_domain', self.app_id_3,
-                    'my://crazy.xmlns/deleted-app']
-        }])
-
 
 @es_test(requires=[form_adapter, user_adapter], setup_class=True)
 @disable_quickcache

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1534,12 +1534,12 @@ ALLOW_USER_DEFINED_EXPORT_COLUMNS = StaticToggle(
 )
 
 
-EXPORTS_APPS_USE_ELASTICSEARCH = StaticToggle(
-    'export_apps_use_elasticsearch',
-    'Use elasticsearch when fetching apps for exports',
-    TAG_DEPRECATED,
-    [NAMESPACE_DOMAIN],
-)
+# EXPORTS_APPS_USE_ELASTICSEARCH = StaticToggle(
+#     'export_apps_use_elasticsearch',
+#     'Use elasticsearch when fetching apps for exports',
+#     TAG_DEPRECATED,
+#     [NAMESPACE_DOMAIN],
+# )
 
 
 DISABLE_COLUMN_LIMIT_IN_UCR = StaticToggle(


### PR DESCRIPTION
## Product Description
No user-facing effects. This toggle was deprecated and not enabled for any domains. It controlled whether elasticsearch was used instead of CouchDB when fetching apps for exports.

## Technical Summary

https://dimagi.atlassian.net/browse/SAAS-19294

Remove the `EXPORTS_APPS_USE_ELASTICSEARCH` (`export_apps_use_elasticsearch`) feature flag, which is deprecated and not enabled for any domains.

**Changes:**
- **`corehq/apps/domain/forms.py`**: Removed the `exports_use_elasticsearch` form field, its handler, save method, and all toggle checks from `DomainGlobalSettingsForm`
- **`corehq/apps/app_manager/fields.py`**: Simplified `_all_forms` to always call `get_exports_by_form(domain)` without the `use_es` parameter, and simplified the `elif` branch to a plain `else`
- **`corehq/ex-submodules/couchforms/analytics.py`**: Removed the ES experiment infrastructure (`Experiment`, `_get_export_forms_by_app_es`, `@experiment` decorator) and simplified `get_exports_by_form` to always use the CouchDB path
- **`corehq/apps/domain/models.py`**: Removed `exports_use_elasticsearch` BooleanProperty from the Domain model
- **`corehq/ex-submodules/couchforms/tests/test_analytics.py`**: Removed `test_get_exports_by_form_es` test
- **`corehq/toggles/__init__.py`**: Commented out the toggle definition

## Feature Flag
- **Variable**: `EXPORTS_APPS_USE_ELASTICSEARCH`
- **Slug**: `export_apps_use_elasticsearch`
- **Tag**: `TAG_DEPRECATED`

## Safety Assurance

### Safety story
This toggle is deprecated (`TAG_DEPRECATED`) and confirmed to have no domains enabled on any environment (production, staging, india, eu). Removing it preserves the default behavior (`False`) — the CouchDB path for fetching export forms, which is what all domains currently use.

### Automated test coverage
- `corehq/apps/domain/tests/test_forms.py` covers `DomainGlobalSettingsForm` behavior
- `corehq/ex-submodules/couchforms/tests/test_analytics.py::test_get_exports_by_form` covers the CouchDB export path

### QA Plan
Verified no domains have this flag enabled:
```
cchq production django-manage list_ff_domains export_apps_use_elasticsearch
cchq staging django-manage list_ff_domains export_apps_use_elasticsearch
cchq india django-manage list_ff_domains export_apps_use_elasticsearch
cchq eu django-manage list_ff_domains export_apps_use_elasticsearch
```

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change