### PR TITLE
  Remove PRODUCTS_PER_LOCATION feature flag

### DIFF
--- a/corehq/apps/locations/templates/locations/manage/location.html
+++ b/corehq/apps/locations/templates/locations/manage/location.html
@@ -80,12 +80,6 @@
           </li>
         {% endif %}
 
-        {% if products_per_location_form %}
-          <li class="nav-item">
-            <a class="nav-link" href="#products" data-bs-toggle="tab">{% trans "Products" %}</a>
-          </li>
-        {% endif %}
-
       </ul>
       <br />
     {% endif %}
@@ -184,23 +178,6 @@
                   {% endblocktrans %}
                 </div>
               {% endif %}
-            </div>
-          </div>
-        </div>
-      {% endif %}
-
-      {% if products_per_location_form %}
-        <div class="tab-pane" id="products">
-          <div class="row">
-            <div class="col-md-12">
-              <div class="card panel-modern-gray panel-form-only">
-                <div class="card-body">
-                  <form class="form-horizontal disable-on-submit{% if request.is_view_only %} form-hide-actions{% endif %}" id="edit_products" action="" method='post'>
-                    <input type="hidden" name="form_type" value="location-products" />
-                    {% crispy products_per_location_form %}
-                  </form>
-                </div>
-              </div>
             </div>
           </div>
         </div>

--- a/corehq/apps/locations/templates/locations/manage/location.html
+++ b/corehq/apps/locations/templates/locations/manage/location.html
@@ -7,7 +7,6 @@
   {% if not creates_new_location %}{{ location.name }} :{% endif %}
   {{ block.super }}
 {% endblock title %}
-
 {% js_entry 'locations/js/location' %}
 
 {% block page_content %}
@@ -19,29 +18,31 @@
   {% initial_page_data 'location_parent_get_id' location.parent.get_id %}
   {% initial_page_data 'can_edit_root' can_edit_root %}
   {% initial_page_data 'show_inactive' show_inactive %}
-
   {% registerurl 'location_search' domain %}
   {% registerurl 'archive_location' domain '---' %}
   {% registerurl 'unarchive_location' domain '---' %}
   {% registerurl 'delete_location' domain '---' %}
   {% registerurl 'location_lineage' domain '---' %}
-  {% registerurl 'location_descendants_count' domain '---'%}
+  {% registerurl 'location_descendants_count' domain '---' %}
   {% registerurl 'edit_location' domain '---' %}
   {% registerurl 'create_location' domain %}
 
   <div>
     {% if not creates_new_location %}
-
       <p class="lead">
         {{ location.name }}
-        <span class="text-body-secondary">({{ location.location_type_name }})</span>
+        <span class="text-body-secondary"
+          >({{ location.location_type_name }})</span
+        >
       </p>
 
       <div class="btn-toolbar mb-3">
-
         {% if location.get_id and location.location_type.can_have_children and not request.is_view_only %}
           <div class="btn-group me-2">
-            <a class="btn btn-primary" href="{% url "create_location" domain %}?parent={{ location.get_id }}">
+            <a
+              class="btn btn-primary"
+              href="{% url "create_location" domain %}?parent={{ location.get_id }}"
+            >
               <i class="fa fa-plus"></i> {% trans "New Child Location" %}
             </a>
           </div>
@@ -49,37 +50,59 @@
 
         {% if location.user_id %}
           <div class="btn-group me-2">
-            <a class="btn btn-outline-primary" href="{% url "edit_commcare_user" domain location.user_id %}">
-              <i class="fa-solid fa-up-right-from-square"></i> {% trans "Location User" %}
+            <a
+              class="btn btn-outline-primary"
+              href="{% url "edit_commcare_user" domain location.user_id %}"
+            >
+              <i class="fa-solid fa-up-right-from-square"></i>
+              {% trans "Location User" %}
             </a>
           </div>
         {% endif %}
 
         {% if location.supply_point_id %}
           <div class="btn-group me-2">
-            <a class="btn btn-outline-primary" href="{% url "case_data" domain location.supply_point_id %}" target="_blank">
-              <i class="fa-solid fa-up-right-from-square"></i> {% trans "View Location Case" %}
+            <a
+              class="btn btn-outline-primary"
+              href="{% url "case_data" domain location.supply_point_id %}"
+              target="_blank"
+            >
+              <i class="fa-solid fa-up-right-from-square"></i>
+              {% trans "View Location Case" %}
             </a>
           </div>
         {% endif %}
-
       </div>
 
       <ul class="nav nav-tabs">
         <li class="nav-item">
-          <a class="nav-link {% if form_tab == "basic" %}active{% endif %}" href="#basic-info" data-bs-toggle="tab">{% trans "Basic" %}</a>
+          <a
+            class="nav-link {% if form_tab == "basic" %}active{% endif %}"
+            href="#basic-info"
+            data-bs-toggle="tab"
+            >{% trans "Basic" %}</a
+          >
         </li>
 
         <li class="nav-item">
-          <a class="nav-link {% if form_tab == "descendants" %}active{% endif %}" href="#descendants-info" data-bs-toggle="tab">{% trans "Child Locations" %}</a>
+          <a
+            class="nav-link {% if form_tab == "descendants" %}active{% endif %}"
+            href="#descendants-info"
+            data-bs-toggle="tab"
+            >{% trans "Child Locations" %}</a
+          >
         </li>
 
         {% if users_per_location_form %}
           <li class="nav-item">
-            <a class="nav-link {% if form_tab == "users" %}active{% endif %}" href="#users" data-bs-toggle="tab">{% trans "Users" %}</a>
+            <a
+              class="nav-link {% if form_tab == "users" %}active{% endif %}"
+              href="#users"
+              data-bs-toggle="tab"
+              >{% trans "Users" %}</a
+            >
           </li>
         {% endif %}
-
       </ul>
       <br />
     {% endif %}
@@ -90,34 +113,45 @@
           {% url 'location_types' domain as levels_url %}
           {% blocktrans %}
             <strong>There was an issue creating this location.</strong><br />
-            Please make sure that at least one <a href="{{ levels_url }}">Organization Level</a>
+            Please make sure that at least one
+            <a href="{{ levels_url }}">Organization Level</a>
             has been created.
           {% endblocktrans %}
         </p>
       </div>
     {% endif %}
     <div class="tab-content">
-      <div class="tab-pane {% if form_tab == "basic" %}active{% endif %}" id="basic-info">
-
+      <div
+        class="tab-pane {% if form_tab == "basic" %}active{% endif %}"
+        id="basic-info"
+      >
         <div class="card panel-modern-gray panel-form-only">
           <div class="card-body">
-            <form id="loc_form" class="form form-horizontal" name="product" method="post">
+            <form
+              id="loc_form"
+              class="form form-horizontal"
+              name="product"
+              method="post"
+            >
               {% bootstrap_form_errors form %}
               {% crispy form.location_form %}
-
               {% crispy form.custom_location_data.form %}
 
               <input type="hidden" name="form_type" value="location-settings" />
 
               {% if consumption %}
-                <legend>{% trans "Default monthly consumption values" %}</legend>
+                <legend>
+                  {% trans "Default monthly consumption values" %}
+                </legend>
                 {% for code, amount in consumption %}
                   <div class="mb-3">
-                    <label class="col-md-3 col-lg-4 col-xl-2 form-label">{{ code }}</label>
+                    <label class="col-md-3 col-lg-4 col-xl-2 form-label"
+                      >{{ code }}</label
+                    >
                     <div class="col-md-4 col-lg-5 col-xl-3 controls">
-                        <span class="form-control uneditable-input">
-                          {{ amount }}
-                        </span>
+                      <span class="form-control uneditable-input">
+                        {{ amount }}
+                      </span>
                     </div>
                   </div>
                 {% endfor %}
@@ -140,13 +174,15 @@
             </form>
           </div>
         </div>
-
       </div>
 
       {% if not creates_new_location %}
         {% initial_page_data 'location' location %}
 
-        <div class="tab-pane {% if form_tab == "descendants" %}active{% endif %}" id="descendants-info">
+        <div
+          class="tab-pane {% if form_tab == "descendants" %}active{% endif %}"
+          id="descendants-info"
+        >
           <div class="card panel-modern-gray panel-form-only">
             <div class="card-body">
               {% include 'locations/manage/location_template.html' with view_only=request.is_view_only %}
@@ -156,15 +192,26 @@
       {% endif %}
 
       {% if users_per_location_form %}
-        <div class="tab-pane {% if form_tab == "users" %}active{% endif %}" id="users">
+        <div
+          class="tab-pane {% if form_tab == "users" %}active{% endif %}"
+          id="users"
+        >
           <div class="row">
             <div class="col-md-12">
-
               <div class="card panel-modern-gray panel-form-only">
                 <div class="card-body">
-                  <form class="form-horizontal disable-on-submit{% if not can_edit_users_in_location or request.is_view_only %} form-hide-actions{% endif %}" id="edit_users" action="" method='post'>
+                  <form
+                    class="form-horizontal disable-on-submit{% if not can_edit_users_in_location or request.is_view_only %}form-hide-actions{% endif %}"
+                    id="edit_users"
+                    action=""
+                    method="post"
+                  >
                     {% crispy users_per_location_form %}
-                    <input type="hidden" name="form_type" value="location-users" />
+                    <input
+                      type="hidden"
+                      name="form_type"
+                      value="location-users"
+                    />
                   </form>
                 </div>
               </div>
@@ -172,9 +219,11 @@
               {% if not request.is_view_only and not can_edit_users_in_location %}
                 <div class="alert alert-info">
                   {% blocktrans %}
-                    Your permissions allow you to <strong>create, update, and delete locations</strong>
-                    and <strong>modify location settings</strong>. However, your project
-                    administrator has not granted you access to change workers at locations.
+                    Your permissions allow you to
+                    <strong>create, update, and delete locations</strong> and
+                    <strong>modify location settings</strong>. However, your
+                    project administrator has not granted you access to change
+                    workers at locations.
                   {% endblocktrans %}
                 </div>
               {% endif %}
@@ -182,8 +231,6 @@
           </div>
         </div>
       {% endif %}
-
     </div>
-
   </div>
 {% endblock %}

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -40,11 +40,10 @@ from corehq.apps.locations.tasks import (
     download_locations_async,
     import_locations_async,
 )
-from corehq.apps.products.models import Product, SQLProduct
+from corehq.apps.products.models import Product
 from corehq.apps.reports.filters.api import EmwfOptionsView
 from corehq.apps.reports.filters.controllers import EmwfOptionsController
 from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
-from corehq.apps.users.forms import MultipleSelectionForm
 from corehq.util import reverse
 from corehq.util.files import file_extention_from_filename
 from corehq.util.workbook_json.excel import WorkbookJSONError, get_workbook
@@ -799,25 +798,6 @@ class EditLocationView(BaseEditLocationView):
 
     @property
     @memoized
-    def products_form(self):
-        if (
-            self.location.location_type.administrative
-            or not toggles.PRODUCTS_PER_LOCATION.enabled(self.request.domain)
-        ):
-            return None
-
-        form = MultipleSelectionForm(
-            initial={'selected_ids': self.products_at_location},
-            submit_label=_("Update Product List"),
-            fieldset_title=_("Specify Products Per Location"),
-            prefix="products",
-        )
-        form.fields['selected_ids'].choices = self.active_products
-        form.fields['selected_ids'].label = _("Products at Location")
-        return form
-
-    @property
-    @memoized
     def users_form(self):
         if not (self.can_edit_commcare_users or self.can_access_all_locations):
             return None
@@ -830,15 +810,6 @@ class EditLocationView(BaseEditLocationView):
             data=self.request.POST if self.request.method == "POST" else None,
         )
         return form
-
-    @property
-    def active_products(self):
-        return [(p.product_id, p.name)
-                for p in SQLProduct.objects.filter(domain=self.domain, is_archived=False).all()]
-
-    @property
-    def products_at_location(self):
-        return [p.product_id for p in self.location.products.all()]
 
     @property
     def page_name(self):
@@ -864,13 +835,11 @@ class EditLocationView(BaseEditLocationView):
         if self.request.is_view_only:
             make_form_readonly(self.location_form.location_form)
             make_form_readonly(self.location_form.custom_location_data.form)
-            make_form_readonly(self.products_form)
             make_form_readonly(self.users_form)
         elif not self.can_edit_users_in_location:
             make_form_readonly(self.users_form)
 
         context.update({
-            'products_per_location_form': self.products_form,
             'users_per_location_form': self.users_form,
             'can_edit_commcare_users': self.can_edit_commcare_users,
             'can_edit_users_in_location': self.can_edit_users_in_location,
@@ -885,14 +854,6 @@ class EditLocationView(BaseEditLocationView):
             self.request.method = "GET"
             self.form_tab = 'users'
             return self.get(request, *args, **kwargs)
-
-    def products_form_post(self, request, *args, **kwargs):
-        products = SQLProduct.objects.filter(
-            product_id__in=request.POST.getlist('products-selected_ids', [])
-        )
-        self.location.products = products
-        self.location.save()
-        return self.form_valid()
 
     @method_decorator(lock_locations)
     def post(self, request, *args, **kwargs):
@@ -912,9 +873,6 @@ class EditLocationView(BaseEditLocationView):
 
         if self.request.POST['form_type'] == "location-settings":
             return self.settings_form_post(request, *args, **kwargs)
-        elif (self.request.POST['form_type'] == "location-products"
-              and toggles.PRODUCTS_PER_LOCATION.enabled(request.domain)):
-            return self.products_form_post(request, *args, **kwargs)
         else:
             raise Http404()
 

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -1,9 +1,15 @@
 import json
 import logging
+from functools import wraps
 
 from django.contrib import messages
 from django.core.cache import cache
-from django.http import Http404, HttpResponseRedirect
+from django.http import (
+    Http404,
+    HttpResponseBadRequest,
+    HttpResponseRedirect,
+    JsonResponse,
+)
 from django.http.response import HttpResponseServerError
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.decorators import method_decorator
@@ -14,7 +20,6 @@ from django.utils.translation import gettext_lazy, gettext_noop
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods, require_POST
 
-from functools import wraps
 from memoized import memoized
 
 from dimagi.utils.couch import get_redis_lock, release_lock
@@ -28,13 +33,14 @@ from corehq import toggles
 from corehq.apps.commtrack.util import unicode_slug
 from corehq.apps.consumption.shortcuts import get_default_monthly_consumption
 from corehq.apps.custom_data_fields.edit_model import CustomDataModelMixin
-from corehq.apps.domain.decorators import domain_admin_required, api_auth
+from corehq.apps.domain.decorators import api_auth, domain_admin_required
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqwebapp.crispy import make_form_readonly
 from corehq.apps.hqwebapp.decorators import use_bootstrap5, waf_allow
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.hqwebapp.views import no_permissions
 from corehq.apps.locations.const import LOCK_LOCATIONS_TIMEOUT
+from corehq.apps.locations.dbaccessors import get_filtered_locations_count
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.locations.tasks import (
     download_locations_async,
@@ -51,12 +57,8 @@ from corehq.util.workbook_json.excel import WorkbookJSONError, get_workbook
 from .analytics import users_have_locations
 from .const import ROOT_LOCATION_TYPE
 from .dbaccessors import get_users_assigned_to_locations
-from .exceptions import LocationConsistencyError, LocationBulkImportError
-from .forms import (
-    LocationFilterForm,
-    LocationFormSet,
-    UsersAtLocationForm,
-)
+from .exceptions import LocationBulkImportError, LocationConsistencyError
+from .forms import LocationFilterForm, LocationFormSet, UsersAtLocationForm
 from .models import LocationType, SQLLocation, filter_for_archived
 from .permissions import (
     can_edit_location,
@@ -68,9 +70,11 @@ from .permissions import (
     user_can_edit_location_types,
 )
 from .tree_utils import assert_no_cycles
-from .util import does_location_type_have_users, load_locs_json, location_hierarchy_config
-from django.http import JsonResponse, HttpResponseBadRequest
-from corehq.apps.locations.dbaccessors import get_filtered_locations_count
+from .util import (
+    does_location_type_have_users,
+    load_locs_json,
+    location_hierarchy_config,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1181,13 +1181,13 @@ MOBILE_PRIVILEGES_FLAG = StaticToggle(
     [NAMESPACE_USER]
 )
 
-PRODUCTS_PER_LOCATION = StaticToggle(
-    'products_per_location',
-    "Products Per Location: Specify products stocked at individual locations.",
-    TAG_DEPRECATED,
-    [NAMESPACE_DOMAIN],
-    description="This doesn't actually do anything yet."
-)
+# PRODUCTS_PER_LOCATION = StaticToggle(
+#     'products_per_location',
+#     "Products Per Location: Specify products stocked at individual locations.",
+#     TAG_DEPRECATED,
+#     [NAMESPACE_DOMAIN],
+#     description="This doesn't actually do anything yet."
+# )
 
 ALLOW_CASE_ATTACHMENTS_VIEW = StaticToggle(
     'allow_case_attachments_view',


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Remove the deprecated `PRODUCTS_PER_LOCATION` feature flag, which controlled a "Products" tab on the Edit Location page allowing users to specify which products are stocked at individual locations.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19327

  ### Changes:
  - `corehq/apps/locations/views.py` — removed `products_form`, `products_form_post`, `active_products`, `products_at_location` properties and toggle checks
  - `corehq/apps/locations/templates/locations/manage/location.html` — removed Products tab nav and content
  - `corehq/toggles/__init__.py` — commented out toggle definition

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`PRODUCTS_PER_LOCATION` (slug: `products_per_location`)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
  - The feature (specifying products per location) is only accessible when **both** the toggle is enabled **and** CommTrack is enabled **and** the location type is non-administrative — a very narrow set
  of conditions
  - The code removal is straightforward: the `products_form` property already returned `None` when the toggle was disabled, so the template blocks guarded by `{% if products_per_location_form %}` were
  already no-ops for all domains without the flag
  - The `post()` handler for `location-products` form submissions was also guarded by the toggle check, so no unauthorized code paths are affected
  - No tests referenced this toggle, confirming it had no test coverage and was not actively maintained
  - The change only removes code — no new logic is introduced, minimizing risk of regressions
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
