### PR TITLE
Remove PREVENT_MOBILE_UCR_SYNC feature flag

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -125,9 +125,6 @@ class ReportFixturesProvider(FixtureProvider):
         if not toggles.MOBILE_UCR.enabled(restore_user.domain) or not _should_sync(restore_state):
             return False
 
-        if toggles.PREVENT_MOBILE_UCR_SYNC.enabled(restore_user.domain):
-            return False
-
         return True
 
 

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -121,11 +121,8 @@ class ReportFixturesProvider(FixtureProvider):
         )
 
     def should_sync(self, restore_state):
-        restore_user = restore_state.restore_user
-        if not toggles.MOBILE_UCR.enabled(restore_user.domain) or not _should_sync(restore_state):
-            return False
-
-        return True
+        domain = restore_state.restore_user.domain
+        return toggles.MOBILE_UCR.enabled(domain) and _should_sync(restore_state)
 
 
 def _parse_apps(restore_state, restore_user):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1652,13 +1652,13 @@ MOBILE_RECOVERY_MEASURES = StaticToggle(
                  "large-scale failures would otherwise be next to impossible."),
 )
 
-PREVENT_MOBILE_UCR_SYNC = StaticToggle(
-    'prevent_mobile_ucr_sync',
-    'Prevent Mobile UCR sync (when a UCR sync is causing operational problems)',
-    TAG_DEPRECATED,
-    [NAMESPACE_DOMAIN],
-    description='Prevents mobile UCRs from being generated or included in the sync payload',
-)
+#PREVENT_MOBILE_UCR_SYNC = StaticToggle(
+#    'prevent_mobile_ucr_sync',
+#    'Prevent Mobile UCR sync (when a UCR sync is causing operational problems)',
+#    TAG_DEPRECATED,
+#    [NAMESPACE_DOMAIN],
+#    description='Prevents mobile UCRs from being generated or included in the sync payload',
+#)
 
 # TWO_FACTOR_SUPERUSER_ROLLOUT = StaticToggle(
 #     'two_factor_superuser_rollout',


### PR DESCRIPTION
No user-facing effects on non-test domains. Mobile UCR sync behavior is unchanged for the vast majority of domains. Any domains that still had this emergency toggle enabled will resume normal UCR sync (governed by the `MOBILE_UCR` toggle and existing sync conditions).

## Technical Summary

Remove the deprecated `PREVENT_MOBILE_UCR_SYNC` toggle, which was added in 2017 as an emergency measure to disable mobile UCR sync when it was causing database problems.

## Feature Flag

`PREVENT_MOBILE_UCR_SYNC` — removed.

## Safety Assurance

### Safety story

This toggle was `TAG_DEPRECATED` and served only as an emergency kill switch for mobile UCR sync. The `MOBILE_UCR` toggle and `_should_sync()` logic continue to independently gate sync behavior. The only behavioral change is for domains that still had `PREVENT_MOBILE_UCR_SYNC` enabled, which are only test domains.

### Automated test coverage

No.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations