### PR TITLE
Put case search icon and audio behind simple FF

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -372,7 +372,7 @@ def _create_case_search_app_strings(
     if module_offers_search(module):
         from corehq.apps.app_manager.models import CaseSearch
 
-        if toggles.USH_CASE_CLAIM_UPDATES.enabled(app.domain):
+        if toggles.SYNC_SEARCH_CASE_CLAIM.enabled(app.domain):
             # search label
             yield (
                 id_strings.case_search_locale(module),

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_search_properties.html
@@ -309,7 +309,7 @@
               </div>
             </div>
           {% endif %}
-          {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
+          {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
             <div class="form-group" data-bind="hidden: inlineSearchActive">
               <label
                 for="search_label"
@@ -327,6 +327,8 @@
                 {% input_trans module.search_config.search_label.label langs input_name='search_label' input_id='search_label' data_bind="value: search_label" %}
               </div>
             </div>
+          {% endif %}
+          {% if request|toggle_enabled:'SYNC_SEARCH_CASE_CLAIM' %}
             <div
               class="case-search-multimedia-input"
               data-bind="hidden: inlineSearchActive"

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_search_properties.html
@@ -309,7 +309,7 @@
               </div>
             </div>
           {% endif %}
-          {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
+          {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
             <div class="form-group" data-bind="hidden: inlineSearchActive">  {# todo B5: css-form-group #}
               <label
                 for="search_label"
@@ -327,6 +327,8 @@
                 {% input_trans module.search_config.search_label.label langs input_name='search_label' input_id='search_label' data_bind="value: search_label" %}
               </div>
             </div>
+          {% endif %}
+          {% if request|toggle_enabled:'SYNC_SEARCH_CASE_CLAIM' %}
             <div
               class="case-search-multimedia-input"
               data-bind="hidden: inlineSearchActive"

--- a/corehq/apps/app_manager/tests/test_app_strings.py
+++ b/corehq/apps/app_manager/tests/test_app_strings.py
@@ -187,7 +187,7 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
         # wrap to have assign_references called
         app = Application.wrap(factory.app.to_json())
 
-        with flag_disabled('USH_CASE_CLAIM_UPDATES'):
+        with flag_disabled('SYNC_SEARCH_CASE_CLAIM'):
             # default language
             self.assertEqual(app.default_language, 'en')
             en_app_strings = self._generate_app_strings(app, 'default', build_profile_id='en')
@@ -201,7 +201,7 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
             self.assertEqual(es_app_strings['case_search.m0'], 'Search All Cases')
             self.assertEqual(es_app_strings['case_search.m0.again'], 'Search Again')
 
-        with flag_enabled('USH_CASE_CLAIM_UPDATES'):
+        with flag_enabled('SYNC_SEARCH_CASE_CLAIM'):
             # default language
             en_app_strings = self._generate_app_strings(app, 'default', build_profile_id='en')
             self.assertEqual(en_app_strings['case_search.m0'], 'Get them')

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_search_properties.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_search_properties.html.diff.txt
@@ -267,7 +267,7 @@
 @@ -310,10 +310,10 @@
              </div>
            {% endif %}
-           {% if request|toggle_enabled:'USH_CASE_CLAIM_UPDATES' %}
+           {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
 -            <div class="form-group" data-bind="hidden: inlineSearchActive">
 +            <div class="form-group" data-bind="hidden: inlineSearchActive">  {# todo B5: css-form-group #}
                <label
@@ -277,7 +277,7 @@
                >
                  {% trans "Label for Searching" %}
                  <span
-@@ -334,14 +334,14 @@
+@@ -336,14 +336,14 @@
                <!-- stopBinding to avoid conflicts with the binding of enclosing template to a different object 'search'-->
                <!-- binding for this partial is done via app_manager/js/nav_menu_media-->
                <!-- ko stopBinding: true -->
@@ -295,7 +295,7 @@
                  >
                    {% trans "Label for Searching Again" %}
                    <span
-@@ -362,20 +362,20 @@
+@@ -364,20 +364,20 @@
                  <!-- stopBinding to avoid conflicts with the binding of enclosing template to a different object 'search'-->
                  <!-- binding for this partial is done via app_manager/js/nav_menu_media-->
                  <!-- ko stopBinding: true -->
@@ -320,7 +320,7 @@
                  >
                  </span>
                </label>
-@@ -383,10 +383,10 @@
+@@ -385,10 +385,10 @@
                  {% input_trans module.search_config.title_label langs input_name='title_label' input_id='title_label' data_bind="value: title_label" %}
                </div>
              </div>
@@ -333,7 +333,7 @@
                >
                  {% trans "Search Screen Subtitle" %}
                  <span
-@@ -401,10 +401,10 @@
+@@ -403,10 +403,10 @@
                </div>
              </div>
            {% endif %}
@@ -346,7 +346,7 @@
              >
                {% trans "Display Condition" %}
                <span
-@@ -431,10 +431,10 @@
+@@ -433,10 +433,10 @@
              </div>
            </div>
            {% if request|toggle_enabled:'USH_SEARCH_FILTER' %}
@@ -359,7 +359,7 @@
                >
                  {% trans "Search Filter" %}
                  <span
-@@ -459,7 +459,7 @@
+@@ -461,7 +461,7 @@
                  ></textarea>
                  <p class="help-block">
                    <button
@@ -368,7 +368,7 @@
                      data-bind="visible: setSearchFilterVisible, enable: setSearchFilterEnabled, click: setSearchFilter"
                    >
                      <i class="fa-solid fa-reply"></i>
-@@ -471,10 +471,10 @@
+@@ -473,10 +473,10 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
@@ -381,7 +381,7 @@
              >
                {% trans "Claim Condition" %}
                <span
-@@ -500,10 +500,10 @@
+@@ -502,10 +502,10 @@
              </div>
            </div>
            {% endif %}
@@ -394,7 +394,7 @@
              >
                {% trans "Don't search cases owned by the following ids" %}
                <span
-@@ -536,10 +536,10 @@
+@@ -538,10 +538,10 @@
              </div>
            </div>
            {% if data_registry_enabled %}
@@ -407,7 +407,7 @@
                >
                  {% trans "Data Registry" %}
                  <span
-@@ -550,7 +550,7 @@
+@@ -552,7 +552,7 @@
                  </span>
                </label>
                <div class="{% css_field_class %}">
@@ -416,7 +416,7 @@
                    class="form-control"
                    id="data-registry"
                    data-bind="value: data_registry"
-@@ -564,15 +564,15 @@
+@@ -566,15 +566,15 @@
                  </select>
                </div>
              </div>
@@ -435,7 +435,7 @@
                    class="form-control"
                    data-bind="value: data_registry_workflow"
                  >
-@@ -583,12 +583,12 @@
+@@ -585,12 +585,12 @@
                </div>
              </div>
              <div
@@ -450,7 +450,7 @@
                >
                  {% trans "Load Additional Data Registry Cases" %}
                  <span
-@@ -610,8 +610,8 @@
+@@ -612,8 +612,8 @@
                      data-bind="visible: additional_registry_cases().length > 0"
                    >
                      <tr>
@@ -461,7 +461,7 @@
                      </tr>
                    </thead>
                    <tbody
-@@ -633,7 +633,7 @@
+@@ -635,7 +635,7 @@
                        </td>
                        <td>
                          <i
@@ -470,7 +470,7 @@
                            class="fa fa-remove"
                            data-bind="click: $parent.removeRegistryQuery"
                          ></i>
-@@ -643,7 +643,7 @@
+@@ -645,7 +645,7 @@
                  </table>
                  <button
                    type="button"
@@ -479,7 +479,7 @@
                    data-bind="click: addRegistryQuery"
                  >
                    <i class="fa fa-plus"></i>
-@@ -653,10 +653,10 @@
+@@ -655,10 +655,10 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
@@ -492,7 +492,7 @@
                >
                  {% trans "Case property with additional case id to add to results" %}
                  <span
-@@ -686,15 +686,15 @@
+@@ -688,15 +688,15 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_RELATED_LOOKUPS' %}
@@ -512,7 +512,7 @@
                        data-bind="checked: include_all_related_cases"
                      />
                    </label>
-@@ -703,18 +703,18 @@
+@@ -705,18 +705,18 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' and not app.split_screen_dynamic_search %}


### PR DESCRIPTION
## Product Description

Icon and audio settings were not part of the initial migration causing an issue where they were included in the suite.xml but not the app strings. This fixes the issue.

## Technical Summary

https://dimagi.atlassian.net/browse/QA-8398

## Feature Flag

* USH_CASE_CLAIM_UPDATES

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

already existing PRs

### QA Plan

tested as part of https://dimagi.atlassian.net/browse/QA-8372

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
