### PR TITLE
Remove SKIP_ORM_FIXTURE_UPLOAD feature flag

### DIFF
--- a/corehq/apps/fixtures/tasks.py
+++ b/corehq/apps/fixtures/tasks.py
@@ -11,12 +11,12 @@ from corehq.apps.hqwebapp.tasks import send_html_email_async
 
 
 @task
-def fixture_upload_async(domain, download_id, replace, skip_orm, user_email=None):
+def fixture_upload_async(domain, download_id, replace, user_email=None):
     task = fixture_upload_async
     DownloadBase.set_progress(task, 0, 100)
     download_ref = DownloadBase.get(download_id)
     time_start = datetime.datetime.now()
-    result = upload_fixture_file(domain, download_ref.get_filename(), replace, task, skip_orm)
+    result = upload_fixture_file(domain, download_ref.get_filename(), replace, task)
     time_end = datetime.datetime.now()
     DownloadBase.set_progress(task, 100, 100)
     messages = {

--- a/corehq/apps/fixtures/tests/test_upload.py
+++ b/corehq/apps/fixtures/tests/test_upload.py
@@ -683,37 +683,6 @@ class TestFixtureUpload(TestCase):
         self.assertNotEqual(new_uid, bad_uid)
         return result
 
-    def test_error_on_non_global_table(self):
-        data = [
-            ('types', [('N', 'things', 'no', 'name', 'yes')]),
-            ('things', [(None, 'N', 'apple')]),
-        ]
-        workbook = self.get_workbook_from_data(self.headers, data)
-        result = self.upload(workbook, skip_orm=True)
-        self.assertEqual(result.errors, ["type things is not defined as global"])
-        self.assertIsNone(self.get_table())
-
-    def test_ownerships_ignored_on_skip_orm(self):
-        user = CommCareUser.create(
-            self.domain, f"user@{self.domain}.commcarehq.org", "pass", None, None)
-        self.addCleanup(user.delete, self.domain, deleted_by=None)
-        region = LocationType(domain=self.domain, name="region", code="region")
-        region.save()
-        SQLLocation(domain=self.domain, name="loc", location_type=region).save()
-
-        headers = TestLookupTableOwnershipUpload.headers
-        data = [
-            ('types', [('N', 'things', 'yes', 'name')]),
-            ('things', [(None, 'N', 'apple', 'user', None, 'loc')]),
-        ]
-        workbook = self.get_workbook_from_data(headers, data)
-        result = self.upload(workbook, skip_orm=True)
-        apple_id, = [r.id for r in self.get_rows(None)]
-
-        ownerships = list(LookupTableRowOwner.objects.filter(domain=self.domain, row_id=apple_id))
-        self.assertFalse(ownerships)
-        self.assertFalse(result.errors)
-
     def test_sql_transaction(self):
         @contextmanager
         def checked_tx():

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -28,30 +28,24 @@ from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import normalize_username
 
 
-def upload_fixture_file(domain, filename, replace, task=None, skip_orm=False):
+def upload_fixture_file(domain, filename, replace, task=None):
     """
     should only ever be called after the same file has been validated
     using validate_fixture_file_format
     """
     workbook = get_workbook(filename)
-    return _run_upload(domain, workbook, replace, task, skip_orm)
+    return _run_upload(domain, workbook, replace, task)
 
 
-def _run_upload(domain, workbook, replace=False, task=None, skip_orm=False):
+def _run_upload(domain, workbook, replace=False, task=None):
     """Run lookup table upload
 
     Performs only deletes and/or inserts on table, row, and ownership
     records to optimize database interactions.
-
-    Upload with `skip_orm=True` is faster than the default with the
-    following trade-off: it does not support fixture ownership. All
-    fixtures must be global.
     """
     def process_table(table, new_table, old_table):
         def process_row(row, new_row, old_row):
             update_progress(table)
-            if skip_orm:
-                return  # fast upload does not do ownership
             owners.process(
                 workbook,
                 old_owners.get(row.id, []),
@@ -63,13 +57,12 @@ def _run_upload(domain, workbook, replace=False, task=None, skip_orm=False):
 
         old_rows = list(LookupTableRow.objects.iter_rows(domain, tag=table.tag))
         sort_keys = {r.id.hex: r.sort_key for r in old_rows}
-        if not skip_orm:
-            old_owners = defaultdict(list)
-            for owner in LookupTableRowOwner.objects.filter(
-                domain=domain,
-                row_id__in=list(sort_keys),
-            ):
-                old_owners[owner.row_id].append(owner)
+        old_owners = defaultdict(list)
+        for owner in LookupTableRowOwner.objects.filter(
+            domain=domain,
+            row_id__in=list(sort_keys),
+        ):
+            old_owners[owner.row_id].append(owner)
 
         row_key_ = row_key
         if table is new_table:
@@ -98,14 +91,7 @@ def _run_upload(domain, workbook, replace=False, task=None, skip_orm=False):
             flush(tables, rows, owners)
 
     result = FixtureUploadResult()
-    if skip_orm:
-        # TODO remove when SKIP_ORM_FIXTURE_UPLOAD feature toggle is removed
-        non_globals = [s.table_id for s in workbook.get_all_type_sheets() if not s.is_global]
-        if non_globals:
-            result.errors.append(non_global_error(non_globals[0]))
-            return result
-    else:
-        owner_ids = load_owner_ids(workbook.get_owners(), domain)
+    owner_ids = load_owner_ids(workbook.get_owners(), domain)
     result.number_of_fixtures, update_progress = setup_progress(task, workbook)
     old_tables = list(LookupTable.objects.by_domain(domain))
     tables = Mutation()
@@ -234,12 +220,6 @@ def setup_progress(task, workbook):
         total_rows = 1
 
     return total_tables, update_progress
-
-
-def non_global_error(tag):
-    return _("type {lookup_table_name} is not defined as global").format(
-        lookup_table_name=tag
-    )
 
 
 def table_key(table):

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -62,7 +62,6 @@ from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.util import format_datatables_data
 from corehq.apps.users.models import HqPermissions
 from corehq.sql_db.jsonops import JsonDelete, JsonGet, JsonSet
-from corehq.toggles import SKIP_ORM_FIXTURE_UPLOAD
 from corehq.util.files import file_extention_from_filename
 from corehq import toggles
 
@@ -324,7 +323,6 @@ class UploadItemLists(TemplateView):
             self.domain,
             file_ref.download_id,
             replace,
-            SKIP_ORM_FIXTURE_UPLOAD.enabled(self.domain),
         )
         file_ref.set_task(task)
         return HttpResponseRedirect(
@@ -468,7 +466,7 @@ def fixture_api_upload_status(request, domain, download_id, **kwargs):
 
 def _upload_fixture_api(request, domain):
     try:
-        excel_file, replace, is_async, skip_orm, email = _get_fixture_upload_args_from_request(request, domain)
+        excel_file, replace, is_async, email = _get_fixture_upload_args_from_request(request, domain)
     except FixtureAPIRequestError as e:
         return UploadFixtureAPIResponse('fail', str(e))
 
@@ -486,7 +484,6 @@ def _upload_fixture_api(request, domain):
                     domain,
                     download_id,
                     replace,
-                    skip_orm,
                     user_email=email
                 )
                 file_ref.set_task(task)
@@ -558,11 +555,7 @@ def _get_fixture_upload_args_from_request(request, domain):
             "User {} doesn't have permission to upload fixtures"
             .format(request.couch_user.username))
 
-    skip_orm = False
-    if request.POST.get('skip_orm') == 'true' and SKIP_ORM_FIXTURE_UPLOAD.enabled(domain):
-        skip_orm = True
-
-    return _excel_upload_file(upload_file), replace, is_async, skip_orm, user_email
+    return _excel_upload_file(upload_file), replace, is_async, user_email
 
 
 @login_and_domain_required

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1817,12 +1817,13 @@ PARTIAL_UI_TRANSLATIONS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-SKIP_ORM_FIXTURE_UPLOAD = StaticToggle(
-    'skip_orm_fixture_upload',
-    'Exposes an option in fixture api upload to skip saving through couchdbkit',
-    TAG_DEPRECATED,
-    [NAMESPACE_DOMAIN]
-)
+# TODO remove commented-out toggle definition
+# SKIP_ORM_FIXTURE_UPLOAD = StaticToggle(
+#     'skip_orm_fixture_upload',
+#     'Exposes an option in fixture api upload to skip saving through couchdbkit',
+#     TAG_DEPRECATED,
+#     [NAMESPACE_DOMAIN]
+# )
 
 ENABLE_UCR_MIRRORS = StaticToggle(
     'enable_ucr_mirrors',


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-19319

## Product Description

No user-facing changes, except getting rid of a flag that did very little. The flag is deprecated with no active domains expected. Furthermore, the original reason for the flag existing is gone, due to optimizations (not behind a flag) made since the flag was introduced.

## Technical Summary

Remove the deprecated `SKIP_ORM_FIXTURE_UPLOAD` feature flag and all associated `skip_orm` code paths. The toggle declaration is commented out to avoid merge conflicts with concurrent toggle removals.

### History

- [#24292](https://github.com/dimagi/commcare-hq/pull/24292) — Introduced the flag and `skip_orm` upload path as a "fast" lookup table upload that bypassed CouchDB ORM and fixture ownership processing, requiring all fixtures to be global. This did this by splitting out the "fast" (but limited) method to a separate implementation given by `_run_fast_fixture_upload`.
- [#31811](https://github.com/dimagi/commcare-hq/pull/31811) — Carried the `skip_orm` logic forward into the new lookup table uploader. It did this by simply imposing the same limitation as before, but got rid of the separate "fast" implementation, removing `_run_fast_fixture_upload`. At this point, there was no longer any real purpose to the flag, as this PR was made to make _all_ fixture uploads faster.
- [#37193](https://github.com/dimagi/commcare-hq/pull/37193) — Marked the flag as `TAG_DEPRECATED`.

## Feature Flag

`SKIP_ORM_FIXTURE_UPLOAD` (being removed)

## Safety Assurance

### Safety story

The flag is tagged `TAG_DEPRECATED`. Removing it means fixture uploads always process ownership, which is the default behavior for all domains not on this flag. The code paths removed were only reachable when the flag was enabled.

### Automated test coverage

Two tests specific to `skip_orm=True` behavior were removed. The remaining fixture upload test suite covers the standard (non-skip_orm) upload path.

### QA Plan

- [x] Verify fixture upload via UI completes successfully
- [x] Verify fixture upload via API (sync and async) completes successfully

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change