### PR TITLE
Remove stray development branches from CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,6 @@ on:
     branches:
     - master
     - hotfix-deploy
-    - mjr/add-change-meta-context
-    - mjr/new_dedupe_model
-    - mjr/dedupe_handle_closed_cases
   schedule:
     # see corehq/apps/hqadmin/management/commands/static_analysis.py
     - cron: '47 12 * * *'


### PR DESCRIPTION
## Product Description
N/A — CI/CD config change only.

## Technical Summary
Three stray personal development branches (`mjr/add-change-meta-context`, `mjr/new_dedupe_model`, `mjr/dedupe_handle_closed_cases`) were listed under `pull_request.branches` in `.github/workflows/tests.yml`, causing CI to run on PRs targeting those branches. Removed them as they are no longer relevant.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Trivially safe — only removes branch targets from a CI trigger list.

### Automated test coverage
N/A

### QA Plan
N/A

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change