### PR TITLE
Remove ADD_LIMITED_FIXTURES_TO_CASE_RESTORE feature flag

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -95,11 +95,6 @@ def item_lists_by_app(app, module):
     return lookup_lists + ret
 
 
-def get_global_items_by_domain(domain, case_id):
-    global_types = LookupTable.objects.by_domain(domain).filter(is_global=True)
-    return ItemListsProvider().get_global_items(domain, global_types, case_id, False)
-
-
 class ItemListsProvider(FixtureProvider):
     id = 'item-list'
 

--- a/corehq/apps/ota/case_restore.py
+++ b/corehq/apps/ota/case_restore.py
@@ -6,11 +6,6 @@ from casexml.apps.phone.xml import (
     get_case_element,
     get_registration_element_for_case,
 )
-from corehq.apps.fixtures.fixturegenerators import get_global_items_by_domain
-from corehq.apps.locations.fixtures import (
-    FlatLocationSerializer
-)
-from corehq.apps.locations.models import get_domain_locations
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase
 
@@ -37,13 +32,3 @@ def get_case_restore_response(domain, case_id):
         payload = content.get_fileobj()
 
     return RestoreResponse(payload).get_http_response()
-
-
-def _add_limited_fixtures(domain, case_id, content):
-    serializer = FlatLocationSerializer()
-    locations = get_domain_locations(domain)
-    nodes = serializer.get_xml_nodes(domain, 'locations', case_id, locations)
-    content.extend(nodes)
-    lookuptable = get_global_items_by_domain(domain, case_id)
-    if lookuptable:
-        content.extend(lookuptable)

--- a/corehq/apps/ota/case_restore.py
+++ b/corehq/apps/ota/case_restore.py
@@ -13,7 +13,6 @@ from corehq.apps.locations.fixtures import (
 from corehq.apps.locations.models import get_domain_locations
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase
-from corehq.toggles import ADD_LIMITED_FIXTURES_TO_CASE_RESTORE
 
 
 def get_case_hierarchy_for_restore(case):
@@ -35,8 +34,6 @@ def get_case_restore_response(domain, case_id):
             # Formplayer will be creating these cases for the first time, so
             # include create blocks
             content.append(get_case_element(case, ('create', 'update'), V2))
-        if ADD_LIMITED_FIXTURES_TO_CASE_RESTORE.enabled(domain):
-            _add_limited_fixtures(domain, case_id, content)
         payload = content.get_fileobj()
 
     return RestoreResponse(payload).get_http_response()

--- a/corehq/apps/ota/tests/test_case_restore.py
+++ b/corehq/apps/ota/tests/test_case_restore.py
@@ -8,14 +8,9 @@ from casexml.apps.case.const import CASE_INDEX_CHILD
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 
 from corehq.apps.app_manager.tests.util import TestXmlMixin
-from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.fixtures.utils import clear_fixture_cache
-from corehq.apps.locations.models import LocationType, SQLLocation
 from corehq.apps.ota.case_restore import get_case_hierarchy_for_restore
 from corehq.form_processor.models import CommCareCase
 from corehq.util.hmac_request import get_hmac_digest
-from corehq.util.test_utils import flag_enabled
-from corehq.apps.fixtures.models import LookupTable, LookupTableRow, Field, TypeField
 
 
 class TestRelatedCases(TestCase, TestXmlMixin):
@@ -69,73 +64,6 @@ class TestRelatedCases(TestCase, TestXmlMixin):
             [self.dad.case_id, self.kid.case_id, self.kid2.case_id,
              self.grandkid.case_id]
         )
-
-    @flag_enabled('ADD_LIMITED_FIXTURES_TO_CASE_RESTORE')
-    def test_locations_in_restore(self):
-        case_id = self.dad.case_id
-
-        domain_obj = create_domain(self.domain)
-
-        self.addCleanup(domain_obj.delete)
-
-        location_type = LocationType.objects.create(domain=self.domain, name="Top", code="top")
-        location = SQLLocation.objects.create(domain=self.domain, name="Top Location", location_type=location_type)
-
-        # a location in different domain that should not be present
-        create_domain("random-domain")
-        another_location_type = LocationType.objects.create(domain="random-domain", name="Top", code="top")
-        SQLLocation.objects.create(domain="random-domain", name="Top Location",
-                                   location_type=another_location_type)
-
-        response = self._generate_restore(case_id)
-        self.assertEqual(response.status_code, 200)
-
-        response_content = next(response.streaming_content)
-
-        locations_content = location_fixture_content.format(
-            user_id=case_id,
-            location_id=location.location_id
-        )
-        self.assertXmlPartialEqual(schema_fixture_content, response_content,
-                                   '{http://openrosa.org/http/response}schema')
-        self.assertXmlPartialEqual(locations_content, response_content,
-                                   '{http://openrosa.org/http/response}fixture[@id="locations"]')
-
-    @flag_enabled('ADD_LIMITED_FIXTURES_TO_CASE_RESTORE')
-    def test_lookup_table_in_restore(self):
-        case_id = self.dad.case_id
-
-        domain_obj = create_domain(self.domain)
-
-        self.addCleanup(domain_obj.delete)
-
-        table_tag = "atable"
-
-        table = LookupTable(domain=self.domain,
-                            tag=table_tag,
-                            description="A Table",
-                            is_global=True,
-                            fields=[TypeField(name="wing")])
-        table.save()
-        self.addCleanup(clear_fixture_cache, self.domain, [table.id])
-        row = LookupTableRow(
-            table_id=table.id,
-            domain=self.domain,
-            fields={
-                "wing": [Field(value="duck", properties={"says": "quack"})],
-            },
-            sort_key=0,
-        )
-        row.save()
-
-        response = self._generate_restore(case_id)
-        self.assertEqual(response.status_code, 200)
-
-        response_content = next(response.streaming_content)
-
-        lookup_table_content = lookup_table_fixture_content.format(table_tag=table_tag, user_id=case_id)
-        xpath = f'{{http://openrosa.org/http/response}}fixture[@id="item-list:{table_tag}"]'
-        self.assertXmlPartialEqual(lookup_table_content, response_content, xpath)
 
     def _generate_restore(self, case_id):
         url = reverse("case_restore", args=[self.domain, case_id])

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2151,16 +2151,16 @@ SSO_OIDC_DEVELOPMENT = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN, NAMESPACE_USER],
 )
 
-ADD_LIMITED_FIXTURES_TO_CASE_RESTORE = StaticToggle(
-    'fixtures_in_case_restore',
-    'Allow limited fixtures to be available in case restore for SMS workflows.',
-    TAG_DEPRECATED,
-    namespaces=[NAMESPACE_DOMAIN],
-    description="""
-    WARNING: To be used only for small templates since the performance implication has not been evaluated.
-    Do not enable on your own.
-    """
-)
+# ADD_LIMITED_FIXTURES_TO_CASE_RESTORE = StaticToggle(
+#     'fixtures_in_case_restore',
+#     'Allow limited fixtures to be available in case restore for SMS workflows.',
+#     TAG_DEPRECATED,
+#     namespaces=[NAMESPACE_DOMAIN],
+#     description="""
+#     WARNING: To be used only for small templates since the performance implication has not been evaluated.
+#     Do not enable on your own.
+#     """
+# )
 
 EMBEDDED_TABLEAU = StaticToggle(
     'embedded_tableau',


### PR DESCRIPTION
## Product Description

No user-facing changes. This PR removes a deprecated feature flag that is no longer in use.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19309

Removes the `ADD_LIMITED_FIXTURES_TO_CASE_RESTORE` feature flag (slug: `fixtures_in_case_restore`) from the codebase. This flag was used to include limited fixtures (locations and lookup tables) in _case_ restores for SMS workflows.

## Feature Flag

- **Toggle variable**: `ADD_LIMITED_FIXTURES_TO_CASE_RESTORE`
- **Slug**: `fixtures_in_case_restore`
- **Tag**: `TAG_DEPRECATED`

## Safety Assurance

### Safety story

This change is safe because:
- The toggle was marked as `TAG_DEPRECATED` and is no longer in active use
- The feature was explicitly marked with a warning: "To be used only for small templates since the performance implication has not been evaluated. Do not enable on your own."
- The feature added fixtures to case restores for SMS workflows, which is not a standard behavior

### Automated test coverage

- The remaining case restore test (`test_get_related_case_ids`) continues to pass
- Tests for the standard case restore functionality remain in place
- The deleted tests only covered the now-removed fixture inclusion feature

### QA Plan
None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)