### PR TITLE
Remove GEOCODER_AUTOLOAD_USER_LOCATION feature flag

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/utils.js
@@ -81,7 +81,6 @@ module.initialRender = function (formJSON, resourceMap, $div) {
  * @param {function} clearCallBack - function to call back after clearing the input
  * @param {function|undefined} inputOnKeyDown - inputOnKeyDown function (optional)
  * @param {boolean} showGeolocationButton - show geolocation button. Defaults to false. (optional)
- * @param {boolean} geolocateOnLoad - geolocate the user's location on load. Defaults to false. (optional)
  * @param {boolean} useBoundingBox - use default locations bbox to filter results. Defaults to false. (optional)
  * @param {string} responseDataTypes - set Mapbox's data type response https://docs.mapbox.com/api/search/geocoding/#data-types (optional)
 */
@@ -91,12 +90,10 @@ module.renderMapboxInput = function ({
     clearCallBack,
     inputOnKeyDown,
     showGeolocationButton = false,
-    geolocateOnLoad = false,
     useBoundingBox = false,
     responseDataTypes = 'address',
 }) {
     showGeolocationButton = showGeolocationButton || toggles.toggleEnabled('GEOCODER_MY_LOCATION_BUTTON');
-    geolocateOnLoad = geolocateOnLoad || toggles.toggleEnabled('GEOCODER_AUTOLOAD_USER_LOCATION');
     var setProximity = toggles.toggleEnabled('GEOCODER_USER_PROXIMITY');
     var defaultGeocoderLocation = initialPageData.get('default_geocoder_location') || {};
     var geocoder = new MapboxGeocoder({
@@ -143,10 +140,6 @@ module.renderMapboxInput = function ({
             liveRegionEl.html("<p>" + items.features[0].place_name + "</p>");
         }
     });
-
-    if (geolocateOnLoad) {
-        geocoder._geolocateUser();
-    }
 };
 
 /**

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1022,18 +1022,18 @@ GEOCODER_MY_LOCATION_BUTTON = StaticToggle(
     parent_toggles=[USH_CASE_CLAIM_UPDATES],
 )
 
-GEOCODER_AUTOLOAD_USER_LOCATION = StaticToggle(
-    "geocoder_autoload_user_location",
-    "USH: Auto-load the geocoder widget with the user's current location",
-    TAG_DEPRECATED,
-    namespaces=[NAMESPACE_DOMAIN],
-    description="""
-    When enabled, and if the user grants permissions, the geocoder widget will automatically do a reverse
-    geocoding query using the user's reported location The result will be used to populate the search field
-    of the geocoder widget.
-    """,
-    parent_toggles=[USH_CASE_CLAIM_UPDATES],
-)
+# GEOCODER_AUTOLOAD_USER_LOCATION = StaticToggle(
+#     "geocoder_autoload_user_location",
+#     "USH: Auto-load the geocoder widget with the user's current location",
+#     TAG_DEPRECATED,
+#     namespaces=[NAMESPACE_DOMAIN],
+#     description="""
+#     When enabled, and if the user grants permissions, the geocoder widget will automatically do a reverse
+#     geocoding query using the user's reported location The result will be used to populate the search field
+#     of the geocoder widget.
+#     """,
+#     parent_toggles=[USH_CASE_CLAIM_UPDATES],
+# )
 
 GEOCODER_USER_PROXIMITY = StaticToggle(
     "geocoder_user_proximity",


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19321
Removes the feature flag as well as the `geolocateOnLoad` option it sets, because the option is never passed in and could only be true if the feature flag was enabled.

## Feature Flag
Removes GEOCODER_AUTOLOAD_USER_LOCATION

## Safety Assurance

### Safety story
This is a very small, limited change to the options in a single javascript function. Confirmed that no uses of `renderMapboxInput` reference the removed `geolocateOnLoad` option.

### Automated test coverage
There is not likely any automated testing for this javascript.

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
