### PR TITLE
Remove VELLUM_CASE_MICRO_IMAGE feature flag

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/utils.js
@@ -103,13 +103,6 @@ module.getFieldFormats = function () {
         });
     }
 
-    if (toggles.toggleEnabled('VELLUM_CASE_MICRO_IMAGE')) {
-        formats.push({
-            value: "image",
-            label: gettext('Image'),
-        });
-    }
-
     return formats;
 };
 

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2728,13 +2728,13 @@ USE_LOGO_IN_SYSTEM_EMAILS = StaticToggle(
     description='The project logo replaces the CommCare logo.',
 )
 
-VELLUM_CASE_MICRO_IMAGE = StaticToggle(
-    slug='case_micro_image',
-    label='Add case micro images to case list',
-    tag=TAG_DEPRECATED,
-    namespaces=[NAMESPACE_DOMAIN],
-    description='Add a micro image to cases in the case list.'
-)
+# VELLUM_CASE_MICRO_IMAGE = StaticToggle(
+#     slug='case_micro_image',
+#     label='Add case micro images to case list',
+#     tag=TAG_DEPRECATED,
+#     namespaces=[NAMESPACE_DOMAIN],
+#     description='Add a micro image to cases in the case list.'
+# )
 
 SUPPORT_GEO_JSON_EXPORT = FrozenPrivilegeToggle(
     privileges.GEOJSON_EXPORT,


### PR DESCRIPTION
## Product Description

No user-facing effects. The `case_micro_image` feature flag was deprecated and had no active domains. This removes the flag entirely, disabling the "Image" format option in case list detail columns that was gated behind it.

## Technical Summary

https://dimagi.atlassian.net/browse/SAAS-19328

- Removed the toggle check from `corehq/apps/app_manager/static/app_manager/js/details/utils.js` that conditionally added an "Image" format option to case list columns
- Commented out the `VELLUM_CASE_MICRO_IMAGE` toggle definition in `corehq/toggles/__init__.py`

**Vellum cleanup needed:** The Vellum repo still references `features.case_micro_image` in `src/parser.js` and `src/core.js`. These will become dead code and should be cleaned up in a separate Vellum PR.

- Vellum PR - https://github.com/dimagi/Vellum/pull/1195


## Feature Flag

- **Variable**: `VELLUM_CASE_MICRO_IMAGE`
- **Slug**: `case_micro_image`
- **Tag**: `TAG_DEPRECATED`
- **Type**: `StaticToggle` (`NAMESPACE_DOMAIN`)

## Safety Assurance

### Safety story

This flag is tagged `TAG_DEPRECATED` and has no active domains on any environment (production, staging, india, eu). Removing it preserves the default behavior (feature disabled). The toggle definition is commented out rather than deleted to preserve it for reference during review.

### Automated test coverage

- All 27 tests in `corehq/toggles/tests.py` pass with the toggle commented out
- No tests in the codebase reference `case_micro_image`

### QA Plan

Verify no domains have this flag enabled:
```
cchq production django-manage list_ff_domains case_micro_image
cchq staging django-manage list_ff_domains case_micro_image
cchq india django-manage list_ff_domains case_micro_image
cchq eu django-manage list_ff_domains case_micro_image
```

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations. 


### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change