### PR TITLE
Handle empty custom headers

### DIFF
--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -192,9 +192,9 @@ class ConnectionSettings(models.Model):
         }
 
     def get_custom_headers_display(self):
-        if not MTN_MOBILE_WORKER_VERIFICATION.enabled(self.domain):
-            return {}
-        return {k: PASSWORD_PLACEHOLDER for k, v in self.custom_headers.items()}
+        if MTN_MOBILE_WORKER_VERIFICATION.enabled(self.domain) and self.custom_headers:
+            return {k: PASSWORD_PLACEHOLDER for k, v in self.custom_headers.items()}
+        return {}
 
     @property
     def last_token(self) -> Optional[dict]:

--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -161,15 +161,15 @@ class ConnectionSettings(models.Model):
 
     @property
     def plaintext_custom_headers(self):
-        if not MTN_MOBILE_WORKER_VERIFICATION.enabled(self.domain):
-            return {}
-
         def decrypt(value):
             if value.startswith(f'${ALGO_AES_CBC}$'):
                 ciphertext = value.split('$', 2)[2]
                 return b64_aes_cbc_decrypt(ciphertext)
             return value
-        return {k: decrypt(v) for k, v in self.custom_headers.items()}
+
+        if MTN_MOBILE_WORKER_VERIFICATION.enabled(self.domain) and self.custom_headers:
+            return {k: decrypt(v) for k, v in self.custom_headers.items()}
+        return {}
 
     def set_custom_headers(self, headers):
         """


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
```
  File "corehq/motech/models.py", line 197, in get_custom_headers_display
    return {k: PASSWORD_PLACEHOLDER for k, v in self.custom_headers.items()}
AttributeError: 'NoneType' object has no attribute 'items'
```

It is possible for custom_headers to be None, so just ensure we are checking that before attempting to access .items().

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
MTN_MOBILE_WORKER_VERIFICATION

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Quite an edge case only possible for those with the MTN_MOBILE_WORKER_VERIFICATION flag enabled, which aren't many. This flag is set to be replaced in the future.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
