### PR TITLE
Delete FF: Allow sum when template columns in dynamic UCRs

### DIFF
--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -51,7 +51,6 @@ from corehq.apps.userreports.reports.sorting import ASCENDING, DESCENDING
 from corehq.apps.userreports.specs import TypeProperty
 from corehq.apps.userreports.transforms.factory import TransformFactory
 from corehq.apps.userreports.util import localize
-from corehq.toggles import UCR_SUM_WHEN_TEMPLATES
 
 SQLAGG_COLUMN_MAP = {
     const.AGGGREGATION_TYPE_AVG: MeanColumn,
@@ -376,12 +375,10 @@ class SumWhenTemplateColumn(SumWhenColumn):
     type = TypeProperty("sum_when_template")
     whens = ListProperty(DictProperty)      # List of SumWhenTemplateSpec dicts
 
-    @classmethod
-    def restricted_to_static(cls, domain):
-        return not UCR_SUM_WHEN_TEMPLATES.enabled(domain)
-
     def get_whens(self):
-        from corehq.apps.userreports.reports.factory import SumWhenTemplateFactory
+        from corehq.apps.userreports.reports.factory import (
+            SumWhenTemplateFactory,
+        )
         whens = []
         for spec in self.whens:
             template = SumWhenTemplateFactory.make_template(spec)

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -31,7 +31,6 @@ from dimagi.ext.jsonobject import (
     BooleanProperty,
     DictProperty,
     IntegerProperty,
-    JsonArray,
     JsonObject,
     ListProperty,
     ObjectProperty,
@@ -199,9 +198,9 @@ class FieldColumn(ReportColumn):
 
     def _use_terms_aggregation_for_max_min(self, data_source_config):
         return (
-            self.aggregation in ['max', 'min'] and
-            self._column_data_type(data_source_config) and
-            self._column_data_type(data_source_config) not in ['integer', 'decimal']
+            self.aggregation in ['max', 'min']
+            and self._column_data_type(data_source_config)
+            and self._column_data_type(data_source_config) not in ['integer', 'decimal']
         )
 
     def get_query_column_ids(self):
@@ -459,7 +458,8 @@ class PercentageColumn(ReportColumn):
         def _pct(data):
             return '{0:.0f}%'.format(_raw_pct(data))
 
-        _fraction = lambda data: '{num}/{denom}'.format(**data)
+        def _fraction(data):
+            return '{num}/{denom}'.format(**data)
 
         return {
             'percent': _pct,
@@ -502,6 +502,7 @@ class ArrayAggLastValueReportColumn(ReportColumn):
                 sortable=False,
             )
         ])
+
 
 def _add_column_id_if_missing(obj):
     if obj.get('column_id') is None:

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -1,12 +1,12 @@
 import uuid
 
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from sqlagg import SumWhen
 
 from casexml.apps.case.mock import CaseBlock
-from corehq.apps.hqcase.utils import submit_case_blocks
 
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.userreports import tasks
 from corehq.apps.userreports.app_manager.helpers import clean_table_name
 from corehq.apps.userreports.columns import get_distinct_values
@@ -24,6 +24,8 @@ from corehq.apps.userreports.reports.specs import (
     AggregateDateColumn,
     FieldColumn,
     PercentageColumn,
+    SumWhenColumn,
+    SumWhenTemplateColumn,
 )
 from corehq.apps.userreports.sql.columns import expand_column
 from corehq.apps.userreports.util import get_indicator_adapter
@@ -495,3 +497,29 @@ class TestPercentageColumn(SimpleTestCase):
                 "type": "field",
             }
         }
+
+
+class TestSumWhenColumnsRestrictedToStatic(SimpleTestCase):
+    """
+    sum_when and sum_when_template columns are restricted to static reports
+    because their conditional expressions lack sufficient safety checks.
+    """
+
+    def test_sum_when_column_restricted_to_static(self):
+        assert SumWhenColumn.restricted_to_static('some-domain') is True
+
+    def test_sum_when_template_column_restricted_to_static(self):
+        assert SumWhenTemplateColumn.restricted_to_static('some-domain') is True
+
+    @override_settings(UNIT_TESTING=False)
+    def test_sum_when_template_raises_in_dynamic_report(self):
+        """sum_when_template must not be usable in dynamic (non-static) UCRs."""
+        spec = {
+            'type': 'sum_when_template',
+            'column_id': 'test_col',
+            'field': 'age',
+            'whens': [],
+            'else_': 0,
+        }
+        with self.assertRaises(BadSpecError):
+            ReportColumnFactory.from_spec(spec, is_static=False, domain='some-domain')

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -862,16 +862,16 @@ REPORT_BUILDER = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-UCR_SUM_WHEN_TEMPLATES = StaticToggle(
-    'ucr_sum_when_templates',
-    'Allow sum when template columns in dynamic UCRs',
-    TAG_DEPRECATED,
-    [NAMESPACE_DOMAIN],
-    description=(
-        "Enables use of SumWhenTemplateColumn with custom expressions in dynamic UCRS."
-    ),
-    help_link='https://commcare-hq.readthedocs.io/ucr.html#sumwhencolumn-and-sumwhentemplatecolumn',
-)
+# UCR_SUM_WHEN_TEMPLATES = StaticToggle(
+#     'ucr_sum_when_templates',
+#     'Allow sum when template columns in dynamic UCRs',
+#     TAG_DEPRECATED,
+#     [NAMESPACE_DOMAIN],
+#     description=(
+#         "Enables use of SumWhenTemplateColumn with custom expressions in dynamic UCRS."
+#     ),
+#     help_link='https://commcare-hq.readthedocs.io/ucr.html#sumwhencolumn-and-sumwhentemplatecolumn',
+# )
 
 ASYNC_RESTORE = StaticToggle(
     'async_restore',


### PR DESCRIPTION
## Technical Summary

Deletes toggle `ucr_sum_when_templates`

:t-rex: Jira: [SAAS-19312](https://dimagi.atlassian.net/browse/SAAS-19312)

## Feature Flag

`ucr_sum_when_templates`

## Safety Assurance

### Safety story

* Small footprint

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19312]: https://dimagi.atlassian.net/browse/SAAS-19312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ