### PR TITLE
Remove NON_COMMTRACK_LEDGERS feature flag

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -312,8 +312,7 @@ def _get_vellum_plugins(domain, form, module, options):
     privileges.
     """
     vellum_plugins = ["modeliteration", "itemset", "atwho"]
-    if (toggles.COMMTRACK.enabled(domain)
-            or toggles.NON_COMMTRACK_LEDGERS.enabled(domain)):
+    if toggles.COMMTRACK.enabled(domain):
         vellum_plugins.append("commtrack")
     if "caseManagement" in options:
         vellum_plugins.append("caseManagement")

--- a/corehq/apps/hqcase/tests/test_explode_cases.py
+++ b/corehq/apps/hqcase/tests/test_explode_cases.py
@@ -6,7 +6,6 @@ from django.test import TestCase
 from casexml.apps.case.mock import CaseBlock, CaseIndex, CaseStructure
 from casexml.apps.case.tests.util import (
     delete_all_cases,
-    delete_all_ledgers,
     delete_all_xforms,
 )
 from casexml.apps.phone.tests.test_sync_mode import BaseSyncTest
@@ -18,7 +17,6 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
 from corehq.form_processor.models import CommCareCase
-from corehq.util.test_utils import flag_enabled
 
 
 class ExplodeCasesDbTest(TestCase):
@@ -205,18 +203,18 @@ class ExplodeExtensionsDBTest(BaseSyncTest):
         self.assertEqual(20, len(case_ids))
 
 
-@flag_enabled('NON_COMMTRACK_LEDGERS')
 class ExplodeLedgersTest(BaseSyncTest):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project.commtrack_enabled = True
+        cls.project.save()
+
     def setUp(self):
         super(ExplodeLedgersTest, self).setUp()
         self.ledger_accessor = LedgerAccessors(self.project.name)
         self._create_ledgers()
-
-    def tearDown(self):
-        delete_all_ledgers()
-        delete_all_cases()
-        delete_all_xforms()
-        super(ExplodeLedgersTest, self).tearDown()
 
     def _create_ledgers(self):
         case_type = 'case'

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/stock.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/stock.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from datetime import datetime
 
-from corehq import toggles
 from corehq.form_processor.exceptions import LedgerValueNotFound
 from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
 from memoized import memoized
@@ -13,8 +12,7 @@ from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
 
 
 def get_stock_payload(project, stock_settings, case_stub_list):
-    uses_ledgers = project.commtrack_enabled or toggles.NON_COMMTRACK_LEDGERS.enabled(project.name)
-    if project and not uses_ledgers:
+    if project and not project.commtrack_enabled:
         return
 
     generator = StockPayloadGenerator(project.name, stock_settings, case_stub_list)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -59,7 +59,6 @@ class BaseSyncTest(TestCase):
         super(BaseSyncTest, cls).setUpClass()
         cls.project = Domain(name=TEST_DOMAIN_NAME)
         cls.project.save()
-        cls.addClassCleanup(cls.project.delete)
         cls.user = create_restore_user(
             cls.project.name,
             USERNAME,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -38,7 +38,7 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.blobs import get_blob_db
-from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
+from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import sharded
 from corehq.util.test_utils import flag_enabled
 
@@ -318,10 +318,6 @@ class SyncTokenUpdateTest(BaseSyncTest):
                 )],
             )
         ])
-        index_ref = CommCareCaseIndex(identifier=index_id,
-                                      referenced_type=PARENT_TYPE,
-                                      referenced_id=parent_id)
-
         self._testUpdate(self.device.last_sync.log.get_id, {parent_id, child_id})
 
         # close the mother case
@@ -350,9 +346,6 @@ class SyncTokenUpdateTest(BaseSyncTest):
                 )],
             )
         ])
-        index_ref = CommCareCaseIndex(identifier=index_id,
-                                      referenced_type=PARENT_TYPE,
-                                      referenced_id=parent_id)
         # should be there
         self._testUpdate(self.device.last_sync.log.get_id, {parent_id, child_id})
 
@@ -711,15 +704,6 @@ class SyncTokenUpdateTest(BaseSyncTest):
             )],
             attrs={'create': True}
         )
-        parent_ref = CommCareCaseIndex(
-            identifier=PARENT_TYPE,
-            referenced_type=PARENT_TYPE,
-            referenced_id=parent.case_id)
-        grandparent_ref = CommCareCaseIndex(
-            identifier=PARENT_TYPE,
-            referenced_type=PARENT_TYPE,
-            referenced_id=grandparent.case_id)
-
         self.device.post_changes(child)
 
         self._testUpdate(
@@ -991,49 +975,49 @@ class ExtensionCasesSyncTokenUpdates(BaseSyncTest):
         """
         case_type = 'case'
 
-        E1 = CaseStructure(
+        extension_one = CaseStructure(
             case_id='extension_1',
             attrs={'create': True, 'owner_id': '-'},
         )
 
-        C = CaseStructure(
+        child = CaseStructure(
             case_id='child',
             attrs={'create': True, 'owner_id': '-'},
             indices=[CaseIndex(
-                E1,
+                extension_one,
                 identifier='extension_1',
                 relationship='extension',
                 related_type=case_type,
             )]
         )
 
-        O = CaseStructure(
+        parent = CaseStructure(
             case_id='owned',
             attrs={'create': True},
             indices=[CaseIndex(
-                C,
+                child,
                 identifier='child',
                 relationship='child',
                 related_type=case_type,
             )]
         )
-        E2 = CaseStructure(
+        extension_two = CaseStructure(
             case_id='extension_2',
             attrs={'create': True, 'owner_id': '-'},
             indices=[CaseIndex(
-                C,
+                child,
                 identifier='extension',
                 relationship='extension',
                 related_type=case_type,
             )]
         )
-        self.device.post_changes([O, E2])
+        self.device.post_changes([parent, extension_two])
         sync_log = self.device.last_sync.get_log()
 
-        expected_dependent_ids = set([C.case_id, E1.case_id, E2.case_id])
+        expected_dependent_ids = set([child.case_id, extension_one.case_id, extension_two.case_id])
         self.assertEqual(sync_log.dependent_case_ids_on_phone, expected_dependent_ids)
 
-        all_ids = set([E1.case_id, E2.case_id, O.case_id, C.case_id])
+        all_ids = set([extension_one.case_id, extension_two.case_id, parent.case_id, child.case_id])
         self.assertEqual(sync_log.case_ids_on_phone, all_ids)
 
 
@@ -1613,10 +1597,6 @@ class MultiUserSyncTest(BaseSyncTest):
                 )],
             )
         ])
-        index_ref = CommCareCaseIndex(identifier=PARENT_TYPE,
-                                      referenced_type=PARENT_TYPE,
-                                      referenced_id=parent_id)
-
         # sanity check that we are in the right state
         sync_log = self.guy.last_sync.get_log()
         self._testUpdate(sync_log._id, {child_id}, {parent_id})

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -39,7 +39,7 @@ from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.blobs import get_blob_db
 from corehq.form_processor.models import CommCareCase
-from corehq.form_processor.tests.utils import sharded
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 from corehq.util.test_utils import flag_enabled
 
 USERNAME = "syncguy"
@@ -72,6 +72,9 @@ class BaseSyncTest(TestCase):
         super(BaseSyncTest, self).setUp()
         self.device = self.get_device()
         self.device.sync(overwrite_cache=True, version=V1)
+        self.addCleanup(FormProcessorTestUtils.delete_all_cases)
+        self.addCleanup(FormProcessorTestUtils.delete_all_xforms)
+        self.addCleanup(FormProcessorTestUtils.delete_all_sync_logs)
 
     def tearDown(self):
         restore_config = RestoreConfig(

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -39,7 +39,7 @@ from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.dbaccessors import delete_all_users
 from corehq.blobs import get_blob_db
 from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
+from corehq.form_processor.tests.utils import sharded
 from corehq.util.test_utils import flag_enabled
 
 USERNAME = "syncguy"
@@ -57,22 +57,20 @@ class BaseSyncTest(TestCase):
     @classmethod
     def setUpClass(cls):
         super(BaseSyncTest, cls).setUpClass()
-        delete_all_users()
-
         cls.project = Domain(name=TEST_DOMAIN_NAME)
         cls.project.save()
+        cls.addClassCleanup(cls.project.delete)
         cls.user = create_restore_user(
             cls.project.name,
             USERNAME,
         )
         cls.user_id = cls.user.user_id
         # this creates the initial blank sync token in the database
+        cls.addClassCleanup(delete_all_users)
+        cls.addClassCleanup(delete_all_domains)
 
     def setUp(self):
         super(BaseSyncTest, self).setUp()
-        FormProcessorTestUtils.delete_all_cases()
-        FormProcessorTestUtils.delete_all_xforms()
-        FormProcessorTestUtils.delete_all_sync_logs()
         self.device = self.get_device()
         self.device.sync(overwrite_cache=True, version=V1)
 
@@ -83,12 +81,6 @@ class BaseSyncTest(TestCase):
         )
         restore_config.restore_payload_path_cache.invalidate()
         super(BaseSyncTest, self).tearDown()
-
-    @classmethod
-    def tearDownClass(cls):
-        delete_all_users()
-        delete_all_domains()
-        super(BaseSyncTest, cls).tearDownClass()
 
     def get_device(self, **kw):
         kw.setdefault("project", self.project)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_utils.py
@@ -4,11 +4,9 @@ from django.test import SimpleTestCase
 
 import casexml.apps.phone.utils as mod
 from casexml.apps.case.mock import CaseStructure
-from casexml.apps.case.tests.util import delete_all_cases, delete_all_ledgers, delete_all_xforms
 from casexml.apps.phone.tests.test_sync_mode import BaseSyncTest
 from casexml.apps.stock.mock import Balance, Entry, Transfer
 from corehq.apps.app_manager.tests.util import TestXmlMixin
-from corehq.util.test_utils import flag_enabled
 
 
 class TestUtils(SimpleTestCase):
@@ -32,17 +30,12 @@ class TestUtils(SimpleTestCase):
         self.assertEqual(num, 1)
 
 
-@flag_enabled('NON_COMMTRACK_LEDGERS')
 class MockDeviceLedgersTest(BaseSyncTest, TestXmlMixin):
     def setUp(self):
         super(MockDeviceLedgersTest, self).setUp()
+        self.project.commtrack_enabled = True
+        self.project.save()
         self._create_ledgers()
-
-    def tearDown(self):
-        delete_all_ledgers()
-        delete_all_cases()
-        delete_all_xforms()
-        super(MockDeviceLedgersTest, self).tearDown()
 
     def _create_ledgers(self):
         case_type = 'case'

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1342,16 +1342,16 @@ COMMTRACK = StaticToggle(
     save_fn=_commtrackify,
 )
 
-NON_COMMTRACK_LEDGERS = StaticToggle(
-    'non_commtrack_ledgers',
-    "Enable ledgers for projects not using Supply.",
-    TAG_DEPRECATED,
-    description=(
-        'Turns on the ledger fixture and ledger transaction question types in '
-        'the form builder. ONLY WORKS ON SQL DOMAINS!'
-    ),
-    namespaces=[NAMESPACE_DOMAIN],
-)
+# NON_COMMTRACK_LEDGERS = StaticToggle(
+#     'non_commtrack_ledgers',
+#     "Enable ledgers for projects not using Supply.",
+#     TAG_DEPRECATED,
+#     description=(
+#         'Turns on the ledger fixture and ledger transaction question types in '
+#         'the form builder. ONLY WORKS ON SQL DOMAINS!'
+#     ),
+#     namespaces=[NAMESPACE_DOMAIN],
+# )
 
 CUSTOM_INSTANCES = StaticToggle(
     'custom_instances',


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19315

Includes some test refactoring as well. The test that was gated by this flag also applied to projects with commtrack enabled, so updated the test, and cleaned up areas where needed.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
[NON_COMMTRACK_LEDGERS](https://www.commcarehq.org/hq/flags/edit/non_commtrack_ledgers/)

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Pretty straightforward since there were two ways to access ledgers, and this just removes one of those, effectively just needing to update a couple of if statements.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
