### PR TITLE
Remove APP_BUILDER_CUSTOM_PARENT_REF feature flag

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap3/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap3/case_config.html
@@ -280,15 +280,6 @@
                     <span class="help-block" data-bind="visible: !case_type()">
                       {% trans "Required" %}
                     </span>
-                    {% if show_custom_ref %}
-                      <label> {% trans "Override reference id: " %} </label>
-                      <input
-                        type="text"
-                        {% if not add_ons_privileges.subcases %}disabled="disabled"{% endif %}
-                        class="form-control"
-                        data-bind="value: reference_id"
-                      />
-                    {% endif %}
                   </span>
                 </div>
               </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap5/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap5/case_config.html
@@ -280,15 +280,6 @@
                     <span class="help-block" data-bind="visible: !case_type()">
                       {% trans "Required" %}
                     </span>
-                    {% if show_custom_ref %}
-                      <label> {% trans "Override reference id: " %} </label>
-                      <input
-                        type="text"
-                        {% if not add_ons_privileges.subcases %}disabled="disabled"{% endif %}
-                        class="form-control"
-                        data-bind="value: reference_id"
-                      />
-                    {% endif %}
                   </span>
                 </div>
               </div>

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -751,7 +751,7 @@ class TestViewGeneric(ViewsBase):
         'is_allowed_to_be_release_notes_form', 'custom_assertions', 'title_context_block', 'id',
         'secure_cookies', 'langs', 'None', 'CUSTOM_LOGO_URL', 'allow_form_copy', 'selected_form', 'slug',
         'env', 'False', 'ANALYTICS_IDS', 'STATIC_URL', 'selected_module', 'role_version', 'allow_usercase',
-        'module_loads_registry_case', 'EULA_COMPLIANCE', 'sentry', 'show_shadow_modules', 'show_custom_ref',
+        'module_loads_registry_case', 'EULA_COMPLIANCE', 'sentry', 'show_shadow_modules',
         'block', 'IS_ANALYTICS_ENVIRONMENT', 'module_type', 'icon_class', 'case_property_warning',
         'form_submit_history_url', 'btn_style', 'ACCOUNTS_EMAIL', 'CHATBOT_ID', 'CHATBOT_TOKEN'
     }

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -885,9 +885,6 @@ def get_form_view_context(
     else:
         # TODO: figure out a cleaner method
         form.actions.make_multi()
-        context.update({
-            'show_custom_ref': toggles.APP_BUILDER_CUSTOM_PARENT_REF.enabled_for_request(request),
-        })
         case_config_options.update({
             'actions': form.actions,
             'allowUsercase': allow_usercase,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/forms/case_config.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/forms/case_config.html.diff.txt
@@ -172,7 +172,7 @@
                        class="form-control"
                        {% if not add_ons_privileges.subcases %}disabled="disabled"{% endif %}
                        data-bind="options: $parent.caseTypes,
-@@ -297,7 +297,7 @@
+@@ -288,7 +288,7 @@
            </div>
          </div>
          {% if add_ons_privileges.subcases %}

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -647,12 +647,12 @@ def _ensure_valid_randomness(randomness):
         raise Exception('randomness must be between 0 and 1!')
 
 
-APP_BUILDER_CUSTOM_PARENT_REF = StaticToggle(
-    'custom-parent-ref',
-    'ICDS: Custom case parent reference',
-    TAG_DEPRECATED,
-    [NAMESPACE_DOMAIN],
-)
+# APP_BUILDER_CUSTOM_PARENT_REF = StaticToggle(
+#     'custom-parent-ref',
+#     'ICDS: Custom case parent reference',
+#     TAG_DEPRECATED,
+#     [NAMESPACE_DOMAIN],
+# )
 
 LAZY_LOAD_MULTIMEDIA = StaticToggle(
     'optional-media',


### PR DESCRIPTION
## Product Description

No user-facing effects. This toggle gated a UI input field ("Override reference id") in the basic case configuration form for advanced modules. The toggle was tagged `TAG_DEPRECATED` and is being removed as part of ICDS cleanup. The underlying `reference_id` functionality remains available in the advanced module case configuration UI (`case_config_advanced.html`).

[Jira: SAAS-19307
](https://dimagi.atlassian.net/browse/SAAS-19307)
## Technical Summary

Removes the `APP_BUILDER_CUSTOM_PARENT_REF` feature flag (slug: `custom-parent-ref`) which controlled visibility of a custom case parent reference ID input in the form designer.

Changes:
- Removed the toggle check (`toggles.APP_BUILDER_CUSTOM_PARENT_REF.enabled_for_request`) from `corehq/apps/app_manager/views/forms.py`
- Removed the `{% if show_custom_ref %}` template blocks from both bootstrap3 and bootstrap5 `case_config.html` templates
- Removed `show_custom_ref` from expected context keys in `test_views.py`
- Commented out the toggle definition in `corehq/toggles/__init__.py`

## Feature Flag

- **Variable**: `APP_BUILDER_CUSTOM_PARENT_REF`
- **Slug**: `custom-parent-ref`
- **Tag**: `TAG_DEPRECATED`
- **Type**: `StaticToggle`

## Safety Assurance

Verified that all the domains enabled on India and Prod are either Test Domains or Paused ones.

### Safety story

This toggle is tagged `TAG_DEPRECATED` and gates only a UI input field for setting custom case index reference IDs. Removing the toggle preserves the default behavior (the input is hidden). The underlying `reference_id` model field and suite XML generation remain unchanged, so existing apps with custom reference IDs already set continue to work. The advanced module case configuration UI still exposes `reference_id` inputs independently of this toggle.

### Automated test coverage

- `TestViewGeneric` in `test_views.py` verifies the form view context keys (updated to remove `show_custom_ref`)
- `test_advanced_suite_parent_child_custom_ref` tests the underlying `reference_id` feature and is unaffected by this change

### QA Plan

Verify no domains have this flag enabled:
```
cchq production django-manage list_ff_domains custom-parent-ref
cchq staging django-manage list_ff_domains custom-parent-ref
cchq india django-manage list_ff_domains custom-parent-ref
cchq eu django-manage list_ff_domains custom-parent-ref
```

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change