### PR TITLE
Remove APP_TESTING feature flag

### DIFF
--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1195,12 +1195,6 @@ class ApplicationsTab(UITab):
                 _('New Application'),
                 url=(reverse('default_new_app', args=[self.domain])),
             ))
-        if toggles.APP_TESTING.enabled_for_request(self._request):
-            submenu_context.append(dropdown_dict(
-                _('Application Testing'),
-                url=(reverse('app_execution:workflow_list', args=[self.domain])),
-            ))
-
         return submenu_context
 
     @property

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2795,13 +2795,13 @@ RESTRICT_DATA_SOURCE_REBUILD = StaticToggle(
                 'for the number of records to be populated during building or rebuilding'
 )
 
-APP_TESTING = StaticToggle(
-    slug='app_testing',
-    label='App Testing UI',
-    tag=TAG_DEPRECATED,
-    namespaces=[NAMESPACE_DOMAIN],
-    description=''
-)
+# APP_TESTING = StaticToggle(
+#     slug='app_testing',
+#     label='App Testing UI',
+#     tag=TAG_DEPRECATED,
+#     namespaces=[NAMESPACE_DOMAIN],
+#     description=''
+# )
 
 CSQL_FIXTURE = StaticToggle(
     slug='module_badges',


### PR DESCRIPTION
## Product Description
No user-facing effects. The `APP_TESTING` feature flag (slug: `app_testing`) controlled visibility of an "Application Testing" link in the Applications tab dropdown menu. The flag was tagged `TAG_DEPRECATED` and is being removed per [SAAS-19323](https://dimagi.atlassian.net/browse/SAAS-19323).

The `app_execution` app itself remains intact and accessible to superusers/contractors via `@require_superuser_or_contractor`.

## Technical Summary
- Removed the toggle-gated "Application Testing" dropdown menu entry from `ApplicationsTab.dropdown_items` in `corehq/tabs/tabclasses.py`
- Commented out the `APP_TESTING` toggle definition in `corehq/toggles/__init__.py`

## Feature Flag
- **Variable**: `APP_TESTING`
- **Slug**: `app_testing`
- **Tag**: `TAG_DEPRECATED`
- **Type**: `StaticToggle`

## Safety Assurance

Verified that this is not used in any environment and on production it is used on a test domain.

### Safety story
This change removes a deprecated feature flag. The toggle evaluated to `False` by default, so removing it preserves the default behavior. The only effect was showing an "Application Testing" link in the Applications dropdown for domains with the flag enabled. The underlying `app_execution` views remain accessible to superusers and contractors independently of this toggle.

### Automated test coverage
The `corehq/tabs/tests/test_tabclasses.py` tests pass with these changes. No tests existed that specifically tested the `APP_TESTING` toggle behavior.

### QA Plan
Verify no domains rely on the flag:
```
cchq production django-manage list_ff_domains app_testing
cchq staging django-manage list_ff_domains app_testing
cchq india django-manage list_ff_domains app_testing
cchq eu django-manage list_ff_domains app_testing
```

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[SAAS-19323]: https://dimagi.atlassian.net/browse/SAAS-19323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ