### PR TITLE
Add script to summarise PR CI test failures

### DIFF
--- a/scripts/pr-failures.sh
+++ b/scripts/pr-failures.sh
@@ -11,18 +11,19 @@ if ! command -v gh &>/dev/null; then
     exit 1
 fi
 
-if ! gh auth status &>/dev/null; then
-    echo "Error: 'gh' is not authenticated. Run 'gh auth login' first." >&2
-    exit 1
-fi
-
 PR=${1:-}
 REPO=$(gh repo view --json nameWithOwner -q ".nameWithOwner")
 
+gh_exit=0
 if [[ -n "$PR" ]]; then
-    FAILED=$(gh pr checks "$PR" --repo "$REPO" 2>/dev/null | awk -F'\t' '$2 == "fail"') || true
+    FAILED=$(gh pr checks "$PR" --repo "$REPO" | awk -F'\t' '$2 == "fail"') || gh_exit=$?
 else
-    FAILED=$(gh pr checks --repo "$REPO" 2>/dev/null | awk -F'\t' '$2 == "fail"') || true
+    FAILED=$(gh pr checks --repo "$REPO" | awk -F'\t' '$2 == "fail"') || gh_exit=$?
+fi
+
+# Non-zero exit + no tab-separated output = real gh error (already printed to stderr)
+if [[ $gh_exit -ne 0 && -z "$FAILED" ]]; then
+    exit 1
 fi
 
 if [[ -z "$FAILED" ]]; then

--- a/scripts/pr-failures.sh
+++ b/scripts/pr-failures.sh
@@ -32,5 +32,5 @@ echo "Failures:"
 for RUN_ID in $RUN_IDS; do
     gh run view "$RUN_ID" --repo "$REPO" --log-failed 2>&1 \
         | grep -E "(FAILED |short test summary info|\[.*\] ERROR:)" \
-        | sed 's/^[^\t]*\t[^\t]*\t[0-9T:.-]*Z //'
+        | sed 's/^[^\t]*\t[^\t]*\t[0-9T:.-]*Z //' || true
 done

--- a/scripts/pr-failures.sh
+++ b/scripts/pr-failures.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Show test failures for a GitHub Actions CI run on a PR.
-# Usage: scripts/pr-failures.sh <pr_number>
+# Usage: scripts/pr-failures.sh [<pr_number>]
+# If no PR number is given, uses the current branch's open PR.
 
 set -euo pipefail
 
@@ -15,13 +16,17 @@ if ! gh auth status &>/dev/null; then
     exit 1
 fi
 
-PR=${1:?Usage: scripts/pr-failures.sh <pr_number>}
-REPO="dimagi/commcare-hq"
+PR=${1:-}
+REPO=$(gh repo view --json nameWithOwner -q ".nameWithOwner")
 
-FAILED=$(gh pr checks "$PR" --repo "$REPO" 2>/dev/null | awk -F'\t' '$2 == "fail"') || true
+if [[ -n "$PR" ]]; then
+    FAILED=$(gh pr checks "$PR" --repo "$REPO" 2>/dev/null | awk -F'\t' '$2 == "fail"') || true
+else
+    FAILED=$(gh pr checks --repo "$REPO" 2>/dev/null | awk -F'\t' '$2 == "fail"') || true
+fi
 
 if [[ -z "$FAILED" ]]; then
-    echo "No failed checks for PR #$PR."
+    echo "No failed checks${PR:+ for PR #$PR}."
     exit 0
 fi
 

--- a/scripts/pr-failures.sh
+++ b/scripts/pr-failures.sh
@@ -18,7 +18,7 @@ echo "Failed checks:"
 echo "$FAILED" | awk -F'\t' '{print "  " $1}'
 
 # Extract unique run IDs from GitHub Actions URLs (runs/<id>/job/<id>)
-RUN_IDS=$(echo "$FAILED" | grep -oE 'runs/[0-9]+' | grep -oE '[0-9]+' | sort -u)
+RUN_IDS=$(echo "$FAILED" | grep -oE 'runs/[0-9]+' | grep -oE '[0-9]+' | sort -u) || true
 
 if [[ -z "$RUN_IDS" ]]; then
     echo ""

--- a/scripts/pr-failures.sh
+++ b/scripts/pr-failures.sh
@@ -18,7 +18,7 @@ gh_exit=0
 if [[ -n "$PR" ]]; then
     FAILED=$(gh pr checks "$PR" --repo "$REPO" | awk -F'\t' '$2 == "fail"') || gh_exit=$?
 else
-    FAILED=$(gh pr checks --repo "$REPO" | awk -F'\t' '$2 == "fail"') || gh_exit=$?
+    FAILED=$(gh pr checks | awk -F'\t' '$2 == "fail"') || gh_exit=$?
 fi
 
 # Non-zero exit + no tab-separated output = real gh error (already printed to stderr)

--- a/scripts/pr-failures.sh
+++ b/scripts/pr-failures.sh
@@ -4,6 +4,17 @@
 
 set -euo pipefail
 
+if ! command -v gh &>/dev/null; then
+    echo "Error: 'gh' (GitHub CLI) is not installed." >&2
+    echo "Install it from https://cli.github.com/" >&2
+    exit 1
+fi
+
+if ! gh auth status &>/dev/null; then
+    echo "Error: 'gh' is not authenticated. Run 'gh auth login' first." >&2
+    exit 1
+fi
+
 PR=${1:?Usage: scripts/pr-failures.sh <pr_number>}
 REPO="dimagi/commcare-hq"
 

--- a/scripts/pr-failures.sh
+++ b/scripts/pr-failures.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Show test failures for a GitHub Actions CI run on a PR.
+# Usage: scripts/pr-failures.sh <pr_number>
+
+set -euo pipefail
+
+PR=${1:?Usage: scripts/pr-failures.sh <pr_number>}
+REPO="dimagi/commcare-hq"
+
+FAILED=$(gh pr checks "$PR" --repo "$REPO" 2>/dev/null | awk -F'\t' '$2 == "fail"') || true
+
+if [[ -z "$FAILED" ]]; then
+    echo "No failed checks for PR #$PR."
+    exit 0
+fi
+
+echo "Failed checks:"
+echo "$FAILED" | awk -F'\t' '{print "  " $1}'
+
+# Extract unique run IDs from GitHub Actions URLs (runs/<id>/job/<id>)
+RUN_IDS=$(echo "$FAILED" | grep -oE 'runs/[0-9]+' | grep -oE '[0-9]+' | sort -u)
+
+if [[ -z "$RUN_IDS" ]]; then
+    echo ""
+    echo "Could not extract run IDs. Check URLs manually:"
+    echo "$FAILED" | awk '{print "  " $NF}'
+    exit 1
+fi
+
+echo ""
+echo "Failures:"
+for RUN_ID in $RUN_IDS; do
+    gh run view "$RUN_ID" --repo "$REPO" --log-failed 2>&1 \
+        | grep -E "(FAILED |short test summary info|\[.*\] ERROR:)" \
+        | sed 's/^[^\t]*\t[^\t]*\t[0-9T:.-]*Z //'
+done


### PR DESCRIPTION

## Technical Summary

`scripts/pr-failures.sh <pr_number>` fetches failed GitHub Actions jobs for a PR and filters the raw log output down to just the pytest failure lines and script-level errors (e.g. missing migrations), stripping verbose noise.

Useful for AI agents to identify and resolve PR test failures. (Faster, uses much less context, single step for including in skills.)

## Safety Assurance

### Safety story

Helper BASH script, non HQ code

### Automated test coverage

Not applicable

### QA Plan

Not applicable

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
