### PR TITLE
Downcase username before checking SSO requirement

### DIFF
--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -1557,7 +1557,7 @@ def check_sso_login_status(request):
     :param request: HttpRequest
     :return: HttpResponse (as JSON)
     """
-    username = request.POST['username']
+    username = request.POST['username'].lower()
     is_sso_required = False
     sso_url = None
     continue_text = None


### PR DESCRIPTION
## Product Description
Fixes a bug where email addresses entered with any capital letters were considered invalid for SSO login.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19361

## Safety Assurance

### Safety story
This is a straightforward change in line with how we handle email address -> username elsewhere. The validator used for SSO that considers capital letters invalid is also in use everywhere else for SSO usernames, including when creating/setting up users, so nobody could be currently using capital letters in SSO usernames (i.e., this won't break anything). Tested on staging.

### Automated test coverage
We have tests for `check_sso_login_status` that would help show if anything was broken by this change.

### QA Plan
No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
