### PR TITLE
Remove FCM_NOTIFICATION feature flag

### DIFF
--- a/corehq/apps/ota/tests/test_heartbeat.py
+++ b/corehq/apps/ota/tests/test_heartbeat.py
@@ -11,7 +11,7 @@ from corehq.apps.app_manager.tests.util import patch_validate_xform, get_simple_
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.tasks import process_reporting_metadata_staging
-from corehq.util.test_utils import flag_enabled
+
 from ..models import DeviceLogRequest
 
 
@@ -48,7 +48,7 @@ class HeartbeatTests(TestCase):
 
     def _do_request(self, user, device_id, app_id=None, app_version=1, last_sync='',
                     unsent_forms=0, quarantined_forms=0, cc_version='2.39', url=None,
-                    response_code=200, fcm_token=''):
+                    response_code=200):
         url = url or self.url
         resp = self.client.get(url, {
             'app_id': app_id or self.app.get_id,
@@ -58,15 +58,12 @@ class HeartbeatTests(TestCase):
             'num_unsent_forms': unsent_forms,
             'num_quarantined_forms': quarantined_forms,
             'cc_version': cc_version,
-            'fcm_token': fcm_token
         }, **self._auth_headers(user))
         self.assertEqual(resp.status_code, response_code)
         process_reporting_metadata_staging()
         return resp
 
-    @flag_enabled('FCM_NOTIFICATION')
     def test_heartbeat(self):
-        fcm_token = 'token-101'
         self._do_request(
             self.user,
             device_id='123123',
@@ -74,15 +71,12 @@ class HeartbeatTests(TestCase):
             last_sync=datetime.utcnow().isoformat(),
             unsent_forms=2,
             quarantined_forms=3,
-            fcm_token=fcm_token
         )
         device = CommCareUser.get(self.user.get_id).get_device('123123')
         self.assertEqual(device.device_id, '123123')
         self.assertIsNotNone(device.last_used)
         self.assertEqual(device.commcare_version, '2.39')
         self.assertEqual(1, len(device.app_meta))
-        self.assertEqual(device.fcm_token, fcm_token)
-        self.assertIsNotNone(device.fcm_token_timestamp)
 
         app_meta = device.app_meta[0]
         self.assertEqual(app_meta.app_id, self.app.get_id)
@@ -126,38 +120,6 @@ class HeartbeatTests(TestCase):
         # ensure the cache was wiped on delete
         device_log_request.delete()
         self.assertFalse(heartbeat_contains_force_logs())
-
-    @flag_enabled('FCM_NOTIFICATION')
-    def test_heartbeat_update_fcm_token(self):
-        self._do_request(
-            self.user,
-            device_id='3',
-            fcm_token='token-101'
-        )
-
-        device = CommCareUser.get(self.user.get_id).get_device('3')
-        self.assertEqual(device.fcm_token, 'token-101')
-
-        updated_fcm_token = 'token-102'
-        self._do_request(
-            self.user,
-            device_id='3',
-            fcm_token=updated_fcm_token
-        )
-        updated_device = CommCareUser.get(self.user.get_id).get_device('3')
-        self.assertEqual(updated_device.fcm_token, updated_fcm_token)
-        self.assertIsNotNone(updated_device.fcm_token_timestamp)
-        self.assertGreater(updated_device.fcm_token_timestamp, device.fcm_token_timestamp)
-
-    def test_heartbeat_update_fcm_token_disabled_domain(self):
-        self._do_request(
-            self.user,
-            device_id='4',
-            fcm_token='token-101'
-        )
-        device = CommCareUser.get(self.user.get_id).get_device('4')
-        self.assertIsNone(device.fcm_token)
-        self.assertIsNone(device.fcm_token_timestamp)
 
     @patch("corehq.apps.ota.views.deterministic_random")
     def test_incude_user_for_integrity_reporting(self, deterministic_random_mock):

--- a/corehq/apps/ota/tests/test_heartbeat.py
+++ b/corehq/apps/ota/tests/test_heartbeat.py
@@ -1,13 +1,16 @@
 import base64
 from datetime import datetime
-from uuid import uuid4
 from unittest.mock import patch
+from uuid import uuid4
 
 from django.test import TestCase
 from django.urls.base import reverse
 
 from corehq.apps.app_manager.tests.app_factory import AppFactory
-from corehq.apps.app_manager.tests.util import patch_validate_xform, get_simple_form
+from corehq.apps.app_manager.tests.util import (
+    get_simple_form,
+    patch_validate_xform,
+)
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.tasks import process_reporting_metadata_staging

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -452,7 +452,6 @@ def update_user_reporting_data(app_build_id, app_id, build_profile_id, couch_use
     num_unsent_forms = _safe_int(request.GET.get('num_unsent_forms', ''))
     num_quarantined_forms = _safe_int(request.GET.get('num_quarantined_forms', ''))
     commcare_version = request.GET.get('cc_version', '')
-    fcm_token = ''
     # if mobile cannot determine app version it sends -1
     if app_version == -1:
         app_version = None
@@ -467,14 +466,14 @@ def update_user_reporting_data(app_build_id, app_id, build_profile_id, couch_use
     if settings.USER_REPORTING_METADATA_BATCH_ENABLED:
         UserReportingMetadataStaging.add_heartbeat(
             request.domain, couch_user._id, app_id, app_build_id, last_sync, device_id,
-            app_version, num_unsent_forms, num_quarantined_forms, commcare_version, build_profile_id, fcm_token
+            app_version, num_unsent_forms, num_quarantined_forms, commcare_version, build_profile_id
         )
     else:
         record = UserReportingMetadataStaging(domain=request.domain, user_id=couch_user._id, app_id=app_id,
             build_id=app_build_id, sync_date=last_sync, device_id=device_id, app_version=app_version,
             num_unsent_forms=num_unsent_forms, num_quarantined_forms=num_quarantined_forms,
             commcare_version=commcare_version, build_profile_id=build_profile_id,
-            last_heartbeat=datetime.utcnow(), modified_on=datetime.utcnow(), fcm_token=fcm_token)
+            last_heartbeat=datetime.utcnow(), modified_on=datetime.utcnow())
         try:
             record.process_record(couch_user)
         except ResourceConflict:

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -37,7 +37,6 @@ from dimagi.utils.logging import notify_exception
 from dimagi.utils.parsing import string_to_utc_datetime
 
 from corehq import toggles
-from corehq.toggles import deterministic_random
 from corehq.apps.app_manager.dbaccessors import (
     get_app_cached,
     get_latest_released_app_version,
@@ -46,7 +45,10 @@ from corehq.apps.app_manager.models import GlobalAppConfig
 from corehq.apps.builds.utils import get_default_build_spec
 from corehq.apps.case_search.const import COMMCARE_PROJECT
 from corehq.apps.case_search.exceptions import CaseSearchUserError
-from corehq.apps.case_search.models import CASE_SEARCH_REGISTRY_ID_KEY, CASE_SEARCH_TAGS_MAPPING
+from corehq.apps.case_search.models import (
+    CASE_SEARCH_REGISTRY_ID_KEY,
+    CASE_SEARCH_TAGS_MAPPING,
+)
 from corehq.apps.case_search.utils import get_case_search_results_from_request
 from corehq.apps.domain.auth import formplayer_auth
 from corehq.apps.domain.decorators import check_domain_mobile_access
@@ -61,19 +63,28 @@ from corehq.apps.registry.exceptions import (
     RegistryNotFound,
 )
 from corehq.apps.registry.helper import DataRegistryHelper
-from corehq.apps.users.device_rate_limiter import device_rate_limiter, DEVICE_RATE_LIMIT_MESSAGE
+from corehq.apps.users.device_rate_limiter import (
+    DEVICE_RATE_LIMIT_MESSAGE,
+    device_rate_limiter,
+)
 from corehq.apps.users.models import CouchUser, UserReportingMetadataStaging
 from corehq.const import ONE_DAY, OPENROSA_VERSION_MAP
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.utils.xform import adjust_text_to_datetime
 from corehq.middleware import OPENROSA_VERSION_HEADER
-from corehq.util.metrics import limit_domains, metrics_histogram, limit_tags
+from corehq.toggles import deterministic_random
+from corehq.util.metrics import limit_domains, limit_tags, metrics_histogram
 from corehq.util.quickcache import quickcache
 from corehq.util.timer import set_request_duration_reporting_threshold
 
 from .case_restore import get_case_restore_response
-from .models import DeviceLogRequest, MobileRecoveryMeasure, SerialIdBucket, IntegritySamplePercentage
+from .models import (
+    DeviceLogRequest,
+    IntegritySamplePercentage,
+    MobileRecoveryMeasure,
+    SerialIdBucket,
+)
 from .rate_limiter import rate_limit_restore
 from .utils import (
     demo_user_restore_response,
@@ -303,8 +314,10 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     if user_id and user_id != couch_user.user_id:
         # sync with a user that has been deleted but a new
         # user was created with the same username and password
-        from couchforms.openrosa_response import get_simple_response_xml
-        from couchforms.openrosa_response import ResponseNature
+        from couchforms.openrosa_response import (
+            ResponseNature,
+            get_simple_response_xml,
+        )
         response = get_simple_response_xml(
             'Attempt to sync with invalid user.',
             ResponseNature.OTA_RESTORE_ERROR

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -440,8 +440,6 @@ def update_user_reporting_data(app_build_id, app_id, build_profile_id, couch_use
     num_quarantined_forms = _safe_int(request.GET.get('num_quarantined_forms', ''))
     commcare_version = request.GET.get('cc_version', '')
     fcm_token = ''
-    if toggles.FCM_NOTIFICATION.enabled(request.domain):
-        fcm_token = request.GET.get('fcm_token', '')
     # if mobile cannot determine app version it sends -1
     if app_version == -1:
         app_version = None

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -3,7 +3,8 @@ import json
 import logging
 import re
 from collections import namedtuple
-from datetime import datetime, date, timezone as tz
+from datetime import date, datetime
+from datetime import timezone as tz
 from hashlib import sha1
 from typing import List
 from uuid import uuid4
@@ -15,13 +16,13 @@ from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db import connection, models, router, IntegrityError
+from django.db import IntegrityError, connection, models, router
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.html import format_html
-from django.utils.translation import override as override_language
 from django.utils.translation import gettext as _
+from django.utils.translation import override as override_language
 
 from couchdbkit import MultipleResultsFound, ResourceNotFound
 from couchdbkit.exceptions import BadValueError, ResourceConflict
@@ -30,8 +31,9 @@ from memoized import memoized
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.phone.models import OTARestoreCommCareUser, OTARestoreWebUser
-from casexml.apps.phone.restore_caching import get_loadtest_factor_for_restore_cache_key
-from corehq.form_processor.models import XFormInstance
+from casexml.apps.phone.restore_caching import (
+    get_loadtest_factor_for_restore_cache_key,
+)
 from dimagi.ext.couchdbkit import (
     BooleanProperty,
     DateProperty,
@@ -57,6 +59,8 @@ from dimagi.utils.logging import log_signal_errors, notify_exception
 from dimagi.utils.modules import to_function
 from dimagi.utils.web import get_static_url_prefix
 
+from corehq import privileges, toggles
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.cleanup.models import DeletedCouchDoc
 from corehq.apps.commtrack.const import USER_LOCATION_OWNER_MAP_TYPE
@@ -72,6 +76,7 @@ from corehq.apps.domain.utils import (
     guess_domain_language,
 )
 from corehq.apps.hqwebapp.tasks import send_html_email_async
+from corehq.apps.mobile_auth.utils import generate_aes_key
 from corehq.apps.reports.const import TABLEAU_ROLES
 from corehq.apps.sms.mixin import CommCareMobileContactMixin, apply_leniency
 from corehq.apps.user_importer.models import UserUploadRecord
@@ -84,20 +89,20 @@ from corehq.apps.users.tasks import (
     undelete_system_forms,
 )
 from corehq.apps.users.util import (
+    bulk_auto_deactivate_commcare_users,
     filter_by_app,
-    log_user_change,
+    is_dimagi_email,
     log_invitation_change,
+    log_user_change,
     user_display_string,
     user_location_data,
     username_to_user_id,
-    bulk_auto_deactivate_commcare_users,
-    is_dimagi_email,
 )
 from corehq.const import INVITATION_CHANGE_VIA_WEB, USER_CHANGE_VIA_WEB
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.supply import SupplyInterface
-from corehq.form_processor.models import CommCareCase
-from corehq.motech.utils import b64_aes_cbc_encrypt, b64_aes_cbc_decrypt
+from corehq.form_processor.models import CommCareCase, XFormInstance
+from corehq.motech.utils import b64_aes_cbc_decrypt, b64_aes_cbc_encrypt
 from corehq.toggles import TABLEAU_USER_SYNCING
 from corehq.util.dates import get_timestamp
 from corehq.util.models import BouncedEmail
@@ -105,17 +110,13 @@ from corehq.util.quickcache import quickcache
 from corehq.util.view_utils import absolute_reverse
 
 from .models_role import (  # noqa
+    Permission,
     RoleAssignableBy,
     RolePermission,
-    Permission,
     StaticRole,
     UserRole,
 )
 from .user_data import SQLUserData  # noqa
-from corehq import toggles, privileges
-from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.apps.mobile_auth.utils import generate_aes_key
-
 
 WEB_USER = 'web'
 COMMCARE_USER = 'commcare'
@@ -586,7 +587,10 @@ class _AuthorizableMixin(IsMemberOfMixin):
         if TABLEAU_USER_SYNCING.enabled(domain) and (tableau_role or tableau_group_ids):
             if tableau_group_ids is None:
                 tableau_group_ids = []
-            from corehq.apps.reports.util import get_tableau_groups_by_ids, update_tableau_user
+            from corehq.apps.reports.util import (
+                get_tableau_groups_by_ids,
+                update_tableau_user,
+            )
             update_tableau_user(domain=domain, username=self.username, role=tableau_role,
                                 groups=get_tableau_groups_by_ids(tableau_group_ids, domain),
                                 blocking_exception=False)
@@ -911,8 +915,6 @@ class DeviceIdLastUsed(DocumentSchema):
     last_used = DateTimeProperty()
     commcare_version = StringProperty()
     app_meta = SchemaListProperty(DeviceAppMeta)
-    fcm_token = StringProperty()
-    fcm_token_timestamp = DateTimeProperty()
 
     def update_meta(self, commcare_version=None, app_meta=None):
         if commcare_version:
@@ -939,10 +941,6 @@ class DeviceIdLastUsed(DocumentSchema):
 
     def __eq__(self, other):
         return all(getattr(self, p) == getattr(other, p) for p in self.properties())
-
-    def update_fcm_token(self, fcm_token, fcm_token_timestamp):
-        self.fcm_token = fcm_token
-        self.fcm_token_timestamp = fcm_token_timestamp
 
 
 class LastSubmission(DocumentSchema):
@@ -1192,9 +1190,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 
     def get_user_session_data(self, domain):
         from corehq.apps.custom_data_fields.models import (
-            SYSTEM_PREFIX,
-            COMMCARE_USER_TYPE_KEY,
             COMMCARE_USER_TYPE_DEMO,
+            COMMCARE_USER_TYPE_KEY,
+            SYSTEM_PREFIX,
         )
 
         session_data = self.get_user_data(domain).to_dict()
@@ -1317,8 +1315,8 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         Returns information about the status of each of this user's phone numbers.
         requesting_user - The user that is requesting this information (from a view)
         """
-        from corehq.apps.sms.models import PhoneNumber
         from corehq.apps.hqwebapp.doc_info import get_object_url
+        from corehq.apps.sms.models import PhoneNumber
 
         phone_entries = self.get_phone_entries()
 
@@ -1625,7 +1623,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         if fire_signals:
             self.fire_signals()
             if not self.to_be_deleted():
-                from corehq.apps.callcenter.tasks import sync_usercases_if_applicable
+                from corehq.apps.callcenter.tasks import (
+                    sync_usercases_if_applicable,
+                )
                 if not domains_to_sync_usercase:
                     domains_to_sync_usercase = getattr(self, 'domains', [])
                 # We need to sync to domains the user is leaving so that usercase is closed
@@ -1827,7 +1827,9 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         return super(CommCareUser, cls).wrap(data)
 
     def _is_demo_user_cached_value_is_stale(self):
-        from corehq.apps.users.dbaccessors import get_practice_mode_mobile_workers
+        from corehq.apps.users.dbaccessors import (
+            get_practice_mode_mobile_workers,
+        )
         cached_demo_users = get_practice_mode_mobile_workers.get_cached_value(self.domain)
         if cached_demo_users is not Ellipsis:
             cached_is_demo_user = any(user['_id'] == self._id for user in cached_demo_users)
@@ -1836,7 +1838,9 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         return False
 
     def clear_quickcache_for_user(self):
-        from corehq.apps.users.dbaccessors import get_practice_mode_mobile_workers
+        from corehq.apps.users.dbaccessors import (
+            get_practice_mode_mobile_workers,
+        )
         self.get_usercase_id.clear(self)
         get_loadtest_factor_for_restore_cache_key.clear(self.domain, self.user_id)
 
@@ -1856,6 +1860,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
 
     def delete(self, deleted_by_domain, deleted_by, deleted_via=None):
         from corehq.apps.ota.utils import delete_demo_restore_for_user
+
         # clear demo restore objects if any
         delete_demo_restore_for_user(self)
 
@@ -2035,7 +2040,9 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
 
         tag_system_forms_as_deleted.delay(self.domain, deleted_forms, deleted_cases, deletion_id, deletion_date)
 
-        from corehq.apps.app_manager.views.utils import unset_practice_mode_configured_apps
+        from corehq.apps.app_manager.views.utils import (
+            unset_practice_mode_configured_apps,
+        )
         unset_practice_mode_configured_apps(self.domain, self.get_id)
 
         return deletion_id, deletion_date
@@ -2052,10 +2059,10 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         self.save()
 
     def get_case_sharing_groups(self, domain=None):
-        from corehq.apps.groups.models import Group
         from corehq.apps.events.models import (
             get_user_case_sharing_groups_for_events,
         )
+        from corehq.apps.groups.models import Group
 
         groups = self._get_case_sharing_groups_for_locations(self.domain)
         groups += [group for group in Group.by_user_id(self._id) if group.case_sharing]
@@ -2272,7 +2279,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
 
     def supply_point_index_mapping(self, supply_point, clear=False):
         from corehq.apps.commtrack.exceptions import (
-            LinkedSupplyPointNotFoundError
+            LinkedSupplyPointNotFoundError,
         )
 
         if supply_point:
@@ -2366,8 +2373,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         case = self.get_usercase()
         return case.case_id if case else None
 
-    def update_device_id_last_used(self, device_id, when=None, commcare_version=None, device_app_meta=None,
-                                   fcm_token=None, fcm_token_timestamp=None):
+    def update_device_id_last_used(self, device_id, when=None, commcare_version=None, device_app_meta=None):
         """
         Sets the last_used date for the device to be the current time
         Does NOT save the user object.
@@ -2401,14 +2407,8 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                 meta = self.last_device.get_last_used_app_meta()
                 self.last_device.app_meta = [meta] if meta else []
                 save_user = True
-            if fcm_token and fcm_token_timestamp:
-                if not device.fcm_token_timestamp or fcm_token_timestamp > device.fcm_token_timestamp:
-                    device.update_fcm_token(fcm_token, fcm_token_timestamp)
-                    save_user = True
         else:
             device = DeviceIdLastUsed(device_id=device_id, last_used=when)
-            if fcm_token and fcm_token_timestamp:
-                device.update_fcm_token(fcm_token, fcm_token_timestamp)
             device.update_meta(commcare_version, device_app_meta)
             self.devices.append(device)
             self.last_device = device
@@ -2425,9 +2425,6 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         for device in self.devices:
             if device.device_id == device_id:
                 return device
-
-    def get_devices_fcm_tokens(self):
-        return [device.fcm_token for device in self.devices if device.fcm_token]
 
 
 class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
@@ -3075,7 +3072,7 @@ class UserReportingMetadataStaging(models.Model):
     @classmethod
     def add_heartbeat(cls, domain, user_id, app_id, build_id, sync_date, device_id,
                       app_version, num_unsent_forms, num_quarantined_forms,
-                      commcare_version, build_profile_id, fcm_token):
+                      commcare_version, build_profile_id):
         params = {
             'domain': domain,
             'user_id': user_id,
@@ -3088,7 +3085,6 @@ class UserReportingMetadataStaging(models.Model):
             'num_quarantined_forms': num_quarantined_forms,
             'commcare_version': commcare_version,
             'build_profile_id': build_profile_id,
-            'fcm_token': fcm_token
         }
         with connection.cursor() as cursor:
             cursor.execute(f"""
@@ -3097,13 +3093,13 @@ class UserReportingMetadataStaging(models.Model):
                     build_id,
                     sync_date, device_id,
                     app_version, num_unsent_forms, num_quarantined_forms,
-                    commcare_version, build_profile_id, last_heartbeat, fcm_token
+                    commcare_version, build_profile_id, last_heartbeat
                 ) VALUES (
                     %(domain)s, %(user_id)s, %(app_id)s, CLOCK_TIMESTAMP(), CLOCK_TIMESTAMP(),
                     %(build_id)s,
                     %(sync_date)s, %(device_id)s,
                     %(app_version)s, %(num_unsent_forms)s, %(num_quarantined_forms)s,
-                    %(commcare_version)s, %(build_profile_id)s, CLOCK_TIMESTAMP(), %(fcm_token)s
+                    %(commcare_version)s, %(build_profile_id)s, CLOCK_TIMESTAMP()
                 )
                 ON CONFLICT (domain, user_id, app_id)
                 DO UPDATE SET
@@ -3116,14 +3112,14 @@ class UserReportingMetadataStaging(models.Model):
                     num_quarantined_forms = EXCLUDED.num_quarantined_forms,
                     commcare_version = EXCLUDED.commcare_version,
                     build_profile_id = EXCLUDED.build_profile_id,
-                    last_heartbeat = CLOCK_TIMESTAMP(),
-                    fcm_token = EXCLUDED.fcm_token
+                    last_heartbeat = CLOCK_TIMESTAMP()
                 WHERE staging.last_heartbeat is NULL or EXCLUDED.last_heartbeat > staging.last_heartbeat
                 """, params)
 
     def process_record(self, user):
-        from corehq.pillows.synclog import mark_last_synclog
         from pillowtop.processors.form import mark_latest_submission
+
+        from corehq.pillows.synclog import mark_last_synclog
 
         save = False
         if not user or user.is_deleted():
@@ -3154,7 +3150,7 @@ class UserReportingMetadataStaging(models.Model):
                 self.domain, user, self.app_id, self.build_id,
                 self.sync_date, latest_build_date, self.device_id, device_app_meta,
                 commcare_version=self.commcare_version, build_profile_id=self.build_profile_id,
-                fcm_token=self.fcm_token, fcm_token_timestamp=self.last_heartbeat, save_user=False
+                save_user=False
             )
         if save:
             # update_django_user=False below is an optimization that allows us to update the CouchUser
@@ -3423,7 +3419,9 @@ class ConnectIDUserLink(models.Model):
     @cached_property
     def messaging_channel(self):
         # inline to prevent circular import
-        from corehq.messaging.smsbackends.connectid.backend import ConnectBackend
+        from corehq.messaging.smsbackends.connectid.backend import (
+            ConnectBackend,
+        )
 
         if self.channel_id is None:
             ConnectBackend().create_channel(self)

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -17,16 +17,15 @@ from casexml.apps.case.const import (
     ARCHIVED_CASE_OWNER_ID,
     UNOWNED_EXTENSION_OWNER_ID,
 )
+# SYSTEM_USER_ID is used when submitting xml to make system-generated case updates
+from dimagi.utils.couch.bulk import get_docs
+from dimagi.utils.parsing import json_format_datetime
 
 from corehq import privileges
 from corehq.apps.callcenter.const import CALLCENTER_USER
 from corehq.apps.users.exceptions import ModifyUserStatusException
 from corehq.const import USER_CHANGE_VIA_AUTO_DEACTIVATE
 from corehq.util.quickcache import quickcache
-
-# SYSTEM_USER_ID is used when submitting xml to make system-generated case updates
-from dimagi.utils.couch.bulk import get_docs
-from dimagi.utils.parsing import json_format_datetime
 
 SYSTEM_USER_ID = 'system'
 DEMO_USER_ID = 'demo_user'
@@ -249,8 +248,7 @@ def user_location_data(location_ids):
     return ' '.join(location_ids)
 
 
-def update_device_meta(user, device_id, commcare_version=None, device_app_meta=None, fcm_token=None,
-                       fcm_token_timestamp=None, save=True):
+def update_device_meta(user, device_id, commcare_version=None, device_app_meta=None, save=True):
     from corehq.apps.users.models import CommCareUser
 
     updated = False
@@ -261,8 +259,6 @@ def update_device_meta(user, device_id, commcare_version=None, device_app_meta=N
                 device_id,
                 commcare_version=commcare_version,
                 device_app_meta=device_app_meta,
-                fcm_token=fcm_token,
-                fcm_token_timestamp=fcm_token_timestamp
             )
             if save and updated:
                 user.save(fire_signals=False)
@@ -367,8 +363,8 @@ def log_user_change(by_domain, for_domain, couch_user, changed_by_user, changed_
     :param for_domain_required_for_log: set to False to allow domain less log for specific changes
     :param bulk_upload_record_id: ID of bulk upload record if changed via bulk upload
     """
-    from corehq.apps.users.models import UserHistory
     from corehq.apps.users.model_log import UserModelAction
+    from corehq.apps.users.models import UserHistory
 
     action = action or UserModelAction.UPDATE
     fields_changed = fields_changed or {}
@@ -463,8 +459,8 @@ def bulk_auto_deactivate_commcare_users(user_ids, domain):
     :param user_ids: list of user IDs
     :param domain: name of domain user IDs belong to
     """
-    from corehq.apps.users.models import UserHistory, CommCareUser
     from corehq.apps.users.model_log import UserModelAction
+    from corehq.apps.users.models import CommCareUser, UserHistory
 
     last_modified = json_format_datetime(datetime.datetime.utcnow())
     user_docs_to_bulk_save = []

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -19,7 +19,7 @@ from django.forms.widgets import (
     HiddenInput,
     Select,
     SelectMultiple,
-    Textarea
+    Textarea,
 )
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property
@@ -2699,7 +2699,9 @@ class ScheduleForm(Form):
             raise json_error()
 
         if self.cleaned_data.get("use_user_case_for_filter"):
-            from corehq.apps.data_dictionary.util import get_data_dict_props_by_case_type
+            from corehq.apps.data_dictionary.util import (
+                get_data_dict_props_by_case_type,
+            )
             user_case_properties = (
                 get_data_dict_props_by_case_type(self.domain, exclude_deprecated=True))[USERCASE_TYPE]
             invalid_keys = \

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -175,15 +175,6 @@ class ContentForm(Form):
     # names in the HTML are prefixed with "content-"
     prefix = 'content'
 
-    FCM_SUBJECT_MAX_LENGTH = 255
-    FCM_MESSAGE_MAX_LENGTH = 2048
-
-    fcm_message_type = ChoiceField(
-        required=False,
-        choices=FCMNotificationContent.MESSAGE_TYPES,
-        initial=FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION,
-        label=''
-    )
     subject = CharField(
         required=False,
         widget=HiddenInput,
@@ -242,11 +233,6 @@ class ContentForm(Form):
         required=False,
         label=gettext_lazy("Intervals"),
     )
-    fcm_action = ChoiceField(
-        required=False,
-        label=gettext_lazy("Action on Notification"),
-        choices=FCMNotificationContent.ACTION_CHOICES,
-    )
 
     def __init__(self, *args, **kwargs):
         if 'schedule_form' not in kwargs:
@@ -268,11 +254,6 @@ class ContentForm(Form):
             }
 
     def clean_subject(self):
-        if (self.schedule_form.cleaned_data.get('content') == ScheduleForm.CONTENT_FCM_NOTIFICATION
-                and self.cleaned_data['fcm_message_type'] == FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION):
-            cleaned_value = self._clean_message_field('subject')
-            return self._validate_fcm_message_length(cleaned_value, self.FCM_SUBJECT_MAX_LENGTH)
-
         if self.schedule_form.cleaned_data.get('content') != ScheduleForm.CONTENT_EMAIL:
             return None
 
@@ -284,10 +265,6 @@ class ContentForm(Form):
                 and self.schedule_form.cleaned_data.get('content') == ScheduleForm.CONTENT_EMAIL
         ):
             return None
-        if (self.schedule_form.cleaned_data.get('content') == ScheduleForm.CONTENT_FCM_NOTIFICATION
-                and self.cleaned_data['fcm_message_type'] == FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION):
-            cleaned_value = self._clean_message_field('message')
-            return self._validate_fcm_message_length(cleaned_value, self.FCM_MESSAGE_MAX_LENGTH)
 
         if self.schedule_form.cleaned_data.get('content') not in (ScheduleForm.CONTENT_SMS,
                                                                   ScheduleForm.CONTENT_EMAIL,
@@ -314,31 +291,6 @@ class ContentForm(Form):
             raise ValidationError(_("Please fill out at least one translation"))
 
         return cleaned_value
-
-    @staticmethod
-    def _validate_fcm_message_length(value, max_length):
-        for data in value.values():
-            if len(data) > max_length:
-                raise ValidationError(_('This field must not exceed {} characters'.format(max_length)))
-        return value
-
-    def clean_fcm_message_type(self):
-        if self.schedule_form.cleaned_data.get('content') != ScheduleForm.CONTENT_FCM_NOTIFICATION:
-            return None
-
-        value = self.cleaned_data.get('fcm_message_type')
-        if not value:
-            raise ValidationError(_("This field is required"))
-        return value
-
-    def clean_fcm_action(self):
-        if self.schedule_form.cleaned_data.get('content') != ScheduleForm.CONTENT_FCM_NOTIFICATION:
-            return None
-
-        value = self.cleaned_data.get('fcm_action')
-        if self.cleaned_data['fcm_message_type'] == FCMNotificationContent.MESSAGE_TYPE_DATA and not value:
-            raise ValidationError(_("This field is required"))
-        return value
 
     def clean_app_and_form_unique_id(self):
         if self.schedule_form.cleaned_data.get('content') not in (ScheduleForm.CONTENT_SMS_SURVEY,
@@ -456,13 +408,6 @@ class ContentForm(Form):
             return CustomContent(
                 custom_content_id=self.cleaned_data['custom_sms_content_id']
             )
-        elif self.schedule_form.cleaned_data['content'] == ScheduleForm.CONTENT_FCM_NOTIFICATION:
-            return FCMNotificationContent(
-                subject=self.cleaned_data['subject'],
-                message=self.cleaned_data['message'],
-                action=self.cleaned_data['fcm_action'],
-                message_type=self.cleaned_data['fcm_message_type'],
-            )
         elif self.schedule_form.cleaned_data['content'] == ScheduleForm.CONTENT_CONNECT_MESSAGE:
             return ConnectMessageContent(
                 message=self.cleaned_data['message'],
@@ -524,11 +469,7 @@ class ContentForm(Form):
                         crispy.Div(template='scheduling/partials/rich_text_message_configuration.html'),
                         data_bind='with: html_message',
                     ),
-                    data_bind=(
-                        f"visible: $root.content() === '{ScheduleForm.CONTENT_EMAIL}' || "
-                        f"($root.content() === '{ScheduleForm.CONTENT_FCM_NOTIFICATION}' && "
-                        f"fcm_message_type() === '{FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION}')"
-                    )
+                    data_bind=f"visible: $root.content() === '{ScheduleForm.CONTENT_EMAIL}'"
                 ),
                 hqcrispy.B3MultiField(
                     _("Message"),
@@ -543,9 +484,7 @@ class ContentForm(Form):
                     data_bind=(
                         f"visible: $root.content() === '{ScheduleForm.CONTENT_SMS}' || "
                         f"$root.content() === '{ScheduleForm.CONTENT_SMS_CALLBACK}' || "
-                        f"$root.content() === '{ScheduleForm.CONTENT_CONNECT_MESSAGE}' || "
-                        f"($root.content() === '{ScheduleForm.CONTENT_FCM_NOTIFICATION}' && "
-                        f"fcm_message_type() === '{FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION}')"
+                        f"$root.content() === '{ScheduleForm.CONTENT_CONNECT_MESSAGE}'"
                     ),
                 )
             ]
@@ -565,29 +504,12 @@ class ContentForm(Form):
                         f"visible: $root.content() === '{ScheduleForm.CONTENT_SMS}' || "
                         f"$root.content() === '{ScheduleForm.CONTENT_EMAIL}' || "
                         f"$root.content() === '{ScheduleForm.CONTENT_SMS_CALLBACK}' || "
-                        f"$root.content() === '{ScheduleForm.CONTENT_CONNECT_MESSAGE}' || "
-                        f"($root.content() === '{ScheduleForm.CONTENT_FCM_NOTIFICATION}' && "
-                        f"fcm_message_type() === '{FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION}')"
+                        f"$root.content() === '{ScheduleForm.CONTENT_CONNECT_MESSAGE}'"
                     ),
                 ),
             ]
 
         return [
-            hqcrispy.B3MultiField(
-                _('Message type'),
-                crispy.Field(
-                    'fcm_message_type',
-                    data_bind='value: fcm_message_type',
-                ),
-                data_bind=f"visible: $root.content() === '{ScheduleForm.CONTENT_FCM_NOTIFICATION}'"
-            ),
-            crispy.Div(
-                crispy.Field('fcm_action'),
-                data_bind=(
-                    f"visible: $root.content() === '{ScheduleForm.CONTENT_FCM_NOTIFICATION}' && "
-                    f"fcm_message_type() === '{FCMNotificationContent.MESSAGE_TYPE_DATA}'"
-                )
-            ),
             hqcrispy.B3MultiField(
                 _("Subject"),
                 crispy.Field(
@@ -598,11 +520,7 @@ class ContentForm(Form):
                     crispy.Div(template='scheduling/partials/message_configuration.html'),
                     data_bind='with: subject',
                 ),
-                data_bind=(
-                    f"visible: $root.content() === '{ScheduleForm.CONTENT_EMAIL}' || "
-                    f"($root.content() === '{ScheduleForm.CONTENT_FCM_NOTIFICATION}' && "
-                    f"fcm_message_type() === '{FCMNotificationContent.MESSAGE_TYPE_NOTIFICATION}')"
-                )
+                data_bind=f"visible: $root.content() === '{ScheduleForm.CONTENT_EMAIL}'"
             ),
             *message_fields,
             crispy.Div(
@@ -718,8 +636,6 @@ class ContentForm(Form):
         elif isinstance(content, FCMNotificationContent):
             result['subject'] = content.subject
             result['message'] = content.message
-            result['fcm_action'] = content.action
-            result['fcm_message_type'] = content.message_type
         elif isinstance(content, ConnectMessageContent):
             result['message'] = content.message
         elif isinstance(content, ConnectMessageSurveyContent):
@@ -3127,17 +3043,6 @@ class ConditionalAlertScheduleForm(ScheduleForm):
     START_OFFSET_POSITIVE = 'POSITIVE'
 
     use_case = 'conditional_alert'
-
-    FCM_SUPPORTED_RECIPIENT_TYPES = [
-        ScheduleInstance.RECIPIENT_TYPE_MOBILE_WORKER,
-        ScheduleInstance.RECIPIENT_TYPE_LOCATION,
-        ScheduleInstance.RECIPIENT_TYPE_USER_GROUP,
-        CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_OWNER,
-        CaseScheduleInstanceMixin.RECIPIENT_TYPE_LAST_SUBMITTING_USER,
-        CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USERNAME,
-        CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER_ID,
-        CaseScheduleInstanceMixin.RECIPIENT_TYPE_CUSTOM,
-    ]
 
     # start_date is defined on the superclass but cleaning it in this subclass
     # depends on start_date_type, which depends on send_frequency

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -108,7 +108,6 @@ from corehq.messaging.scheduling.scheduling_partitioned.models import (
 from corehq.toggles import (
     COMMCARE_CONNECT,
     EXTENSION_CASES_SYNC_ENABLED,
-    FCM_NOTIFICATION,
     RICH_TEXT_EMAILS,
 )
 
@@ -3313,10 +3312,7 @@ class ConditionalAlertScheduleForm(ScheduleForm):
                 (self.CONTENT_CUSTOM_SMS, _("Custom SMS")),
             ]
 
-        if (
-            self.initial.get('content') == self.CONTENT_FCM_NOTIFICATION
-            or (FCM_NOTIFICATION.enabled(self.domain) and settings.FCM_CREDS)
-        ):
+        if self.initial.get('content') == self.CONTENT_FCM_NOTIFICATION:
             self.fields['content'].choices += [
                 (self.CONTENT_FCM_NOTIFICATION, _("Push Notification"))
             ]
@@ -3914,20 +3910,9 @@ class ConditionalAlertScheduleForm(ScheduleForm):
                 raise ValidationError(_("Email case property can only be used with Email content"))
 
         if self.cleaned_data.get('content') == self.CONTENT_FCM_NOTIFICATION:
-            if not settings.FCM_CREDS:
-                raise ValidationError(_("Push Notifications is no longer available on this environment."
-                                        " Please contact Administrator."))
-            if not FCM_NOTIFICATION.enabled(self.domain):
-                raise ValidationError(_("Push Notifications is not available for your project."
-                                        " Please contact Administrator."))
-
-            recipient_types_choices = dict(self.fields['recipient_types'].choices)
-            unsupported_recipient_types = {str(recipient_types_choices[recipient_type])
-                                           for recipient_type in recipient_types
-                                           if recipient_type not in self.FCM_SUPPORTED_RECIPIENT_TYPES}
-            if unsupported_recipient_types:
-                raise ValidationError(_("'{}' recipient types are not supported for Push Notifications"
-                                        .format(', '.join(unsupported_recipient_types))))
+            raise ValidationError(
+                _("Push Notifications is no longer available. Please contact Administrator.")
+            )
 
     def distill_start_offset(self):
         send_frequency = self.cleaned_data.get('send_frequency')

--- a/corehq/messaging/scheduling/tests/test_content.py
+++ b/corehq/messaging/scheduling/tests/test_content.py
@@ -1,34 +1,27 @@
-import datetime
 from unittest.mock import Mock
 
 from django.test import TestCase, override_settings
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.sms.forms import (
+    LANGUAGE_FALLBACK_DOMAIN,
     LANGUAGE_FALLBACK_NONE,
     LANGUAGE_FALLBACK_SCHEDULE,
-    LANGUAGE_FALLBACK_DOMAIN,
     LANGUAGE_FALLBACK_UNTRANSLATED,
 )
 from corehq.apps.sms.models import MessagingEvent
 from corehq.apps.users.models import CommCareUser
-from corehq.messaging.fcm.exceptions import FCMTokenValidationException
 from corehq.messaging.scheduling.exceptions import EmailValidationException
-from corehq.messaging.scheduling.models import (
-    Content as AbstractContent,
-    CustomContent,
-    Schedule as AbstractSchedule,
-    EmailContent,
-    FCMNotificationContent,
-)
+from corehq.messaging.scheduling.models import Content as AbstractContent
+from corehq.messaging.scheduling.models import CustomContent, EmailContent
+from corehq.messaging.scheduling.models import Schedule as AbstractSchedule
 from corehq.messaging.scheduling.scheduling_partitioned.models import (
     AlertScheduleInstance,
-    TimedScheduleInstance,
     CaseAlertScheduleInstance,
     CaseTimedScheduleInstance,
+    TimedScheduleInstance,
 )
 from corehq.util.test_utils import unregistered_django_model
-
 
 AVAILABLE_CUSTOM_SCHEDULING_CONTENT = {
     'TEST': ['corehq.messaging.scheduling.tests.test_content.custom_content_handler', "Test"]
@@ -51,7 +44,6 @@ class TestContent(TestCase):
         cls.sms_translations = get_or_create_sms_translations(cls.domain)
         cls.sms_translations.set_translations('es', {})
         cls.sms_translations.save()
-        cls.mobile_user = CommCareUser.create(cls.domain, 'mobile', 'abc', None, None, device_id='test_dev')
 
     @classmethod
     def tearDownClass(cls):
@@ -241,37 +233,6 @@ class TestContent(TestCase):
         with self.assertRaises(EmailValidationException) as e:
             EmailContent().get_recipient_email(recipient)
         self.assertEqual(e.exception.error_type, MessagingEvent.ERROR_INVALID_EMAIL_ADDRESS)
-
-    def _reset_user_fcm_tokens(self):
-        for device in self.mobile_user.devices:
-            device.fcm_token = None
-            device.fcm_token_timestamp = None
-            device.save()
-
-    def test_fcm_recipient_token_absent(self):
-        self._reset_user_fcm_tokens()
-        with self.assertRaises(FCMTokenValidationException) as e:
-            FCMNotificationContent().get_recipient_devices_fcm_tokens(self.mobile_user)
-        self.assertEqual(e.exception.error_type, MessagingEvent.ERROR_NO_FCM_TOKENS)
-
-    def test_fcm_recipient_token_present(self):
-        self._reset_user_fcm_tokens()
-        self.mobile_user.update_device_id_last_used(self.mobile_user.device_ids[0], fcm_token='abcd',
-                                                    fcm_token_timestamp=datetime.datetime.utcnow())
-        devices_token = FCMNotificationContent().get_recipient_devices_fcm_tokens(self.mobile_user)
-        self.assertEqual(devices_token, ['abcd'])
-
-    def test_fcm_content_data_field_action_absent(self):
-        fcm_content = FCMNotificationContent()
-        data = fcm_content.build_fcm_data_field(self.mobile_user)
-        self.assertEqual(data, {})
-
-    def test_fcm_content_data_field_action_present(self):
-        fcm_content = FCMNotificationContent(action='SYNC')
-        data = fcm_content.build_fcm_data_field(self.mobile_user)
-        self.assertEqual(data['action'], 'SYNC')
-        self.assertEqual(data['domain'], self.mobile_user.domain)
-        self.assertEqual(data['username'], self.mobile_user.raw_username)
 
 
 @unregistered_django_model

--- a/corehq/pillows/synclog.py
+++ b/corehq/pillows/synclog.py
@@ -2,8 +2,6 @@ from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS
 
 from casexml.apps.phone.models import SyncLogSQL
-from corehq import toggles
-from corehq.sql_db.util import handle_connection_failure
 from dimagi.utils.parsing import string_to_utc_datetime
 from pillowtop.checkpoints.manager import KafkaPillowCheckpoint
 from pillowtop.feed.interface import Change
@@ -11,6 +9,7 @@ from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.interface import PillowProcessor
 from pillowtop.reindexer.reindexer import Reindexer, ReindexerFactory
 
+from corehq import toggles
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import (
     KafkaChangeFeed,
@@ -29,6 +28,7 @@ from corehq.apps.users.util import (
     update_last_sync,
     update_latest_builds,
 )
+from corehq.sql_db.util import handle_connection_failure
 from corehq.util.doc_processor.couch import CouchDocumentProvider
 from corehq.util.doc_processor.interface import (
     BaseDocProcessor,
@@ -120,8 +120,8 @@ class UserSyncHistoryProcessor(PillowProcessor):
 
 
 def mark_last_synclog(domain, user, app_id, build_id, sync_date, latest_build_date, device_id,
-                      device_app_meta, commcare_version=None, build_profile_id=None, fcm_token=None,
-                      fcm_token_timestamp=None, save_user=True):
+                      device_app_meta, commcare_version=None, build_profile_id=None,
+                      save_user=True):
     version = None
     if build_id:
         version = get_version_from_build_id(domain, build_id)
@@ -136,8 +136,7 @@ def mark_last_synclog(domain, user, app_id, build_id, sync_date, latest_build_da
 
     if device_id:
         local_save |= update_device_meta(user, device_id, commcare_version=commcare_version,
-                                         device_app_meta=device_app_meta, fcm_token=fcm_token,
-                                         fcm_token_timestamp=fcm_token_timestamp, save=False)
+                                         device_app_meta=device_app_meta, save=False)
     if local_save and save_user:
         user.save(fire_signals=False)
     return local_save

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2480,14 +2480,14 @@ COMMCARE_CONNECT = StaticToggle(
     description='More details to come',
 )
 
-FCM_NOTIFICATION = StaticToggle(
-    'fcm_notification',
-    'FCM Push Notifications - no longer functional',
-    TAG_DEPRECATED,
-    namespaces=[NAMESPACE_DOMAIN],
-    description='Push Notification option will be available in content for '
-                'Conditional Alerts in Messaging.'
-)
+# FCM_NOTIFICATION = StaticToggle(
+#     'fcm_notification',
+#     'FCM Push Notifications - no longer functional',
+#     TAG_DEPRECATED,
+#     namespaces=[NAMESPACE_DOMAIN],
+#     description='Push Notification option will be available in content for '
+#                 'Conditional Alerts in Messaging.'
+# )
 
 SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER_TOGGLE = StaticToggle(
     'show_owner_location_property_in_report_builder',

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1120,10 +1120,10 @@ PAUSE_DATA_FORWARDING = StaticToggle(
 
 
 def _ensure_search_index_is_enabled(domain, enabled):
+    from corehq.apps.case_search.models import DomainsNotInCaseSearchIndex
     from corehq.apps.case_search.tasks import reindex_case_search_for_domain
     from corehq.apps.es import CaseSearchES
     from corehq.pillows.case_search import domain_needs_search_index
-    from corehq.apps.case_search.models import DomainsNotInCaseSearchIndex
 
     if enabled and DomainsNotInCaseSearchIndex.objects.filter(domain=domain).exists():
         DomainsNotInCaseSearchIndex.objects.filter(domain=domain).delete()
@@ -2442,9 +2442,9 @@ ATTENDANCE_TRACKING = StaticToggle(
 
 
 def _handle_geospatial_es_index(domain, is_enabled):
+    from corehq.apps.geospatial.const import ES_INDEX_TASK_HELPER_BASE_KEY
     from corehq.apps.geospatial.tasks import index_es_docs_with_location_props
     from corehq.apps.geospatial.utils import get_celery_task_tracker
-    from corehq.apps.geospatial.const import ES_INDEX_TASK_HELPER_BASE_KEY
 
     if is_enabled:
         celery_task_tracker = get_celery_task_tracker(domain, ES_INDEX_TASK_HELPER_BASE_KEY)

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -173,7 +173,7 @@ class XFormPillowTest(TestCase):
         UserReportingMetadataStaging.add_heartbeat(
             self.domain, self.user._id, self.metadata.app_id,
             '123', sync_date, 'heartbeat_device_id',
-            230, 2, 10, 'CommCare 2.28', 'en', 'acegi'
+            230, 2, 10, 'CommCare 2.28', 'en'
         )
 
         self.assertEqual(UserReportingMetadataStaging.objects.count(), 1)
@@ -188,7 +188,6 @@ class XFormPillowTest(TestCase):
         self.assertEqual(ccuser.reporting_metadata.last_syncs[0].sync_date, sync_date)
         self.assertEqual(ccuser.reporting_metadata.last_sync_for_user.sync_date, sync_date)
         self.assertEqual(ccuser.last_device.device_id, 'heartbeat_device_id')
-        self.assertEqual(ccuser.last_device.fcm_token, 'acegi')
         app_meta = ccuser.last_device.get_last_used_app_meta()
         self.assertEqual(app_meta.num_unsent_forms, 2)
         self.assertEqual(app_meta.num_quarantined_forms, 10)


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/SAAS-19314 

No user-facing effects. The FCM_NOTIFICATION feature flag was a pre-release feature that was never fully rolled out and has been deprecated. This PR removes all toggle checks from application code while preserving backward compatibility with any existing FCM notification schedules in the database.

## Technical Summary

Removes the `FCM_NOTIFICATION` (`fcm_notification`) StaticToggle and all associated toggle checks from the codebase.

**Files changed:**
- `corehq/apps/ota/views.py` — Removed toggle check from heartbeat endpoint
- `corehq/messaging/scheduling/forms.py` — Removed toggle-gated content choices, FCM form fields, validation methods, and data-bind visibility expressions
- `corehq/apps/ota/tests/test_heartbeat.py` — Removed `@flag_enabled` decorators and FCM-specific test methods
- `corehq/toggles/__init__.py` — Commented out toggle definition

**Note:** Model field removals and database migrations are in a follow-up PR - https://github.com/dimagi/commcare-hq/pull/37415 

I plan to deploy https://github.com/dimagi/commcare-hq/pull/37415 after this is merged, I will apply the migrations manually and then do the deploy. 

## Feature Flag
- **Variable**: `FCM_NOTIFICATION`
- **Slug**: `fcm_notification`
- **Tag**: `TAG_DEPRECATED`
- **Type**: `StaticToggle`
- **Namespaces**: `NAMESPACE_DOMAIN`

## Safety Assurance

### Safety story

### Automated test coverage
- `corehq/apps/ota/tests/test_heartbeat.py` — Tests heartbeat endpoint behavior
- `corehq/messaging/scheduling/tests/test_content.py` — Tests scheduling content types

### QA Plan
Verify no domains rely on this flag:
```
cchq production django-manage list_ff_domains fcm_notification
cchq staging django-manage list_ff_domains fcm_notification
cchq india django-manage list_ff_domains fcm_notification
cchq eu django-manage list_ff_domains fcm_notification
```

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change