### PR TITLE
Tell AI tools to create PRs with DON'T REVIEW YET label

### DIFF
--- a/ai_rules.txt
+++ b/ai_rules.txt
@@ -1,4 +1,4 @@
-When creating PRs, always create them as drafts and always use the GitHub PR template.
+When creating PRs, always create them as drafts with the "DON'T REVIEW YET" label and always use the GitHub PR template.
 
 When adding template descriptions, avoid verbally restating the code diff. Focus on useful context for the reviewer.
 


### PR DESCRIPTION
## Product Description
N/A

## Technical Summary
Updates `ai_rules.txt` to instruct AI tools to add the "DON'T REVIEW YET" label when creating PRs as drafts.

## Feature Flag
N/A

## Safety Assurance

### Safety story
This change only affects the AI rules text file, which has no runtime impact.

### Automated test coverage
N/A — no code logic changed.

### QA Plan
N/A

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change