### PR TITLE
Consolidate AI tool rules into ai_guidelines.md

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,1 +1,0 @@
-ai_rules.txt

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-ai_rules.txt

--- a/ai_guidelines.md
+++ b/ai_guidelines.md
@@ -158,8 +158,16 @@ codebase. These guidelines apply in the following circumstances:
 
 ## Version Control
 
+- Always commit on a branch, never directly on master.
+- When creating a new branch, each author has a prefix they use. Use the
+  prefix the author has used most on local git branches, or else their
+  initials (from `git config user.name`).
 - When changes are ready to be committed, the changes should be broken into
   logical steps to make reviewing easier. Each step should be staged with a
   suggested commit message that summarizes the step.
 - The AI Assistant should leave it to the developer to commit the staged
   changes, and to sign the commit if applicable.
+- When creating PRs, always create them as drafts with the "DON'T REVIEW
+  YET" label, and always use the GitHub PR template.
+- When adding PR descriptions, avoid restating the code diff. Focus on
+  useful context for the reviewer.

--- a/ai_rules.txt
+++ b/ai_rules.txt
@@ -1,8 +1,0 @@
-When creating PRs, always create them as drafts with the "DON'T REVIEW YET" label and always use the GitHub PR template.
-
-When adding template descriptions, avoid verbally restating the code diff. Focus on useful context for the reviewer.
-
-When committing new changes, always commit on a branch.
-
-When creating a new branch, each author has a prefix they use. Use the prefix the author has used most
-on local git branches or else their initials (from `git config user.name`).


### PR DESCRIPTION
## Product Description

N/A — no user-facing effects.

## Technical Summary

Moves version control rules from `ai_rules.txt` into the Version Control section of `ai_guidelines.md` and removes the now-redundant `.clinerules` and `.cursorrules` symlinks. This consolidates AI tool instructions into a single file.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Only changes AI tool configuration files — no application code affected.

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)