### PR TITLE
Speed up TestCreditLines by avoiding CouchDB user operations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,7 @@ jobs:
         --divided-we-run=${{ matrix.DIVIDED_WE_RUN }}
         --showlocals
         --max-test-time=29
+        --durations=50
         -p no:cacheprovider
     - name: "Codecov upload"
       env:

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -35,15 +35,12 @@ class TestCreditLines(BaseInvoiceTestCase):
         self.user_rate = self.subscription.plan_version.feature_rates.filter(
             feature__feature_type=FeatureType.USER)[:1].get()
 
-        num_active = random.randint(self.user_rate.monthly_limit + 1, self.user_rate.monthly_limit + 2)
-        generator.arbitrary_commcare_users_for_domain(self.domain.name, num_active)
-        num_excess = num_active - self.user_rate.monthly_limit
+        self.num_active_users = random.randint(
+            self.user_rate.monthly_limit + 1,
+            self.user_rate.monthly_limit + 2,
+        )
+        num_excess = self.num_active_users - self.user_rate.monthly_limit
         self.monthly_user_fee = num_excess * self.user_rate.per_excess_fee
-
-    def tearDown(self):
-        for user in self.domain.all_users():
-            user.delete(self.domain.name, deleted_by=None)
-        super().tearDown()
 
     def test_product_line_item_credits(self):
         """
@@ -117,14 +114,13 @@ class TestCreditLines(BaseInvoiceTestCase):
         self._test_credit_use(rate_credit_by_account)
         self._test_credit_use(rate_credit_by_subscription)
 
-    def _generate_users_fee_to_credit_against(self):
-        user_rate = self.subscription.plan_version.feature_rates.filter(
-            feature__feature_type=FeatureType.USER)[:1].get()
-        num_active = random.randint(user_rate.monthly_limit + 1, user_rate.monthly_limit + 2)
-        generator.arbitrary_commcare_users_for_domain(self.domain.name, num_active)
-        num_excess = num_active - user_rate.monthly_limit
-        per_month_fee = num_excess * user_rate.per_excess_fee
-        return user_rate, per_month_fee
+    def _create_user_history(self, invoice_date):
+        record_date = invoice_date - relativedelta(days=1)
+        DomainUserHistory.objects.create(
+            domain=self.domain.name,
+            num_users=self.num_active_users,
+            record_date=record_date,
+        )
 
     def _test_line_item_crediting(self, get_line_item_from_invoice):
         """
@@ -132,7 +128,7 @@ class TestCreditLines(BaseInvoiceTestCase):
         """
         for month_num in range(2, 5):
             invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, month_num)
-            tasks.calculate_users_in_all_domains(invoice_date)
+            self._create_user_history(invoice_date)
             tasks.generate_invoices_based_on_date(invoice_date)
             invoice = self.subscription.invoice_set.latest('date_end')
 
@@ -233,7 +229,7 @@ class TestCreditLines(BaseInvoiceTestCase):
     def _test_final_invoice_balance(self):
         for month_num in range(2, 5):
             invoice_date = utils.get_first_day_x_months_later(self.subscription.date_start, month_num)
-            tasks.calculate_users_in_all_domains(invoice_date)
+            self._create_user_history(invoice_date)
             tasks.generate_invoices_based_on_date(invoice_date)
             invoice = self.subscription.invoice_set.latest('date_end')
 


### PR DESCRIPTION
## Product Description

N/A — test-only change.

## Technical Summary

`TestCreditLines` was taking 200+ seconds in CI due to CouchDB operations:
creating `CommCareUser` documents, querying CouchDB views to count them via
`calculate_users_in_all_domains`, and deleting them in teardown.

The invoicing code only reads `DomainUserHistory` SQL records, so we can
create those directly instead of round-tripping through CouchDB. This follows
the same pattern already used by `TestSubscriptionChangeTransfersSubscriptionLevelCredit`
in the same file.

Also removes `_generate_users_fee_to_credit_against` which was dead code
(defined but never called).

## Feature Flag

N/A

## Safety Assurance

### Safety story

Test-only change. The refactored tests exercise the same invoicing and credit
line logic — the only difference is how `DomainUserHistory` records are
created (directly via SQL instead of via CouchDB user creation + counting).

### Automated test coverage

The 5 test methods in `TestCreditLines` themselves verify the behavior is
unchanged.

### QA Plan

CI passing is sufficient.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change