### PR TITLE
Ignore celerybeat-schedule*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,8 +61,8 @@ ptop*.json
 /coverage-js
 
 # Celery
-celery.db
-celerybeat-schedule*
+/celery.db
+/celerybeat-schedule*
 
 # Sphinx
 docs/_build

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ bad/
 *.log*
 /CommCare.ja*
 startover.sh
-celery.db
 tmp.sh
 /requirements/local.in
 /requirements/local*.txt
@@ -61,9 +60,12 @@ ptop*.json
 /coverage-report
 /coverage-js
 
+# Celery
+celery.db
+celerybeat-schedule*
+
 # Sphinx
 docs/_build
-celerybeat-schedule
 
 # compiled translations
 /locale/*/*/*.mo


### PR DESCRIPTION
## Technical Summary

Extends `.gitignore` to include

* celery.db
* celerybeat-schedule
* celerybeat-schedule.db
* celerybeat-schedule-wal (Celery Beat's SQLite write-ahead log file)
* celerybeat-schedule-shm (Celery Beat's shared memory index into the WAL file)

## Safety Assurance

### Safety story

Non-code change

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
