### PR TITLE
Memoize bootstrap_test_software_plan_versions to speed up tests

### DIFF
--- a/corehq/apps/accounting/tests/generator.py
+++ b/corehq/apps/accounting/tests/generator.py
@@ -8,6 +8,7 @@ from unittest import mock
 from django.apps import apps
 from django.conf import settings
 from django.core.management import call_command
+from memoized import memoized
 
 from nose.tools import nottest
 
@@ -55,6 +56,7 @@ def bootstrap_accounting():
 
 @unit_testing_only
 @nottest
+@memoized  # run once per test runner
 def bootstrap_test_software_plan_versions():
     ensure_plans(BOOTSTRAP_CONFIG_TESTING, verbose=False, apps=apps)
 


### PR DESCRIPTION
## Product Description
No user-facing effects. Test-only change.

## Technical Summary
`bootstrap_test_software_plan_versions()` calls `ensure_plans()` which is expensive and produces the same result every time within a test runner process. Any test class using `DomainSubscriptionMixin` triggers this function, and it was being re-executed unnecessarily. Adding `@memoized` ensures it only runs once per process.

This targets tests like `test_with_subscription` and `test_infobip_inbound_sms` that spend significant time in subscription setup.

(Note from Danny: I'm not sure whether this saves significant time or not; that's part of what I'm opening this PR to figure out.)

## Feature Flag
N/A

## Safety Assurance

### Safety story
This only affects test code. `@memoized` on a no-arg function caches the result after the first call. Since `ensure_plans` is idempotent (it creates-or-updates plan versions), skipping redundant calls is safe.

### Automated test coverage
The existing tests that call `bootstrap_test_software_plan_versions()` (via `DomainSubscriptionMixin.setup_subscription`) serve as coverage.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change