### PR TITLE
Remove commented-out feature flag definitions

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -647,13 +647,6 @@ def _ensure_valid_randomness(randomness):
         raise Exception('randomness must be between 0 and 1!')
 
 
-# APP_BUILDER_CUSTOM_PARENT_REF = StaticToggle(
-#     'custom-parent-ref',
-#     'ICDS: Custom case parent reference',
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN],
-# )
-
 LAZY_LOAD_MULTIMEDIA = StaticToggle(
     'optional-media',
     'ICDS: Lazy load multimedia files in Updates',
@@ -862,17 +855,6 @@ REPORT_BUILDER = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-# UCR_SUM_WHEN_TEMPLATES = StaticToggle(
-#     'ucr_sum_when_templates',
-#     'Allow sum when template columns in dynamic UCRs',
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN],
-#     description=(
-#         "Enables use of SumWhenTemplateColumn with custom expressions in dynamic UCRS."
-#     ),
-#     help_link='https://commcare-hq.readthedocs.io/ucr.html#sumwhencolumn-and-sumwhentemplatecolumn',
-# )
-
 ASYNC_RESTORE = StaticToggle(
     'async_restore',
     'Generate restore response in an asynchronous task to prevent timeouts',
@@ -1022,19 +1004,6 @@ GEOCODER_MY_LOCATION_BUTTON = StaticToggle(
     parent_toggles=[USH_CASE_CLAIM_UPDATES],
 )
 
-# GEOCODER_AUTOLOAD_USER_LOCATION = StaticToggle(
-#     "geocoder_autoload_user_location",
-#     "USH: Auto-load the geocoder widget with the user's current location",
-#     TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_DOMAIN],
-#     description="""
-#     When enabled, and if the user grants permissions, the geocoder widget will automatically do a reverse
-#     geocoding query using the user's reported location The result will be used to populate the search field
-#     of the geocoder widget.
-#     """,
-#     parent_toggles=[USH_CASE_CLAIM_UPDATES],
-# )
-
 GEOCODER_USER_PROXIMITY = StaticToggle(
     "geocoder_user_proximity",
     "USH: Adjust geocoder result to be more relevant to user and project.",
@@ -1134,14 +1103,6 @@ def _ensure_search_index_is_enabled(domain, enabled):
         reindex_case_search_for_domain.delay(domain)
 
 
-# SAAS_PROTOTYPE = StaticToggle(
-#     'saas_prototype',
-#     'Use allowed to view SaaS prototypes',
-#     TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_USER],
-#     description='Use this for rapid prototypes developed by the SaaS product team.',
-# )
-
 FORMBUILDER_SAVE_TO_CASE = StaticToggle(
     'saas_formbuilder_save_to_case',
     'Form Builder - Save Questions to Case Properties',
@@ -1181,27 +1142,12 @@ MOBILE_PRIVILEGES_FLAG = StaticToggle(
     [NAMESPACE_USER]
 )
 
-# PRODUCTS_PER_LOCATION = StaticToggle(
-#     'products_per_location',
-#     "Products Per Location: Specify products stocked at individual locations.",
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN],
-#     description="This doesn't actually do anything yet."
-# )
-
 ALLOW_CASE_ATTACHMENTS_VIEW = StaticToggle(
     'allow_case_attachments_view',
     "Explicitly allow user to access case attachments, even if they can't view the case list report.",
     TAG_DEPRECATED,
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
-
-# TRANSFER_DOMAIN = StaticToggle(
-#     'transfer_domain',
-#     'Transfer domains to different users',
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN]
-# )
 
 SECURE_SESSION_TIMEOUT = StaticToggle(
     'secure_session_timeout',
@@ -1342,17 +1288,6 @@ COMMTRACK = StaticToggle(
     save_fn=_commtrackify,
 )
 
-# NON_COMMTRACK_LEDGERS = StaticToggle(
-#     'non_commtrack_ledgers',
-#     "Enable ledgers for projects not using Supply.",
-#     TAG_DEPRECATED,
-#     description=(
-#         'Turns on the ledger fixture and ledger transaction question types in '
-#         'the form builder. ONLY WORKS ON SQL DOMAINS!'
-#     ),
-#     namespaces=[NAMESPACE_DOMAIN],
-# )
-
 CUSTOM_INSTANCES = StaticToggle(
     'custom_instances',
     'Inject custom instance declarations',
@@ -1436,14 +1371,6 @@ EXPORT_DATA_SOURCE_DATA = StaticToggle(
     description="Add the Export Data Source Data page to the Data tab",
 )
 
-
-# ENABLE_INCLUDE_SMS_GATEWAY_CHARGING = StaticToggle(
-#     'enable_include_sms_gateway_charging',
-#     'Enable include SMS gateway charging',
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN]
-# )
-
 MESSAGE_LOG_METADATA = StaticToggle(
     'message_log_metadata',
     'Include message id in Message Log export.',
@@ -1474,14 +1401,6 @@ CASE_DEDUPE_UPDATES = StaticToggle(
     help_link='https://confluence.dimagi.com/display/saas/Surfacing+Case+Duplicates+in+CommCare',
 )
 
-# TODO remove this toggle definition once the other feature flag removal PRs have landed
-# LEGACY_SYNC_SUPPORT = StaticToggle(
-#     'legacy_sync_support',
-#     "Support mobile sync bugs in older projects (2.9 and below).",
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN]
-# )
-
 CALL_CENTER_LOCATION_OWNERS = StaticToggle(
     'call_center_location_owners',
     'ICDS: Enable the use of locations as owners of call center cases',
@@ -1511,13 +1430,6 @@ INBOUND_SMS_LENIENCY = StaticToggle(
     [NAMESPACE_DOMAIN],
     description="WARNING: This wil be rolled out slowly; do not enable on your own.",
 )
-
-# WHATSAPP_MESSAGING = StaticToggle(
-#     'whatsapp_messaging',
-#     "Default SMS to send messages via Whatsapp, where available",
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN]
-# )
 
 UNLIMITED_REPORT_BUILDER_REPORTS = StaticToggle(
     'unlimited_report_builder_reports',
@@ -1571,14 +1483,6 @@ CAUTIOUS_MULTIMEDIA = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-# LOCALE_ID_INTEGRITY = StaticToggle(
-#     'locale_id_integrity',
-#     'Verify all locale ids in suite are present in app strings before allowing CCZ download',
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN],
-#     notification_emails=['jschweers']
-# )
-
 BULK_UPDATE_MULTIMEDIA_PATHS = StaticToggle(
     'bulk_update_multimedia_paths',
     'Bulk multimedia path management',
@@ -1629,13 +1533,6 @@ PAGINATED_EXPORTS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-# CLEAR_MOBILE_WORKER_DATA = StaticToggle(
-#     'clear_mobile_worker_data',
-#     "Allows a web user to clear mobile workers' data",
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN],
-# )
-
 SKIP_REMOVE_INDICES = StaticToggle(
     'skip_remove_indices',
     'Make _remove_indices_from_deleted_cases_task into a no-op.',
@@ -1651,21 +1548,6 @@ MOBILE_RECOVERY_MEASURES = StaticToggle(
     description=("Used for widely deployed projects where recovery from "
                  "large-scale failures would otherwise be next to impossible."),
 )
-
-#PREVENT_MOBILE_UCR_SYNC = StaticToggle(
-#    'prevent_mobile_ucr_sync',
-#    'Prevent Mobile UCR sync (when a UCR sync is causing operational problems)',
-#    TAG_DEPRECATED,
-#    [NAMESPACE_DOMAIN],
-#    description='Prevents mobile UCRs from being generated or included in the sync payload',
-#)
-
-# TWO_FACTOR_SUPERUSER_ROLLOUT = StaticToggle(
-#     'two_factor_superuser_rollout',
-#     'Users in this list will be forced to have Two-Factor Auth enabled',
-#     TAG_DEPRECATED,
-#     [NAMESPACE_USER]
-# )
 
 CUSTOM_ICON_BADGES = FrozenPrivilegeToggle(
     privilege_slug=privileges.CUSTOM_ICON_BADGES,
@@ -1727,27 +1609,12 @@ TRAINING_MODULE = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-# APP_TRANSLATIONS_WITH_TRANSIFEX = StaticToggle(
-#     'app_trans_with_transifex',
-#     'Translate Application Content With Transifex',
-#     TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_USER]
-# )
-
 VALIDATE_APP_TRANSLATIONS = StaticToggle(
     'validate_app_translations',
     'Validate app translations before uploading them',
     TAG_FROZEN,
     namespaces=[NAMESPACE_USER]
 )
-
-# AGGREGATE_UCRS = StaticToggle(
-#     'aggregate_ucrs',
-#     'Enable experimental aggregate UCR support',
-#     TAG_DEPRECATED,  # this might change in the future
-#     namespaces=[NAMESPACE_DOMAIN],
-#     notification_emails=['czue'],
-# )
 
 SHOW_RAW_DATA_SOURCES_IN_REPORT_BUILDER = StaticToggle(
     'show_raw_data_sources_in_report_builder',
@@ -1780,14 +1647,6 @@ SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL = DynamicallyPredictablyRandomToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-
-# RELEASE_BUILDS_PER_PROFILE = StaticToggle(
-#     'release_builds_per_profile',
-#     'Do not release builds for all app profiles by default. Then manage via Source files view',
-#     TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_DOMAIN],
-# )
-
 MANAGE_RELEASES_PER_LOCATION = StaticToggle(
     'manage_releases_per_location',
     'Manage releases per location',
@@ -1802,35 +1661,6 @@ COPY_CASES = StaticToggle(
     TAG_INTERNAL,
     namespaces=[NAMESPACE_DOMAIN],
 )
-
-# DASHBOARD_REACH_REPORT = StaticToggle(
-#     'dashboard_reach_reports',
-#     'REACH: Enable access to the AAA Convergence Dashboard reports for REACH',
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN]
-# )
-
-# PARTIAL_UI_TRANSLATIONS = StaticToggle(
-#     'partial_ui_translations',
-#     'Enable uploading a subset of translations in the UI Translations Excel upload',
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN]
-# )
-
-# TODO remove commented-out toggle definition
-# SKIP_ORM_FIXTURE_UPLOAD = StaticToggle(
-#     'skip_orm_fixture_upload',
-#     'Exposes an option in fixture api upload to skip saving through couchdbkit',
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN]
-# )
-
-# ENABLE_UCR_MIRRORS = StaticToggle(
-#     'enable_ucr_mirrors',
-#     'Enable the mirrored engines for UCRs in this domain',
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN]
-# )
 
 LOCATION_COLUMNS_APP_STATUS_REPORT = FrozenPrivilegeToggle(
     privilege_slug=privileges.LOCATION_COLUMNS_IN_USER_LAST_ACTIVITY_REPORT,
@@ -1978,24 +1808,6 @@ IP_ACCESS_CONTROLS = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-# SHOW_BUILD_PROFILE_IN_APPLICATION_STATUS = StaticToggle(
-#     'show_build_profile_in_app_status',
-#     'Show build profile installed on phone tracked via heartbeat request in App Status Report',
-#     TAG_DEPRECATED,
-#     [NAMESPACE_DOMAIN]
-# )
-
-#LIVEQUERY_READ_FROM_STANDBYS = DynamicallyPredictablyRandomToggle(
-#    'livequery_read_from_standbys',
-#    'Allow livequery restore to read data from plproxy standbys if they are available',
-#    TAG_DEPRECATED,
-#    [NAMESPACE_USER],
-#    description="""
-#    To allow a gradual rollout and testing of using the standby
-#    databases to generate restore payloads.
-#    """
-#)
-
 ACCOUNTING_TESTING_TOOLS = StaticToggle(
     'accounting_testing_tools',
     'Enable Accounting Testing Tools',
@@ -2113,14 +1925,6 @@ BLOCKED_DOMAIN_EMAIL_SENDERS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-# CLEAN_OLD_FORMPLAYER_SYNCS = DynamicallyPredictablyRandomToggle(
-#     'clean_old_formplayer_syncs',
-#     'Delete old formplayer syncs during submission processing',
-#     TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_OTHER],
-#     default_randomness=0.001
-# )
-
 PRIME_FORMPLAYER_DBS_BHA = StaticToggle(
     'prime_formplayer_dbs_bha',
     'USH-BHA: Control which domains will be included in the prime formplayer task runs',
@@ -2151,17 +1955,6 @@ SSO_OIDC_DEVELOPMENT = StaticToggle(
     TAG_DEPRECATED,
     namespaces=[NAMESPACE_DOMAIN, NAMESPACE_USER],
 )
-
-# ADD_LIMITED_FIXTURES_TO_CASE_RESTORE = StaticToggle(
-#     'fixtures_in_case_restore',
-#     'Allow limited fixtures to be available in case restore for SMS workflows.',
-#     TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_DOMAIN],
-#     description="""
-#     WARNING: To be used only for small templates since the performance implication has not been evaluated.
-#     Do not enable on your own.
-#     """
-# )
 
 EMBEDDED_TABLEAU = StaticToggle(
     'embedded_tableau',
@@ -2199,13 +1992,6 @@ REPORT_TIMING_PROFILING = StaticToggle(
     TAG_INTERNAL,
     namespaces=[NAMESPACE_USER],
 )
-
-# COWIN_INTEGRATION = StaticToggle(
-#     'cowin_integration',
-#     'Integrate with COWIN APIs',
-#     TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_DOMAIN],
-# )
 
 EXPRESSION_REPEATER = StaticToggle(
     'expression_repeater',
@@ -2350,24 +2136,6 @@ SUPERSET_ANALYTICS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-# TWO_STAGE_USER_PROVISIONING_BY_SMS = StaticToggle(
-#     'two_stage_user_provisioning_by_sms',
-#     'Enable two-stage user provisioning (users confirm and set their own passwords via sms).',
-#     TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_DOMAIN],
-# )
-
-# SMS_USE_LATEST_DEV_APP = FeatureRelease(
-#     'sms_use_latest_dev_app',
-#     'Use latest development version of the app for SMS processing',
-#     TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_DOMAIN],
-#     owner='Simon Kelly',
-#     description='This will revert the SMS processing to previous functionality of using the '
-#                 'development version of the app instead of the latest release. It should only'
-#                 'be used temporarily if a domain needs unreleased app changes to be used for SMS.',
-# )
-
 VIEW_FORM_ATTACHMENT = StaticToggle(
     'view_form_attachments',
     'Allow users on the domain to view form attachments without having to have the report Submission History permission.',  # noqa: E501
@@ -2479,15 +2247,6 @@ COMMCARE_CONNECT = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
     description='More details to come',
 )
-
-# FCM_NOTIFICATION = StaticToggle(
-#     'fcm_notification',
-#     'FCM Push Notifications - no longer functional',
-#     TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_DOMAIN],
-#     description='Push Notification option will be available in content for '
-#                 'Conditional Alerts in Messaging.'
-# )
 
 SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER_TOGGLE = StaticToggle(
     'show_owner_location_property_in_report_builder',
@@ -2729,14 +2488,6 @@ USE_LOGO_IN_SYSTEM_EMAILS = StaticToggle(
     description='The project logo replaces the CommCare logo.',
 )
 
-# VELLUM_CASE_MICRO_IMAGE = StaticToggle(
-#     slug='case_micro_image',
-#     label='Add case micro images to case list',
-#     tag=TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_DOMAIN],
-#     description='Add a micro image to cases in the case list.'
-# )
-
 SUPPORT_GEO_JSON_EXPORT = FrozenPrivilegeToggle(
     privileges.GEOJSON_EXPORT,
     'support_geo_json_export',
@@ -2762,16 +2513,6 @@ INCREASED_MAX_SEARCH_RESULTS = StaticToggle(
     description='Temporary increase of the max number of search results.',
 )
 
-
-# DEPRECATED: Road Network Algorithm feature removed (Feb 2026)
-# SUPPORT_ROAD_NETWORK_DISBURSEMENT_ALGORITHM = StaticToggle(
-#     slug='support_road_network_disbursement_algorithm',
-#     label='Add Road Network disbursement algorithm on geospatial settings page',
-#     tag=TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_DOMAIN],
-#     description='Add support for the Road Network disbursement algorithm for the Geospatial feature',
-# )
-
 USH_RESTORE_FILE_LOCATION_CASE_SYNC_RESTRICTION = StaticToggle(
     'ush_restore_file_location_case_sync_restriction',
     'USH: Limit the location-owned cases in a user\'s restore file, and allow marking whether a '
@@ -2795,14 +2536,6 @@ RESTRICT_DATA_SOURCE_REBUILD = StaticToggle(
     description='Force data sources to be marked for asynchronous processing from UI if it crosses a threshold '
                 'for the number of records to be populated during building or rebuilding'
 )
-
-# APP_TESTING = StaticToggle(
-#     slug='app_testing',
-#     label='App Testing UI',
-#     tag=TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_DOMAIN],
-#     description=''
-# )
 
 CSQL_FIXTURE = StaticToggle(
     slug='module_badges',
@@ -2844,11 +2577,3 @@ ACTIVATE_DATADOG_APM_TRACES = StaticToggle(
     tag=TAG_INTERNAL,
     namespaces=[NAMESPACE_DOMAIN]
 )
-
-# Removed 2026-02-17
-# CONVERT_XML_GROUP_SEPARATOR = StaticToggle(
-#     slug='convert_xml_group_separator',
-#     label='Convert the group separator to a symbol XML can support',
-#     tag=TAG_DEPRECATED,
-#     namespaces=[NAMESPACE_DOMAIN]
-# )


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19349
Removes commented-out feature flag definitions that were temporarily left in `toggles/__init__.py` to avoid merge conflicts.

## Safety Assurance

### Safety story
No functional effects here; just removes commented-out code.

### Automated test coverage
n/a

### QA Plan
n/a

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
