### PR TITLE
Conditional Alerts : Support for additional messaging recipients for Connect Messaging and Surveys

### DIFF
--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1115,7 +1115,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
     ERROR_NO_FCM_TOKENS = 'NO_FCM_TOKENS'
     FILTER_MISMATCH = 'FILTER_MISMATCH'
     ERROR_CONNECT_USER_NOT_FOUND = 'CONNECT_USER_NOT_FOUND'
-    ERROR_CONNECT_USER_NOT_SUPPORTED = 'CONNECT_USER_NOT_SUPPORTED'
+    ERROR_USER_NOT_SUPPORTED = 'USER_NOT_SUPPORTED'
 
     ERROR_MESSAGES = {
         ERROR_NO_RECIPIENT:
@@ -1174,7 +1174,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
         ERROR_NO_FCM_TOKENS: gettext_noop("No FCM tokens found for recipient."),
         FILTER_MISMATCH: gettext_noop("Recipient did not match filters:"),
         ERROR_CONNECT_USER_NOT_FOUND: gettext_noop("Connect user not found for recipient."),
-        ERROR_CONNECT_USER_NOT_SUPPORTED:
+        ERROR_USER_NOT_SUPPORTED:
             gettext_noop("Only Mobile workers with Connect accounts are supported as recipients "
                 "for Connect Message and Surveys."),
     }

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1114,6 +1114,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
     ERROR_EMAIL_GATEWAY = 'EMAIL_GATEWAY_ERROR'
     ERROR_NO_FCM_TOKENS = 'NO_FCM_TOKENS'
     FILTER_MISMATCH = 'FILTER_MISMATCH'
+    ERROR_CONNECT_USER_NOT_FOUND = 'CONNECT_USER_NOT_FOUND'
 
     ERROR_MESSAGES = {
         ERROR_NO_RECIPIENT:
@@ -1170,7 +1171,8 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
         ERROR_EMAIL_BOUNCED: gettext_noop("Email Bounced"),
         ERROR_EMAIL_GATEWAY: gettext_noop("Email Gateway Error"),
         ERROR_NO_FCM_TOKENS: gettext_noop("No FCM tokens found for recipient."),
-        FILTER_MISMATCH: gettext_noop("Recipient did not match filters:")
+        FILTER_MISMATCH: gettext_noop("Recipient did not match filters:"),
+        ERROR_CONNECT_USER_NOT_FOUND: gettext_noop("Connect user not found for recipient."),
     }
 
     domain = models.CharField(max_length=126, null=False, db_index=True)

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1115,6 +1115,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
     ERROR_NO_FCM_TOKENS = 'NO_FCM_TOKENS'
     FILTER_MISMATCH = 'FILTER_MISMATCH'
     ERROR_CONNECT_USER_NOT_FOUND = 'CONNECT_USER_NOT_FOUND'
+    ERROR_CONNECT_USER_NOT_SUPPORTED = 'CONNECT_USER_NOT_SUPPORTED'
 
     ERROR_MESSAGES = {
         ERROR_NO_RECIPIENT:
@@ -1173,6 +1174,9 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
         ERROR_NO_FCM_TOKENS: gettext_noop("No FCM tokens found for recipient."),
         FILTER_MISMATCH: gettext_noop("Recipient did not match filters:"),
         ERROR_CONNECT_USER_NOT_FOUND: gettext_noop("Connect user not found for recipient."),
+        ERROR_CONNECT_USER_NOT_SUPPORTED:
+            gettext_noop("Only Mobile workers with Connect accounts are supported as recipients "
+                "for Connect Message and Surveys."),
     }
 
     domain = models.CharField(max_length=126, null=False, db_index=True)

--- a/corehq/messaging/scheduling/const.py
+++ b/corehq/messaging/scheduling/const.py
@@ -1,4 +1,4 @@
-
+from corehq.messaging.scheduling.scheduling_partitioned.models import ScheduleInstance, CaseScheduleInstanceMixin
 
 # Constants to describe the start, end, and actual due date of a
 # visit window in a scheduler module.
@@ -126,3 +126,13 @@ ALLOWED_CSS_PROPERTIES = {
 
 MAX_IMAGE_UPLOAD_SIZE = 1024 * 1024  # 1MB
 VALID_EMAIL_IMAGE_MIMETYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+
+# Recipient types that never resolve to a CommCareUser and are therefore
+# incompatible with Connect Messages / Connect Surveys.
+CONNECT_INCOMPATIBLE_RECIPIENT_TYPES = {
+    ScheduleInstance.RECIPIENT_TYPE_CASE_GROUP,
+    CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF,
+    CaseScheduleInstanceMixin.RECIPIENT_TYPE_PARENT_CASE,
+    CaseScheduleInstanceMixin.RECIPIENT_TYPE_ALL_CHILD_CASES,
+    CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL,
+}

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -1989,42 +1989,8 @@ class ScheduleForm(Form):
         return [
             crispy.Field(
                 'recipient_types',
-                data_bind=(
-                    "selectedOptions: recipient_types, "
-                    f"enable: content() !== '{self.CONTENT_CONNECT_MESSAGE}' && "
-                    f"content() !== '{self.CONTENT_CONNECT_SURVEY}'"
-                ),
+                data_bind="selectedOptions: recipient_types",
                 style="width: 100%;"
-            ),
-            # Hidden fields to submit recipient_types values when the visible field is disabled.
-            crispy.Div(
-                crispy.HTML(
-                    '<!-- ko foreach: recipient_types -->'
-                    f'<input type="hidden" name="{self.prefix}-recipient_types" data-bind="value: $data" />'
-                    '<!-- /ko -->'
-                ),
-                data_bind=(
-                    f"if: content() === '{self.CONTENT_CONNECT_MESSAGE}' || "
-                    f"content() === '{self.CONTENT_CONNECT_SURVEY}'"
-                )
-            ),
-            crispy.Div(
-                crispy.HTML(
-                    """
-                        <p class="help-block alert alert-info">
-                        <i class="fa fa-info-circle"></i>
-                            %s
-                        </p>
-                    """
-                    % _(
-                        """
-                            Connect Messages can only be sent to users who have a PersonalID account.
-                        """
-                    )),
-                data_bind=(
-                    f"visible: content() === '{self.CONTENT_CONNECT_MESSAGE}' || "
-                    f"content() === '{self.CONTENT_CONNECT_SURVEY}'"
-                )
             ),
             crispy.Div(
                 crispy.HTML(

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -73,6 +73,7 @@ from corehq.messaging.scheduling.const import (
     ALLOWED_CSS_PROPERTIES,
     ALLOWED_HTML_ATTRIBUTES,
     ALLOWED_HTML_TAGS,
+    CONNECT_INCOMPATIBLE_RECIPIENT_TYPES,
     VISIT_WINDOW_DUE_DATE,
     VISIT_WINDOW_END,
     VISIT_WINDOW_START,
@@ -2309,9 +2310,18 @@ class ScheduleForm(Form):
     def clean_recipient_types(self):
         content = self.data.get(f'{self.prefix}-content')
         recipient_types = self.cleaned_data.get('recipient_types')
-        is_connect_message = content in (self.CONTENT_CONNECT_MESSAGE, self.CONTENT_CONNECT_SURVEY)
-        if is_connect_message and recipient_types != [ScheduleInstance.RECIPIENT_TYPE_MOBILE_WORKER]:
-            raise ValidationError(_("Connect Messages can only be sent to users."))
+        is_connect_content = content in (self.CONTENT_CONNECT_MESSAGE, self.CONTENT_CONNECT_SURVEY)
+        if is_connect_content and recipient_types:
+            recipient_type_choices = dict(self.fields['recipient_types'].choices)
+            incompatible_types = [
+                recipient_type_choices.get(recipient_type)
+                for recipient_type in recipient_types
+                if recipient_type in CONNECT_INCOMPATIBLE_RECIPIENT_TYPES
+            ]
+            if incompatible_types:
+                raise ValidationError(_(
+                    "The following recipient type(s) are not supported for Connect Messages: {types}"
+                ).format(types=', '.join(incompatible_types)))
         return recipient_types
 
     def clean_user_group_recipients(self):
@@ -3778,7 +3788,7 @@ class ConditionalAlertScheduleForm(ScheduleForm):
 
     def clean(self):
         recipient_types = self.cleaned_data.get('recipient_types')
-        if CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL in recipient_types:
+        if recipient_types and CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL in recipient_types:
             if self.cleaned_data.get('content') != self.CONTENT_EMAIL:
                 raise ValidationError(_("Email case property can only be used with Email content"))
 

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -582,6 +582,7 @@ class SurveyContent(Content):
             return None, None, None, None
 
         return app, module, form, form_requires_input(form)
+
     def start_smsforms_session(self, domain, recipient, case_id, phone_entry_or_number, logged_subevent, workflow,
             app, form):
         # Close all currently open sessions

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -624,7 +624,7 @@ class ConnectMessageContent(Content):
         )
 
         if not isinstance(recipient, CommCareUser):
-            logged_subevent.error(MessagingEvent.ERROR_CONNECT_USER_NOT_SUPPORTED)
+            logged_subevent.error(MessagingEvent.ERROR_USER_NOT_SUPPORTED)
             return
 
         message = self.get_translation_from_message_dict(
@@ -668,7 +668,7 @@ class ConnectMessageSurveyContent(SurveyContent):
         )
 
         if not isinstance(recipient, CommCareUser):
-            logged_subevent.error(MessagingEvent.ERROR_CONNECT_USER_NOT_SUPPORTED)
+            logged_subevent.error(MessagingEvent.ERROR_USER_NOT_SUPPORTED)
             return
 
         connect_number = ConnectMessagingNumber(recipient)

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext as _
 
 import jsonfield as old_jsonfield
 
+from corehq.apps.users.models import ConnectIDUserLink
 from dimagi.utils.logging import notify_error
 from dimagi.utils.modules import to_function
 
@@ -627,8 +628,11 @@ class ConnectMessageContent(Content):
             recipient.get_language_code()
         )
         connect_number = ConnectMessagingNumber(recipient)
-
-        send_message_to_verified_number(connect_number, message, logged_subevent=logged_subevent)
+        try:
+            send_message_to_verified_number(connect_number, message, logged_subevent=logged_subevent)
+        except ConnectIDUserLink.DoesNotExist:
+            logged_subevent.error(MessagingEvent.ERROR_CONNECT_USER_NOT_FOUND)
+            return
 
 
 class ConnectMessageSurveyContent(SurveyContent):
@@ -670,16 +674,20 @@ class ConnectMessageSurveyContent(SurveyContent):
                 logged_subevent.error(MessagingEvent.ERROR_NO_CASE_GIVEN)
                 return
 
-            session, responses = self.start_smsforms_session(
-                logged_event.domain,
-                recipient,
-                case_id,
-                connect_number.phone_number,
-                logged_subevent,
-                self.get_workflow(logged_event),
-                app,
-                form
-            )
+            try:
+                session, responses = self.start_smsforms_session(
+                    logged_event.domain,
+                    recipient,
+                    case_id,
+                    connect_number.phone_number,
+                    logged_subevent,
+                    self.get_workflow(logged_event),
+                    app,
+                    form
+                )
+            except ConnectIDUserLink.DoesNotExist:
+                logged_subevent.error(MessagingEvent.ERROR_CONNECT_USER_NOT_FOUND)
+                return
 
             if session:
                 logged_subevent.xforms_session = session

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext as _
 
 import jsonfield as old_jsonfield
 
-from corehq.apps.users.models import ConnectIDUserLink
+from corehq.apps.users.models import ConnectIDUserLink, CommCareUser
 from dimagi.utils.logging import notify_error
 from dimagi.utils.modules import to_function
 
@@ -622,6 +622,11 @@ class ConnectMessageContent(Content):
             self,
             case_id=None,
         )
+
+        if not isinstance(recipient, CommCareUser):
+            logged_subevent.error(MessagingEvent.ERROR_CONNECT_USER_NOT_SUPPORTED)
+            return
+
         message = self.get_translation_from_message_dict(
             domain_obj,
             self.message,
@@ -661,6 +666,10 @@ class ConnectMessageSurveyContent(SurveyContent):
             self,
             case_id=self.case.case_id if self.case else None,
         )
+
+        if not isinstance(recipient, CommCareUser):
+            logged_subevent.error(MessagingEvent.ERROR_CONNECT_USER_NOT_SUPPORTED)
+            return
 
         connect_number = ConnectMessagingNumber(recipient)
 

--- a/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/create_schedule.js
@@ -273,8 +273,6 @@ var CreateScheduleViewModel = function (initialValues, select2UserRecipients,
 
     self.content.subscribe(function (newValue) {
         if (newValue === 'connect_message' || newValue === 'connect_survey') {
-            self.recipient_types(['CommCareUser']);
-            $('#id_schedule-recipient_types').val(['CommCareUser']).trigger('change');
             self.user_recipients.value('');
             $('#id_schedule-user_recipients').val(null).trigger('change');
         }


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Users can now select multiple recipient types when configuring Connect Messages and Connect Surveys, rather than being restricted to only mobile workers. The system validates that selected recipient types are compatible with Connect (i.e., they resolve to `CommCareUser` recipients).

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket - https://dimagi.atlassian.net/browse/CI-518

Previously, the UI forced the recipient type to be "CommCareUser" for Connect Messages/Surveys by:
- Disabling the recipient type selector
- Auto-selecting "CommCareUser" via JavaScript when Connect content was selected

This PR removes those restrictions and implements server-side validation instead.
This allows users to select multiple compatible recipient types (e.g., mobile workers, users in groups, case owners) while preventing selection of incompatible types like case groups or parent cases.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- The validation is more permissive than before (allowing multiple compatible types vs. only one), so existing schedules will continue to work
- To be tested on Staging

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Existing tests for scheduling forms cover recipient type validation.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None planned, however do let know if you think we should do QA based on changes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
