### PR TITLE
Form action diff JS refactor and other minor cleanup

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -348,7 +348,7 @@ class FormAction(UpdateableDocument):
             yield path
 
     @classmethod
-    def get_action_properties(self, action):
+    def get_action_properties(cls, action):
         action_properties = action.properties()
         if 'name_path' in action_properties and action.name_path:
             yield 'name', action.name_path

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/case_config_ui.js
@@ -650,12 +650,11 @@ $(function () {
             const openCase = o.open_case || {};
             self.open_case = {
                 condition: openCase.condition || DEFAULT_CONDITION_ALWAYS,
-                name_update: openCase.name_update || DEFAULT_UPDATE_ALWAYS,
                 name_update_multi: openCase.name_update_multi || [DEFAULT_UPDATE_ALWAYS],
             };
             const updateCase = o.update_case || {};
             self.update_case = {
-                update: updateCase.update || {},
+                update: updateCase.update || {},  // for to_usercase_transaction
                 update_multi: updateCase.update_multi || {},
             };
             self.case_preload = {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/case_config_ui.js
@@ -690,7 +690,7 @@ $(function () {
 
             var requiredProperties = (caseConfig.requires() === 'none' &&
                 caseConfig.actions.open_case.condition.type !== "never" &&
-                !o.update_case.update.name) ? nameProperties : [];
+                !o.update_case.update_multi.name) ? nameProperties : [];
             var caseProperties = caseConfigUtils.propertyMultiDictToArray(
                 requiredProperties,
                 self.update_case.update_multi,

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/case_config_ui.js
@@ -650,12 +650,11 @@ $(function () {
             const openCase = o.open_case || {};
             self.open_case = {
                 condition: openCase.condition || DEFAULT_CONDITION_ALWAYS,
-                name_update: openCase.name_update || DEFAULT_UPDATE_ALWAYS,
                 name_update_multi: openCase.name_update_multi || [DEFAULT_UPDATE_ALWAYS],
             };
             const updateCase = o.update_case || {};
             self.update_case = {
-                update: updateCase.update || {},
+                update: updateCase.update || {},  // for to_usercase_transaction
                 update_multi: updateCase.update_multi || {},
             };
             self.case_preload = {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/case_config_ui.js
@@ -690,7 +690,7 @@ $(function () {
 
             var requiredProperties = (caseConfig.requires() === 'none' &&
                 caseConfig.actions.open_case.condition.type !== "never" &&
-                !o.update_case.update.name) ? nameProperties : [];
+                !o.update_case.update_multi.name) ? nameProperties : [];
             var caseProperties = caseConfigUtils.propertyMultiDictToArray(
                 requiredProperties,
                 self.update_case.update_multi,

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_action_diffs.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_action_diffs.js
@@ -31,9 +31,9 @@ function getUpdateMultiDiff(original, incoming) {
     const updates = {};
 
     const allKeys = new Set([...Object.keys(original), ...Object.keys(incoming)]);
-    const baseline = Object.fromEntries(Object.entries(original).map(([key, items]) => {
-        [key, items.map(omitDocType)];
-    }));
+    const baseline = Object.fromEntries(
+        Object.entries(original).map(([key, items]) => [key, items.map(omitDocType)]),
+    );
 
     allKeys.forEach(key => {
         if (Object.hasOwn(baseline, key) && Object.hasOwn(incoming, key)) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_action_diffs.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_action_diffs.js
@@ -36,34 +36,32 @@ function getUpdateMultiDiff(original, incoming) {
     }));
 
     allKeys.forEach(key => {
-        // If the question is part of the incoming updates, then it is either an addition or an update
         if (Object.hasOwn(baseline, key) && Object.hasOwn(incoming, key)) {
-            incoming[key].forEach(update => {
-                const originalMatch = baseline[key].find(
-                    original => update.question_path === original.question_path);
-                if (!originalMatch) {
+            incoming[key].forEach(item => {
+                const match = baseline[key].find(q => q.question_path === item.question_path);
+                if (!match) {
                     additions[key] = additions[key] || [];
-                    additions[key].push(update);
-                } else if (originalMatch.update_mode !== update.update_mode) {
+                    additions[key].push(item);
+                } else if (match.update_mode !== item.update_mode) {
                     updates[key] = updates[key] || [];
-                    updates[key].push(update);
+                    updates[key].push(item);
                 }
             });
-            baseline[key].forEach(original => {
-                if (!incoming[key].find(update => update.question_path === original.question_path)) {
+            baseline[key].forEach(item => {
+                if (!incoming[key].find(q => q.question_path === item.question_path)) {
                     deletions[key] = deletions[key] || [];
-                    deletions[key].push(original);
+                    deletions[key].push(item);
                 }
             });
         } else if (Object.hasOwn(incoming, key)) {  // not in baseline
-            incoming[key].forEach(update => {
+            incoming[key].forEach(item => {
                 additions[key] = additions[key] || [];
-                additions[key].push(update);
+                additions[key].push(item);
             });
         } else {  // key in baseline, not in incoming
-            baseline[key].forEach(update => {
+            baseline[key].forEach(item => {
                 deletions[key] = deletions[key] || [];
-                deletions[key].push(update);
+                deletions[key].push(item);
             });
         }
     });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_action_diffs.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_action_diffs.js
@@ -66,15 +66,15 @@ function getUpdateMultiDiff(original, incoming) {
         }
     });
 
-    let diff = {};
+    const diff = {};
     if (Object.keys(additions).length) {
-        diff['add'] = additions;
+        diff.add = additions;
     }
     if (Object.keys(deletions).length) {
-        diff['delete'] = deletions;
+        diff.delete = deletions;
     }
     if (Object.keys(updates).length) {
-        diff['update'] = updates;
+        diff.update = updates;
     }
     return diff;
 }

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_action_diffs.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_action_diffs.js
@@ -31,22 +31,15 @@ function getUpdateMultiDiff(original, incoming) {
     const updates = {};
 
     const allKeys = new Set([...Object.keys(original), ...Object.keys(incoming)]);
-    const normalizedOriginal = {};
-    Object.entries(original).forEach(([key, updateList]) => {
-        normalizedOriginal[key] = updateList.map(update => normalizeUpdateObject(update));
-    });
-
+    const baseline = Object.fromEntries(Object.entries(original).map(([key, items]) => {
+        [key, items.map(omitDocType)];
+    }));
 
     allKeys.forEach(key => {
         // If the question is part of the incoming updates, then it is either an addition or an update
-        if (!(key in normalizedOriginal)) {
+        if (Object.hasOwn(baseline, key) && Object.hasOwn(incoming, key)) {
             incoming[key].forEach(update => {
-                additions[key] = additions[key] || [];
-                additions[key].push(update);
-            });
-        } else if (key in incoming) {
-            incoming[key].forEach(update => {
-                const originalMatch = normalizedOriginal[key].find(
+                const originalMatch = baseline[key].find(
                     original => update.question_path === original.question_path);
                 if (!originalMatch) {
                     additions[key] = additions[key] || [];
@@ -56,20 +49,21 @@ function getUpdateMultiDiff(original, incoming) {
                     updates[key].push(update);
                 }
             });
-        }
-
-        // If the question is missing from the incoming updates, then it is a deletion
-        if (!(key in incoming)) {
-            normalizedOriginal[key].forEach(update => {
-                deletions[key] = deletions[key] || [];
-                deletions[key].push(update);
-            });
-        } else if (key in normalizedOriginal) {
-            normalizedOriginal[key].forEach(original => {
+            baseline[key].forEach(original => {
                 if (!incoming[key].find(update => update.question_path === original.question_path)) {
                     deletions[key] = deletions[key] || [];
                     deletions[key].push(original);
                 }
+            });
+        } else if (Object.hasOwn(incoming, key)) {  // not in baseline
+            incoming[key].forEach(update => {
+                additions[key] = additions[key] || [];
+                additions[key].push(update);
+            });
+        } else {  // key in baseline, not in incoming
+            baseline[key].forEach(update => {
+                deletions[key] = deletions[key] || [];
+                deletions[key].push(update);
             });
         }
     });
@@ -78,15 +72,12 @@ function getUpdateMultiDiff(original, incoming) {
     if (Object.keys(additions).length) {
         diff['add'] = additions;
     }
-
     if (Object.keys(deletions).length) {
         diff['delete'] = deletions;
     }
-
     if (Object.keys(updates).length) {
         diff['update'] = updates;
     }
-
     return diff;
 }
 
@@ -111,7 +102,7 @@ function getNameDiff(original, updated) {
     return result;
 }
 
-function normalizeUpdateObject(updateObject) {
+function omitDocType(updateObject) {
     // The server sends the raw data from couch that includes keys not used in our javascript representation.
     // Ideally, the server would strip would these values for us, but because that doesn't happen,
     // remove these extraneous keys here


### PR DESCRIPTION
## Product Description

No user-facing effects. This is a code cleanup and bug fix in the form action diff logic used in the App Manager case configuration UI.

## Technical Summary
Cleans up and fixes issues in the form action JavaScript diff code and related case configuration UI.

:blowfish: Review by commit.

## Safety Assurance

### Safety story

These are small, targeted changes:
- The `update.name` -> `update_multi.name` fix corrects a check that was always falsy, meaning the `nameProperties` were never being included when they should have been. This restores the intended behavior.
- The removed `name_update` property was unused — no code reads it.
- The diff logic refactor preserves identical behavior with clearer structure. It passes tests for the same code in Vellum: https://github.com/dimagi/Vellum/commit/639c9b7e2616cc476668b9dc299844d84f7e9928 (not yet PR'd, but will be soon).
- The `self` -> `cls` classmethod fix is cosmetic (Python passes the class either way).

### Automated test coverage
Minimal if any.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
