### PR TITLE
Upgrade qs to 6.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
         "minimatch": "^3.1.3",
         "mocha-headless-chrome/puppeteer/tar-fs": "^2.1.4",
         "moment-timezone": "^0.5.35",
-        "qs": "^6.14.1",
+        "qs": "^6.14.2",
         "set-value": "^4.0.1",
         "tough-cookie": "^4.1.3",
         "yargs-parser": "^18.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6930,10 +6930,10 @@ qrcode-terminal@^0.12.0:
   resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz#bb5b699ef7f9f0505092a3748be4464fe71b5819"
   integrity sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==
 
-qs@^6.14.1, qs@^6.4.0, qs@~6.5.2:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
-  integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
+qs@^6.14.2, qs@^6.4.0, qs@~6.5.2:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.0.tgz#db8fd5d1b1d2d6b5b33adaf87429805f1909e7b3"
+  integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19414

[Changelog](https://github.com/ljharb/qs/blob/main/CHANGELOG.md)

~There is version 6.15.0, but opting to stick with 6.14.2 for stability.~

The changelog for 6.15.0 looks pretty harmless. Here is claude's take:
> No issues foreseen. The changes in 6.15.0 are purely additive:
>  - New strictMerge parse option — opt-in, no effect unless explicitly used
> - Bug fix for duplicates option with bracket notation — a correctness fix; the only risk would be if existing code > was relying on the buggy behavior, but since CommCare
> HQ doesn't call qs directly, this is a non-issue
>
> Since qs is only used transitively (by request and tiny-lr) and neither uses these specific options, upgrading to 6.15.0 should be safe.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
