### PR TITLE
Use ngettext for 'day'/'days' in invoice reminder email 

### DIFF
--- a/corehq/apps/accounting/utils/unpaid_invoice.py
+++ b/corehq/apps/accounting/utils/unpaid_invoice.py
@@ -3,6 +3,7 @@ import datetime
 from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 
 from corehq.apps.accounting.const import (
     DAYS_BEFORE_DUE_TO_TRIGGER_REMINDER,
@@ -145,12 +146,16 @@ class InvoiceReminder(UnpaidInvoiceAction):
             account_name = invoice.get_domain()
 
         if invoice.account.auto_pay_enabled:
-            subject = _(
-                "Your Automatic Payment for CommCare Account {account_name} is scheduled in {num_days} day"
+            subject = ngettext(
+                "Your Automatic Payment for CommCare Account {account_name} is scheduled in {num_days} day",
+                "Your Automatic Payment for CommCare Account {account_name} is scheduled in {num_days} days",
+                DAYS_BEFORE_DUE_TO_TRIGGER_REMINDER,
             ).format(account_name=account_name, num_days=DAYS_BEFORE_DUE_TO_TRIGGER_REMINDER)
         else:
-            subject = _(
-                "Your CommCare Billing Statement for {account_name} is due in {num_days} day"
+            subject = ngettext(
+                "Your CommCare Billing Statement for {account_name} is due in {num_days} day",
+                "Your CommCare Billing Statement for {account_name} is due in {num_days} days",
+                DAYS_BEFORE_DUE_TO_TRIGGER_REMINDER,
             ).format(account_name=account_name, num_days=DAYS_BEFORE_DUE_TO_TRIGGER_REMINDER)
 
         send_HTML_email(

--- a/corehq/apps/accounting/utils/unpaid_invoice.py
+++ b/corehq/apps/accounting/utils/unpaid_invoice.py
@@ -146,11 +146,11 @@ class InvoiceReminder(UnpaidInvoiceAction):
 
         if invoice.account.auto_pay_enabled:
             subject = _(
-                "Your Automatic Payment for CommCare Account {account_name} is scheduled in {num_days} days"
+                "Your Automatic Payment for CommCare Account {account_name} is scheduled in {num_days} day"
             ).format(account_name=account_name, num_days=DAYS_BEFORE_DUE_TO_TRIGGER_REMINDER)
         else:
             subject = _(
-                "Your CommCare Billing Statement for {account_name} is due in {num_days} days"
+                "Your CommCare Billing Statement for {account_name} is due in {num_days} day"
             ).format(account_name=account_name, num_days=DAYS_BEFORE_DUE_TO_TRIGGER_REMINDER)
 
         send_HTML_email(


### PR DESCRIPTION
## Technical Summary
`DAYS_BEFORE_DUE_TO_TRIGGER_REMINDER` is a constant set to 1, so we should say "1 day" not "1 days". To make sure this uses the correct form in the future (e.g. if we update the constant again), this is changed to use `ngettext`.

## Safety Assurance

### Safety story
Just a small change to text - the subject of an email.

### Automated test coverage
There is automated testing for some of the underlying functionality, but not the email subject line.

### QA Plan
n/a


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
