### PR TITLE
Add Subscription Management & Billing help link to Current Subscription page

### DIFF
--- a/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap3/current_subscription.html
@@ -18,6 +18,13 @@
     <div class="col-sm-12">
       <article id="subscriptionSummary" class="form-horizontal">
         <legend>{% trans 'Current Subscription' %}</legend>
+        <p>
+          {% blocktrans with help_url="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing" %}
+            For more information on Subscription Management & Billing, please
+            see the
+            <a href="{{ help_url }}" target="_blank">Help Site</a>.
+          {% endblocktrans %}
+        </p>
         <div class="form-group">
           <label class="control-label col-sm-2">{% trans 'Plan' %}</label>
           <div class="col-sm-10">

--- a/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/bootstrap5/current_subscription.html
@@ -18,6 +18,13 @@
     <div class="col-md-12">
       <article id="subscriptionSummary" class="form-horizontal">
         <legend>{% trans 'Current Subscription' %}</legend>
+        <p>
+          {% blocktrans with help_url="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing" %}
+            For more information on Subscription Management & Billing, please
+            see the
+            <a href="{{ help_url }}" target="_blank">Help Site</a>.
+          {% endblocktrans %}
+        </p>
         <div class="form-group">  {# todo B5: css-form-group #}
           <label class="form-label col-md-2">{% trans 'Plan' %}</label>
           <div class="col-md-10">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/domain/current_subscription.html.diff.txt
@@ -10,7 +10,7 @@
  
  {% block page_content %}
    {% initial_page_data "stripe_public_key" stripe_public_key %}
-@@ -15,12 +15,12 @@
+@@ -15,7 +15,7 @@
    {% registerurl "domain_wire_payment" domain %}
  
    <div class="row">
@@ -18,6 +18,11 @@
 +    <div class="col-md-12">
        <article id="subscriptionSummary" class="form-horizontal">
          <legend>{% trans 'Current Subscription' %}</legend>
+         <p>
+@@ -25,9 +25,9 @@
+             <a href="{{ help_url }}" target="_blank">Help Site</a>.
+           {% endblocktrans %}
+         </p>
 -        <div class="form-group">
 -          <label class="control-label col-sm-2">{% trans 'Plan' %}</label>
 -          <div class="col-sm-10">
@@ -27,7 +32,7 @@
              <div class="{{ plan.css_class }}">
                <h4>
                  {% if plan.is_paused %}
-@@ -61,7 +61,7 @@
+@@ -68,7 +68,7 @@
              {% endif %}
              {% if can_change_subscription %}
                {% if plan.is_annual_plan and not plan.upgrade_available %}
@@ -36,7 +41,7 @@
                    {% trans "Questions about your plan?" %}
                    <a href="{% url "annual_plan_request_quote" domain %}"
                      >{% trans "Contact us" %}</a
-@@ -69,11 +69,7 @@
+@@ -76,11 +76,7 @@
                  </div>
                {% else %}
                  <p>
@@ -49,7 +54,7 @@
                      {% if plan.is_paused %}
                        {% trans "Subscribe to Plan" %}
                      {% elif plan.is_annual_plan and plan.upgrade_available %}
-@@ -106,21 +102,21 @@
+@@ -113,21 +109,21 @@
          </div>
          {% if not plan.is_trial and not plan.is_paused %}
            {% if plan.date_start %}
@@ -77,7 +82,7 @@
                  <p class="form-control-text">{{ plan.date_end }}</p>
                  {% if plan.is_auto_renew %}
                    <div class="alert alert-success">
-@@ -147,8 +143,8 @@
+@@ -154,8 +150,8 @@
                    <button
                      type="button"
                      class="btn btn-default"
@@ -88,7 +93,7 @@
                    >
                      {% if plan.is_auto_renew %}
                        {% trans "Disable Auto Renewal" %}
-@@ -161,26 +157,26 @@
+@@ -168,26 +164,26 @@
              </div>
            {% endif %}
            <div data-bind="foreach: products">
@@ -122,7 +127,7 @@
                {% endif %}
                (<a href="{{ manage_autopay_url }}#payment-methods">Manage</a>)
              </p>
-@@ -194,29 +190,29 @@
+@@ -201,29 +197,29 @@
            </div>
          </div>
          {% if plan.next_subscription.exists and not plan.next_subscription.is_paused %}
@@ -161,7 +166,7 @@
                <p class="form-control-text">
                  {{ plan.next_subscription.price }}
                </p>
-@@ -229,26 +225,26 @@
+@@ -236,26 +232,26 @@
          <div class="form form-horizontal">
            {% if plan.has_credits_in_non_general_credit_line %}
              <div data-bind="foreach: products">
@@ -194,7 +199,7 @@
                  <p class="form-control-text js-general-credit">
                    {{ plan.general_credit.amount }}
                  </p>
-@@ -256,29 +252,29 @@
+@@ -263,29 +259,29 @@
              </div>
            {% endif %}
            <div data-bind="with: prepayments">
@@ -232,7 +237,7 @@
                      <i class="fa fa-info-circle"></i>
                      {% trans "Not Billing Admin, Can't Add Credit" %}
                    </span>
-@@ -291,8 +287,8 @@
+@@ -298,8 +294,8 @@
            <legend>{% trans 'Account Credit' %}</legend>
            <div class="form form-horizontal">
              <div data-bind="foreach: products">
@@ -243,7 +248,7 @@
                    {% trans 'Plan Credit' %}
                    <div class="hq-help">
                      <a
-@@ -307,7 +303,7 @@
+@@ -314,7 +310,7 @@
                      </a>
                    </div>
                  </label>
@@ -252,7 +257,7 @@
                    <p
                      class="form-control-text"
                      data-bind="text: accountAmount"
-@@ -316,8 +312,8 @@
+@@ -323,8 +319,8 @@
                </div>
              </div>
              {% if plan.account_general_credit and plan.account_general_credit.is_visible %}
@@ -263,7 +268,7 @@
                    {% trans 'General Credit' %}
                    <div class="hq-help">
                      <a
-@@ -333,7 +329,7 @@
+@@ -340,7 +336,7 @@
                      </a>
                    </div>
                  </label>
@@ -272,7 +277,7 @@
                    <p class="form-control-text">
                      {{ plan.account_general_credit.amount }}
                    </p>
-@@ -403,8 +399,8 @@
+@@ -410,8 +406,8 @@
  
  {% block modals %}
    {{ block.super }}


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-19427

## Product Description
Adds a help link under the "Current Subscription" heading on the subscription page that points to the [Subscription Management & Billing Help Site](https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143955299/Subscription+Management+Billing).
**Before**
<img width="1299" height="393" alt="Screenshot 2026-03-02 at 5 41 28 PM" src="https://github.com/user-attachments/assets/5479a6c1-53a9-4fac-bcbb-e1b9f50a7136" />

**After**
<img width="1483" height="348" alt="Screenshot 2026-03-02 at 5 40 41 PM" src="https://github.com/user-attachments/assets/2b6b71c1-c1cf-49d4-8c6b-882dcb53db41" />

## Technical Summary

Added a `blocktrans` block with the help URL to both bootstrap3 and bootstrap5 `current_subscription.html` templates.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Template-only change adding a static link. No logic changes.

### Automated test coverage
N/A — static template content.

### QA Plan
- Verify the link appears on the Current Subscription page and opens the correct Confluence help page.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change