### PR TITLE
Bootstrap 5 Migration: linked_domain

### DIFF
--- a/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
+++ b/corehq/apps/hqwebapp/utils/bootstrap/status/bootstrap3_to_5.json
@@ -159,6 +159,9 @@
   "integration": {
     "is_complete": true
   },
+  "linked_domain": {
+    "is_complete": true
+  },
   "locations": {
     "is_complete": true
   },

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -3,7 +3,7 @@ import RMI from "jquery.rmi/jquery.rmi";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import _ from "underscore";
 import ko from "knockout";
-import alertUser from "hqwebapp/js/bootstrap3/alert_user";
+import alertUser from "hqwebapp/js/bootstrap5/alert_user";
 import multiselectUtils from "hqwebapp/js/multiselect_utils";
 import noopMetrics from "analytix/js/noopMetrics";
 import "hqwebapp/js/components/pagination";

--- a/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
+++ b/corehq/apps/linked_domain/static/linked_domain/js/domain_links.js
@@ -128,11 +128,11 @@ var DomainLinksViewModel = function (data) {
 
     // Tab Content Statuses
     self.manageTabActiveStatus = ko.computed(function () {
-        return self.isUpstreamDomain() && !window.location.hash ? "in active" : "";
+        return self.isUpstreamDomain() && !window.location.hash ? "show active" : "";
     });
 
     self.pullTabActiveStatus = ko.computed(function () {
-        return self.isOnlyDownstreamDomain() ? "in active" : "";
+        return self.isOnlyDownstreamDomain() ? "show active" : "";
     });
 
     self.showGetStarted = ko.computed(function () {
@@ -223,13 +223,6 @@ var DomainLinksViewModel = function (data) {
         }).fail(function () {
             alertUser.alert_user(gettext('Something unexpected happened.\n' +
                 'Please try again, or report an issue if the problem persists.'), 'danger');
-        }).always(function () {
-            // fix for b3
-            $('body').removeClass('modal-open');
-            var $modalBackdrop = $('.modal-backdrop');
-            if ($modalBackdrop) {
-                $modalBackdrop.remove();
-            }
         });
     };
 
@@ -527,7 +520,7 @@ var GettingStartedViewModel = function (data) {
     self.upstreamDomains = ko.observableArray(sortedUpstreamDomains);
 
     self.upstreamButtonClass = ko.computed(function () {
-        return self.upstreamDomains().length > 0 ? "btn-default" : "btn-primary";
+        return self.upstreamDomains().length > 0 ? "btn-outline-primary" : "btn-primary";
     });
 
     self.goToUpstream = function (data) {

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -1,8 +1,8 @@
-{% extends "hqwebapp/bootstrap3/base_section.html" %}
+{% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% js_entry_b3 "linked_domain/js/domain_links" %}
+{% js_entry "linked_domain/js/domain_links" %}
 
 {% block page_content %}
   {% initial_page_data 'view_data' view_data %}
@@ -15,15 +15,15 @@
     <!-- /ko -->
     <!-- ko ifnot: showGetStarted -->
       <!-- ko if: showMultipleTabs -->
-        <ul class="nav nav-tabs">
+        <ul class="nav nav-tabs">  {# todo B5: css-nav #}
           <!-- ko if: isUpstreamDomain -->
-            <li data-bind="class: manageDownstreamDomainsTabStatus"><a data-toggle="tab" href="#tabs-manage-downstream">{% trans "Downstream Project Spaces" %}</a></li>
-            <li><a data-toggle="tab" href="#tabs-push-content">{% trans "Push Content" %}</a></li>
+            <li data-bind="class: manageDownstreamDomainsTabStatus"><a data-bs-toggle="tab" href="#tabs-manage-downstream">{% trans "Downstream Project Spaces" %}</a></li>
+            <li><a data-bs-toggle="tab" href="#tabs-push-content">{% trans "Push Content" %}</a></li>
           <!-- /ko -->
           <!-- ko if: isDownstreamDomain -->
-            <li data-bind="class: pullContentTabStatus"><a data-toggle="tab" href="#tabs-pull-content">{% trans "Manage Linked Project Space" %}</a></li>
+            <li data-bind="class: pullContentTabStatus"><a data-bs-toggle="tab" href="#tabs-pull-content">{% trans "Manage Linked Project Space" %}</a></li>
             {% if view_data.linkable_ucr %}
-              <li><a data-toggle="tab" href="#tabs-remote-report">{% trans "Add Remote Reports" %}</a></li>
+              <li><a data-bs-toggle="tab" href="#tabs-remote-report">{% trans "Add Remote Reports" %}</a></li>
             {% endif %}
           <!-- /ko -->
         </ul>
@@ -60,7 +60,7 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>  {# todo B5: css-close #}
           <h4 class="modal-title">{% trans 'Add Downstream Project Space' %}</h4>
           <!-- ko if: parent.showGetStarted -->
             <p>{% trans 'To make this project space an upstream project space, you need to add a downstream project space.' %}</p>
@@ -70,15 +70,15 @@
           <div class="ko-model">
             <label >{% trans 'Project Space:' %}</label>
             {% if view_data.is_superuser %}
-              <select class="form-control" data-bind="autocompleteSelect2: availableDomains, value: domainToAdd"></select>
+              <select class="form-select" data-bind="autocompleteSelect2: availableDomains, value: domainToAdd"></select>
             {% else %}
-              <select class="form-control" data-bind="select2: availableDomains, value: domainToAdd"></select>
+              <select class="form-select" data-bind="select2: availableDomains, value: domainToAdd"></select>
             {% endif %}
           </div>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
-          <button type="button" class="btn btn-primary" data-dismiss="modal" data-bind="click: addDownstreamDomain, enable: didSelectDomain">{% trans 'Add' %}</button>
+          <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal" data-bind="click: addDownstreamDomain, enable: didSelectDomain">{% trans 'Add' %}</button>
         </div>
       </div>
     </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -55,7 +55,7 @@
     <h2>{% trans "Manage Linked Project Space" %}</h2>
     {# header for the only tab that will be displayed #}
     <!-- /ko -->
-    <div id="domain_links">
+    <div id="domain_links" class="mt-3">
       <div class="tab-content">
         <div
           class="tab-pane fade"

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -1,7 +1,6 @@
 {% extends "hqwebapp/bootstrap5/base_section.html" %}
 {% load hq_shared_tags %}
 {% load i18n %}
-
 {% js_entry "linked_domain/js/domain_links" %}
 
 {% block page_content %}
@@ -11,47 +10,79 @@
 
   <div id="ko-linked-projects" class="ko-template">
     <!-- ko if: showGetStarted -->
-        {% include 'linked_domain/partials/get_started.html' %}
+    {% include 'linked_domain/partials/get_started.html' %}
     <!-- /ko -->
     <!-- ko ifnot: showGetStarted -->
-      <!-- ko if: showMultipleTabs -->
-        <ul class="nav nav-tabs">
-          <!-- ko if: isUpstreamDomain -->
-            <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#tabs-manage-downstream" data-bind="css: manageDownstreamDomainsTabStatus">{% trans "Downstream Project Spaces" %}</a></li>
-            <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#tabs-push-content">{% trans "Push Content" %}</a></li>
-          <!-- /ko -->
-          <!-- ko if: isDownstreamDomain -->
-            <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#tabs-pull-content" data-bind="css: pullContentTabStatus">{% trans "Manage Linked Project Space" %}</a></li>
-            {% if view_data.linkable_ucr %}
-              <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#tabs-remote-report">{% trans "Add Remote Reports" %}</a></li>
-            {% endif %}
-          <!-- /ko -->
-        </ul>
+    <!-- ko if: showMultipleTabs -->
+    <ul class="nav nav-tabs">
+      <!-- ko if: isUpstreamDomain -->
+      <li class="nav-item">
+        <a
+          class="nav-link"
+          data-bs-toggle="tab"
+          href="#tabs-manage-downstream"
+          data-bind="css: manageDownstreamDomainsTabStatus"
+          >{% trans "Downstream Project Spaces" %}</a
+        >
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" data-bs-toggle="tab" href="#tabs-push-content"
+          >{% trans "Push Content" %}</a
+        >
+      </li>
       <!-- /ko -->
-      <!-- ko ifnot: showMultipleTabs -->
-        <h2>{% trans "Manage Linked Project Space" %}</h2>  {# header for the only tab that will be displayed #}
+      <!-- ko if: isDownstreamDomain -->
+      <li class="nav-item">
+        <a
+          class="nav-link"
+          data-bs-toggle="tab"
+          href="#tabs-pull-content"
+          data-bind="css: pullContentTabStatus"
+          >{% trans "Manage Linked Project Space" %}</a
+        >
+      </li>
+      {% if view_data.linkable_ucr %}
+        <li class="nav-item">
+          <a class="nav-link" data-bs-toggle="tab" href="#tabs-remote-report"
+            >{% trans "Add Remote Reports" %}</a
+          >
+        </li>
+      {% endif %}
       <!-- /ko -->
-      <div id="domain_links">
-        <div class="tab-content">
-          <div class="tab-pane fade" id="tabs-pull-content" data-bind="css: pullTabActiveStatus">
-            {% include 'linked_domain/partials/pull_content.html' %}
-          </div>
-          <div class="tab-pane fade" id="tabs-manage-downstream" data-bind="css: manageTabActiveStatus">
-            {% include 'linked_domain/partials/manage_downstream_domains.html' %}
-          </div>
-          <div class="tab-pane fade" id="tabs-push-content">
-            {% include 'linked_domain/partials/push_content.html' %}
-          </div>
-          {% if view_data.linkable_ucr %}
-            <div class="tab-pane fade" id="tabs-remote-report">
-              {% include 'linked_domain/partials/link_remote_ucr.html' %}
-            </div>
-          {% endif %}
+    </ul>
+    <!-- /ko -->
+    <!-- ko ifnot: showMultipleTabs -->
+    <h2>{% trans "Manage Linked Project Space" %}</h2>
+    {# header for the only tab that will be displayed #}
+    <!-- /ko -->
+    <div id="domain_links">
+      <div class="tab-content">
+        <div
+          class="tab-pane fade"
+          id="tabs-pull-content"
+          data-bind="css: pullTabActiveStatus"
+        >
+          {% include 'linked_domain/partials/pull_content.html' %}
         </div>
+        <div
+          class="tab-pane fade"
+          id="tabs-manage-downstream"
+          data-bind="css: manageTabActiveStatus"
+        >
+          {% include 'linked_domain/partials/manage_downstream_domains.html' %}
+        </div>
+        <div class="tab-pane fade" id="tabs-push-content">
+          {% include 'linked_domain/partials/push_content.html' %}
+        </div>
+        {% if view_data.linkable_ucr %}
+          <div class="tab-pane fade" id="tabs-remote-report">
+            {% include 'linked_domain/partials/link_remote_ucr.html' %}
+          </div>
+        {% endif %}
       </div>
+    </div>
     <!-- /ko -->
   </div>
-
 {% endblock %}
 
 {% block modals %}
@@ -60,25 +91,53 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h4 class="modal-title">{% trans 'Add Downstream Project Space' %}</h4>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'></button>
+          <h4 class="modal-title">
+            {% trans 'Add Downstream Project Space' %}
+          </h4>
+          <button
+            type="button"
+            class="btn-close"
+            data-bs-dismiss="modal"
+            aria-label="{% trans_html_attr "Close" %}"
+          ></button>
         </div>
         <div class="modal-body">
           <!-- ko if: parent.showGetStarted -->
-            <p>{% trans 'To make this project space an upstream project space, you need to add a downstream project space.' %}</p>
+          <p>
+            {% trans 'To make this project space an upstream project space, you need to add a downstream project space.' %}
+          </p>
           <!-- /ko -->
           <div class="ko-model">
-            <label >{% trans 'Project Space:' %}</label>
+            <label>{% trans 'Project Space:' %}</label>
             {% if view_data.is_superuser %}
-              <select class="form-select" data-bind="autocompleteSelect2: availableDomains, value: domainToAdd"></select>
+              <select
+                class="form-select"
+                data-bind="autocompleteSelect2: availableDomains, value: domainToAdd"
+              ></select>
             {% else %}
-              <select class="form-select" data-bind="select2: availableDomains, value: domainToAdd"></select>
+              <select
+                class="form-select"
+                data-bind="select2: availableDomains, value: domainToAdd"
+              ></select>
             {% endif %}
           </div>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
-          <button type="button" class="btn btn-primary" data-bs-dismiss="modal" data-bind="click: addDownstreamDomain, enable: didSelectDomain">{% trans 'Add' %}</button>
+          <button
+            type="button"
+            class="btn btn-outline-primary"
+            data-bs-dismiss="modal"
+          >
+            {% trans 'Cancel' %}
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-bs-dismiss="modal"
+            data-bind="click: addDownstreamDomain, enable: didSelectDomain"
+          >
+            {% trans 'Add' %}
+          </button>
         </div>
       </div>
     </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -15,15 +15,15 @@
     <!-- /ko -->
     <!-- ko ifnot: showGetStarted -->
       <!-- ko if: showMultipleTabs -->
-        <ul class="nav nav-tabs">  {# todo B5: css-nav #}
+        <ul class="nav nav-tabs">
           <!-- ko if: isUpstreamDomain -->
-            <li data-bind="class: manageDownstreamDomainsTabStatus"><a data-bs-toggle="tab" href="#tabs-manage-downstream">{% trans "Downstream Project Spaces" %}</a></li>
-            <li><a data-bs-toggle="tab" href="#tabs-push-content">{% trans "Push Content" %}</a></li>
+            <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#tabs-manage-downstream" data-bind="css: manageDownstreamDomainsTabStatus">{% trans "Downstream Project Spaces" %}</a></li>
+            <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#tabs-push-content">{% trans "Push Content" %}</a></li>
           <!-- /ko -->
           <!-- ko if: isDownstreamDomain -->
-            <li data-bind="class: pullContentTabStatus"><a data-bs-toggle="tab" href="#tabs-pull-content">{% trans "Manage Linked Project Space" %}</a></li>
+            <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#tabs-pull-content" data-bind="css: pullContentTabStatus">{% trans "Manage Linked Project Space" %}</a></li>
             {% if view_data.linkable_ucr %}
-              <li><a data-bs-toggle="tab" href="#tabs-remote-report">{% trans "Add Remote Reports" %}</a></li>
+              <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#tabs-remote-report">{% trans "Add Remote Reports" %}</a></li>
             {% endif %}
           <!-- /ko -->
         </ul>
@@ -33,10 +33,10 @@
       <!-- /ko -->
       <div id="domain_links">
         <div class="tab-content">
-          <div class="tab-pane fade" id="tabs-pull-content" data-bind="class: pullTabActiveStatus">
+          <div class="tab-pane fade" id="tabs-pull-content" data-bind="css: pullTabActiveStatus">
             {% include 'linked_domain/partials/pull_content.html' %}
           </div>
-          <div class="tab-pane fade" id="tabs-manage-downstream" data-bind="class: manageTabActiveStatus">
+          <div class="tab-pane fade" id="tabs-manage-downstream" data-bind="css: manageTabActiveStatus">
             {% include 'linked_domain/partials/manage_downstream_domains.html' %}
           </div>
           <div class="tab-pane fade" id="tabs-push-content">
@@ -60,13 +60,13 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>  {# todo B5: css-close #}
           <h4 class="modal-title">{% trans 'Add Downstream Project Space' %}</h4>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'></button>
+        </div>
+        <div class="modal-body">
           <!-- ko if: parent.showGetStarted -->
             <p>{% trans 'To make this project space an upstream project space, you need to add a downstream project space.' %}</p>
           <!-- /ko -->
-        </div>
-        <div class="modal-body">
           <div class="ko-model">
             <label >{% trans 'Project Space:' %}</label>
             {% if view_data.is_superuser %}

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/get_started.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/get_started.html
@@ -3,7 +3,9 @@
 
 <div id="ko-getting-started" data-bind="with: $root.gettingStartedViewModel">
   <h3>{% trans "Linked Project Spaces" %}</h3>
-  <p>{% trans "Create links between upstream and downstream project spaces." %}</p>
+  <p>
+    {% trans "Create links between upstream and downstream project spaces." %}
+  </p>
   <p>{% trans "Linked project spaces allow you to:" %}</p>
   <ol>
     <li>{% trans "Push content to a downstream project space" %}</li>
@@ -11,49 +13,60 @@
   </ol>
   <p>
     {% blocktrans %}
-      <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about Linked Project Spaces.
+      <a
+        href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces"
+        target="_blank"
+        >Learn more</a
+      >
+      about Linked Project Spaces.
     {% endblocktrans %}
   </p>
   <div class="spacer"></div>
   <div class="row">
     <!-- ko if: upstreamDomains().length > 0 -->
-      <div class="col-md-6">
-        <h4>{% trans "Link to an existing upstream project space" %}</h4>
-        <p>
-          {% blocktrans %}
-            To pull content from an upstream project space, link this project space to an upstream project space.
-            The link can only be created from the upstream project space.
-          {% endblocktrans %}
-        </p>
-        <!-- ko if: upstreamDomains().length == 1 -->
-          <button type="button"
-                class="btn btn-primary"
-                id="go-to-upstream-project"
-                data-bind="click: goToUpstream">
-            {% trans "Go To Upstream Project Space" %}
-          </button>
-        <!-- /ko -->
-        <!-- ko if: upstreamDomains().length > 1 -->
-          <ul data-bind="foreach: upstreamDomains">
-            <li><a data-bind="attr: {'href': $data.url}, text: $data.name"></a></li>
-          </ul>
-        <!-- /ko -->
-      </div>
+    <div class="col-md-6">
+      <h4>{% trans "Link to an existing upstream project space" %}</h4>
+      <p>
+        {% blocktrans %}
+          To pull content from an upstream project space, link this project
+          space to an upstream project space. The link can only be created from
+          the upstream project space.
+        {% endblocktrans %}
+      </p>
+      <!-- ko if: upstreamDomains().length == 1 -->
+      <button
+        type="button"
+        class="btn btn-primary"
+        id="go-to-upstream-project"
+        data-bind="click: goToUpstream"
+      >
+        {% trans "Go To Upstream Project Space" %}
+      </button>
+      <!-- /ko -->
+      <!-- ko if: upstreamDomains().length > 1 -->
+      <ul data-bind="foreach: upstreamDomains">
+        <li><a data-bind="attr: {'href': $data.url}, text: $data.name"></a></li>
+      </ul>
+      <!-- /ko -->
+    </div>
     <!-- /ko -->
     <div class="col-md-6">
       <h4>{% trans "Make this an upstream project space" %}</h4>
       <p>
         {% blocktrans %}
-          To push content from this project space to other project spaces, make this project space an upstream project space.
-          This can be done by linking this project space to downstream project spaces.
+          To push content from this project space to other project spaces, make
+          this project space an upstream project space. This can be done by
+          linking this project space to downstream project spaces.
         {% endblocktrans %}
       </p>
-      <button type="button"
-              class="btn"
-              data-bind="class: upstreamButtonClass"
-              id="add-downstream-domain"
-              data-bs-toggle="modal"
-              data-bs-target="#new-downstream-domain-modal">
+      <button
+        type="button"
+        class="btn"
+        data-bind="class: upstreamButtonClass"
+        id="add-downstream-domain"
+        data-bs-toggle="modal"
+        data-bs-target="#new-downstream-domain-modal"
+      >
         {% trans "Link Downstream Project Spaces" %}
       </button>
     </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/get_started.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/get_started.html
@@ -17,7 +17,7 @@
   <div class="spacer"></div>
   <div class="row">
     <!-- ko if: upstreamDomains().length > 0 -->
-      <div class="col-sm-6">
+      <div class="col-md-6">
         <h4>{% trans "Link to an existing upstream project space" %}</h4>
         <p>
           {% blocktrans %}
@@ -40,7 +40,7 @@
         <!-- /ko -->
       </div>
     <!-- /ko -->
-    <div class="col-sm-6">
+    <div class="col-md-6">
       <h4>{% trans "Make this an upstream project space" %}</h4>
       <p>
         {% blocktrans %}
@@ -52,8 +52,8 @@
               class="btn"
               data-bind="class: upstreamButtonClass"
               id="add-downstream-domain"
-              data-toggle="modal"
-              data-target="#new-downstream-domain-modal">
+              data-bs-toggle="modal"
+              data-bs-target="#new-downstream-domain-modal">
         {% trans "Link Downstream Project Spaces" %}
       </button>
     </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/manage_downstream_domains.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/manage_downstream_domains.html
@@ -20,7 +20,7 @@
       <i class="fa fa-plus"></i> {% trans "Add Downstream Project Space" %}
     </button>
     <div class="spacer"></div>
-    <div class="card ">  {# todo B5: css-panel #}
+    <div class="card">
       <div class="card-header">
         <h3 class="card-title">{% trans 'Downstream Project Spaces' %}</h3>
       </div>
@@ -51,8 +51,8 @@
                 <div class="modal-dialog" role="document">
                   <div class="modal-content">
                     <div class="modal-header">
-                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>  {# todo B5: css-close #}
                       <h4 class="modal-title">{% trans 'Remove Project Space Link' %}</h4>
+                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'></button>
                     </div>
                     <div class="modal-body">
                       <h4>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/manage_downstream_domains.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/manage_downstream_domains.html
@@ -13,18 +13,18 @@
     <button type="button"
             class="btn btn-primary"
             id="add-downstream-domain"
-            data-toggle="modal"
-            data-target="#new-downstream-domain-modal"
+            data-bs-toggle="modal"
+            data-bs-target="#new-downstream-domain-modal"
             data-bind="click: addDownstreamProjectSpace"
     >
       <i class="fa fa-plus"></i> {% trans "Add Downstream Project Space" %}
     </button>
     <div class="spacer"></div>
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">{% trans 'Downstream Project Spaces' %}</h3>
+    <div class="card ">  {# todo B5: css-panel #}
+      <div class="card-header">
+        <h3 class="card-title">{% trans 'Downstream Project Spaces' %}</h3>
       </div>
-      <div class="panel-body">
+      <div class="card-body">
         <search-box data-apply-bindings="false"
                   params="value: query,
                           action: filter,
@@ -43,7 +43,7 @@
             <td><a data-bind="attr: {'href': downstreamUrl}, text: downstreamDomain"></a></td>
             <td data-bind="text: lastUpdate"></td>
             <td>
-              <button type="button" class="btn btn-danger" data-toggle="modal" data-bind="attr: {'data-target': '#remove-link-modal-' + $index()}">
+              <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bind="attr: {'data-bs-target': '#remove-link-modal-' + $index()}">
                 <i class="fa-regular fa-trash-can"></i>
                 {% trans 'Remove Link' %}
               </button>
@@ -51,7 +51,7 @@
                 <div class="modal-dialog" role="document">
                   <div class="modal-content">
                     <div class="modal-header">
-                      <button type="button" class="close" data-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>
+                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>  {# todo B5: css-close #}
                       <h4 class="modal-title">{% trans 'Remove Project Space Link' %}</h4>
                     </div>
                     <div class="modal-body">
@@ -67,8 +67,8 @@
                       </p>
                     </div>
                     <div class="modal-footer">
-                      <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
-                      <button type="button" class="btn btn-danger" data-bind="click: $root.deleteLink.bind($data)" data-dismiss="modal">{% trans 'Remove' %}</button>
+                      <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
+                      <button type="button" class="btn btn-outline-danger" data-bind="click: $root.deleteLink.bind($data)" data-bs-dismiss="modal">{% trans 'Remove' %}</button>
                     </div>
                   </div>
                 </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/manage_downstream_domains.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/manage_downstream_domains.html
@@ -6,16 +6,23 @@
     <h3>{% trans "Manage Downstream Project Spaces" %}</h3>
     <p>
       {% blocktrans trimmed %}
-        This project space is an upstream project space for the project spaces listed below.<br/>
-        <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about Linked Project Spaces.
+        This project space is an upstream project space for the project spaces
+        listed below.<br />
+        <a
+          href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces"
+          target="_blank"
+          >Learn more</a
+        >
+        about Linked Project Spaces.
       {% endblocktrans %}
     </p>
-    <button type="button"
-            class="btn btn-primary"
-            id="add-downstream-domain"
-            data-bs-toggle="modal"
-            data-bs-target="#new-downstream-domain-modal"
-            data-bind="click: addDownstreamProjectSpace"
+    <button
+      type="button"
+      class="btn btn-primary"
+      id="add-downstream-domain"
+      data-bs-toggle="modal"
+      data-bs-target="#new-downstream-domain-modal"
+      data-bind="click: addDownstreamProjectSpace"
     >
       <i class="fa fa-plus"></i> {% trans "Add Downstream Project Space" %}
     </button>
@@ -25,63 +32,111 @@
         <h3 class="card-title">{% trans 'Downstream Project Spaces' %}</h3>
       </div>
       <div class="card-body">
-        <search-box data-apply-bindings="false"
-                  params="value: query,
+        <search-box
+          data-apply-bindings="false"
+          params="value: query,
                           action: filter,
                           immediate: true,
-                          placeholder: '{% trans_html_attr "Search Downstream Project Spaces..." %}'"></search-box>
-        <table class="table table-striped table-hover" id="linked-domains-table">
+                          placeholder: '{% trans_html_attr "Search Downstream Project Spaces..." %}'"
+        ></search-box>
+        <table
+          class="table table-striped table-hover"
+          id="linked-domains-table"
+        >
           <thead>
-          <tr>
-            <th>{% trans "Project Space Name" %}</th>
-            <th>{% trans "Last Updated" %} ({{ timezone }})</th>
-            <th></th>
-          </tr>
+            <tr>
+              <th>{% trans "Project Space Name" %}</th>
+              <th>{% trans "Last Updated" %} ({{ timezone }})</th>
+              <th></th>
+            </tr>
           </thead>
           <tbody data-bind="foreach: paginatedDomainLinks">
-          <tr>
-            <td><a data-bind="attr: {'href': downstreamUrl}, text: downstreamDomain"></a></td>
-            <td data-bind="text: lastUpdate"></td>
-            <td>
-              <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bind="attr: {'data-bs-target': '#remove-link-modal-' + $index()}">
-                <i class="fa-regular fa-trash-can"></i>
-                {% trans 'Remove Link' %}
-              </button>
-              <div class="modal fade" tabindex="-1" role="dialog" data-bind="attr: {'id': 'remove-link-modal-' + $index()}">
-                <div class="modal-dialog" role="document">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <h4 class="modal-title">{% trans 'Remove Project Space Link' %}</h4>
-                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'></button>
-                    </div>
-                    <div class="modal-body">
-                      <h4>
-                        {% blocktrans trimmed %}
-                          Are you sure you want to remove the downstream link to <b data-bind="text: downstreamDomain"></b>?
-                        {% endblocktrans %}
-                      </h4>
-                      <p>
-                        {% blocktrans trimmed %}
-                          <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about what happens when downstream project space links are removed.
-                        {% endblocktrans %}
-                      </p>
-                    </div>
-                    <div class="modal-footer">
-                      <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
-                      <button type="button" class="btn btn-outline-danger" data-bind="click: $root.deleteLink.bind($data)" data-bs-dismiss="modal">{% trans 'Remove' %}</button>
+            <tr>
+              <td>
+                <a
+                  data-bind="attr: {'href': downstreamUrl}, text: downstreamDomain"
+                ></a>
+              </td>
+              <td data-bind="text: lastUpdate"></td>
+              <td>
+                <button
+                  type="button"
+                  class="btn btn-outline-danger"
+                  data-bs-toggle="modal"
+                  data-bind="attr: {'data-bs-target': '#remove-link-modal-' + $index()}"
+                >
+                  <i class="fa-regular fa-trash-can"></i>
+                  {% trans 'Remove Link' %}
+                </button>
+                <div
+                  class="modal fade"
+                  tabindex="-1"
+                  role="dialog"
+                  data-bind="attr: {'id': 'remove-link-modal-' + $index()}"
+                >
+                  <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <h4 class="modal-title">
+                          {% trans 'Remove Project Space Link' %}
+                        </h4>
+                        <button
+                          type="button"
+                          class="btn-close"
+                          data-bs-dismiss="modal"
+                          aria-label="{% trans_html_attr "Close" %}"
+                        ></button>
+                      </div>
+                      <div class="modal-body">
+                        <h4>
+                          {% blocktrans trimmed %}
+                            Are you sure you want to remove the downstream link
+                            to <b data-bind="text: downstreamDomain"></b>?
+                          {% endblocktrans %}
+                        </h4>
+                        <p>
+                          {% blocktrans trimmed %}
+                            <a
+                              href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces"
+                              target="_blank"
+                              >Learn more</a
+                            >
+                            about what happens when downstream project space
+                            links are removed.
+                          {% endblocktrans %}
+                        </p>
+                      </div>
+                      <div class="modal-footer">
+                        <button
+                          type="button"
+                          class="btn btn-outline-primary"
+                          data-bs-dismiss="modal"
+                        >
+                          {% trans 'Cancel' %}
+                        </button>
+                        <button
+                          type="button"
+                          class="btn btn-outline-danger"
+                          data-bind="click: $root.deleteLink.bind($data)"
+                          data-bs-dismiss="modal"
+                        >
+                          {% trans 'Remove' %}
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </td>
-          </tr>
+              </td>
+            </tr>
           </tbody>
         </table>
-        <pagination data-apply-bindings="false"
+        <pagination
+          data-apply-bindings="false"
           params="goToPage: goToPage,
                   perPage: itemsPerPage,
                   totalItems: totalItems,
-                  onLoad: onPaginationLoad"></pagination>
+                  onLoad: onPaginationLoad"
+        ></pagination>
       </div>
     </div>
   </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/pull_content.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/pull_content.html
@@ -11,7 +11,7 @@
       {% endblocktrans %}
     </p>
 
-    <div class="card ">  {# todo B5: css-panel #}
+    <div class="card">
       <div class="card-header">
         <h3 class="card-title">{% trans 'Linked Content' %}</h3>
       </div>
@@ -33,7 +33,7 @@
           <tr>
             <td data-bind="text: name"></td>
             <td data-bind="text: lastUpdate"></td>
-            <td data-bind="css: {'has-error': error}">  {# todo B5: css-has-error #}
+            <td>
               <button class="btn btn-outline-danger" data-bind="visible: showUpdate() && !update_url, click: update">
                 <i class="fa fa-refresh"></i> {% trans "Sync" %}
               </button>
@@ -44,8 +44,8 @@
                 <div class="modal-dialog" role="document">
                   <div class="modal-content">
                     <div class="modal-header">
-                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>  {# todo B5: css-close #}
                       <h4 class="modal-title">{% trans 'Sync & Overwrite Matches?' %}</h4>
+                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'></button>
                     </div>
                     <div class="modal-body">
                       <p>
@@ -70,7 +70,7 @@
               <button class="btn btn-outline-danger" data-bind="visible: error, click: resetStatus">
                 <i class="fa fa-times"></i> {% trans "Error" %}
               </button>
-              <span class="help-block" data-bind="visible: error, text: error"></span>
+              <span class="text-danger" data-bind="visible: error, text: error"></span>
               <a data-bind="visible: showUpdate && update_url, attr: {href: update_url}">{% trans "Go to update page" %}</a>
             </td>
           </tr>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/pull_content.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/pull_content.html
@@ -11,11 +11,11 @@
       {% endblocktrans %}
     </p>
 
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">{% trans 'Linked Content' %}</h3>
+    <div class="card ">  {# todo B5: css-panel #}
+      <div class="card-header">
+        <h3 class="card-title">{% trans 'Linked Content' %}</h3>
       </div>
-      <div class="panel-body">
+      <div class="card-body">
         <search-box data-apply-bindings="false"
           params="value: query,
                   action: filter,
@@ -24,27 +24,27 @@
         <table class="table table-striped table-hover">
           <thead>
           <tr>
-            <th class="col-sm-5">{% trans "Linked Content" %}</th>
-            <th class="col-sm-2">{% trans "Last Updated" %} ({{ timezone }})</th>
-            <th class="col-sm-5"></th>
+            <th class="col-md-5">{% trans "Linked Content" %}</th>
+            <th class="col-md-2">{% trans "Last Updated" %} ({{ timezone }})</th>
+            <th class="col-md-5"></th>
           </tr>
           </thead>
           <tbody data-bind="foreach: paginatedLinkedDataViewModels">
           <tr>
             <td data-bind="text: name"></td>
             <td data-bind="text: lastUpdate"></td>
-            <td data-bind="css: {'has-error': error}">
-              <button class="btn btn-danger" data-bind="visible: showUpdate() && !update_url, click: update">
+            <td data-bind="css: {'has-error': error}">  {# todo B5: css-has-error #}
+              <button class="btn btn-outline-danger" data-bind="visible: showUpdate() && !update_url, click: update">
                 <i class="fa fa-refresh"></i> {% trans "Sync" %}
               </button>
-              <button class="btn btn-danger" data-toggle="modal" data-bind="visible: showUpdate() && !update_url, attr: {'data-target': '#overwrite-content-modal-' + $index()}">
+              <button class="btn btn-outline-danger" data-bs-toggle="modal" data-bind="visible: showUpdate() && !update_url, attr: {'data-bs-target': '#overwrite-content-modal-' + $index()}">
                 <i class="fa fa-refresh"></i> {% trans "Sync & Overwrite Matches" %}
               </button>
               <div class="modal fade" tabindex="-1" role="dialog" data-bind="attr: {'id': 'overwrite-content-modal-' + $index()}">
                 <div class="modal-dialog" role="document">
                   <div class="modal-content">
                     <div class="modal-header">
-                      <button type="button" class="close" data-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>
+                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>  {# todo B5: css-close #}
                       <h4 class="modal-title">{% trans 'Sync & Overwrite Matches?' %}</h4>
                     </div>
                     <div class="modal-body">
@@ -55,19 +55,19 @@
                       </p>
                     </div>
                     <div class="modal-footer">
-                      <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
-                      <button type="button" class="btn btn-primary" data-bind="click: forceUpdate" data-dismiss="modal">{% trans 'Sync & Overwrite' %}</button>
+                      <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
+                      <button type="button" class="btn btn-primary" data-bind="click: forceUpdate" data-bs-dismiss="modal">{% trans 'Sync & Overwrite' %}</button>
                     </div>
                   </div>
                 </div>
               </div>
-              <button class="btn btn-default disabled" data-bind="visible: showSpinner">
+              <button class="btn btn-outline-primary disabled" data-bind="visible: showSpinner">
                 <i class="fa fa-spinner"></i>
               </button>
               <button class="btn btn-success" data-bind="visible: hasSuccess, click: resetStatus">
                 <i class="fa fa-check"></i> {% trans "Success" %}
               </button>
-              <button class="btn btn-danger" data-bind="visible: error, click: resetStatus">
+              <button class="btn btn-outline-danger" data-bind="visible: error, click: resetStatus">
                 <i class="fa fa-times"></i> {% trans "Error" %}
               </button>
               <span class="help-block" data-bind="visible: error, text: error"></span>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/pull_content.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/pull_content.html
@@ -5,9 +5,19 @@
   <div data-bind="if: domainLink">
     <p>
       {% blocktrans trimmed %}
-        This project space is linked to the upstream project space <a data-bind="attr: {'href': domainLink.upstreamUrl}, text: domainLink.upstreamDomain"></a>.<br/>
-        The content below can be synced with the existing content in the upstream project space.<br/>
-        <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pulling content with Linked Project Spaces.
+        This project space is linked to the upstream project space
+        <a
+          data-bind="attr: {'href': domainLink.upstreamUrl}, text: domainLink.upstreamDomain"
+        ></a
+        >.<br />
+        The content below can be synced with the existing content in the
+        upstream project space.<br />
+        <a
+          href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces"
+          target="_blank"
+          >Learn more</a
+        >
+        about pulling content with Linked Project Spaces.
       {% endblocktrans %}
     </p>
 
@@ -16,71 +26,134 @@
         <h3 class="card-title">{% trans 'Linked Content' %}</h3>
       </div>
       <div class="card-body">
-        <search-box data-apply-bindings="false"
+        <search-box
+          data-apply-bindings="false"
           params="value: query,
                   action: filter,
                   immediate: true,
-                  placeholder: '{% trans_html_attr "Search Content..." %}'"></search-box>
+                  placeholder: '{% trans_html_attr "Search Content..." %}'"
+        ></search-box>
         <table class="table table-striped table-hover">
           <thead>
-          <tr>
-            <th class="col-md-5">{% trans "Linked Content" %}</th>
-            <th class="col-md-2">{% trans "Last Updated" %} ({{ timezone }})</th>
-            <th class="col-md-5"></th>
-          </tr>
+            <tr>
+              <th class="col-md-5">{% trans "Linked Content" %}</th>
+              <th class="col-md-2">
+                {% trans "Last Updated" %} ({{ timezone }})
+              </th>
+              <th class="col-md-5"></th>
+            </tr>
           </thead>
           <tbody data-bind="foreach: paginatedLinkedDataViewModels">
-          <tr>
-            <td data-bind="text: name"></td>
-            <td data-bind="text: lastUpdate"></td>
-            <td>
-              <button class="btn btn-outline-danger" data-bind="visible: showUpdate() && !update_url, click: update">
-                <i class="fa fa-refresh"></i> {% trans "Sync" %}
-              </button>
-              <button class="btn btn-outline-danger" data-bs-toggle="modal" data-bind="visible: showUpdate() && !update_url, attr: {'data-bs-target': '#overwrite-content-modal-' + $index()}">
-                <i class="fa fa-refresh"></i> {% trans "Sync & Overwrite Matches" %}
-              </button>
-              <div class="modal fade" tabindex="-1" role="dialog" data-bind="attr: {'id': 'overwrite-content-modal-' + $index()}">
-                <div class="modal-dialog" role="document">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <h4 class="modal-title">{% trans 'Sync & Overwrite Matches?' %}</h4>
-                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'></button>
-                    </div>
-                    <div class="modal-body">
-                      <p>
-                        {% blocktrans trimmed %}
-                        If this project space has unlinked configurations that match with the configurations being synced from the upstream project space, continuing will overwrite them and establish them as linked configurations. <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn More</a>
-                        {% endblocktrans %}
-                      </p>
-                    </div>
-                    <div class="modal-footer">
-                      <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
-                      <button type="button" class="btn btn-primary" data-bind="click: forceUpdate" data-bs-dismiss="modal">{% trans 'Sync & Overwrite' %}</button>
+            <tr>
+              <td data-bind="text: name"></td>
+              <td data-bind="text: lastUpdate"></td>
+              <td>
+                <button
+                  class="btn btn-outline-danger"
+                  data-bind="visible: showUpdate() && !update_url, click: update"
+                >
+                  <i class="fa fa-refresh"></i> {% trans "Sync" %}
+                </button>
+                <button
+                  class="btn btn-outline-danger"
+                  data-bs-toggle="modal"
+                  data-bind="visible: showUpdate() && !update_url, attr: {'data-bs-target': '#overwrite-content-modal-' + $index()}"
+                >
+                  <i class="fa fa-refresh"></i>
+                  {% trans "Sync & Overwrite Matches" %}
+                </button>
+                <div
+                  class="modal fade"
+                  tabindex="-1"
+                  role="dialog"
+                  data-bind="attr: {'id': 'overwrite-content-modal-' + $index()}"
+                >
+                  <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <h4 class="modal-title">
+                          {% trans 'Sync & Overwrite Matches?' %}
+                        </h4>
+                        <button
+                          type="button"
+                          class="btn-close"
+                          data-bs-dismiss="modal"
+                          aria-label="{% trans_html_attr "Close" %}"
+                        ></button>
+                      </div>
+                      <div class="modal-body">
+                        <p>
+                          {% blocktrans trimmed %}
+                            If this project space has unlinked configurations
+                            that match with the configurations being synced from
+                            the upstream project space, continuing will
+                            overwrite them and establish them as linked
+                            configurations.
+                            <a
+                              href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces"
+                              target="_blank"
+                              >Learn More</a
+                            >
+                          {% endblocktrans %}
+                        </p>
+                      </div>
+                      <div class="modal-footer">
+                        <button
+                          type="button"
+                          class="btn btn-outline-primary"
+                          data-bs-dismiss="modal"
+                        >
+                          {% trans 'Cancel' %}
+                        </button>
+                        <button
+                          type="button"
+                          class="btn btn-primary"
+                          data-bind="click: forceUpdate"
+                          data-bs-dismiss="modal"
+                        >
+                          {% trans 'Sync & Overwrite' %}
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <button class="btn btn-outline-primary disabled" data-bind="visible: showSpinner">
-                <i class="fa fa-spinner"></i>
-              </button>
-              <button class="btn btn-success" data-bind="visible: hasSuccess, click: resetStatus">
-                <i class="fa fa-check"></i> {% trans "Success" %}
-              </button>
-              <button class="btn btn-outline-danger" data-bind="visible: error, click: resetStatus">
-                <i class="fa fa-times"></i> {% trans "Error" %}
-              </button>
-              <span class="text-danger" data-bind="visible: error, text: error"></span>
-              <a data-bind="visible: showUpdate && update_url, attr: {href: update_url}">{% trans "Go to update page" %}</a>
-            </td>
-          </tr>
+                <button
+                  class="btn btn-outline-primary disabled"
+                  data-bind="visible: showSpinner"
+                >
+                  <i class="fa fa-spinner"></i>
+                </button>
+                <button
+                  class="btn btn-success"
+                  data-bind="visible: hasSuccess, click: resetStatus"
+                >
+                  <i class="fa fa-check"></i> {% trans "Success" %}
+                </button>
+                <button
+                  class="btn btn-outline-danger"
+                  data-bind="visible: error, click: resetStatus"
+                >
+                  <i class="fa fa-times"></i> {% trans "Error" %}
+                </button>
+                <span
+                  class="text-danger"
+                  data-bind="visible: error, text: error"
+                ></span>
+                <a
+                  data-bind="visible: showUpdate && update_url, attr: {href: update_url}"
+                  >{% trans "Go to update page" %}</a
+                >
+              </td>
+            </tr>
           </tbody>
         </table>
-        <pagination data-apply-bindings="false"
+        <pagination
+          data-apply-bindings="false"
           params="goToPage: goToPage,
                   perPage: itemsPerPage,
                   totalItems: totalItems,
-                  onLoad: onPaginationLoad"></pagination>
+                  onLoad: onPaginationLoad"
+        ></pagination>
       </div>
     </div>
   </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
@@ -6,8 +6,14 @@
     <h3>{% trans "Push Content" %}</h3>
     <p>
       {% blocktrans %}
-        Select which content you would like to push to the specified downstream project spaces.<br/>
-        <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pushing content with Linked Project Spaces.
+        Select which content you would like to push to the specified downstream
+        project spaces.<br />
+        <a
+          href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces"
+          target="_blank"
+          >Learn more</a
+        >
+        about pushing content with Linked Project Spaces.
       {% endblocktrans %}
     </p>
     <div class="spacer"></div>
@@ -17,18 +23,26 @@
           {% trans "Content" %}
         </label>
         <div class="field-control">
-          <select multiple class="form-select" id="model-multiselect"
-                  data-bind="selectedOptions: modelsToPush,
+          <select
+            multiple
+            class="form-select"
+            id="model-multiselect"
+            data-bind="selectedOptions: modelsToPush,
                              multiselect: {
                                  properties: {
                                     selectableHeaderTitle: '{% trans_html_attr "All content" %}',
                                     selectedHeaderTitle: '{% trans_html_attr "Content to push" %}',
                                     searchItemTitle: '{% trans_html_attr "Search content" %}',
                                  }
-                            }">
+                            }"
+          >
             {% for model in view_data.view_models_to_push %}
-              <option value="{% html_attr model %}" {% if not model.is_linkable %} disabled {% endif %}>
-                {{ model.name }} {% if not model.is_linkable %}({% trans 'unlinkable'%}){% endif %}
+              <option
+                value="{% html_attr model %}"
+                {% if not model.is_linkable %}disabled{% endif %}
+              >
+                {{ model.name }}
+                {% if not model.is_linkable %}({% trans 'unlinkable' %}){% endif %}
               </option>
             {% endfor %}
           </select>
@@ -39,20 +53,35 @@
           {% trans "Project Spaces" %}
         </label>
         <div class="field-control">
-          <select multiple class="form-select" id="domain-multiselect"
-                  data-bind="selectedOptions: domainsToPush, multiselect: domainMultiselect">
-          </select>
+          <select
+            multiple
+            class="form-select"
+            id="domain-multiselect"
+            data-bind="selectedOptions: domainsToPush, multiselect: domainMultiselect"
+          ></select>
           <div class="spacer"></div>
           <p data-bind="visible: shouldShowSelectedMRMDomain">
             <i class="fa fa-info-circle" aria-hidden="true"></i>
             {% blocktrans %}
-              The selected project can only be pushed individually. See <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Linked Project Spaces</a> documentation for more information.
+              The selected project can only be pushed individually. See
+              <a
+                href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces"
+                target="_blank"
+                >Linked Project Spaces</a
+              >
+              documentation for more information.
             {% endblocktrans %}
           </p>
           <p data-bind="visible: shouldShowSelectedERMDomain">
             <i class="fa fa-info-circle" aria-hidden="true"></i>
             {% blocktrans %}
-              Disabled project spaces can only be pushed individually. See <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Linked Project Spaces</a> documentation for more information.
+              Disabled project spaces can only be pushed individually. See
+              <a
+                href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces"
+                target="_blank"
+                >Linked Project Spaces</a
+              >
+              documentation for more information.
             {% endblocktrans %}
           </p>
         </div>
@@ -63,7 +92,12 @@
         </label>
         <div class="field-control">
           <div class="form-check">
-            <input class="form-check-input" type="checkbox" id="build-apps" data-bind="checked: buildAppsOnPush" />
+            <input
+              class="form-check-input"
+              type="checkbox"
+              id="build-apps"
+              data-bind="checked: buildAppsOnPush"
+            />
             <label class="form-check-label" for="build-apps">
               {% trans "Create and release new build for apps" %}
             </label>
@@ -71,13 +105,32 @@
         </div>
       </div>
       <div class="form-actions">
-        <div class="offset-md-3 offset-lg-2 controls col-md-9 col-lg-8 col-xl-6">
-          <button type="button" class="btn btn-primary" data-bind="click: pushContent, enable: enablePushButton">
-            <i class="fa fa-refresh fa-spin icon-refresh icon-spin" data-bind="visible: pushType() === PUSH_TYPE_NORMAL"></i>
+        <div
+          class="offset-md-3 offset-lg-2 controls col-md-9 col-lg-8 col-xl-6"
+        >
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-bind="click: pushContent, enable: enablePushButton"
+          >
+            <i
+              class="fa fa-refresh fa-spin icon-refresh icon-spin"
+              data-bind="visible: pushType() === PUSH_TYPE_NORMAL"
+            ></i>
             {% trans "Push Content" %}
           </button>
-          <button type="button" class="btn btn-outline-primary" id="overwrite-btn" data-bs-toggle="modal" data-bs-target="#push-warning-dialog" data-bind="enable: enablePushButton">
-            <i class="fa fa-refresh fa-spin icon-refresh icon-spin" data-bind="visible: pushType() === PUSH_TYPE_OVERWRITE"></i>
+          <button
+            type="button"
+            class="btn btn-outline-primary"
+            id="overwrite-btn"
+            data-bs-toggle="modal"
+            data-bs-target="#push-warning-dialog"
+            data-bind="enable: enablePushButton"
+          >
+            <i
+              class="fa fa-refresh fa-spin icon-refresh icon-spin"
+              data-bind="visible: pushType() === PUSH_TYPE_OVERWRITE"
+            ></i>
             {% trans "Push & Overwrite Matches" %}
           </button>
         </div>
@@ -87,8 +140,13 @@
   <div data-bind="if: !canPush()">
     <p>
       {% blocktrans %}
-        You have no linked project spaces that allow you to push data.<br/>
-        <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn more</a> about pushing content with Linked Project Spaces.
+        You have no linked project spaces that allow you to push data.<br />
+        <a
+          href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces"
+          target="_blank"
+          >Learn more</a
+        >
+        about pushing content with Linked Project Spaces.
       {% endblocktrans %}
     </p>
   </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
@@ -12,11 +12,11 @@
     </p>
     <div class="spacer"></div>
     <form class="form-horizontal">
-      <div class="form-group">  {# todo B5: css-form-group #}
-        <label class="col-md-3 col-lg-2 form-label">
+      <div class="row mb-3">
+        <label class="col-form-label field-label">
           {% trans "Content" %}
         </label>
-        <div class="col-md-9 col-lg-10 controls">
+        <div class="field-control">
           <select multiple class="form-select" id="model-multiselect"
                   data-bind="selectedOptions: modelsToPush,
                              multiselect: {
@@ -34,11 +34,11 @@
           </select>
         </div>
       </div>
-      <div class="form-group">  {# todo B5: css-form-group #}
-        <label class="col-md-3 col-lg-2 form-label">
+      <div class="row mb-3">
+        <label class="col-form-label field-label">
           {% trans "Project Spaces" %}
         </label>
-        <div class="col-md-9 col-lg-10 controls">
+        <div class="field-control">
           <select multiple class="form-select" id="domain-multiselect"
                   data-bind="selectedOptions: domainsToPush, multiselect: domainMultiselect">
           </select>
@@ -57,15 +57,17 @@
           </p>
         </div>
       </div>
-      <div class="form-group">  {# todo B5: css-form-group #}
-        <label class="col-md-3 col-lg-2 form-label" for="build-apps">
+      <div class="row mb-3">
+        <label class="col-form-label field-label" for="build-apps">
           {% trans "Rebuild Applications" %}
         </label>
-        <div class="col-md-9 col-lg-10 controls">
-          <label class="checkbox">  {# todo B5: css-checkbox #}
-            <input type="checkbox" data-bind="checked: buildAppsOnPush" />  {# todo B5: css-checkbox #}
-            {% trans "Create and release new build for apps" %}
-          </label>
+        <div class="field-control">
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="build-apps" data-bind="checked: buildAppsOnPush" />
+            <label class="form-check-label" for="build-apps">
+              {% trans "Create and release new build for apps" %}
+            </label>
+          </div>
         </div>
       </div>
       <div class="form-actions">

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/push_content.html
@@ -12,12 +12,12 @@
     </p>
     <div class="spacer"></div>
     <form class="form-horizontal">
-      <div class="form-group">
-        <label class="col-sm-3 col-md-2 control-label">
+      <div class="form-group">  {# todo B5: css-form-group #}
+        <label class="col-md-3 col-lg-2 form-label">
           {% trans "Content" %}
         </label>
-        <div class="col-sm-9 col-md-10 controls">
-          <select multiple class="form-control" id="model-multiselect"
+        <div class="col-md-9 col-lg-10 controls">
+          <select multiple class="form-select" id="model-multiselect"
                   data-bind="selectedOptions: modelsToPush,
                              multiselect: {
                                  properties: {
@@ -34,12 +34,12 @@
           </select>
         </div>
       </div>
-      <div class="form-group">
-        <label class="col-sm-3 col-md-2 control-label">
+      <div class="form-group">  {# todo B5: css-form-group #}
+        <label class="col-md-3 col-lg-2 form-label">
           {% trans "Project Spaces" %}
         </label>
-        <div class="col-sm-9 col-md-10 controls">
-          <select multiple class="form-control" id="domain-multiselect"
+        <div class="col-md-9 col-lg-10 controls">
+          <select multiple class="form-select" id="domain-multiselect"
                   data-bind="selectedOptions: domainsToPush, multiselect: domainMultiselect">
           </select>
           <div class="spacer"></div>
@@ -57,24 +57,24 @@
           </p>
         </div>
       </div>
-      <div class="form-group">
-        <label class="col-sm-3 col-md-2 control-label" for="build-apps">
+      <div class="form-group">  {# todo B5: css-form-group #}
+        <label class="col-md-3 col-lg-2 form-label" for="build-apps">
           {% trans "Rebuild Applications" %}
         </label>
-        <div class="col-sm-9 col-md-10 controls">
-          <label class="checkbox">
-            <input type="checkbox" data-bind="checked: buildAppsOnPush" />
+        <div class="col-md-9 col-lg-10 controls">
+          <label class="checkbox">  {# todo B5: css-checkbox #}
+            <input type="checkbox" data-bind="checked: buildAppsOnPush" />  {# todo B5: css-checkbox #}
             {% trans "Create and release new build for apps" %}
           </label>
         </div>
       </div>
       <div class="form-actions">
-        <div class="col-sm-offset-3 col-md-offset-2 controls col-sm-9 col-md-8 col-lg-6">
+        <div class="offset-md-3 offset-lg-2 controls col-md-9 col-lg-8 col-xl-6">
           <button type="button" class="btn btn-primary" data-bind="click: pushContent, enable: enablePushButton">
             <i class="fa fa-refresh fa-spin icon-refresh icon-spin" data-bind="visible: pushType() === PUSH_TYPE_NORMAL"></i>
             {% trans "Push Content" %}
           </button>
-          <button type="button" class="btn btn-default" id="overwrite-btn" data-toggle="modal" data-target="#push-warning-dialog" data-bind="enable: enablePushButton">
+          <button type="button" class="btn btn-outline-primary" id="overwrite-btn" data-bs-toggle="modal" data-bs-target="#push-warning-dialog" data-bind="enable: enablePushButton">
             <i class="fa fa-refresh fa-spin icon-refresh icon-spin" data-bind="visible: pushType() === PUSH_TYPE_OVERWRITE"></i>
             {% trans "Push & Overwrite Matches" %}
           </button>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/push_warning_dialog.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/push_warning_dialog.html
@@ -2,23 +2,49 @@
 {% load i18n %}
 
 <div class="modal fade" id="push-warning-dialog" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title">{% trans 'Push & Overwrite Matches?' %}</h4>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'></button>
-            </div>
-            <div class="modal-body">
-                <p>
-                {% blocktrans trimmed %}
-                If any of the selected downstream project spaces have unlinked configurations that match with the configurations being pushed, continuing will overwrite them and establish them as linked configurations. <a href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces" target="_blank">Learn More</a>
-                {% endblocktrans %}
-                </p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
-                <button type="button" class="btn btn-primary" data-bind="click: pushAndOverwrite" data-bs-dismiss="modal">{% trans 'Push & Overwrite Matches' %}</button>
-            </div>
-        </div>
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">{% trans 'Push & Overwrite Matches?' %}</h4>
+        <button
+          type="button"
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="{% trans_html_attr "Close" %}"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <p>
+          {% blocktrans trimmed %}
+            If any of the selected downstream project spaces have unlinked
+            configurations that match with the configurations being pushed,
+            continuing will overwrite them and establish them as linked
+            configurations.
+            <a
+              href="https://confluence.dimagi.com/display/commcarepublic/Linked+Project+Spaces"
+              target="_blank"
+              >Learn More</a
+            >
+          {% endblocktrans %}
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button
+          type="button"
+          class="btn btn-outline-primary"
+          data-bs-dismiss="modal"
+        >
+          {% trans 'Cancel' %}
+        </button>
+        <button
+          type="button"
+          class="btn btn-primary"
+          data-bind="click: pushAndOverwrite"
+          data-bs-dismiss="modal"
+        >
+          {% trans 'Push & Overwrite Matches' %}
+        </button>
+      </div>
     </div>
+  </div>
 </div>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/push_warning_dialog.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/push_warning_dialog.html
@@ -5,8 +5,8 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>  {# todo B5: css-close #}
                 <h4 class="modal-title">{% trans 'Push & Overwrite Matches?' %}</h4>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'></button>
             </div>
             <div class="modal-body">
                 <p>

--- a/corehq/apps/linked_domain/templates/linked_domain/partials/push_warning_dialog.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/partials/push_warning_dialog.html
@@ -5,7 +5,7 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label='{% trans_html_attr "Close" %}'><span aria-hidden="true">&times;</span></button>  {# todo B5: css-close #}
                 <h4 class="modal-title">{% trans 'Push & Overwrite Matches?' %}</h4>
             </div>
             <div class="modal-body">
@@ -16,8 +16,8 @@
                 </p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
-                <button type="button" class="btn btn-primary" data-bind="click: pushAndOverwrite" data-dismiss="modal">{% trans 'Push & Overwrite Matches' %}</button>
+                <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
+                <button type="button" class="btn btn-primary" data-bind="click: pushAndOverwrite" data-bs-dismiss="modal">{% trans 'Push & Overwrite Matches' %}</button>
             </div>
         </div>
     </div>

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -30,6 +30,7 @@ from corehq.apps.domain.exceptions import DomainDoesNotExist
 from corehq.apps.domain.views.base import DomainViewMixin
 from corehq.apps.domain.views.settings import BaseProjectSettingsView
 from corehq.apps.fixtures.models import LookupTable
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import pretty_doc_info
 from corehq.apps.linked_domain.const import (
@@ -244,6 +245,7 @@ def pull_missing_multimedia(request, domain, app_id):
 
 
 @method_decorator(require_access_to_linked_domains, name='dispatch')
+@method_decorator(use_bootstrap5, name='dispatch')
 class DomainLinkView(BaseProjectSettingsView):
     urlname = 'domain_links'
     page_title = gettext_lazy("Linked Project Spaces")
@@ -341,6 +343,7 @@ class DomainLinkView(BaseProjectSettingsView):
 
 
 @method_decorator(require_access_to_linked_domains, name='dispatch')
+@method_decorator(use_bootstrap5, name='dispatch')
 class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
     urlname = "domain_link_rmi"
 
@@ -544,7 +547,8 @@ def validate_pull(user, domain_link):
 
 class DomainLinkHistoryReport(GenericTabularReport):
     name = 'Linked Project Space History'
-    base_template = "reports/bootstrap3/base_template.html"
+    base_template = "reports/bootstrap5/base_template.html"
+    use_bootstrap5 = True
     section_name = 'Project Settings'
     slug = 'project_link_report'
     dispatcher = ReleaseManagementReportDispatcher


### PR DESCRIPTION
## Product Description
Migrates the `linked_domain` app from Bootstrap 3 to Bootstrap 5. No user-facing behavior changes intended — this is a visual framework upgrade for functional parity.

| Before | After |
|--------|-------|
| <img width="2044" height="1122" alt="Screenshot 2026-03-03 at 12 54 19 PM" src="https://github.com/user-attachments/assets/6d8cd2fe-cb39-4e55-ab84-d2f7341e36e8" /> | <img width="2030" height="1129" alt="Screenshot 2026-03-03 at 12 56 31 PM" src="https://github.com/user-attachments/assets/1107e0aa-19d3-4306-ac65-6d51be226f54" /> |
| <img width="2044" height="1130" alt="Screenshot 2026-03-03 at 12 54 08 PM" src="https://github.com/user-attachments/assets/1a796f9c-df34-4c48-981d-c8fa855f5096" /> | <img width="2029" height="1132" alt="Screenshot 2026-03-03 at 12 56 21 PM" src="https://github.com/user-attachments/assets/e8b6441b-fa68-475e-9206-93ebf0af0aa0" /> |
| <img width="2043" height="1130" alt="Screenshot 2026-03-03 at 12 54 00 PM" src="https://github.com/user-attachments/assets/c79273fc-0011-434f-921d-829bca2026b5" /> | <img width="2031" height="1130" alt="Screenshot 2026-03-03 at 12 56 09 PM" src="https://github.com/user-attachments/assets/a32cca93-7d10-4ec4-9c2e-8dc806be1315" /> |

## Technical Summary

Bootstrap upgrades already largely scripted, so I want to split out what the script did, what Claude did (following a [Skill](https://github.com/dimagi/commcare-hq/pull/37460) I asked it to write from our bootstrap migration documentation), and what I had it do after visually inspecting the page after its changes.

The first commits (which Claude ran, but the script commited, and which thus do NOT have Claude as a co-committer) are just the Standard Bootstrap 3→5 no-split migration using `migrate_app_to_bootstrap5 --no-split`. That script itself made those commits.

Claude then used our documentation, including the very rich case by case examples we provide for each of the types of "todos" that the script generates, to follow the prescribed steps.

Then it did the following after I visually inspected and I asked it to:
- Added `mt-3` spacing between nav tabs and tab content (B5 nav-tabs lack the built-in bottom margin B3 had)

## Feature Flag
N/A

## Safety Assurance

### Safety story
- Tested locally on the domain links settings page
- Changes are limited to CSS classes, data attributes, and template structure — no business logic changes
- The `linked_domain` app has a small frontend footprint (7 templates, 1 JS file)

### Automated test coverage
Bootstrap migration — no existing automated UI tests for this page.

### QA Plan
Manually verify on `/a/<domain>/settings/project/domain_links/`:
- Tabs render and switch correctly (upstream: "Downstream Project Spaces" + "Push Content"; downstream: "Manage Linked Project Space")
- Modals open/close: add downstream domain, remove link confirmation, overwrite warning
- Push content form: multiselects, checkbox, buttons
- Pull content: sync buttons, error/success states
- Report at `/a/<domain>/reports/release_management/project_link_report/`

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change