### PR TITLE
Bump Django to 5.2.12

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1000,16 +1000,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.11"
+version = "5.2.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/f2/3e57ef696b95067e05ae206171e47a8e53b9c84eec56198671ef9eaa51a6/django-5.2.11.tar.gz", hash = "sha256:7f2d292ad8b9ee35e405d965fbbad293758b858c34bbf7f3df551aeeac6f02d3", size = 10885017, upload-time = "2026-02-03T13:52:50.554Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/55/b9445fc0695b03746f355c05b2eecc54c34e05198c686f4fc4406b722b52/django-5.2.12.tar.gz", hash = "sha256:6b809af7165c73eff5ce1c87fdae75d4da6520d6667f86401ecf55b681eb1eeb", size = 10860574, upload-time = "2026-03-03T13:56:05.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/a7/2b112ab430575bf3135b8304ac372248500d99c352f777485f53fdb9537e/django-5.2.11-py3-none-any.whl", hash = "sha256:e7130df33ada9ab5e5e929bc19346a20fe383f5454acb2cc004508f242ee92c0", size = 8291375, upload-time = "2026-02-03T13:52:42.47Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/32/4b144e125678efccf5d5b61581de1c4088d6b0286e46096e3b8de0d556c8/django-5.2.12-py3-none-any.whl", hash = "sha256:4853482f395c3a151937f6991272540fcbf531464f254a347bf7c89f53c8cff7", size = 8310245, upload-time = "2026-03-03T13:56:01.174Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Product Description

## Technical Summary
Jira: [SAAS-19432](https://dimagi.atlassian.net/browse/SAAS-19432)

[Release notes for 5.2.12](https://docs.djangoproject.com/en/6.0/releases/5.2.12/)

We use form URLFields [here](https://github.com/dimagi/commcare-hq/blob/8f544e322ef5fa337883d9139f54bbe1f24139b8/corehq/apps/domain/forms.py#L2848-L2848) and [here](https://github.com/dimagi/commcare-hq/blob/8f544e322ef5fa337883d9139f54bbe1f24139b8/corehq/apps/notifications/forms.py#L22-L22), so the blast radius of any potential issues is very low. Django mentions to check if using custom validators, but from what I can tell neither of these instances use custom validators.
 
## Feature Flag
N/A

## Safety Assurance

### Safety story
Patch version upgrade within the 5.2.x series — no breaking changes expected.

### Automated test coverage
Existing test suite covers Django compatibility.

### QA Plan
Standard CI run.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[SAAS-19432]: https://dimagi.atlassian.net/browse/SAAS-19432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ