### PR TITLE
Continue datasource deletion if table no longer exists

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -24,6 +24,7 @@ from django.views.generic import View
 from couchdbkit.exceptions import ResourceNotFound
 from memoized import memoized
 from no_exceptions.exceptions import HttpException
+from psycopg2.errors import UndefinedTable
 from sqlalchemy import exc, types
 from sqlalchemy.exc import ProgrammingError
 
@@ -1275,7 +1276,14 @@ def delete_data_source_shared(domain, config_id, request=None):
     adapter = get_indicator_adapter(config)
     username = request.user.username if request else None
     skip = not request  # skip logging when we remove temporary tables
-    adapter.drop_table(initiated_by=username, source='delete_data_source', skip_log=skip)
+    try:
+        adapter.drop_table(initiated_by=username, source='delete_data_source', skip_log=skip)
+    except ProgrammingError as e:
+        if isinstance(e.orig, UndefinedTable):
+            # Table doesn't exist anymore, just continue with deletion
+            pass
+        else:
+            raise
     soft_delete(config)
     if request:
         messages.success(


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Noticed this [sentry error](https://dimagi.sentry.io/issues/6842115944/?environment=eu&project=136860&query=delete_data_source&referrer=issue-stream) and just thought it was funny that this blocks the deletion.

To be fair, I have not done my due diligence here but from what I can tell this is a very safe change given the underlying table no longer exists, and we will only carry on with deletion of the data source if it is clear that the underlying table no longer exists.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is a deletion task, so in the worst case we delete something we shouldn't have, but this appears to only be called from the [temp data source code](https://github.com/dimagi/commcare-hq/blob/7d186c5ac83fbabc51cb3a707a21a2a3bc229eff/corehq/apps/userreports/reports/builder/forms.py#L1344-L1347) which isn't particularly important (my understanding is this is used for previews of reports).
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Not that I'm aware of.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
