### PR TITLE
Do not let superuser access all domains when using oauth

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -240,6 +240,7 @@ def _oauth2_check(scopes):
         valid, r = oauthlib_core.verify_request(request, scopes=scopes)
         if valid:
             request.user = r.user
+            request._auth_method_restricts_superuser_access = True
             return True
 
     def real_decorator(view):

--- a/corehq/apps/domain/tests/test_oauth_superuser_access.py
+++ b/corehq/apps/domain/tests/test_oauth_superuser_access.py
@@ -1,0 +1,58 @@
+from django.test import RequestFactory, SimpleTestCase
+from unittest.mock import patch, MagicMock
+
+from corehq.apps.domain.decorators import _oauth2_check
+from corehq.apps.users.models import WebUser
+from corehq.util.global_request.api import set_request
+
+
+def _make_superuser():
+    user = WebUser()
+    user.is_superuser = True
+    return user
+
+
+def _simulate_oauth_request():
+    """Simulate a request that was authenticated via OAuth,
+    returning the request object."""
+    request = RequestFactory().get('/')
+    mock_oauthlib_core = MagicMock()
+    mock_request_info = MagicMock()
+    mock_oauthlib_core.verify_request.return_value = (True, mock_request_info)
+
+    with patch('corehq.apps.domain.decorators.get_oauthlib_core', return_value=mock_oauthlib_core):
+        decorator = _oauth2_check(['access_apis'])
+        wrapped = decorator(lambda req, *a, **kw: None)
+        wrapped(request)
+
+    return request
+
+
+def _simulate_non_oauth_request():
+    return RequestFactory().get('/')
+
+
+class TestSuperuserIsGlobalAdminByAuthMethod(SimpleTestCase):
+    """Superusers should be global admins for session-based requests,
+    but NOT for OAuth-authenticated requests."""
+
+    def setUp(self):
+        self.addCleanup(set_request, None)
+
+    def test_superuser_is_global_admin_for_non_oauth_request(self):
+        set_request(_simulate_non_oauth_request())
+        self.assertTrue(_make_superuser().is_global_admin())
+
+    def test_superuser_is_not_global_admin_for_oauth_request(self):
+        set_request(_simulate_oauth_request())
+        self.assertFalse(_make_superuser().is_global_admin())
+
+    def test_non_superuser_is_not_global_admin_for_non_oauth_request(self):
+        set_request(_simulate_non_oauth_request())
+        user = WebUser()
+        user.is_superuser = False
+        self.assertFalse(user.is_global_admin())
+
+    def test_superuser_is_global_admin_when_no_request(self):
+        set_request(None)
+        self.assertTrue(_make_superuser().is_global_admin())

--- a/corehq/apps/domain/tests/test_oauth_superuser_access.py
+++ b/corehq/apps/domain/tests/test_oauth_superuser_access.py
@@ -1,14 +1,20 @@
-from django.test import RequestFactory, SimpleTestCase
-from unittest.mock import patch, MagicMock
+from django.test import RequestFactory
 
 from corehq.apps.domain.decorators import _oauth2_check
 from corehq.apps.users.models import WebUser
 from corehq.util.global_request.api import set_request
+from unittest.mock import MagicMock, patch
 
 
 def _make_superuser():
     user = WebUser()
     user.is_superuser = True
+    return user
+
+
+def _make_non_superuser():
+    user = WebUser()
+    user.is_superuser = False
     return user
 
 
@@ -32,27 +38,29 @@ def _simulate_non_oauth_request():
     return RequestFactory().get('/')
 
 
-class TestSuperuserIsGlobalAdminByAuthMethod(SimpleTestCase):
+class TestSuperuserIsGlobalAdminByAuthMethod:
     """Superusers should be global admins for session-based requests,
     but NOT for OAuth-authenticated requests."""
 
-    def setUp(self):
-        self.addCleanup(set_request, None)
+    def setup_method(self):
+        set_request(None)
 
     def test_superuser_is_global_admin_for_non_oauth_request(self):
         set_request(_simulate_non_oauth_request())
-        self.assertTrue(_make_superuser().is_global_admin())
+        assert _make_superuser().is_global_admin()
 
     def test_superuser_is_not_global_admin_for_oauth_request(self):
         set_request(_simulate_oauth_request())
-        self.assertFalse(_make_superuser().is_global_admin())
+        assert not _make_superuser().is_global_admin()
 
     def test_non_superuser_is_not_global_admin_for_non_oauth_request(self):
         set_request(_simulate_non_oauth_request())
-        user = WebUser()
-        user.is_superuser = False
-        self.assertFalse(user.is_global_admin())
+        assert not _make_non_superuser().is_global_admin()
+
+    def test_non_superuser_is_not_global_admin_for_oauth_request(self):
+        set_request(_simulate_oauth_request())
+        assert not _make_non_superuser().is_global_admin()
 
     def test_superuser_is_global_admin_when_no_request(self):
         set_request(None)
-        self.assertTrue(_make_superuser().is_global_admin())
+        assert _make_superuser().is_global_admin()

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -107,7 +107,7 @@ from corehq.toggles import TABLEAU_USER_SYNCING
 from corehq.util.dates import get_timestamp
 from corehq.util.models import BouncedEmail
 from corehq.util.quickcache import quickcache
-from corehq.util.view_utils import absolute_reverse
+from corehq.util.view_utils import absolute_reverse, get_request
 
 from .models_role import (  # noqa
     Permission,
@@ -2432,8 +2432,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
         )
 
     def is_global_admin(self):
-        # override this function to pass global admin rights off to django
-        return self.is_superuser
+        return self.is_superuser and not getattr(get_request(), '_auth_method_restricts_superuser_access', False)
 
     @classmethod
     def create(cls, domain, username, password, created_by, created_via, email=None, uuid='', date='',


### PR DESCRIPTION
## Product Description
No user-facing effects for non-superusers. This is a security hardening change. For superusers, when they use oauth, it will determine domain access _without_ taking into account their superuser status—i.e. they will only be able to use oauth to access apis on domains that they have explicit access to.

## Technical Summary
When a superuser authenticates via OAuth, they should not automatically get global admin access to all domains. This change sets a flag on the request during OAuth authentication (`_auth_method_restricts_superuser_access`) and checks it in `WebUser.is_global_admin()`, so that OAuth-authenticated superusers are treated as regular users with respect to domain access.

## Feature Flag
N/A

## Safety Assurance

### Safety story
This is a security tightening — it restricts access that was previously granted. The change is minimal (two lines of logic) and only affects the OAuth authentication path. Session-based and other auth methods are unaffected.

### Automated test coverage
Unit tests in `test_oauth_superuser_access.py` confirm that `is_global_admin()` returns `False` for a superuser when the request has gone through `_oauth2_check`, and `True` otherwise. The OAuth verification itself is mocked, so these tests only cover the flag-setting and flag-checking plumbing between the decorator and the model method—they do not verify that real OAuth tokens are validated correctly, nor do they test the downstream domain-access checks that rely on `is_global_admin()`.

### QA Plan
Manual testing: authenticate as a superuser via OAuth and confirm that API requests to domains the user is not a member of are rejected.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change