### PR TITLE
Validate save to case question when make build

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -1149,6 +1149,18 @@ class IndexedFormBaseValidator(FormBaseValidator):
 
         return errors
 
+    def check_save_to_case_references(self):
+        errors = []
+        save_references = self.form.case_references_data.get_save_references()
+        for save_ref in save_references:
+            if save_ref.create:
+                if 'case_type' not in save_ref.properties:
+                    errors.append({'type': 'save_to_case_missing_case_type', 'case_tag': save_ref.path})
+                if 'case_name' not in save_ref.properties:
+                    errors.append({'type': 'save_to_case_missing_case_name', 'case_tag': save_ref.path})
+
+        return errors
+
 
 class FormValidator(IndexedFormBaseValidator):
     def check_actions(self):
@@ -1164,6 +1176,7 @@ class FormValidator(IndexedFormBaseValidator):
         if self.form.requires == 'none' and self.form.actions.open_case.is_active() \
                 and not self.form.actions.open_case.has_name_update():
             errors.append({'type': 'case_name required'})
+        errors.extend(self.check_save_to_case_references())
 
         errors.extend(self.check_case_properties(
             all_names=self.form.actions.all_property_names(),
@@ -1315,6 +1328,8 @@ class AdvancedFormValidator(IndexedFormBaseValidator):
                 all_names=action.get_property_names(),
                 case_tag=action.case_tag
             ))
+
+        errors.extend(self.check_save_to_case_references())
 
         if self.form.form_filter:
             # Replace any dots with #case, which doesn't make for valid xpath

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap3/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap3/build_errors.html
@@ -455,17 +455,19 @@
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "save_to_case_missing_case_type" %}
+            {% blocktrans with case_tag=error.case_tag %}
             <strong>Save to Case question is missing a case type.</strong>
-            Please add the "case_type" property mapping for
-            "{{ error.case_tag }}"
+            Please add the "case_type" property mapping for "{{ case_tag }}"
+            {% endblocktrans %}
             {% if not not_actual_build %}
               in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "save_to_case_missing_case_name" %}
+            {% blocktrans with case_tag=error.case_tag %}
             <strong>Save to Case question is missing a case name.</strong>
-            Please add the "case_name" property mapping for
-            "{{ error.case_tag }}"
+            Please add the "case_name" property mapping for "{{ case_tag }}"
+            {% endblocktrans %}
             {% if not not_actual_build %}
               in
               {% include "app_manager/partials/form_error_message.html" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap3/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap3/build_errors.html
@@ -454,6 +454,22 @@
               in form
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
+            {% case "save_to_case_missing_case_type" %}
+            <strong>Save to Case question is missing a case type.</strong>
+            Please add the "case_type" property mapping for
+            "{{ error.case_tag }}"
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
+            {% case "save_to_case_missing_case_name" %}
+            <strong>Save to Case question is missing a case name.</strong>
+            Please add the "case_name" property mapping for
+            "{{ error.case_tag }}"
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "path error" %}
             {% if error.path %}
               The case management

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap3/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap3/build_errors.html
@@ -434,16 +434,14 @@
             Case Update uses reserved word "{{ error.word }}"
             {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "update_case word illegal" %}
             Case Update "{{ error.word }}" should start with a letter and only
             contain letters, numbers, '-', and '_'
             {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "case_name required" %}
             <strong>Every case must have a name.</strong> Please specify a value
@@ -451,33 +449,29 @@
             properties"
             {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "save_to_case_missing_case_type" %}
             {% blocktrans with case_tag=error.case_tag %}
-            <strong>Save to Case question is missing a case type.</strong>
-            Please add the "case_type" property mapping for "{{ case_tag }}"
+              <strong>Save to Case question is missing a case type.</strong>
+              Please add the "case_type" property mapping for "{{ case_tag }}"
             {% endblocktrans %}
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "save_to_case_missing_case_name" %}
             {% blocktrans with case_tag=error.case_tag %}
-            <strong>Save to Case question is missing a case name.</strong>
-            Please add the "case_name" property mapping for "{{ case_tag }}"
+              <strong>Save to Case question is missing a case name.</strong>
+              Please add the "case_name" property mapping for "{{ case_tag }}"
             {% endblocktrans %}
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "path error" %}
             {% if error.path %}
               The case management
               {% if "VISIT_SCHEDULER" in toggles %}or visit scheduler{% endif %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
               references a question that no longer exists: "{{ error.path }}".
               It is likely that this question has been renamed or deleted.
               Please update or delete this question reference before you make a
@@ -505,58 +499,50 @@
             A subcase is referencing a parent case tag that does not exist:
             "{{ error.case_tag }}"
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "missing relationship question" %}
             A subcase's index relationship with parent case tag
             "{{ error.case_tag }}" is determined by a question, but no question
             is specified.
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "subcase repeat context" %}
             The subcase "{{ error.case_tag }}" is in a different repeat context
             to its parent "{{ error.parent_tag }}"
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "auto select key" %}
             The auto-select case action is missing the "{{ error.key_name }}"
             value
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "auto select source" %}
             The auto-select case action is missing the "{{ error.source_name }}"
             value
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "auto select case ref" %}
             The case tag referenced in the auto-select expression of
             "{{ error.case_tag }}" was not found
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "no case type in action" %}
             The form action "{{ error.case_tag }}" does not have a case type
             selected
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "filtering without case" %}
             The form has filtering enabled but no cases are being loaded
             (excluding auto-loaded cases)
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}.
             {% case "invalid case xpath reference" %}
             {% if error.form %}
@@ -656,8 +642,11 @@
               <code>{{ column.header|trans:langs }}</code>.
             {% endblocktrans %}
             {% case "conflicting questions" %}
-              Multiple questions are attempting to save to case property "{{ error.property }}"
-              {% if not not_actual_build %}in {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            Multiple questions are attempting to save to case property
+            "{{ error.property }}"
+            {% if not not_actual_build %}
+              in {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "error" %}
               Details: {{ error.message }}
             {% else %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap3/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap3/build_errors.html
@@ -53,7 +53,7 @@
             {% include "app_manager/partials/form_error_message.html" %}
             {% case "validation error" %}
             {{ error.validation_message|linebreaksbr }}
-            in form {% include "app_manager/partials/form_error_message.html" %}
+            in {% include "app_manager/partials/form_error_message.html" %}
             {% case "no form links" %}
             {% blocktrans %}
               Link to other form or menu is selected, but no links have been
@@ -411,7 +411,7 @@
               <a href="{{ module_url }}">{{ module_name }}</a>
             {% endblocktrans %}
             {% case "subcase has no case type" %}
-            Child case specifies no case list in form
+            Child case specifies no case list in
             {% include "app_manager/partials/form_error_message.html" %}
             {% case "form error" %}
             {% blocktrans %}
@@ -434,7 +434,7 @@
             Case Update uses reserved word "{{ error.word }}"
             {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "update_case word illegal" %}
@@ -442,7 +442,7 @@
             contain letters, numbers, '-', and '_'
             {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "case_name required" %}
@@ -451,7 +451,7 @@
             properties"
             {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "save_to_case_missing_case_type" %}
@@ -459,7 +459,7 @@
             Please add the "case_type" property mapping for
             "{{ error.case_tag }}"
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "save_to_case_missing_case_name" %}
@@ -467,14 +467,14 @@
             Please add the "case_name" property mapping for
             "{{ error.case_tag }}"
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "path error" %}
             {% if error.path %}
               The case management
               {% if "VISIT_SCHEDULER" in toggles %}or visit scheduler{% endif %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
               references a question that no longer exists: "{{ error.path }}".
               It is likely that this question has been renamed or deleted.
@@ -503,7 +503,7 @@
             A subcase is referencing a parent case tag that does not exist:
             "{{ error.case_tag }}"
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "missing relationship question" %}
@@ -511,49 +511,49 @@
             "{{ error.case_tag }}" is determined by a question, but no question
             is specified.
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "subcase repeat context" %}
             The subcase "{{ error.case_tag }}" is in a different repeat context
             to its parent "{{ error.parent_tag }}"
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "auto select key" %}
             The auto-select case action is missing the "{{ error.key_name }}"
             value
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "auto select source" %}
             The auto-select case action is missing the "{{ error.source_name }}"
             value
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "auto select case ref" %}
             The case tag referenced in the auto-select expression of
             "{{ error.case_tag }}" was not found
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "no case type in action" %}
             The form action "{{ error.case_tag }}" does not have a case type
             selected
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "filtering without case" %}
             The form has filtering enabled but no cases are being loaded
             (excluding auto-loaded cases)
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}.
             {% case "invalid case xpath reference" %}
@@ -655,7 +655,7 @@
             {% endblocktrans %}
             {% case "conflicting questions" %}
               Multiple questions are attempting to save to case property "{{ error.property }}"
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+              {% if not not_actual_build %}in {% include "app_manager/partials/form_error_message.html" %}{% endif %}
             {% case "error" %}
               Details: {{ error.message }}
             {% else %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/build_errors.html
@@ -455,17 +455,19 @@
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "save_to_case_missing_case_type" %}
+            {% blocktrans with case_tag=error.case_tag %}
             <strong>Save to Case question is missing a case type.</strong>
-            Please add the "case_type" property mapping for
-            "{{ error.case_tag }}"
+            Please add the "case_type" property mapping for "{{ case_tag }}"
+            {% endblocktrans %}
             {% if not not_actual_build %}
               in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "save_to_case_missing_case_name" %}
+            {% blocktrans with case_tag=error.case_tag %}
             <strong>Save to Case question is missing a case name.</strong>
-            Please add the "case_name" property mapping for
-            "{{ error.case_tag }}"
+            Please add the "case_name" property mapping for "{{ case_tag }}"
+            {% endblocktrans %}
             {% if not not_actual_build %}
               in
               {% include "app_manager/partials/form_error_message.html" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/build_errors.html
@@ -434,16 +434,14 @@
             Case Update uses reserved word "{{ error.word }}"
             {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "update_case word illegal" %}
             Case Update "{{ error.word }}" should start with a letter and only
             contain letters, numbers, '-', and '_'
             {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "case_name required" %}
             <strong>Every case must have a name.</strong> Please specify a value
@@ -451,33 +449,29 @@
             properties"
             {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "save_to_case_missing_case_type" %}
             {% blocktrans with case_tag=error.case_tag %}
-            <strong>Save to Case question is missing a case type.</strong>
-            Please add the "case_type" property mapping for "{{ case_tag }}"
+              <strong>Save to Case question is missing a case type.</strong>
+              Please add the "case_type" property mapping for "{{ case_tag }}"
             {% endblocktrans %}
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "save_to_case_missing_case_name" %}
             {% blocktrans with case_tag=error.case_tag %}
-            <strong>Save to Case question is missing a case name.</strong>
-            Please add the "case_name" property mapping for "{{ case_tag }}"
+              <strong>Save to Case question is missing a case name.</strong>
+              Please add the "case_name" property mapping for "{{ case_tag }}"
             {% endblocktrans %}
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "path error" %}
             {% if error.path %}
               The case management
               {% if "VISIT_SCHEDULER" in toggles %}or visit scheduler{% endif %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
               references a question that no longer exists: "{{ error.path }}".
               It is likely that this question has been renamed or deleted.
               Please update or delete this question reference before you make a
@@ -487,8 +481,8 @@
               {% if "VISIT_SCHEDULER" in toggles %}or visit scheduler{% endif %}
               in the
               form{% include "app_manager/partials/form_error_message.html" with no_form="." %}
-              is missing a question. Please choose a question from the dropdown  {# todo B5: css-dropdown #}
-              next to the case property.
+              is missing a question. Please choose a question from the dropdown
+              {# todo B5: css-dropdown #} next to the case property.
             {% endif %}
             {% case "multimedia case property not supported" %}
             {% blocktrans with path=error.path %}
@@ -505,58 +499,50 @@
             A subcase is referencing a parent case tag that does not exist:
             "{{ error.case_tag }}"
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "missing relationship question" %}
             A subcase's index relationship with parent case tag
             "{{ error.case_tag }}" is determined by a question, but no question
             is specified.
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "subcase repeat context" %}
             The subcase "{{ error.case_tag }}" is in a different repeat context
             to its parent "{{ error.parent_tag }}"
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "auto select key" %}
             The auto-select case action is missing the "{{ error.key_name }}"
             value
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "auto select source" %}
             The auto-select case action is missing the "{{ error.source_name }}"
             value
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "auto select case ref" %}
             The case tag referenced in the auto-select expression of
             "{{ error.case_tag }}" was not found
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "no case type in action" %}
             The form action "{{ error.case_tag }}" does not have a case type
             selected
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "filtering without case" %}
             The form has filtering enabled but no cases are being loaded
             (excluding auto-loaded cases)
             {% if not not_actual_build %}
-              in
-              {% include "app_manager/partials/form_error_message.html" %}
+              in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}.
             {% case "invalid case xpath reference" %}
             {% if error.form %}
@@ -566,8 +552,9 @@
                 but cases are not available for this form. Please either remove
                 the case reference or (1) make sure that the case list is set to
                 display the case list first and then form, and (2) make sure
-                that all forms in this case list update or btn-close a case (which  {# todo B5: css-close #}
-                means registration forms must go in a different case list).
+                that all forms in this case list update or btn-close a case
+                (which {# todo B5: css-close #} means registration forms must go
+                in a different case list).
               {% endblocktrans %}
             {% else %}
               {% blocktrans %}
@@ -575,8 +562,9 @@
                 are not available. Please either remove the case reference or
                 (1) make sure that the case list is set to display the case list
                 first and then form, and (2) make sure that all forms in this
-                case list update or btn-close a case (which means registration forms  {# todo B5: css-close #}
-                must go in a different case list).
+                case list update or btn-close a case (which means registration
+                forms {# todo B5: css-close #} must go in a different case
+                list).
               {% endblocktrans %}
             {% endif %}
             {% case "practice user config error" %}
@@ -656,8 +644,11 @@
               <code>{{ column.header|trans:langs }}</code>.
             {% endblocktrans %}
             {% case "conflicting questions" %}
-              Multiple questions are attempting to save to case property "{{ error.property }}"
-              {% if not not_actual_build %}in {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            Multiple questions are attempting to save to case property
+            "{{ error.property }}"
+            {% if not not_actual_build %}
+              in {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "error" %}
               Details: {{ error.message }}
             {% else %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/build_errors.html
@@ -454,6 +454,22 @@
               in form
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
+            {% case "save_to_case_missing_case_type" %}
+            <strong>Save to Case question is missing a case type.</strong>
+            Please add the "case_type" property mapping for
+            "{{ error.case_tag }}"
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
+            {% case "save_to_case_missing_case_name" %}
+            <strong>Save to Case question is missing a case name.</strong>
+            Please add the "case_name" property mapping for
+            "{{ error.case_tag }}"
+            {% if not not_actual_build %}
+              in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "path error" %}
             {% if error.path %}
               The case management

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/build_errors.html
@@ -53,7 +53,7 @@
             {% include "app_manager/partials/form_error_message.html" %}
             {% case "validation error" %}
             {{ error.validation_message|linebreaksbr }}
-            in form {% include "app_manager/partials/form_error_message.html" %}
+            in {% include "app_manager/partials/form_error_message.html" %}
             {% case "no form links" %}
             {% blocktrans %}
               Link to other form or menu is selected, but no links have been
@@ -411,7 +411,7 @@
               <a href="{{ module_url }}">{{ module_name }}</a>
             {% endblocktrans %}
             {% case "subcase has no case type" %}
-            Child case specifies no case list in form
+            Child case specifies no case list in
             {% include "app_manager/partials/form_error_message.html" %}
             {% case "form error" %}
             {% blocktrans %}
@@ -434,7 +434,7 @@
             Case Update uses reserved word "{{ error.word }}"
             {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "update_case word illegal" %}
@@ -442,7 +442,7 @@
             contain letters, numbers, '-', and '_'
             {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "case_name required" %}
@@ -451,7 +451,7 @@
             properties"
             {% if error.case_tag %}for action "{{ error.case_tag }}"{% endif %}
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "save_to_case_missing_case_type" %}
@@ -459,7 +459,7 @@
             Please add the "case_type" property mapping for
             "{{ error.case_tag }}"
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "save_to_case_missing_case_name" %}
@@ -467,14 +467,14 @@
             Please add the "case_name" property mapping for
             "{{ error.case_tag }}"
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "path error" %}
             {% if error.path %}
               The case management
               {% if "VISIT_SCHEDULER" in toggles %}or visit scheduler{% endif %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
               references a question that no longer exists: "{{ error.path }}".
               It is likely that this question has been renamed or deleted.
@@ -503,7 +503,7 @@
             A subcase is referencing a parent case tag that does not exist:
             "{{ error.case_tag }}"
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "missing relationship question" %}
@@ -511,49 +511,49 @@
             "{{ error.case_tag }}" is determined by a question, but no question
             is specified.
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "subcase repeat context" %}
             The subcase "{{ error.case_tag }}" is in a different repeat context
             to its parent "{{ error.parent_tag }}"
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "auto select key" %}
             The auto-select case action is missing the "{{ error.key_name }}"
             value
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "auto select source" %}
             The auto-select case action is missing the "{{ error.source_name }}"
             value
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "auto select case ref" %}
             The case tag referenced in the auto-select expression of
             "{{ error.case_tag }}" was not found
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "no case type in action" %}
             The form action "{{ error.case_tag }}" does not have a case type
             selected
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
             {% case "filtering without case" %}
             The form has filtering enabled but no cases are being loaded
             (excluding auto-loaded cases)
             {% if not not_actual_build %}
-              in form
+              in
               {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}.
             {% case "invalid case xpath reference" %}
@@ -655,7 +655,7 @@
             {% endblocktrans %}
             {% case "conflicting questions" %}
               Multiple questions are attempting to save to case property "{{ error.property }}"
-              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+              {% if not not_actual_build %}in {% include "app_manager/partials/form_error_message.html" %}{% endif %}
             {% case "error" %}
               Details: {{ error.message }}
             {% else %}

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -14,6 +14,8 @@ from corehq.apps.app_manager.const import (
 from corehq.apps.app_manager.models import (
     Application,
     CaseList,
+    CaseReferences,
+    CaseSaveReference,
     CaseSearch,
     CaseSearchLabel,
     CaseSearchProperty,
@@ -24,6 +26,7 @@ from corehq.apps.app_manager.models import (
     SortElement,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.apps.app_manager.tests.util import get_simple_form
 from corehq.util.test_utils import flag_enabled, privilege_enabled
 
 
@@ -68,6 +71,36 @@ class BuildErrorsTest(TestCase):
         self._clean_unique_id(errors)
         self.assertIn(update_path_error, errors)
         self.assertIn(subcase_path_error, errors)
+
+    def test_save_to_case_create_requires_case_type_and_case_name(self, *args):
+        factory = AppFactory()
+        _, form = factory.new_basic_module('save_to_case', 'household')
+        # Use a minimal valid form source so validate_for_build() runs action checks.
+        # Save-to-case references are set explicitly below via case_references_data.
+        form.source = get_simple_form()
+        form.case_references_data = CaseReferences(
+            load={},
+            save={
+                '/data/save_to_case': CaseSaveReference(
+                    case_type='',
+                    properties=[],
+                    create=True,
+                    close=False,
+                )
+            },
+        )
+
+        errors = form.validate_for_build()
+        self.assertTrue(any(
+            error.get('type') == 'save_to_case_missing_case_type'
+            and error.get('case_tag') == '/data/save_to_case'
+            for error in errors
+        ))
+        self.assertTrue(any(
+            error.get('type') == 'save_to_case_missing_case_name'
+            and error.get('case_tag') == '/data/save_to_case'
+            for error in errors
+        ))
 
     def test_empty_module_errors(self, *args):
         factory = AppFactory(build_version='2.24.0')

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/build_errors.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/build_errors.html.diff.txt
@@ -1,29 +1,35 @@
 --- 
 +++ 
-@@ -485,7 +485,7 @@
-               {% if "VISIT_SCHEDULER" in toggles %}or visit scheduler{% endif %}
+@@ -482,7 +482,7 @@
                in the
                form{% include "app_manager/partials/form_error_message.html" with no_form="." %}
--              is missing a question. Please choose a question from the dropdown
-+              is missing a question. Please choose a question from the dropdown  {# todo B5: css-dropdown #}
-               next to the case property.
+               is missing a question. Please choose a question from the dropdown
+-              next to the case property.
++              {# todo B5: css-dropdown #} next to the case property.
              {% endif %}
              {% case "multimedia case property not supported" %}
-@@ -564,7 +564,7 @@
+             {% blocktrans with path=error.path %}
+@@ -552,8 +552,9 @@
                  but cases are not available for this form. Please either remove
                  the case reference or (1) make sure that the case list is set to
                  display the case list first and then form, and (2) make sure
 -                that all forms in this case list update or close a case (which
-+                that all forms in this case list update or btn-close a case (which  {# todo B5: css-close #}
-                 means registration forms must go in a different case list).
+-                means registration forms must go in a different case list).
++                that all forms in this case list update or btn-close a case
++                (which {# todo B5: css-close #} means registration forms must go
++                in a different case list).
                {% endblocktrans %}
              {% else %}
-@@ -573,7 +573,7 @@
+               {% blocktrans %}
+@@ -561,8 +562,9 @@
                  are not available. Please either remove the case reference or
                  (1) make sure that the case list is set to display the case list
                  first and then form, and (2) make sure that all forms in this
 -                case list update or close a case (which means registration forms
-+                case list update or btn-close a case (which means registration forms  {# todo B5: css-close #}
-                 must go in a different case list).
+-                must go in a different case list).
++                case list update or btn-close a case (which means registration
++                forms {# todo B5: css-close #} must go in a different case
++                list).
                {% endblocktrans %}
              {% endif %}
+             {% case "practice user config error" %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/build_errors.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/build_errors.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -469,7 +469,7 @@
+@@ -485,7 +485,7 @@
                {% if "VISIT_SCHEDULER" in toggles %}or visit scheduler{% endif %}
                in the
                form{% include "app_manager/partials/form_error_message.html" with no_form="." %}
@@ -9,7 +9,7 @@
                next to the case property.
              {% endif %}
              {% case "multimedia case property not supported" %}
-@@ -548,7 +548,7 @@
+@@ -564,7 +564,7 @@
                  but cases are not available for this form. Please either remove
                  the case reference or (1) make sure that the case list is set to
                  display the case list first and then form, and (2) make sure
@@ -18,7 +18,7 @@
                  means registration forms must go in a different case list).
                {% endblocktrans %}
              {% else %}
-@@ -557,7 +557,7 @@
+@@ -573,7 +573,7 @@
                  are not available. Please either remove the case reference or
                  (1) make sure that the case list is set to display the case list
                  first and then form, and (2) make sure that all forms in this


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
<img width="1083" height="285" alt="image" src="https://github.com/user-attachments/assets/03f4aca6-c9cf-4ac7-bfcd-87155a5d1f9b" />

Add validation so that if a save to case question want to create a case but doesn't provide `case_type` and `case_name` will not be allowed to make new version.

I tried to play around with other validation errors. This is so far the only thing left that is not guarded. If we encounter some edge cases in the future, we can add more validation.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19387

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`VELLUM_SAVE_TO_CASE`
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. Only add validation.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
