### PR TITLE
Upgrade pytz to 2026.1.post1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2691,11 +2691,11 @@ wheels = [
 
 [[package]]
 name = "pytz"
-version = "2024.1"
+version = "2026.1.post1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/26/9f1f00a5d021fff16dee3de13d43e5e978f3d58928e129c3a62cf7eb9738/pytz-2024.1.tar.gz", hash = "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812", size = 316214, upload-time = "2024-02-02T01:18:41.693Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/3d/a121f284241f08268b21359bd425f7d4825cffc5ac5cd0e1b3d82ffd2b10/pytz-2024.1-py2.py3-none-any.whl", hash = "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319", size = 505474, upload-time = "2024-02-02T01:18:37.283Z" },
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Product Description

Updates the pytz timezone library from 2024.1 to 2026.1.post1, bringing in the latest IANA timezone database.

## Technical Summary

Upgrades pytz from 2024.1 (IANA tzdata 2024a) to 2026.1.post1 (IANA tzdata 2026a).

pytz releases contain no API changes — each release simply bundles an updated IANA timezone database with the latest timezone rule changes worldwide. There is no changelog beyond the [IANA tzdata release notes](https://www.iana.org/time-zones). The [GitHub releases page](https://github.com/stub42/pytz/releases) confirms this pattern.

## Feature Flag

N/A

## Safety Assurance

### Safety story

pytz is a pure data package — its Python API has been stable for years and releases only update the bundled IANA timezone database. The codebase uses pytz across ~54 files for standard operations (`pytz.timezone()`, `pytz.utc`, `localize()`, `normalize()`), none of which are affected by timezone data updates. This is a low-risk, data-only upgrade.

### Automated test coverage

Existing timezone-related tests in `corehq/util/timezones/` cover the core usage patterns.

### QA Plan

No QA needed — timezone data update only.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change