### PR TITLE
Add dependency-upgrade and cve skills, simplify jira-cve

### DIFF
--- a/.claude/skills/cve/SKILL.md
+++ b/.claude/skills/cve/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: cve
+description: Create a Jira security ticket for a CVE and upgrade the dependency via a PR.
+argument-hint: <github_dependabot_alert_url>
+---
+
+# Fix CVE End-to-End
+
+Given a GitHub Dependabot security alert URL, create the Jira ticket and upgrade the dependency.
+
+## Input
+
+`$ARGUMENTS` — A GitHub Dependabot security alert URL. Example:
+
+- `/cve https://github.com/dimagi/commcare-hq/security/dependabot/740`
+
+## Step 1: Create the Jira Ticket
+
+Invoke `/jira-cve` with the URL from `$ARGUMENTS`. Let it run to completion and note the Jira ticket key (e.g. `SAAS-1234`) and its URL (`https://dimagi.atlassian.net/browse/SAAS-1234`).
+
+## Step 2: Upgrade the Dependency
+
+From the Dependabot alert (already fetched by `/jira-cve`), identify the package name.
+
+Invoke `/dependency-upgrade <package>`. When it creates the PR, ensure the Jira ticket URL is included in the Technical Summary alongside the changelog link.

--- a/.claude/skills/dependency-upgrade/SKILL.md
+++ b/.claude/skills/dependency-upgrade/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: dependency-upgrade
+description: Investigate and upgrade a Python or JavaScript dependency, then open a PR with a safety assessment.
+argument-hint: <package_name>
+---
+
+# Dependency Upgrade
+
+Given a package name, investigate the upgrade, make the change, and open a PR.
+
+## Input
+
+`$ARGUMENTS` — the package name. Examples:
+
+- `/dependency-upgrade pillow`
+- `/dependency-upgrade dompurify`
+
+## Step 1: Determine the ecosystem and current version
+
+**Python:** Search `uv.lock` for the package name and note the pinned version.
+
+**JavaScript:** Check `package.json`.
+
+Note the current pinned version.
+
+## Step 2: Find the latest version
+
+**Python:**
+```bash
+curl -s https://pypi.org/pypi/<package>/json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['info']['version'])"
+```
+
+**JavaScript:**
+```bash
+npm view <package> version
+```
+
+## Step 3: Evaluate the target version
+
+- **Skip brand new major releases** — if the latest version is a new major (e.g. `5.0.0` released within the last ~3 months), target the previous major's latest patch instead to allow time for bugs to surface.
+- Otherwise, target the latest version.
+
+## Step 4: Pull the changelog
+
+Fetch the changelog between the current version and the target version. Try in order:
+
+1. The package's GitHub releases page via `gh` or `WebFetch`
+2. PyPI / npm for a changelog or release notes link
+3. The project's `CHANGELOG.md` or `HISTORY.md` on GitHub
+
+Note the URL where you found the changelog — you will include it in the PR.
+
+Read the changelog for:
+- **Breaking changes** — API removals, behavior changes, renamed options
+- **Security fixes**
+- **Bug fixes** relevant to how CommCare HQ uses the package
+
+## Step 5: Assess how CommCare HQ uses the package
+
+Search the codebase to understand actual usage. Cross-reference against the changelog findings. Consider:
+- Is this a runtime dependency or a build/dev tool?
+- Which features/APIs does HQ actually call?
+- Do any breaking changes touch those call sites?
+
+If breaking changes affect HQ's usage, make the necessary code changes alongside the version bump.
+
+## Step 6: Make the upgrade
+
+**Python** — update the version in each `requirements/*.txt` file that pins it. Keep the existing pin style (`==` stays `==`, `>=` stays `>=`). Do not run `pip install`.
+
+**JavaScript** — update `package.json`, then run:
+```bash
+yarn upgrade <package>@<target_version>
+```
+Commit `yarn.lock` if present.
+
+## Step 7: Commit and open a PR
+
+Follow the version control instructions in `CLAUDE.md` (branch prefix, draft PR, PR template, etc.).
+
+Branch name: `<prefix>/<package>/<target_version>`
+
+Commit message: `Upgrade <package> to <target_version>`
+
+PR title: `Upgrade <package> to <target_version>`
+
+Fill in the PR template with your findings. The technical summary should include a link to the changelog. The safety story should explain why this upgrade is safe given HQ's actual usage. Omit the Migrations section. Check the rollback box. Add the `product/invisible` label.

--- a/.claude/skills/dependency-upgrade/SKILL.md
+++ b/.claude/skills/dependency-upgrade/SKILL.md
@@ -66,7 +66,14 @@ If breaking changes affect HQ's usage, make the necessary code changes alongside
 
 ## Step 6: Make the upgrade
 
-**Python** — update the version in each `requirements/*.txt` file that pins it. Keep the existing pin style (`==` stays `==`, `>=` stays `>=`). Do not run `pip install`.
+**Python** — run:
+```bash
+uv lock --upgrade-package <package>
+```
+or if not the latest
+```bash
+uv lock --upgrade-package <package>==<version>
+```
 
 **JavaScript** — update `package.json`, then run:
 ```bash

--- a/.claude/skills/jira-cve/SKILL.md
+++ b/.claude/skills/jira-cve/SKILL.md
@@ -69,16 +69,11 @@ Examples:
 - `[Security: commcare-hq py high] Upgrade pillow to 10.3.0 or later`
 - `[Security: commcare-hq js critical] Upgrade lodash to 4.17.21 or later`
 
-## Severity / Priority Mapping
+## Priority
 
-| Severity | Jira Priority | Jira ID |
-|---|---|---|
-| critical | P1 | `1` |
-| high | P2 | `2` |
-| medium | P3 | `3` |
-| low | P5 | `5` |
+Always use **P3** (`id: 3`) regardless of severity.
 
-Always set `priority` via `additional_fields`: `"priority": {"id": "<id>"}`.
+Set `priority` via `additional_fields`: `"priority": {"id": "3"}`.
 
 ## Assignee
 
@@ -121,7 +116,7 @@ Set sprint via `additional_fields`: `"customfield_10010": <sprint_id_number>`.
 
 ## Epic
 
-Assume no epic.
+Never assign an epic.
 
 ## Steps
 
@@ -129,13 +124,12 @@ Assume no epic.
 2. Run `gh api repos/<owner>/<repo>/dependabot/alerts/<alert_number>` to fetch
    alert data.
 3. Extract package, ecosystem, severity, patched version, CVE ID, and summary.
-4. Ask the user: "Should this go under a security epic? Paste a SAAS key or say 'no'."
-5. Construct the formatted summary and description (see formats above).
-6. Delegate to the `/jira-ticket` skill by invoking it with a single string
+4. Construct the formatted summary and description (see formats above).
+5. Delegate to the `/jira-ticket` skill by invoking it with a single string
    argument that contains all the relevant information:
 
    ```
-   /jira-ticket <formatted_summary>. Component: Data Privacy / Security. <priority>. Platform sprint. Description — Package: <package>, Patched version: <patched_version> or later, Ecosystem: <py|js>, CVE: <CVE-ID> (<cve_url>), GitHub alert: <alert_html_url>. <advisory_summary>. Fix: upgrade <package> to <patched_version> or later in the relevant dependency file.<if epic:  Epic: <SAAS-key>.>
+   /jira-ticket <formatted_summary>. Component: Data Privacy / Security. P3. Platform sprint. Description — Package: <package>, Patched version: <patched_version> or later, Ecosystem: <py|js>, CVE: <CVE-ID> (<cve_url>), GitHub alert: <alert_html_url>. <advisory_summary>. Fix: upgrade <package> to <patched_version> or later in the relevant dependency file.
    ```
 
    **Always include the GitHub alert URL** (`html_url` from the API response, or the original `$ARGUMENTS` URL as fallback) in the description. This is required so the ticket links back to the Dependabot alert.


### PR DESCRIPTION
## Product Description

No user-facing changes. Adds and improves Claude Code skills for handling CVE security upgrades.

## Technical Summary

https://dimagi.atlassian.net/browse/SAAS-19411

Three commits:

1. **Simplify jira-cve skill** — always use P3 priority for CVEs (removes severity→priority mapping and the epic question prompt), removes the "no epic" question step
2. **Add dependency-upgrade skill** — new skill that investigates a package upgrade (changelog, codebase usage, breaking changes) and opens a PR with a safety assessment
3. **Add cve skill** — composes `jira-cve` + `dependency-upgrade` into a single end-to-end workflow: create the Jira ticket then upgrade the dependency in one invocation

## Feature Flag

N/A

## Safety Assurance

### Safety story

Skill files only affect Claude Code agent behavior — no runtime code changes.

### Automated test coverage

N/A

### QA Plan

Manually tested `jira-cve` and `dependency-upgrade` individually against live Dependabot alerts.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change