### PR TITLE
Add agent instructions for new domain models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ corehq/apps/hqwebapp/static/hqwebapp/js/lib/modernizr.js
 
 # ruff
 ruff.toml
+CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,16 @@ scripts/pr-failures.sh [pr_number]  # uses current branch if omitted
 
 - **migrations.lock** — If you wrote a migration instead of generating one,
   run `./manage.py makemigrations --lock-update` to update the lock file.
+- **New domain-scoped models** — Any new model with a `domain` field (or
+  reachable via FK to a domain) must be registered in two places or CI will
+  fail:
+  - `corehq/apps/dump_reload/sql/dump.py` — add a
+    `FilteredModelIteratorBuilder` entry so the model is included in domain
+    data exports.
+  - `corehq/apps/domain/deletion.py` — add a `ModelDeletion` entry so the
+    model is cleaned up when a domain is deleted.
+  Use `SimpleFilter('domain')` for direct domain fields, or
+  `SimpleFilter('parent__domain')` for FK traversal.
 - **CouchDB is legacy** — Use PostgreSQL for new data models
 - **Knockout.js is legacy** — Prefer HTMX or Alpine.js for new frontend code
 - **Bootstrap 3 is legacy** — Prefer Bootstrap 5; both coexist in the codebase


### PR DESCRIPTION
## Product Description

I had not been aware of the checks for domain-scoped models and did not initially give claude instructions to add to the list of models linked to a domain. I am adding these instructions so it can pick up on that automaticllay.

Also, ignore CLAUDE.local.md, which is meant for devs instructions that are not shared

## Technical Summary

None

## Feature Flag

None

## Safety Assurance

No code changes

### Safety story

Not changing any code.

### Automated test coverage

None

### QA Plan

None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
