### PR TITLE
Remove ZAPIER_INTEGRATION privilege check in 'user domains' API

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1116,8 +1116,6 @@ class UserDomainsResource(ApiVersioningMixin, CorsResourceMixin, Resource):
         username = request.user.username
         results = []
         for domain in couch_user.get_domains():
-            if not domain_has_privilege(domain, privileges.ZAPIER_INTEGRATION):
-                continue
             domain_object = Domain.get_by_name(domain)
             if feature_flag and feature_flag not in toggles.toggles_dict(username=username, domain=domain):
                 continue

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -51,6 +51,7 @@ from corehq.apps.api.resources.v0_5 import (
     DomainUsernames,
     UserDomainsResource,
 )
+from corehq.apps.zapier.api.v0_5 import ZapierUserDomains
 from corehq.apps.commtrack.resources.v0_1 import ProductResource
 from corehq.apps.fixtures import resources as fixtures
 from corehq.apps.hqcase.views import case_api, case_api_bulk_fetch
@@ -221,7 +222,7 @@ ADMIN_API_LIST = (
     accounting.BillingRecordResource,
     MaltResource,
     GIRResource,
-    UserDomainsResource,
+    ZapierUserDomains,
 )
 
 

--- a/corehq/apps/zapier/api/v0_5.py
+++ b/corehq/apps/zapier/api/v0_5.py
@@ -4,12 +4,13 @@ from tastypie.exceptions import NotFound
 from tastypie.resources import Resource
 from corehq import privileges
 
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.api.resources.meta import CustomResourceMeta
 from corehq.apps.api.resources.v0_4 import (
     BaseApplicationResource,
     XFormInstanceResource,
 )
-from corehq.apps.api.resources.v0_5 import DoesNothingPaginator
+from corehq.apps.api.resources.v0_5 import DoesNothingPaginator, UserDomainsResource
 from corehq.apps.app_manager.app_schemas.case_properties import (
     get_all_case_properties_for_case_type,
 )
@@ -241,3 +242,15 @@ class ZapierCustomActionFieldCaseResource(BaseZapierCustomFieldResource):
 
     class Meta(BaseZapierCustomFieldResource.Meta):
         resource_name = 'custom_action_fields_case'
+
+
+class ZapierUserDomains(UserDomainsResource):
+    """
+    UserDomainsResource filtered to only domains with the ZAPIER_INTEGRATION privilege.
+    """
+
+    def get_object_list(self, request):
+        return [
+            user_domain for user_domain in super().get_object_list(request)
+            if domain_has_privilege(user_domain.domain_name, privileges.ZAPIER_INTEGRATION)
+        ]


### PR DESCRIPTION
## Product Description
The [user_domains](https://commcare-hq.readthedocs.io/api/user-domain-list.html) API currently only includes domains that have the 'ZAPIER' privilege. This PR removes that restriction so that the API returns ALL domains the user is a member of.

Zapier uses the `hq/admin/api/global/user_domains/` so to avoid making changes to that API I have created a new API resource class which keeps the filtering functionality for the 'global' endpoint.

### Why

The primary reason is that this API endpoint is useful for many integrations, not only Zapier. The documentation does not mention this restriction which makes the output misleading. Zapier uses a different endpoint which can keep the filtering without impacting the v1 API.

## Technical Summary

This removes a check in the user domains loop which previously skipped domains that did not have the Zapier privilege. This only impacts the v1 user domains list API and not the legacy 'global' user domains list.

## Safety Assurance

### Safety story
As best I can tell (by looking at the Zapier configuration), Zapier uses the 'global' endpoint. The `v1` API was added in in Oct 2024 (https://github.com/dimagi/commcare-hq/pull/35048) which post dates the Zapier setup.

This change only affects the v1 API and not the legacy 'global' API.

### Automated test coverage

None

### QA Plan

None


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
