### PR TITLE
Remove trailing space from API key display string

### DIFF
--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -725,7 +725,7 @@ class ApiKeyView(BaseMyAccountView, CRUDPaginatedViewMixin):
                 key = api_key.plaintext_key
             else:
                 copy_msg = _("Copy this in a secure place. It will not be shown again.")
-                key = f"{api_key.plaintext_key} ({copy_msg})",
+                key = f"{api_key.plaintext_key}({copy_msg})",
             full_key = api_key.plaintext_key
 
         if api_key.expiration_date and api_key.expiration_date < datetime.now():


### PR DESCRIPTION
## Product Description
On the API keys page (`/account/api_keys/`), when a new key is generated, the displayed string includes a space between the key and the parenthetical copy message:

`xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (Copy this in a secure place. It will not be shown again.)`

When a user double-clicks the API key to select it, this trailing space is included in the selection, which can cause issues when pasting the key. This removes that space so the key can be cleanly selected via double-click:

`xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(Copy this in a secure place. It will not be shown again.)`

## Technical Summary
One-character change in `corehq/apps/settings/views.py` in the `ApiKeyView._to_json` method. Removes the space in the f-string between `{api_key.plaintext_key}` and `(`.

## Feature Flag
N/A

## Safety Assurance

### Safety story
This is a display-only change affecting a single space character in a UI string. No data, logic, or API behavior is modified.

### Automated test coverage
N/A — cosmetic string formatting change with no behavioral impact.

### QA Plan
- Generate a new API key on `/account/api_keys/`
- Verify the key and message display without a space before the parenthesis
- Double-click the key and confirm only the key text is selected (no trailing space)

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change