### PR TITLE
Fix product label check for PRs from forks

### DIFF
--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,7 +1,7 @@
 name: Labels
 
 on:
-  pull_request:
+  pull_request_target:  # safe as long as we do not check out and run code from the branch to be merged
     branches:
       - master
     types: [labeled, unlabeled, opened, reopened]


### PR DESCRIPTION
## Product Description
N/A — CI workflow fix only.

## Technical Summary
The "Product label" required check was failing on PRs from forks with a 403 because the `GITHUB_TOKEN` for fork PRs is read-only, and the workflow needs `checks:write` to call `checks.create()`.

Switches the trigger from `pull_request` to `pull_request_target`, which runs in the base repo's context and grants the needed write permission. This is safe because the workflow only reads labels from the event payload and never checks out or executes code from the PR branch.

## Feature Flag
N/A

## Safety Assurance

### Safety story
`pull_request_target` is only dangerous when a workflow checks out and runs fork code with an elevated token. This workflow does neither — it reads labels from `context.payload` and creates a check run. The inline comment documents this invariant.

### Automated test coverage
N/A — GitHub Actions workflow change.

### QA Plan
- Open a PR from a fork and verify the product label check runs without a 403.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)