### PR TITLE
Fix get_case_properties query: use LEFT OUTER JOIN

### DIFF
--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -5,6 +5,7 @@ from operator import attrgetter
 from urllib.parse import parse_qsl, urlencode, urlparse
 
 from django.core.exceptions import ValidationError
+from django.db.models import Q
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
@@ -407,15 +408,20 @@ def is_case_property_unused(domain, case_type, case_property):
 
 def get_case_properties(domain, case_type_name):
     return CaseProperty.objects.filter(
+        Q(group__isnull=True) | Q(group__deprecated=False),
         case_type__name=case_type_name,
         case_type__domain=domain,
         deprecated=False,
-        group__deprecated=False,
     )
 
 
 def get_case_property_group_name_for_properties(domain, case_type_name):
-    return dict(get_case_properties(domain, case_type_name).values_list('name', 'group__name'))
+    return dict(CaseProperty.objects.filter(
+        case_type__name=case_type_name,
+        case_type__domain=domain,
+        deprecated=False,
+        group__deprecated=False
+    ).values_list('name', 'group__name'))
 
 
 def update_url_query_params(url, params):


### PR DESCRIPTION
`LEFT OUTER JOIN` causes the query to include properties that have no related `CasePropertyGroup`.

Restore property/group query in `get_case_property_group_name_for_properties` to previous structure, which appropriately uses `INNER JOIN`.

## Feature Flag
`FORMBUILDER_SAVE_TO_CASE`

## Safety Assurance

### Safety story

`get_case_properties` is used in one place, and it was broken for the purpose it served, which was to get all case properties from the data dictionary for a given domain and case type. The only use is behind the `FORMBUILDER_SAVE_TO_CASE` feature flag.

### Automated test coverage

No.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations