### PR TITLE
Remove pyopenssl dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,6 @@ docs = [
     "Sphinx",
     "sphinxcontrib-django",
     "sphinx-rtd-theme",
-    "pyOpenSSL", # CI builds fail without OpenSSL
     "urllib3<=2.6.3", # fix doc tests AssertionError: Current app already created
 ]
 prod = [

--- a/uv.lock
+++ b/uv.lock
@@ -593,7 +593,6 @@ dev = [
 docs = [
     { name = "django-extensions" },
     { name = "myst-parser" },
-    { name = "pyopenssl" },
     { name = "sphinx" },
     { name = "sphinx-rtd-theme" },
     { name = "sphinxcontrib-django" },
@@ -758,7 +757,6 @@ dev = [
 docs = [
     { name = "django-extensions" },
     { name = "myst-parser" },
-    { name = "pyopenssl" },
     { name = "sphinx" },
     { name = "sphinx-rtd-theme" },
     { name = "sphinxcontrib-django" },
@@ -2512,18 +2510,6 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
-]
-
-[[package]]
-name = "pyopenssl"
-version = "25.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/80/be/97b83a464498a79103036bc74d1038df4a7ef0e402cfaf4d5e113fb14759/pyopenssl-25.3.0.tar.gz", hash = "sha256:c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329", size = 184073, upload-time = "2025-09-17T00:32:21.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/81/ef2b1dfd1862567d573a4fdbc9f969067621764fbb74338496840a1d2977/pyopenssl-25.3.0-py3-none-any.whl", hash = "sha256:1fda6fc034d5e3d179d39e59c1895c9faeaf40a79de5fc4cbbfbe0d36f4a77b6", size = 57268, upload-time = "2025-09-17T00:32:19.474Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Product Description

No user-facing effects.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19495

Removes `pyOpenSSL` from the docs dependency group in `pyproject.toml`. I don't have a clear idea of why this is no longer needed, but it appears to be the case that our CI passes without it and it can therefore be removed since that was the reason to include it in the first place.

There are **zero direct imports** of `OpenSSL` (pyopenssl's module) anywhere in the codebase:
- SSO/SAML uses `python3-saml` (onelogin), which depends on `xmlsec`/`lxml`, not pyopenssl
- SSO/OIDC uses `oic`, which lists pyopenssl only as an optional dev dependency
- Certificate handling (`corehq/apps/sso/certificates.py`) uses the `cryptography` library, not pyopenssl

## Feature Flag

N/A

## Safety Assurance

### Safety story

- pyopenssl is not imported anywhere in the codebase
- The docs CI workflow was triggered against this branch and passed
- The full test suite was also triggered against this branch

### Automated test coverage

The docs CI build is the only thing that could be affected, and it passes.

### QA Plan

N/A — no runtime behavior changes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change