### PR TITLE
Fetch sentry URL from settings

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -469,7 +469,7 @@ def report_sentry_error(request, domain):
         if header.get("dsn") != settings.SENTRY_DSN:
             raise Exception(f"Invalid Sentry DSN: {header.get('dsn')}")
 
-        dsn = urllib.parse.urlparse(header.get("dsn"))
+        dsn = urllib.parse.urlparse(settings.SENTRY_DSN)
         project_id = dsn.path.strip("/")
         if project_id != settings.SENTRY_DSN.split('/')[-1]:
             raise Exception(f"Invalid Sentry Project ID: {project_id}")


### PR DESCRIPTION
## Product Description


## Technical Summary
Should hopefully fix https://github.com/dimagi/commcare-hq/security/code-scanning/477
We already check that the URL equals `settings.SENTRY_DSN`, but we can just use that directly and avoid having to explain to CodeQL that this isn't a real problem.

## Feature Flag


## Safety Assurance
Real simple substitution.  Failure mode is we get errors when reporting webapps errors to Sentry.

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
