### PR TITLE
Revert part of "Make split-screen case search always enabled in Web Apps"

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1259,7 +1259,6 @@ const CaseListView = Marionette.CollectionView.extend({
             isMultiSelect: false,
             mapAvailable: this.mapAvailable,
             sidebarEnabled: this.options.sidebarEnabled,
-            splitScreenToggleEnabled: toggles.toggleEnabled('SYNC_SEARCH_CASE_CLAIM'),
             smallScreenEnabled: this.smallScreenEnabled,
             triggerEmptyCaseList: this.options.triggerEmptyCaseList,
 
@@ -1777,7 +1776,6 @@ const PersistentMenuView = Marionette.View.extend({
         $('#persistent-menu-region').removeClass('d-none');
         this.sidebarEnabled = options.sidebarEnabled;
         this.menuExpanded;
-        this.splitScreenToggleEnabled = toggles.toggleEnabled('SYNC_SEARCH_CASE_CLAIM'),
         this.offcanvas = 'offcanvas';
         this.collapse = 'collapse';
         this.containerCollapseClasses = this.collapse + ' position-relative';
@@ -1904,7 +1902,7 @@ const PersistentMenuView = Marionette.View.extend({
             persistentMenuContainer.addClass('border-top');
         }
 
-        if (this.splitScreenToggleEnabled && !sessionStorage.getItem('handledDefaultClosed')) {
+        if (this.sidebarEnabled && !sessionStorage.getItem('handledDefaultClosed')) {
             self.hideMenu();
             self.unlockMenu();
             self.flipArrowRight();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1259,6 +1259,7 @@ const CaseListView = Marionette.CollectionView.extend({
             isMultiSelect: false,
             mapAvailable: this.mapAvailable,
             sidebarEnabled: this.options.sidebarEnabled,
+            splitScreenToggleEnabled: toggles.toggleEnabled('SYNC_SEARCH_CASE_CLAIM'),
             smallScreenEnabled: this.smallScreenEnabled,
             triggerEmptyCaseList: this.options.triggerEmptyCaseList,
 
@@ -1776,6 +1777,7 @@ const PersistentMenuView = Marionette.View.extend({
         $('#persistent-menu-region').removeClass('d-none');
         this.sidebarEnabled = options.sidebarEnabled;
         this.menuExpanded;
+        this.splitScreenToggleEnabled = toggles.toggleEnabled('SYNC_SEARCH_CASE_CLAIM'),
         this.offcanvas = 'offcanvas';
         this.collapse = 'collapse';
         this.containerCollapseClasses = this.collapse + ' position-relative';
@@ -1902,7 +1904,7 @@ const PersistentMenuView = Marionette.View.extend({
             persistentMenuContainer.addClass('border-top');
         }
 
-        if (!sessionStorage.getItem('handledDefaultClosed')) {
+        if (this.splitScreenToggleEnabled && !sessionStorage.getItem('handledDefaultClosed')) {
             self.hideMenu();
             self.unlockMenu();
             self.flipArrowRight();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
@@ -2,6 +2,7 @@ import _ from "underscore";
 import Backbone from "backbone";
 import Marionette from "backbone.marionette";
 import sinon from "sinon";
+import Toggles from "hqwebapp/js/toggles";
 import FormplayerFrontend from "cloudcare/js/formplayer/app";
 import API from "cloudcare/js/formplayer/menus/api";
 import Controller from "cloudcare/js/formplayer/menus/controller";
@@ -40,6 +41,7 @@ describe('Split Screen Case Search', function () {
             },
             addRegions: function () { return; },
         };
+        stubs.splitScreenToggleEnabled = sinon.stub(Toggles, 'toggleEnabled').withArgs('SPLIT_SCREEN_CASE_SEARCH');
     });
 
     beforeEach(function () {
@@ -47,6 +49,7 @@ describe('Split Screen Case Search', function () {
         user.displayOptions = {
             singleAppMode: false,
         };
+        stubs.splitScreenToggleEnabled.returns(true);
     });
 
     afterEach(function () {
@@ -136,6 +139,12 @@ describe('Split Screen Case Search', function () {
             assert.isTrue(stubs.regions['sidebar'].empty.called);
         });
 
+        it('should empty sidebar if feature flag disabled', function () {
+            stubs.splitScreenToggleEnabled.returns(false);
+            Controller.showMenu(splitScreenCaseListResponse);
+
+            assert.isTrue(stubs.regions['sidebar'].empty.called);
+        });
     });
 
     describe('FormplayerFrontend actions', function () {

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/list.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/list.html
@@ -13,7 +13,7 @@
 
     {% include "cloudcare/partials/case_list/menu_header.html" %}
 
-    <% if (!splitScreenToggleEnabled) { %>
+    <% if (!sidebarEnabled) { %>
     <div class="module-search-container">
       <div class="input-group input-group-lg">
         <input type="text"

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/list.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/case_list/list.html
@@ -13,6 +13,22 @@
 
     {% include "cloudcare/partials/case_list/menu_header.html" %}
 
+    <% if (!splitScreenToggleEnabled) { %>
+    <div class="module-search-container">
+      <div class="input-group input-group-lg">
+        <input type="text"
+               class="form-control"
+               placeholder="Search"
+               id="searchText">
+        <button class="btn btn-outline-primary"
+                type="button"
+                id="case-list-search-button">
+          <i class="fa fa-search" aria-hidden="true"></i>
+        </button>
+      </div>
+    </div>
+    <% } %>
+
     <div id="module-case-list-container__results-container"
          class="row g-0">
       <% if (mapAvailable) { %>


### PR DESCRIPTION
## Product Description

This reverts parts of commit f4df216e2a42761fd78d9729f8911d18553f5dc9.
* The search box for searching in case db search should not have been removed
* The persistent menu should still behave differently when split screen case search is enabled
* Use sidebarEnabled instead of splitScreenToggleEnabled to determine if the search field and persistent
   menu should be shown.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6496

## Feature Flag

* SYNC_SEARCH_CASE_CLAIM

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
