### PR TITLE
Add fields/exclude params to Case API v2

### DIFF
--- a/corehq/apps/hqcase/api/core.py
+++ b/corehq/apps/hqcase/api/core.py
@@ -68,7 +68,9 @@ def serialize_es_case(case_doc):
 
 
 class UserError(Exception):
-    pass
+    def __init__(self, message):
+        self.message = message
+        super().__init__(message)
 
 
 class SubmissionError(Exception):

--- a/corehq/apps/hqcase/api/field_filters.py
+++ b/corehq/apps/hqcase/api/field_filters.py
@@ -35,4 +35,14 @@ def _limit_fields(data, field_tree):
 
 
 def _exclude_fields(data, field_tree):
-    raise NotImplementedError
+    """Return a copy of data with the fields in field_tree removed."""
+    result = {}
+    for key, value in data.items():
+        if key not in field_tree:
+            result[key] = value
+        elif field_tree[key]:
+            if isinstance(value, dict):
+                result[key] = _exclude_fields(value, field_tree[key])
+            else:
+                result[key] = value
+    return result

--- a/corehq/apps/hqcase/api/field_filters.py
+++ b/corehq/apps/hqcase/api/field_filters.py
@@ -2,14 +2,16 @@ from corehq.apps.hqcase.api.core import UserError
 
 
 def get_fields_filter_fn(query_dict):
-    fields = _get_tree(query_dict, 'fields')
-    exclude = _get_tree(query_dict, 'exclude')
-    if fields and exclude:
-        raise UserError("You cannot specify both 'fields' and 'exclude'")
+    uses_fields = any(p.split('.')[0] == 'fields' for p in query_dict)
+    uses_exclude = any(p.split('.')[0] == 'exclude' for p in query_dict)
 
-    if fields:
+    if uses_fields and uses_exclude:
+        raise UserError("You cannot specify both 'fields' and 'exclude'")
+    if uses_fields:
+        fields = _get_tree(query_dict, 'fields')
         return lambda data: _limit_fields(data, fields)
-    if exclude:
+    if uses_exclude:
+        exclude = _get_tree(query_dict, 'exclude')
         return lambda data: _exclude_fields(data, exclude)
     return lambda data: data
 
@@ -27,17 +29,22 @@ def _get_tree(query_dict, param_name):
     """
     tree = {}
     for path in _extract_paths(query_dict, param_name):
-        _add_to_tree(tree, path)
+        if all(path):  # If the path has empty sections, they match nothing
+            _add_to_tree(tree, path)
     return tree
 
 
 def _extract_paths(query_dict, param_name):
-    for p, vals in query_dict.lists():
-        path = p.split('.')
+    for param, vals in query_dict.lists():
+        path = _split_and_strip(param, '.')
         if path[0] == param_name:
             for val in vals:
-                for v in val.split(','):
-                    yield path[1:] + v.split('.')
+                for v in _split_and_strip(val, ','):
+                    yield path[1:] + _split_and_strip(v, '.')
+
+
+def _split_and_strip(string, sep):
+    return [part.strip() for part in string.split(sep)]
 
 
 def _add_to_tree(tree, path):

--- a/corehq/apps/hqcase/api/field_filters.py
+++ b/corehq/apps/hqcase/api/field_filters.py
@@ -1,83 +1,51 @@
 from corehq.apps.hqcase.api.core import UserError
 
-FIELDS_PARAM = 'fields'
-EXCLUDE_PARAM = 'exclude'
 
-
-def extract_fields_params(params):
-    """Read 'fields'/'exclude' params from QueryDict, return filter function.
-
-    Reads but does not pop params from the QueryDict. The params remain
-    in the QueryDict so they are preserved in pagination cursors.
-
-    Returns a callable (dict -> dict) that applies field filtering.
-    Returns the identity function if neither fields nor exclude was specified.
-    """
-    has_fields, fields_spec = _collect_field_spec(params, FIELDS_PARAM)
-    has_exclude, exclude_spec = _collect_field_spec(params, EXCLUDE_PARAM)
-
-    if has_fields and has_exclude:
+def get_fields_filter_fn(query_dict):
+    fields = _get_tree(query_dict, 'fields')
+    exclude = _get_tree(query_dict, 'exclude')
+    if fields and exclude:
         raise UserError("You cannot specify both 'fields' and 'exclude'")
 
-    if has_fields:
-        tree = _build_field_tree(fields_spec)
-        return lambda data: _limit_fields(data, tree)
-    if has_exclude:
-        tree = _build_field_tree(exclude_spec)
-        return lambda data: _exclude_fields(data, tree)
-    return _identity
+    if fields:
+        return lambda data: _limit_fields(data, fields)
+    if exclude:
+        return lambda data: _exclude_fields(data, exclude)
+    return lambda data: data
 
 
-def _identity(data):
-    return data
+def _get_tree(query_dict, name):
+    """Turn URL parameters into tree of properties to keep/exclude
 
-
-def _collect_field_spec(params, prefix):
-    """Collect field paths from a QueryDict for the given prefix.
-
-    Reads 'prefix' and all 'prefix.*' keys. Values are comma-separated.
-    Returns (key_present, fields) where key_present is True if any
-    matching keys exist in the QueryDict (even if values are empty).
-    """
-    fields = []
-    key_present = False
-    for key in list(params.keys()):
-        if key == prefix:
-            key_present = True
-            for value in params.getlist(key):
-                fields.extend(part.strip() for part in value.split(",") if part.strip())
-        elif key.startswith(prefix + "."):
-            key_present = True
-            nesting = key[len(prefix) + 1:]  # e.g. "properties" from "fields.properties"
-            for value in params.getlist(key):
-                for part in value.split(","):
-                    part = part.strip()
-                    if part:
-                        fields.append(f"{nesting}.{part}")
-    return key_present, fields
-
-
-def _build_field_tree(fields):
-    """Build a nested dict (field tree) from a list of dot-separated field paths.
-
-    A leaf ({}) means "include/exclude this entire value."
-    A branch (non-empty dict) means "descend and apply sub-tree."
+    >>> qs = 'fields=case_id&fields=case_name&fields.properties=dob,edd'
+    >>> _get_tree(QueryDict(qs), 'fields')
+    {
+        'case_id': {},
+        'case_name': {},
+        'properties': {'dob': {}, 'edd': {}},
+    }
     """
     tree = {}
-    for field in fields:
-        parts = field.split(".")
-        node = tree
-        for part in parts[:-1]:
-            if part in node and node[part] == {}:
-                break
-            node = node.setdefault(part, {})
-        else:
-            last = parts[-1]
-            if last in node and isinstance(node[last], dict) and node[last]:
-                node[last] = {}
-            else:
-                node.setdefault(last, {})
+    for path in _extract_paths(query_dict, name):
+        _add_to_tree(tree, path)
     return tree
+
+
+def _extract_paths(query_dict, name):
+    for p, vals in query_dict.lists():
+        path = p.split('.')
+        if path[0] == name:
+            for val in vals:
+                for v in val.split(','):
+                    yield path[1:] + v.split('.')
+
+
+def _add_to_tree(tree, path):
+    if path:
+        node = path[0]
+        if node not in tree:
+            tree[node] = {}
+        _add_to_tree(tree[node], path[1:])
 
 
 def _limit_fields(data, field_tree):

--- a/corehq/apps/hqcase/api/field_filters.py
+++ b/corehq/apps/hqcase/api/field_filters.py
@@ -1,0 +1,29 @@
+def _build_field_tree(fields):
+    """Build a nested dict (field tree) from a list of dot-separated field paths.
+
+    A leaf ({}) means "include/exclude this entire value."
+    A branch (non-empty dict) means "descend and apply sub-tree."
+    """
+    tree = {}
+    for field in fields:
+        parts = field.split(".")
+        node = tree
+        for part in parts[:-1]:
+            if part in node and node[part] == {}:
+                break
+            node = node.setdefault(part, {})
+        else:
+            last = parts[-1]
+            if last in node and isinstance(node[last], dict) and node[last]:
+                node[last] = {}
+            else:
+                node.setdefault(last, {})
+    return tree
+
+
+def _limit_fields(data, field_tree):
+    raise NotImplementedError
+
+
+def _exclude_fields(data, field_tree):
+    raise NotImplementedError

--- a/corehq/apps/hqcase/api/field_filters.py
+++ b/corehq/apps/hqcase/api/field_filters.py
@@ -22,7 +22,16 @@ def _build_field_tree(fields):
 
 
 def _limit_fields(data, field_tree):
-    raise NotImplementedError
+    """Return a copy of data containing only the fields in field_tree."""
+    result = {}
+    for key, subtree in field_tree.items():
+        if key not in data:
+            continue
+        if not subtree:
+            result[key] = data[key]
+        elif isinstance(data[key], dict):
+            result[key] = _limit_fields(data[key], subtree)
+    return result
 
 
 def _exclude_fields(data, field_tree):

--- a/corehq/apps/hqcase/api/field_filters.py
+++ b/corehq/apps/hqcase/api/field_filters.py
@@ -14,7 +14,7 @@ def get_fields_filter_fn(query_dict):
     return lambda data: data
 
 
-def _get_tree(query_dict, name):
+def _get_tree(query_dict, param_name):
     """Turn URL parameters into tree of properties to keep/exclude
 
     >>> qs = 'fields=case_id&fields=case_name&fields.properties=dob,edd'
@@ -26,15 +26,15 @@ def _get_tree(query_dict, name):
     }
     """
     tree = {}
-    for path in _extract_paths(query_dict, name):
+    for path in _extract_paths(query_dict, param_name):
         _add_to_tree(tree, path)
     return tree
 
 
-def _extract_paths(query_dict, name):
+def _extract_paths(query_dict, param_name):
     for p, vals in query_dict.lists():
         path = p.split('.')
-        if path[0] == name:
+        if path[0] == param_name:
             for val in vals:
                 for v in val.split(','):
                     yield path[1:] + v.split('.')

--- a/corehq/apps/hqcase/api/field_filters.py
+++ b/corehq/apps/hqcase/api/field_filters.py
@@ -1,3 +1,62 @@
+from corehq.apps.hqcase.api.core import UserError
+
+FIELDS_PARAM = 'fields'
+EXCLUDE_PARAM = 'exclude'
+
+
+def extract_fields_params(params):
+    """Read 'fields'/'exclude' params from QueryDict, return filter function.
+
+    Reads but does not pop params from the QueryDict. The params remain
+    in the QueryDict so they are preserved in pagination cursors.
+
+    Returns a callable (dict -> dict) that applies field filtering.
+    Returns the identity function if neither fields nor exclude was specified.
+    """
+    has_fields, fields_spec = _collect_field_spec(params, FIELDS_PARAM)
+    has_exclude, exclude_spec = _collect_field_spec(params, EXCLUDE_PARAM)
+
+    if has_fields and has_exclude:
+        raise UserError("You cannot specify both 'fields' and 'exclude'")
+
+    if has_fields:
+        tree = _build_field_tree(fields_spec)
+        return lambda data: _limit_fields(data, tree)
+    if has_exclude:
+        tree = _build_field_tree(exclude_spec)
+        return lambda data: _exclude_fields(data, tree)
+    return _identity
+
+
+def _identity(data):
+    return data
+
+
+def _collect_field_spec(params, prefix):
+    """Collect field paths from a QueryDict for the given prefix.
+
+    Reads 'prefix' and all 'prefix.*' keys. Values are comma-separated.
+    Returns (key_present, fields) where key_present is True if any
+    matching keys exist in the QueryDict (even if values are empty).
+    """
+    fields = []
+    key_present = False
+    for key in list(params.keys()):
+        if key == prefix:
+            key_present = True
+            for value in params.getlist(key):
+                fields.extend(part.strip() for part in value.split(",") if part.strip())
+        elif key.startswith(prefix + "."):
+            key_present = True
+            nesting = key[len(prefix) + 1:]  # e.g. "properties" from "fields.properties"
+            for value in params.getlist(key):
+                for part in value.split(","):
+                    part = part.strip()
+                    if part:
+                        fields.append(f"{nesting}.{part}")
+    return key_present, fields
+
+
 def _build_field_tree(fields):
     """Build a nested dict (field tree) from a list of dot-separated field paths.
 

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -15,6 +15,7 @@ from corehq.apps.reports.standard.cases.utils import (
 from corehq.apps.data_dictionary.util import get_data_dict_deprecated_case_types
 from dimagi.utils.parsing import FALSE_STRINGS
 from .core import UserError, serialize_es_case
+from .field_filters import get_fields_filter_fn
 
 DEFAULT_PAGE_SIZE = 20
 MAX_PAGE_SIZE = 5000
@@ -97,9 +98,10 @@ def get_list(domain, couch_user, params):
 
     es_result = query.run()
     hits = es_result.hits
+    filter_fields = get_fields_filter_fn(params)
     ret = {
         "matching_records": es_result.total,
-        "cases": [serialize_es_case(case) for case in hits],
+        "cases": [filter_fields(serialize_es_case(case)) for case in hits],
     }
 
     cases_in_result = len(hits)

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -131,6 +131,8 @@ def _get_query(domain, params):
              .size(page_size))
     query = query.sort('@indexed_on').sort('doc_id', reset_sort=False)
     for key, val in params.lists():
+        if _is_handled_elsewhere(key):
+            continue
         if len(val) == 1:
             query = query.filter(_get_filter(domain, key, val[0]))
         else:
@@ -140,16 +142,15 @@ def _get_query(domain, params):
     return query
 
 
-def _is_field_filter_param(key):
-    return key in ('fields', 'exclude') or key.startswith(('fields.', 'exclude.'))
+def _is_handled_elsewhere(key):
+    return (
+        key in ('limit', 'fields', 'exclude')
+        or key.startswith(('fields.', 'exclude.'))
+    )
 
 
 def _get_filter(domain, key, val):
-    if key == 'limit':
-        return filters.match_all()
-    elif _is_field_filter_param(key):
-        return filters.match_all()
-    elif key == 'query':
+    if key == 'query':
         return _get_query_filter(domain, val)
     elif key in SIMPLE_FILTERS:
         if key == INCLUDE_DEPRECATED:

--- a/corehq/apps/hqcase/api/get_list.py
+++ b/corehq/apps/hqcase/api/get_list.py
@@ -140,8 +140,14 @@ def _get_query(domain, params):
     return query
 
 
+def _is_field_filter_param(key):
+    return key in ('fields', 'exclude') or key.startswith(('fields.', 'exclude.'))
+
+
 def _get_filter(domain, key, val):
     if key == 'limit':
+        return filters.match_all()
+    elif _is_field_filter_param(key):
         return filters.match_all()
     elif key == 'query':
         return _get_query_filter(domain, val)

--- a/corehq/apps/hqcase/api/updates.py
+++ b/corehq/apps/hqcase/api/updates.py
@@ -252,7 +252,7 @@ def _get_bulk_updates(all_data, user_id):
             else:
                 updates.append(_get_individual_update(data, user_id, create_flag))
         except UserError as e:
-            errors.append(f'Error in row {i}: {e}')
+            errors.append(f'Error in row {i}: {e.message}')
 
     if errors:
         raise UserError("; ".join(errors))

--- a/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
+++ b/corehq/apps/hqcase/tests/test_case_api_bulk_get.py
@@ -86,6 +86,24 @@ class TestCaseAPIBulkGet(TestCase):
         case_ids = self.case_ids[0:2]
         self._call_get_api_check_results(case_ids, matching=2, missing=0)
 
+    def test_bulk_get_restrict_fields(self):
+        url = reverse('case_api_detail', args=(self.domain, ','.join(self.case_ids[0:2])))
+        res = self.client.get(f'{url}?fields=case_id,case_name')
+        assert res.status_code == 200
+        for case in res.json()['cases']:
+            assert set(case.keys()) == {'case_id', 'case_name'}
+
+    def test_bulk_post_restrict_fields(self):
+        url = reverse('case_api_bulk_fetch', args=(self.domain,))
+        res = self.client.post(
+            f'{url}?fields=case_id,case_name',
+            data={'case_ids': self.case_ids[0:2]},
+            content_type="application/json",
+        )
+        assert res.status_code == 200
+        for case in res.json()['cases']:
+            assert set(case.keys()) == {'case_id', 'case_name'}
+
     def test_bulk_get_domain_filter(self):
         case_ids = self.case_ids[0:2] + [self.other_domain_case_id]
         result = self._call_get_api_check_results(case_ids, matching=2, missing=1)

--- a/corehq/apps/hqcase/tests/test_case_api_get.py
+++ b/corehq/apps/hqcase/tests/test_case_api_get.py
@@ -78,6 +78,18 @@ class TestCaseAPIGet(TestCase):
         assert res.status_code == 200
         assert res.json()['case_id'] == self.case_ids[0]
 
+    def test_get_single_case_restrict_fields(self):
+        url = reverse('case_api_detail', args=(self.domain, self.case_ids[0]))
+        res = self.client.get(f'{url}?fields=case_id,case_name')
+        assert res.status_code == 200
+        assert set(res.json().keys()) == {'case_id', 'case_name'}
+
+    def test_get_by_external_id_restrict_fields(self):
+        url = reverse('case_api_detail_ext', args=(self.domain, 'vera'))
+        res = self.client.get(f'{url}?fields=case_id,case_name')
+        assert res.status_code == 200
+        assert set(res.json().keys()) == {'case_id', 'case_name'}
+
     def test_get_single_case_by_external_id(self):
         case_id = '11111111-1111-4111-8111-111111111111'
         external_id = 'ext-get-case'

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -121,18 +121,27 @@ class TestCaseListAPI(TestCase):
         self.assertFalse(res['cases'])  # empty result set
         self.assertNotIn('next', res)  # no next param
 
-    def test_fields_preserved_in_cursor(self):
-        params = QueryDict("case_type=person&limit=2&fields=case_id,external_id")
-        res = get_list(self.domain, self.couch_user, params)
-        cursor = b64decode(res['next']['cursor']).decode('utf-8')
-        self.assertIn('fields=', cursor)
+    def test_fields_filtering_across_pages(self):
+        """Field filtering should work on page 2+, not just page 1."""
+        params = QueryDict("case_type=person&limit=3&fields=case_id,external_id")
 
-    def test_dot_param_fields_preserved_in_cursor(self):
-        params = QueryDict("case_type=person&limit=2&fields=case_id&fields.properties=alias")
         res = get_list(self.domain, self.couch_user, params)
-        cursor = b64decode(res['next']['cursor']).decode('utf-8')
-        self.assertIn('fields=case_id', cursor)
-        self.assertIn('fields.properties=alias', cursor)
+        self.assertEqual(set(res['cases'][0].keys()), {'case_id', 'external_id'})
+
+        res2 = get_list(self.domain, self.couch_user, res['next'])
+        self.assertEqual(set(res2['cases'][0].keys()), {'case_id', 'external_id'})
+
+    def test_dot_param_fields_filtering_across_pages(self):
+        params = QueryDict("case_type=person&limit=3&fields=case_id&fields.properties=alias")
+
+        res = get_list(self.domain, self.couch_user, params)
+        self.assertEqual(set(res['cases'][0].keys()), {'case_id', 'properties'})
+        # cases[1] is rooster, who has an alias property
+        self.assertEqual(set(res['cases'][1]['properties'].keys()), {'alias'})
+
+        res2 = get_list(self.domain, self.couch_user, res['next'])
+        self.assertEqual(set(res2['cases'][0].keys()), {'case_id', 'properties'})
+        self.assertEqual(set(res2['cases'][0]['properties'].keys()), {'alias'})
 
     def test_deprecated_case_type(self):
         self.case_type_obj.is_deprecated = True

--- a/corehq/apps/hqcase/tests/test_case_list_api.py
+++ b/corehq/apps/hqcase/tests/test_case_list_api.py
@@ -121,6 +121,19 @@ class TestCaseListAPI(TestCase):
         self.assertFalse(res['cases'])  # empty result set
         self.assertNotIn('next', res)  # no next param
 
+    def test_fields_preserved_in_cursor(self):
+        params = QueryDict("case_type=person&limit=2&fields=case_id,external_id")
+        res = get_list(self.domain, self.couch_user, params)
+        cursor = b64decode(res['next']['cursor']).decode('utf-8')
+        self.assertIn('fields=', cursor)
+
+    def test_dot_param_fields_preserved_in_cursor(self):
+        params = QueryDict("case_type=person&limit=2&fields=case_id&fields.properties=alias")
+        res = get_list(self.domain, self.couch_user, params)
+        cursor = b64decode(res['next']['cursor']).decode('utf-8')
+        self.assertIn('fields=case_id', cursor)
+        self.assertIn('fields.properties=alias', cursor)
+
     def test_deprecated_case_type(self):
         self.case_type_obj.is_deprecated = True
         self.case_type_obj.save()

--- a/corehq/apps/hqcase/tests/test_case_update_api.py
+++ b/corehq/apps/hqcase/tests/test_case_update_api.py
@@ -880,3 +880,21 @@ class TestCaseAPI(TestCase):
         assert external_id in error_response['error']
         assert case1.case_id in error_response['error']
         assert case2.case_id in error_response['error']
+
+    def test_create_case_with_fields_filter(self):
+        url = reverse('case_api', args=(self.domain,))
+        res = self.client.post(
+            f'{url}?fields=case_id,case_type',
+            {
+                'case_type': 'player',
+                'case_name': 'Elizabeth Harmon',
+                'owner_id': 'methuen_home',
+                'properties': {'sport': 'chess'},
+            },
+            content_type="application/json;charset=utf-8",
+            HTTP_USER_AGENT="user agent string",
+        ).json()
+        assert set(res['case'].keys()) == {'case_id', 'case_type'}
+        assert res['case']['case_type'] == 'player'
+        # form_id is an envelope field, not part of the case — should be present
+        assert 'form_id' in res

--- a/corehq/apps/hqcase/tests/test_field_filters.py
+++ b/corehq/apps/hqcase/tests/test_field_filters.py
@@ -44,6 +44,15 @@ def test_get_tree_realistic():
 
     ("", {}),
     ("somethingelse=yes", {}),
+
+    # Whitespace is not stripped: "a=x, y" produces a key " y", not "y"
+    ("a=x, y", {'x': {}, ' y': {}}),
+    # Trailing comma produces an empty-string key
+    ("a=x,", {'x': {}, '': {}}),
+    # Empty value produces an empty-string key
+    ("a=", {'': {}}),
+    # Empty dot-param value produces an empty-string key in the subtree
+    ("a.b=", {'b': {'': {}}}),
 ])
 def test_get_tree(querystring, expected):
     assert _get_tree(QueryDict(querystring), 'a') == expected

--- a/corehq/apps/hqcase/tests/test_field_filters.py
+++ b/corehq/apps/hqcase/tests/test_field_filters.py
@@ -1,5 +1,4 @@
 from django.http import QueryDict
-from django.test import SimpleTestCase
 
 import pytest
 
@@ -50,108 +49,70 @@ def test_get_tree(querystring, expected):
     assert _get_tree(QueryDict(querystring), 'a') == expected
 
 
-class TestLimitFields(SimpleTestCase):
-    def test_top_level_only(self):
-        tree = {"case_id": {}, "case_type": {}}
-        result = _limit_fields(SAMPLE_CASE, tree)
-        self.assertEqual(result, {"case_id": "abc123", "case_type": "pregnant_mother"})
-
-    def test_nested_fields(self):
-        tree = {"case_id": {}, "properties": {"edd": {}, "age": {}}}
-        result = _limit_fields(SAMPLE_CASE, tree)
-        self.assertEqual(result, {
-            "case_id": "abc123",
-            "properties": {"edd": "2013-12-09", "age": "22"},
-        })
-
-    def test_whole_nested_object(self):
-        tree = {"properties": {}}
-        result = _limit_fields(SAMPLE_CASE, tree)
-        self.assertEqual(result, {"properties": SAMPLE_CASE["properties"]})
-
-    def test_nonexistent_fields_ignored(self):
-        tree = {"case_id": {}, "nonexistent": {}}
-        result = _limit_fields(SAMPLE_CASE, tree)
-        self.assertEqual(result, {"case_id": "abc123"})
-
-    def test_empty_tree_returns_empty(self):
-        result = _limit_fields(SAMPLE_CASE, {})
-        self.assertEqual(result, {})
-
-    def test_nested_path_through_scalar(self):
-        tree = {"case_id": {"nested": {}}}
-        result = _limit_fields(SAMPLE_CASE, tree)
-        self.assertEqual(result, {})
-
-    def test_nested_path_through_none(self):
-        data = {"case_id": "abc", "value": None}
-        tree = {"value": {"nested": {}}}
-        result = _limit_fields(data, tree)
-        self.assertEqual(result, {})
-
-    def test_deep_nesting(self):
-        data = {"a": {"b": {"c": "deep", "d": "also_deep"}}}
-        tree = {"a": {"b": {"c": {}}}}
-        result = _limit_fields(data, tree)
-        self.assertEqual(result, {"a": {"b": {"c": "deep"}}})
+@pytest.mark.parametrize("tree, expected", [
+    ({"case_id": {}, "case_type": {}},
+     {"case_id": "abc123", "case_type": "pregnant_mother"}),
+    ({"case_id": {}, "properties": {"edd": {}, "age": {}}},
+     {"case_id": "abc123", "properties": {"edd": "2013-12-09", "age": "22"}}),
+    ({"properties": {}},
+     {"properties": SAMPLE_CASE["properties"]}),
+    ({"case_id": {}, "nonexistent": {}},
+     {"case_id": "abc123"}),
+    ({}, {}),
+    # nested path through scalar — skipped
+    ({"case_id": {"nested": {}}}, {}),
+])
+def test_limit_fields(tree, expected):
+    assert _limit_fields(SAMPLE_CASE, tree) == expected
 
 
-class TestExcludeFields(SimpleTestCase):
-    def test_top_level_exclusion(self):
-        tree = {"case_name": {}}
-        result = _exclude_fields(SAMPLE_CASE, tree)
-        expected = {k: v for k, v in SAMPLE_CASE.items() if k != "case_name"}
-        self.assertEqual(result, expected)
-
-    def test_nested_exclusion(self):
-        tree = {"properties": {"husband_name": {}}}
-        result = _exclude_fields(SAMPLE_CASE, tree)
-        self.assertEqual(result["properties"], {"edd": "2013-12-09", "age": "22"})
-        self.assertEqual(result["case_id"], "abc123")
-
-    def test_exclude_whole_nested_object(self):
-        tree = {"properties": {}}
-        result = _exclude_fields(SAMPLE_CASE, tree)
-        self.assertNotIn("properties", result)
-        self.assertEqual(result["case_id"], "abc123")
-
-    def test_nonexistent_fields_ignored(self):
-        tree = {"nonexistent": {}}
-        result = _exclude_fields(SAMPLE_CASE, tree)
-        self.assertEqual(result, SAMPLE_CASE)
-
-    def test_empty_tree_returns_all(self):
-        result = _exclude_fields(SAMPLE_CASE, {})
-        self.assertEqual(result, SAMPLE_CASE)
-
-    def test_nested_path_through_scalar(self):
-        tree = {"case_id": {"nested": {}}}
-        result = _exclude_fields(SAMPLE_CASE, tree)
-        self.assertEqual(result, SAMPLE_CASE)
-
-    def test_deep_nesting(self):
-        data = {"a": {"b": {"c": "deep", "d": "also_deep"}}}
-        tree = {"a": {"b": {"c": {}}}}
-        result = _exclude_fields(data, tree)
-        self.assertEqual(result, {"a": {"b": {"d": "also_deep"}}})
+def test_limit_fields_nested_path_through_none():
+    data = {"case_id": "abc", "value": None}
+    assert _limit_fields(data, {"value": {"nested": {}}}) == {}
 
 
-class TestGetFieldsFilterFn(SimpleTestCase):
-    """Tests for get_fields_filter_fn behavior not covered by the unit tests above."""
+def test_limit_fields_deep_nesting():
+    data = {"a": {"b": {"c": "deep", "d": "also_deep"}}}
+    assert _limit_fields(data, {"a": {"b": {"c": {}}}}) == {"a": {"b": {"c": "deep"}}}
 
-    def test_no_params_returns_identity(self):
-        fn = get_fields_filter_fn(QueryDict(""))
-        data = {"case_id": "abc", "case_type": "foo"}
-        self.assertEqual(fn(data), data)
 
-    def test_both_raises_error(self):
-        with self.assertRaises(UserError):
-            get_fields_filter_fn(QueryDict("fields=case_id&exclude=case_name"))
+@pytest.mark.parametrize("tree, expected", [
+    ({"case_name": {}},
+     {k: v for k, v in SAMPLE_CASE.items() if k != "case_name"}),
+    ({"properties": {"husband_name": {}}},
+     {**SAMPLE_CASE, "properties": {"edd": "2013-12-09", "age": "22"}}),
+    ({"properties": {}},
+     {k: v for k, v in SAMPLE_CASE.items() if k != "properties"}),
+    ({"nonexistent": {}}, SAMPLE_CASE),
+    ({}, SAMPLE_CASE),
+    # nested path through scalar — data unchanged
+    ({"case_id": {"nested": {}}}, SAMPLE_CASE),
+])
+def test_exclude_fields(tree, expected):
+    assert _exclude_fields(SAMPLE_CASE, tree) == expected
 
-    def test_empty_fields_returns_empty(self):
-        fn = get_fields_filter_fn(QueryDict("fields="))
-        self.assertEqual(fn(SAMPLE_CASE), {})
 
-    def test_empty_exclude_returns_all(self):
-        fn = get_fields_filter_fn(QueryDict("exclude="))
-        self.assertEqual(fn(SAMPLE_CASE), SAMPLE_CASE)
+def test_exclude_fields_deep_nesting():
+    data = {"a": {"b": {"c": "deep", "d": "also_deep"}}}
+    assert _exclude_fields(data, {"a": {"b": {"c": {}}}}) == {"a": {"b": {"d": "also_deep"}}}
+
+
+def test_filter_fn_no_params_returns_identity():
+    fn = get_fields_filter_fn(QueryDict(""))
+    data = {"case_id": "abc", "case_type": "foo"}
+    assert fn(data) == data
+
+
+def test_filter_fn_both_raises_error():
+    with pytest.raises(UserError):
+        get_fields_filter_fn(QueryDict("fields=case_id&exclude=case_name"))
+
+
+def test_filter_fn_empty_fields_returns_empty():
+    fn = get_fields_filter_fn(QueryDict("fields="))
+    assert fn(SAMPLE_CASE) == {}
+
+
+def test_filter_fn_empty_exclude_returns_all():
+    fn = get_fields_filter_fn(QueryDict("exclude="))
+    assert fn(SAMPLE_CASE) == SAMPLE_CASE

--- a/corehq/apps/hqcase/tests/test_field_filters.py
+++ b/corehq/apps/hqcase/tests/test_field_filters.py
@@ -41,18 +41,13 @@ def test_get_tree_realistic():
     ("a.A=B&a=A.C", {'A': {'B': {}, 'C': {}}}),
     ("a.A=B,C", {'A': {'B': {}, 'C': {}}}),
     ("a.A=B,C&a.A=D", {'A': {'B': {}, 'C': {}, 'D': {}}}),
-
+    ("a.A=B.C,D.E&", {'A': {'B': {'C': {}}, 'D': {'E': {}}}}),
     ("", {}),
     ("somethingelse=yes", {}),
-
-    # Whitespace is not stripped: "a=x, y" produces a key " y", not "y"
-    ("a=x, y", {'x': {}, ' y': {}}),
-    # Trailing comma produces an empty-string key
-    ("a=x,", {'x': {}, '': {}}),
-    # Empty value produces an empty-string key
-    ("a=", {'': {}}),
-    # Empty dot-param value produces an empty-string key in the subtree
-    ("a.b=", {'b': {'': {}}}),
+    ("a=x, y", {'x': {}, 'y': {}}),  # Strip whitespace
+    ("a=x,", {'x': {}}),  # Ignore paths with blank segments
+    ("a=", {}),
+    ("a.b=", {}),
 ])
 def test_get_tree(querystring, expected):
     assert _get_tree(QueryDict(querystring), 'a') == expected
@@ -122,6 +117,16 @@ def test_filter_fn_empty_fields_returns_empty():
     assert fn(SAMPLE_CASE) == {}
 
 
+def test_filter_fn_empty_nested_fields_returns_empty():
+    fn = get_fields_filter_fn(QueryDict("fields.properties="))
+    assert fn(SAMPLE_CASE) == {}
+
+
 def test_filter_fn_empty_exclude_returns_all():
     fn = get_fields_filter_fn(QueryDict("exclude="))
+    assert fn(SAMPLE_CASE) == SAMPLE_CASE
+
+
+def test_filter_fn_empty_nested_exclude_returns_all():
+    fn = get_fields_filter_fn(QueryDict("exclude.properties="))
     assert fn(SAMPLE_CASE) == SAMPLE_CASE

--- a/corehq/apps/hqcase/tests/test_field_filters.py
+++ b/corehq/apps/hqcase/tests/test_field_filters.py
@@ -216,3 +216,67 @@ class TestExtractFieldsParams(SimpleTestCase):
         fn = extract_fields_params(params)
         result = fn(data)
         self.assertEqual(result, {"a": {"b": {"c": "deep"}}})
+
+
+class TestFieldFilterPipeline(SimpleTestCase):
+    """Integration-style tests: extract params then apply to case dicts."""
+
+    CASE = {
+        "case_id": "abc123",
+        "case_type": "person",
+        "case_name": "Test",
+        "properties": {"edd": "2013-12-09", "age": "22", "secret": "hidden"},
+        "indices": {"parent": {"case_id": "def456", "case_type": "household"}},
+    }
+
+    def test_fields_on_case_list_envelope(self):
+        """Envelope fields are not filtered - only case dicts are."""
+        params = QueryDict("fields=case_id")
+        filter_fn = extract_fields_params(params)
+        envelope = {
+            "matching_records": 5,
+            "cases": [self.CASE],
+            "next": {"cursor": "abc"},
+        }
+        # Apply filter to each case (as views.py does), not the envelope
+        filtered_cases = [filter_fn(c) for c in envelope["cases"]]
+        self.assertEqual(filtered_cases, [{"case_id": "abc123"}])
+        # Envelope keys untouched
+        self.assertIn("matching_records", envelope)
+        self.assertIn("next", envelope)
+
+    def test_bulk_error_stubs_not_filtered(self):
+        """Error stubs should pass through unfiltered."""
+        params = QueryDict("fields=case_id")
+        filter_fn = extract_fields_params(params)
+        cases = [
+            self.CASE,
+            {"case_id": "missing1", "error": "not found"},
+        ]
+        filtered = [
+            filter_fn(c) if "error" not in c else c
+            for c in cases
+        ]
+        self.assertEqual(filtered[0], {"case_id": "abc123"})
+        self.assertEqual(filtered[1], {"case_id": "missing1", "error": "not found"})
+
+    def test_fields_on_update_response(self):
+        """Update response: form_id is envelope, case is filtered."""
+        params = QueryDict("fields=case_id,case_type")
+        filter_fn = extract_fields_params(params)
+        response = {
+            "form_id": "form-xyz",
+            "case": filter_fn(self.CASE),
+        }
+        self.assertEqual(response["form_id"], "form-xyz")
+        self.assertEqual(response["case"], {"case_id": "abc123", "case_type": "person"})
+
+    def test_exclude_nested_fields(self):
+        params = QueryDict("exclude.properties=secret")
+        filter_fn = extract_fields_params(params)
+        result = filter_fn(self.CASE)
+        self.assertNotIn("secret", result["properties"])
+        self.assertIn("edd", result["properties"])
+        # Top-level fields unchanged
+        self.assertIn("case_id", result)
+        self.assertIn("indices", result)

--- a/corehq/apps/hqcase/tests/test_field_filters.py
+++ b/corehq/apps/hqcase/tests/test_field_filters.py
@@ -1,0 +1,140 @@
+from django.test import SimpleTestCase
+
+from corehq.apps.hqcase.api.field_filters import (
+    _build_field_tree,
+    _exclude_fields,
+    _limit_fields,
+)
+
+SAMPLE_CASE = {
+    "case_id": "abc123",
+    "case_type": "pregnant_mother",
+    "case_name": "Hermes Adama",
+    "properties": {
+        "edd": "2013-12-09",
+        "age": "22",
+        "husband_name": "",
+    },
+    "indices": {},
+}
+
+
+class TestBuildFieldTree(SimpleTestCase):
+    def test_top_level_fields(self):
+        self.assertEqual(
+            _build_field_tree(["case_id", "case_type"]),
+            {"case_id": {}, "case_type": {}},
+        )
+
+    def test_dotted_fields(self):
+        self.assertEqual(
+            _build_field_tree(["properties.edd", "properties.age"]),
+            {"properties": {"edd": {}, "age": {}}},
+        )
+
+    def test_mixed_top_and_dotted(self):
+        self.assertEqual(
+            _build_field_tree(["case_id", "properties.edd"]),
+            {"case_id": {}, "properties": {"edd": {}}},
+        )
+
+    def test_deep_nesting(self):
+        self.assertEqual(
+            _build_field_tree(["a.b.c.d"]),
+            {"a": {"b": {"c": {"d": {}}}}},
+        )
+
+    def test_whole_object_and_sub_field(self):
+        self.assertEqual(
+            _build_field_tree(["properties", "properties.edd"]),
+            {"properties": {}},
+        )
+
+    def test_empty_list(self):
+        self.assertEqual(_build_field_tree([]), {})
+
+
+class TestLimitFields(SimpleTestCase):
+    def test_top_level_only(self):
+        tree = {"case_id": {}, "case_type": {}}
+        result = _limit_fields(SAMPLE_CASE, tree)
+        self.assertEqual(result, {"case_id": "abc123", "case_type": "pregnant_mother"})
+
+    def test_nested_fields(self):
+        tree = {"case_id": {}, "properties": {"edd": {}, "age": {}}}
+        result = _limit_fields(SAMPLE_CASE, tree)
+        self.assertEqual(result, {
+            "case_id": "abc123",
+            "properties": {"edd": "2013-12-09", "age": "22"},
+        })
+
+    def test_whole_nested_object(self):
+        tree = {"properties": {}}
+        result = _limit_fields(SAMPLE_CASE, tree)
+        self.assertEqual(result, {"properties": SAMPLE_CASE["properties"]})
+
+    def test_nonexistent_fields_ignored(self):
+        tree = {"case_id": {}, "nonexistent": {}}
+        result = _limit_fields(SAMPLE_CASE, tree)
+        self.assertEqual(result, {"case_id": "abc123"})
+
+    def test_empty_tree_returns_empty(self):
+        result = _limit_fields(SAMPLE_CASE, {})
+        self.assertEqual(result, {})
+
+    def test_nested_path_through_scalar(self):
+        tree = {"case_id": {"nested": {}}}
+        result = _limit_fields(SAMPLE_CASE, tree)
+        self.assertEqual(result, {})
+
+    def test_nested_path_through_none(self):
+        data = {"case_id": "abc", "value": None}
+        tree = {"value": {"nested": {}}}
+        result = _limit_fields(data, tree)
+        self.assertEqual(result, {})
+
+    def test_deep_nesting(self):
+        data = {"a": {"b": {"c": "deep", "d": "also_deep"}}}
+        tree = {"a": {"b": {"c": {}}}}
+        result = _limit_fields(data, tree)
+        self.assertEqual(result, {"a": {"b": {"c": "deep"}}})
+
+
+class TestExcludeFields(SimpleTestCase):
+    def test_top_level_exclusion(self):
+        tree = {"case_name": {}}
+        result = _exclude_fields(SAMPLE_CASE, tree)
+        expected = {k: v for k, v in SAMPLE_CASE.items() if k != "case_name"}
+        self.assertEqual(result, expected)
+
+    def test_nested_exclusion(self):
+        tree = {"properties": {"husband_name": {}}}
+        result = _exclude_fields(SAMPLE_CASE, tree)
+        self.assertEqual(result["properties"], {"edd": "2013-12-09", "age": "22"})
+        self.assertEqual(result["case_id"], "abc123")
+
+    def test_exclude_whole_nested_object(self):
+        tree = {"properties": {}}
+        result = _exclude_fields(SAMPLE_CASE, tree)
+        self.assertNotIn("properties", result)
+        self.assertEqual(result["case_id"], "abc123")
+
+    def test_nonexistent_fields_ignored(self):
+        tree = {"nonexistent": {}}
+        result = _exclude_fields(SAMPLE_CASE, tree)
+        self.assertEqual(result, SAMPLE_CASE)
+
+    def test_empty_tree_returns_all(self):
+        result = _exclude_fields(SAMPLE_CASE, {})
+        self.assertEqual(result, SAMPLE_CASE)
+
+    def test_nested_path_through_scalar(self):
+        tree = {"case_id": {"nested": {}}}
+        result = _exclude_fields(SAMPLE_CASE, tree)
+        self.assertEqual(result, SAMPLE_CASE)
+
+    def test_deep_nesting(self):
+        data = {"a": {"b": {"c": "deep", "d": "also_deep"}}}
+        tree = {"a": {"b": {"c": {}}}}
+        result = _exclude_fields(data, tree)
+        self.assertEqual(result, {"a": {"b": {"d": "also_deep"}}})

--- a/corehq/apps/hqcase/tests/test_field_filters.py
+++ b/corehq/apps/hqcase/tests/test_field_filters.py
@@ -1,9 +1,12 @@
+from django.http import QueryDict
 from django.test import SimpleTestCase
 
+from corehq.apps.hqcase.api.core import UserError
 from corehq.apps.hqcase.api.field_filters import (
     _build_field_tree,
     _exclude_fields,
     _limit_fields,
+    extract_fields_params,
 )
 
 SAMPLE_CASE = {
@@ -138,3 +141,78 @@ class TestExcludeFields(SimpleTestCase):
         tree = {"a": {"b": {"c": {}}}}
         result = _exclude_fields(data, tree)
         self.assertEqual(result, {"a": {"b": {"d": "also_deep"}}})
+
+
+class TestExtractFieldsParams(SimpleTestCase):
+
+    def test_no_params_returns_identity(self):
+        params = QueryDict("")
+        fn = extract_fields_params(params)
+        data = {"case_id": "abc", "case_type": "foo"}
+        self.assertEqual(fn(data), data)
+
+    def test_fields_basic(self):
+        params = QueryDict("fields=case_id,case_type")
+        fn = extract_fields_params(params)
+        result = fn(SAMPLE_CASE)
+        self.assertEqual(result, {"case_id": "abc123", "case_type": "pregnant_mother"})
+
+    def test_exclude_basic(self):
+        params = QueryDict("exclude=case_name")
+        fn = extract_fields_params(params)
+        result = fn(SAMPLE_CASE)
+        self.assertNotIn("case_name", result)
+        self.assertIn("case_id", result)
+
+    def test_both_raises_error(self):
+        params = QueryDict("fields=case_id&exclude=case_name")
+        with self.assertRaises(UserError):
+            extract_fields_params(params)
+
+    def test_dot_param_fields(self):
+        params = QueryDict("fields=case_id&fields.properties=edd,age")
+        fn = extract_fields_params(params)
+        result = fn(SAMPLE_CASE)
+        self.assertEqual(result, {
+            "case_id": "abc123",
+            "properties": {"edd": "2013-12-09", "age": "22"},
+        })
+
+    def test_dot_param_without_base(self):
+        params = QueryDict("fields.properties=edd")
+        fn = extract_fields_params(params)
+        result = fn(SAMPLE_CASE)
+        self.assertEqual(result, {"properties": {"edd": "2013-12-09"}})
+
+    def test_repeated_params(self):
+        params = QueryDict("fields=case_id&fields=case_type")
+        fn = extract_fields_params(params)
+        result = fn(SAMPLE_CASE)
+        self.assertEqual(result, {"case_id": "abc123", "case_type": "pregnant_mother"})
+
+    def test_empty_fields_returns_empty(self):
+        params = QueryDict("fields=")
+        fn = extract_fields_params(params)
+        result = fn(SAMPLE_CASE)
+        self.assertEqual(result, {})
+
+    def test_empty_exclude_returns_all(self):
+        params = QueryDict("exclude=")
+        fn = extract_fields_params(params)
+        result = fn(SAMPLE_CASE)
+        self.assertEqual(result, SAMPLE_CASE)
+
+    def test_dot_param_exclude(self):
+        params = QueryDict("exclude=case_name&exclude.properties=husband_name")
+        fn = extract_fields_params(params)
+        result = fn(SAMPLE_CASE)
+        self.assertNotIn("case_name", result)
+        self.assertNotIn("husband_name", result["properties"])
+        self.assertIn("edd", result["properties"])
+
+    def test_deep_dot_param(self):
+        params = QueryDict("fields.a.b=c")
+        data = {"a": {"b": {"c": "deep", "d": "other"}}, "x": "y"}
+        fn = extract_fields_params(params)
+        result = fn(data)
+        self.assertEqual(result, {"a": {"b": {"c": "deep"}}})

--- a/corehq/apps/hqcase/tests/test_field_filters.py
+++ b/corehq/apps/hqcase/tests/test_field_filters.py
@@ -136,140 +136,22 @@ class TestExcludeFields(SimpleTestCase):
         self.assertEqual(result, {"a": {"b": {"d": "also_deep"}}})
 
 
-class TestExtractFieldsParams(SimpleTestCase):
+class TestGetFieldsFilterFn(SimpleTestCase):
+    """Tests for get_fields_filter_fn behavior not covered by the unit tests above."""
 
     def test_no_params_returns_identity(self):
-        params = QueryDict("")
-        fn = get_fields_filter_fn(params)
+        fn = get_fields_filter_fn(QueryDict(""))
         data = {"case_id": "abc", "case_type": "foo"}
         self.assertEqual(fn(data), data)
 
-    def test_fields_basic(self):
-        params = QueryDict("fields=case_id,case_type")
-        fn = get_fields_filter_fn(params)
-        result = fn(SAMPLE_CASE)
-        self.assertEqual(result, {"case_id": "abc123", "case_type": "pregnant_mother"})
-
-    def test_exclude_basic(self):
-        params = QueryDict("exclude=case_name")
-        fn = get_fields_filter_fn(params)
-        result = fn(SAMPLE_CASE)
-        self.assertNotIn("case_name", result)
-        self.assertIn("case_id", result)
-
     def test_both_raises_error(self):
-        params = QueryDict("fields=case_id&exclude=case_name")
         with self.assertRaises(UserError):
-            get_fields_filter_fn(params)
-
-    def test_dot_param_fields(self):
-        params = QueryDict("fields=case_id&fields.properties=edd,age")
-        fn = get_fields_filter_fn(params)
-        result = fn(SAMPLE_CASE)
-        self.assertEqual(result, {
-            "case_id": "abc123",
-            "properties": {"edd": "2013-12-09", "age": "22"},
-        })
-
-    def test_dot_param_without_base(self):
-        params = QueryDict("fields.properties=edd")
-        fn = get_fields_filter_fn(params)
-        result = fn(SAMPLE_CASE)
-        self.assertEqual(result, {"properties": {"edd": "2013-12-09"}})
-
-    def test_repeated_params(self):
-        params = QueryDict("fields=case_id&fields=case_type")
-        fn = get_fields_filter_fn(params)
-        result = fn(SAMPLE_CASE)
-        self.assertEqual(result, {"case_id": "abc123", "case_type": "pregnant_mother"})
+            get_fields_filter_fn(QueryDict("fields=case_id&exclude=case_name"))
 
     def test_empty_fields_returns_empty(self):
-        params = QueryDict("fields=")
-        fn = get_fields_filter_fn(params)
-        result = fn(SAMPLE_CASE)
-        self.assertEqual(result, {})
+        fn = get_fields_filter_fn(QueryDict("fields="))
+        self.assertEqual(fn(SAMPLE_CASE), {})
 
     def test_empty_exclude_returns_all(self):
-        params = QueryDict("exclude=")
-        fn = get_fields_filter_fn(params)
-        result = fn(SAMPLE_CASE)
-        self.assertEqual(result, SAMPLE_CASE)
-
-    def test_dot_param_exclude(self):
-        params = QueryDict("exclude=case_name&exclude.properties=husband_name")
-        fn = get_fields_filter_fn(params)
-        result = fn(SAMPLE_CASE)
-        self.assertNotIn("case_name", result)
-        self.assertNotIn("husband_name", result["properties"])
-        self.assertIn("edd", result["properties"])
-
-    def test_deep_dot_param(self):
-        params = QueryDict("fields.a.b=c")
-        data = {"a": {"b": {"c": "deep", "d": "other"}}, "x": "y"}
-        fn = get_fields_filter_fn(params)
-        result = fn(data)
-        self.assertEqual(result, {"a": {"b": {"c": "deep"}}})
-
-
-class TestFieldFilterPipeline(SimpleTestCase):
-    """Integration-style tests: extract params then apply to case dicts."""
-
-    CASE = {
-        "case_id": "abc123",
-        "case_type": "person",
-        "case_name": "Test",
-        "properties": {"edd": "2013-12-09", "age": "22", "secret": "hidden"},
-        "indices": {"parent": {"case_id": "def456", "case_type": "household"}},
-    }
-
-    def test_fields_on_case_list_envelope(self):
-        """Envelope fields are not filtered - only case dicts are."""
-        params = QueryDict("fields=case_id")
-        filter_fn = get_fields_filter_fn(params)
-        envelope = {
-            "matching_records": 5,
-            "cases": [self.CASE],
-            "next": {"cursor": "abc"},
-        }
-        # Apply filter to each case (as views.py does), not the envelope
-        filtered_cases = [filter_fn(c) for c in envelope["cases"]]
-        self.assertEqual(filtered_cases, [{"case_id": "abc123"}])
-        # Envelope keys untouched
-        self.assertIn("matching_records", envelope)
-        self.assertIn("next", envelope)
-
-    def test_bulk_error_stubs_not_filtered(self):
-        """Error stubs should pass through unfiltered."""
-        params = QueryDict("fields=case_id")
-        filter_fn = get_fields_filter_fn(params)
-        cases = [
-            self.CASE,
-            {"case_id": "missing1", "error": "not found"},
-        ]
-        filtered = [
-            filter_fn(c) if "error" not in c else c
-            for c in cases
-        ]
-        self.assertEqual(filtered[0], {"case_id": "abc123"})
-        self.assertEqual(filtered[1], {"case_id": "missing1", "error": "not found"})
-
-    def test_fields_on_update_response(self):
-        """Update response: form_id is envelope, case is filtered."""
-        params = QueryDict("fields=case_id,case_type")
-        filter_fn = get_fields_filter_fn(params)
-        response = {
-            "form_id": "form-xyz",
-            "case": filter_fn(self.CASE),
-        }
-        self.assertEqual(response["form_id"], "form-xyz")
-        self.assertEqual(response["case"], {"case_id": "abc123", "case_type": "person"})
-
-    def test_exclude_nested_fields(self):
-        params = QueryDict("exclude.properties=secret")
-        filter_fn = get_fields_filter_fn(params)
-        result = filter_fn(self.CASE)
-        self.assertNotIn("secret", result["properties"])
-        self.assertIn("edd", result["properties"])
-        # Top-level fields unchanged
-        self.assertIn("case_id", result)
-        self.assertIn("indices", result)
+        fn = get_fields_filter_fn(QueryDict("exclude="))
+        self.assertEqual(fn(SAMPLE_CASE), SAMPLE_CASE)

--- a/corehq/apps/hqcase/tests/test_field_filters.py
+++ b/corehq/apps/hqcase/tests/test_field_filters.py
@@ -1,12 +1,14 @@
 from django.http import QueryDict
 from django.test import SimpleTestCase
 
+import pytest
+
 from corehq.apps.hqcase.api.core import UserError
 from corehq.apps.hqcase.api.field_filters import (
-    _build_field_tree,
     _exclude_fields,
+    _get_tree,
     _limit_fields,
-    extract_fields_params,
+    get_fields_filter_fn,
 )
 
 SAMPLE_CASE = {
@@ -22,39 +24,30 @@ SAMPLE_CASE = {
 }
 
 
-class TestBuildFieldTree(SimpleTestCase):
-    def test_top_level_fields(self):
-        self.assertEqual(
-            _build_field_tree(["case_id", "case_type"]),
-            {"case_id": {}, "case_type": {}},
-        )
+def test_get_tree_realistic():
+    qs = 'fields=case_id&fields=case_name&fields.properties=dob,edd'
+    assert _get_tree(QueryDict(qs), 'fields') == {
+        'case_id': {},
+        'case_name': {},
+        'properties': {'dob': {}, 'edd': {}},
+    }
 
-    def test_dotted_fields(self):
-        self.assertEqual(
-            _build_field_tree(["properties.edd", "properties.age"]),
-            {"properties": {"edd": {}, "age": {}}},
-        )
 
-    def test_mixed_top_and_dotted(self):
-        self.assertEqual(
-            _build_field_tree(["case_id", "properties.edd"]),
-            {"case_id": {}, "properties": {"edd": {}}},
-        )
+@pytest.mark.parametrize("querystring, expected", [
+    ("a=A&a=B&x=Y", {'A': {}, 'B': {}}),
+    ("a.A=B&a.C=D", {'A': {'B': {}},
+                     'C': {'D': {}}}),
+    ("a.A=B&a.A=C", {'A': {'B': {}, 'C': {}}}),
+    ("a=A.B&a=A.C", {'A': {'B': {}, 'C': {}}}),
+    ("a.A=B&a=A.C", {'A': {'B': {}, 'C': {}}}),
+    ("a.A=B,C", {'A': {'B': {}, 'C': {}}}),
+    ("a.A=B,C&a.A=D", {'A': {'B': {}, 'C': {}, 'D': {}}}),
 
-    def test_deep_nesting(self):
-        self.assertEqual(
-            _build_field_tree(["a.b.c.d"]),
-            {"a": {"b": {"c": {"d": {}}}}},
-        )
-
-    def test_whole_object_and_sub_field(self):
-        self.assertEqual(
-            _build_field_tree(["properties", "properties.edd"]),
-            {"properties": {}},
-        )
-
-    def test_empty_list(self):
-        self.assertEqual(_build_field_tree([]), {})
+    ("", {}),
+    ("somethingelse=yes", {}),
+])
+def test_get_tree(querystring, expected):
+    assert _get_tree(QueryDict(querystring), 'a') == expected
 
 
 class TestLimitFields(SimpleTestCase):
@@ -147,19 +140,19 @@ class TestExtractFieldsParams(SimpleTestCase):
 
     def test_no_params_returns_identity(self):
         params = QueryDict("")
-        fn = extract_fields_params(params)
+        fn = get_fields_filter_fn(params)
         data = {"case_id": "abc", "case_type": "foo"}
         self.assertEqual(fn(data), data)
 
     def test_fields_basic(self):
         params = QueryDict("fields=case_id,case_type")
-        fn = extract_fields_params(params)
+        fn = get_fields_filter_fn(params)
         result = fn(SAMPLE_CASE)
         self.assertEqual(result, {"case_id": "abc123", "case_type": "pregnant_mother"})
 
     def test_exclude_basic(self):
         params = QueryDict("exclude=case_name")
-        fn = extract_fields_params(params)
+        fn = get_fields_filter_fn(params)
         result = fn(SAMPLE_CASE)
         self.assertNotIn("case_name", result)
         self.assertIn("case_id", result)
@@ -167,11 +160,11 @@ class TestExtractFieldsParams(SimpleTestCase):
     def test_both_raises_error(self):
         params = QueryDict("fields=case_id&exclude=case_name")
         with self.assertRaises(UserError):
-            extract_fields_params(params)
+            get_fields_filter_fn(params)
 
     def test_dot_param_fields(self):
         params = QueryDict("fields=case_id&fields.properties=edd,age")
-        fn = extract_fields_params(params)
+        fn = get_fields_filter_fn(params)
         result = fn(SAMPLE_CASE)
         self.assertEqual(result, {
             "case_id": "abc123",
@@ -180,31 +173,31 @@ class TestExtractFieldsParams(SimpleTestCase):
 
     def test_dot_param_without_base(self):
         params = QueryDict("fields.properties=edd")
-        fn = extract_fields_params(params)
+        fn = get_fields_filter_fn(params)
         result = fn(SAMPLE_CASE)
         self.assertEqual(result, {"properties": {"edd": "2013-12-09"}})
 
     def test_repeated_params(self):
         params = QueryDict("fields=case_id&fields=case_type")
-        fn = extract_fields_params(params)
+        fn = get_fields_filter_fn(params)
         result = fn(SAMPLE_CASE)
         self.assertEqual(result, {"case_id": "abc123", "case_type": "pregnant_mother"})
 
     def test_empty_fields_returns_empty(self):
         params = QueryDict("fields=")
-        fn = extract_fields_params(params)
+        fn = get_fields_filter_fn(params)
         result = fn(SAMPLE_CASE)
         self.assertEqual(result, {})
 
     def test_empty_exclude_returns_all(self):
         params = QueryDict("exclude=")
-        fn = extract_fields_params(params)
+        fn = get_fields_filter_fn(params)
         result = fn(SAMPLE_CASE)
         self.assertEqual(result, SAMPLE_CASE)
 
     def test_dot_param_exclude(self):
         params = QueryDict("exclude=case_name&exclude.properties=husband_name")
-        fn = extract_fields_params(params)
+        fn = get_fields_filter_fn(params)
         result = fn(SAMPLE_CASE)
         self.assertNotIn("case_name", result)
         self.assertNotIn("husband_name", result["properties"])
@@ -213,7 +206,7 @@ class TestExtractFieldsParams(SimpleTestCase):
     def test_deep_dot_param(self):
         params = QueryDict("fields.a.b=c")
         data = {"a": {"b": {"c": "deep", "d": "other"}}, "x": "y"}
-        fn = extract_fields_params(params)
+        fn = get_fields_filter_fn(params)
         result = fn(data)
         self.assertEqual(result, {"a": {"b": {"c": "deep"}}})
 
@@ -232,7 +225,7 @@ class TestFieldFilterPipeline(SimpleTestCase):
     def test_fields_on_case_list_envelope(self):
         """Envelope fields are not filtered - only case dicts are."""
         params = QueryDict("fields=case_id")
-        filter_fn = extract_fields_params(params)
+        filter_fn = get_fields_filter_fn(params)
         envelope = {
             "matching_records": 5,
             "cases": [self.CASE],
@@ -248,7 +241,7 @@ class TestFieldFilterPipeline(SimpleTestCase):
     def test_bulk_error_stubs_not_filtered(self):
         """Error stubs should pass through unfiltered."""
         params = QueryDict("fields=case_id")
-        filter_fn = extract_fields_params(params)
+        filter_fn = get_fields_filter_fn(params)
         cases = [
             self.CASE,
             {"case_id": "missing1", "error": "not found"},
@@ -263,7 +256,7 @@ class TestFieldFilterPipeline(SimpleTestCase):
     def test_fields_on_update_response(self):
         """Update response: form_id is envelope, case is filtered."""
         params = QueryDict("fields=case_id,case_type")
-        filter_fn = extract_fields_params(params)
+        filter_fn = get_fields_filter_fn(params)
         response = {
             "form_id": "form-xyz",
             "case": filter_fn(self.CASE),
@@ -273,7 +266,7 @@ class TestFieldFilterPipeline(SimpleTestCase):
 
     def test_exclude_nested_fields(self):
         params = QueryDict("exclude.properties=secret")
-        filter_fn = extract_fields_params(params)
+        filter_fn = get_fields_filter_fn(params)
         result = filter_fn(self.CASE)
         self.assertNotIn("secret", result["properties"])
         self.assertIn("edd", result["properties"])

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -109,7 +109,7 @@ def case_api(request, domain, case_id=None, external_id=None):
             return _handle_case_put_post(request, is_creation=False, case_id=case_id)
         return JsonResponse({'error': "Request method not allowed"}, status=405)
     except UserError as e:
-        return JsonResponse({'error': str(e)}, status=400)
+        return JsonResponse({'error': e.message}, status=400)
 
 
 @waf_allow('XSS_BODY')
@@ -124,7 +124,7 @@ def case_api_bulk_fetch(request, domain):
     try:
         return _handle_bulk_fetch(request)
     except UserError as e:
-        return JsonResponse({'error': str(e)}, status=400)
+        return JsonResponse({'error': e.message}, status=400)
 
 
 def _handle_get(request, case_id):

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -215,9 +215,6 @@ def _handle_list_view(request):
     except UserError as e:
         return JsonResponse({'error': str(e)}, status=400)
 
-    filter_fields = get_fields_filter_fn(request.GET)
-    res['cases'] = [filter_fields(case) for case in res['cases']]
-
     if 'next' in res:
         res['next'] = reverse('case_api', args=[request.domain], params=res['next'], absolute=True)
     return JsonResponse(res)

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -29,7 +29,7 @@ from corehq.apps.locations.permissions import location_safe
 from corehq.form_processor.models import CommCareCase
 
 from .api.core import SubmissionError, UserError, serialize_case, serialize_es_case
-from .api.field_filters import extract_fields_params
+from .api.field_filters import get_fields_filter_fn
 from .api.get_list import get_list
 from .api.get_bulk import get_bulk
 from .api.updates import handle_case_update
@@ -133,7 +133,7 @@ def _get_bulk_cases(request, case_ids=None, external_ids=None):
     except UserError as e:
         return JsonResponse({'error': str(e)}, status=400)
 
-    filter_fields = extract_fields_params(request.GET)
+    filter_fields = get_fields_filter_fn(request.GET)
     res['cases'] = [
         filter_fields(case) if 'error' not in case else case
         for case in res['cases']
@@ -152,7 +152,7 @@ def _get_single_case(request, case_id):
         return JsonResponse({'error': f"Case '{case_id}' not found"}, status=404)
     except PermissionDenied:
         return JsonResponse({'error': f"Insufficent permission for Case '{case_id}'"}, status=403)
-    filter_fields = extract_fields_params(request.GET)
+    filter_fields = get_fields_filter_fn(request.GET)
     return JsonResponse(filter_fields(serialize_es_case(case)))
 
 
@@ -191,7 +191,7 @@ def _handle_ext_get(request, external_id):
             {'error': f"Insufficent permission for Case '{case.case_id}'"},
             status=403,
         )
-    filter_fields = extract_fields_params(request.GET)
+    filter_fields = get_fields_filter_fn(request.GET)
     return JsonResponse(filter_fields(serialize_case(case)))
 
 
@@ -215,7 +215,7 @@ def _handle_list_view(request):
     except UserError as e:
         return JsonResponse({'error': str(e)}, status=400)
 
-    filter_fields = extract_fields_params(request.GET)
+    filter_fields = get_fields_filter_fn(request.GET)
     res['cases'] = [filter_fields(case) for case in res['cases']]
 
     if 'next' in res:
@@ -299,7 +299,7 @@ def _handle_case_update(request, data, is_creation):
             'form_id': e.form_id,
         }, status=400)
 
-    filter_fields = extract_fields_params(request.GET)
+    filter_fields = get_fields_filter_fn(request.GET)
     if isinstance(case_or_cases, list):
         return JsonResponse({
             'form_id': xform.form_id,

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -94,19 +94,22 @@ class ExplodeCasesView(BaseProjectSettingsView, TemplateView):
 @api_throttle
 @location_safe
 def case_api(request, domain, case_id=None, external_id=None):
-    if request.method == 'GET' and case_id:
-        return _handle_get(request, case_id)
-    if request.method == 'GET' and external_id:
-        return _handle_ext_get(request, external_id)
-    if request.method == 'GET' and not case_id:
-        return _handle_list_view(request)
-    if request.method == 'POST' and not case_id:
-        return _handle_case_put_post(request, is_creation=True)
-    if request.method == 'PUT' and external_id:
-        return _handle_ext_put(request, external_id)
-    if request.method == 'PUT':
-        return _handle_case_put_post(request, is_creation=False, case_id=case_id)
-    return JsonResponse({'error': "Request method not allowed"}, status=405)
+    try:
+        if request.method == 'GET' and case_id:
+            return _handle_get(request, case_id)
+        if request.method == 'GET' and external_id:
+            return _handle_ext_get(request, external_id)
+        if request.method == 'GET' and not case_id:
+            return _handle_list_view(request)
+        if request.method == 'POST' and not case_id:
+            return _handle_case_put_post(request, is_creation=True)
+        if request.method == 'PUT' and external_id:
+            return _handle_ext_put(request, external_id)
+        if request.method == 'PUT':
+            return _handle_case_put_post(request, is_creation=False, case_id=case_id)
+        return JsonResponse({'error': "Request method not allowed"}, status=405)
+    except UserError as e:
+        return JsonResponse({'error': str(e)}, status=400)
 
 
 @waf_allow('XSS_BODY')
@@ -118,7 +121,10 @@ def case_api(request, domain, case_id=None, external_id=None):
 @requires_privilege_with_fallback(privileges.API_ACCESS)
 @api_throttle
 def case_api_bulk_fetch(request, domain):
-    return _handle_bulk_fetch(request)
+    try:
+        return _handle_bulk_fetch(request)
+    except UserError as e:
+        return JsonResponse({'error': str(e)}, status=400)
 
 
 def _handle_get(request, case_id):
@@ -128,11 +134,7 @@ def _handle_get(request, case_id):
 
 
 def _get_bulk_cases(request, case_ids=None, external_ids=None):
-    try:
-        res = get_bulk(request.domain, request.couch_user, case_ids, external_ids)
-    except UserError as e:
-        return JsonResponse({'error': str(e)}, status=400)
-
+    res = get_bulk(request.domain, request.couch_user, case_ids, external_ids)
     filter_fields = get_fields_filter_fn(request.GET)
     res['cases'] = [
         filter_fields(case) if 'error' not in case else case
@@ -157,19 +159,7 @@ def _get_single_case(request, case_id):
 
 
 def _handle_ext_get(request, external_id):
-    try:
-        case = CommCareCase.objects.get_case_by_external_id(
-            request.domain,
-            external_id,
-            raise_multiple=True,
-        )
-    except CommCareCase.MultipleObjectsReturned as err:
-        case_ids = [case.case_id for case in err.cases]
-        return JsonResponse(
-            {'error': f"Multiple cases found with external_id '{external_id}': "
-                      f"{', '.join(case_ids)}"},
-            status=400,
-        )
+    case = _get_by_external_id(request.domain, external_id)
     if case is None:
         return JsonResponse(
             {'error': f"Case '{external_id}' not found"},
@@ -195,26 +185,37 @@ def _handle_ext_get(request, external_id):
     return JsonResponse(filter_fields(serialize_case(case)))
 
 
+def _get_by_external_id(domain, external_id):
+    try:
+        return CommCareCase.objects.get_case_by_external_id(
+            domain,
+            external_id,
+            raise_multiple=True,
+        )
+    except CommCareCase.MultipleObjectsReturned as err:
+        case_ids = [case.case_id for case in err.cases]
+        raise UserError(
+            f"Multiple cases found with external_id '{external_id}': "
+            f"{', '.join(case_ids)}"
+        )
+
+
 def _handle_bulk_fetch(request):
     try:
         data = json.loads(request.body.decode('utf-8'))
     except (UnicodeDecodeError, json.JSONDecodeError):
-        return JsonResponse({'error': "Payload must be valid JSON"}, status=400)
+        raise UserError("Payload must be valid JSON")
 
     case_ids = data.get('case_ids')
     external_ids = data.get('external_ids')
     if not case_ids and not external_ids:
-        return JsonResponse({'error': "Payload must include 'case_ids' or 'external_ids' fields"}, status=400)
+        raise UserError("Payload must include 'case_ids' or 'external_ids' fields")
 
     return _get_bulk_cases(request, case_ids=case_ids, external_ids=external_ids)
 
 
 def _handle_list_view(request):
-    try:
-        res = get_list(request.domain, request.couch_user, request.GET)
-    except UserError as e:
-        return JsonResponse({'error': str(e)}, status=400)
-
+    res = get_list(request.domain, request.couch_user, request.GET)
     if 'next' in res:
         res['next'] = reverse('case_api', args=[request.domain], params=res['next'], absolute=True)
     return JsonResponse(res)
@@ -224,29 +225,13 @@ def _handle_ext_put(request, external_id):
     try:
         data = json.loads(request.body.decode('utf-8'))
     except (UnicodeDecodeError, json.JSONDecodeError):
-        return JsonResponse({'error': "Payload must be valid JSON"}, status=400)
+        raise UserError("Payload must be valid JSON")
     if not isinstance(data, dict):
-        return JsonResponse(
-            {'error': "Payload must be a single JSON object"},
-            status=400,
-        )
+        raise UserError("Payload must be a single JSON object")
     if 'external_id' not in data:
         data['external_id'] = external_id
 
-    try:
-        # Use PG instead of ES to ensure immediate consistency
-        case = CommCareCase.objects.get_case_by_external_id(
-            request.domain,
-            external_id,
-            raise_multiple=True,
-        )
-    except CommCareCase.MultipleObjectsReturned as err:
-        case_ids = [case.case_id for case in err.cases]
-        return JsonResponse(
-            {'error': f"Multiple cases found with external_id '{external_id}': "
-                      f"{', '.join(case_ids)}"},
-            status=400,
-        )
+    case = _get_by_external_id(request.domain, external_id)
     if case is None:
         is_creation = True
     else:
@@ -254,12 +239,10 @@ def _handle_ext_put(request, external_id):
         if 'case_id' not in data:
             data['case_id'] = case.case_id
         elif data['case_id'] != case.case_id:
-            return JsonResponse(
-                {'error': 'The given value of "case_id" does not match the '
-                          'existing value for the case identified by '
-                          f'external_id = "{external_id}". "case_id" is '
-                          'read-only and cannot be modified.'},
-                status=400,
+            raise UserError(
+                'The given value of "case_id" does not match the existing value '
+                f'for the case identified by external_id = "{external_id}". '
+                '"case_id" is read-only and cannot be modified.'
             )
 
     return _handle_case_update(request, data, is_creation)
@@ -269,7 +252,7 @@ def _handle_case_put_post(request, is_creation, case_id=None):
     try:
         data = json.loads(request.body.decode('utf-8'))
     except (UnicodeDecodeError, json.JSONDecodeError):
-        return JsonResponse({'error': "Payload must be valid JSON"}, status=400)
+        raise UserError("Payload must be valid JSON")
 
     if not is_creation and case_id and 'case_id' not in data:
         data['case_id'] = case_id
@@ -288,8 +271,6 @@ def _handle_case_update(request, data, is_creation):
         )
     except PermissionDenied as e:
         return JsonResponse({'error': str(e)}, status=403)
-    except UserError as e:
-        return JsonResponse({'error': str(e)}, status=400)
     except SubmissionError as e:
         return JsonResponse({
             'error': str(e),

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -261,6 +261,7 @@ def _handle_case_put_post(request, is_creation, case_id=None):
 
 
 def _handle_case_update(request, data, is_creation):
+    filter_fields = get_fields_filter_fn(request.GET)
     try:
         xform, case_or_cases = handle_case_update(
             domain=request.domain,
@@ -277,7 +278,6 @@ def _handle_case_update(request, data, is_creation):
             'form_id': e.form_id,
         }, status=400)
 
-    filter_fields = get_fields_filter_fn(request.GET)
     if isinstance(case_or_cases, list):
         return JsonResponse({
             'form_id': xform.form_id,

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -153,7 +153,7 @@ def _get_single_case(request, case_id):
     except NotFoundError:
         return JsonResponse({'error': f"Case '{case_id}' not found"}, status=404)
     except PermissionDenied:
-        return JsonResponse({'error': f"Insufficent permission for Case '{case_id}'"}, status=403)
+        return JsonResponse({'error': f"Insufficient permission for Case '{case_id}'"}, status=403)
     filter_fields = get_fields_filter_fn(request.GET)
     return JsonResponse(filter_fields(serialize_es_case(case)))
 
@@ -178,7 +178,7 @@ def _handle_ext_get(request, external_id):
         )
     except PermissionDenied:
         return JsonResponse(
-            {'error': f"Insufficent permission for Case '{case.case_id}'"},
+            {'error': f"Insufficient permission for Case '{case.case_id}'"},
             status=403,
         )
     filter_fields = get_fields_filter_fn(request.GET)

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -29,6 +29,7 @@ from corehq.apps.locations.permissions import location_safe
 from corehq.form_processor.models import CommCareCase
 
 from .api.core import SubmissionError, UserError, serialize_case, serialize_es_case
+from .api.field_filters import extract_fields_params
 from .api.get_list import get_list
 from .api.get_bulk import get_bulk
 from .api.updates import handle_case_update
@@ -132,6 +133,11 @@ def _get_bulk_cases(request, case_ids=None, external_ids=None):
     except UserError as e:
         return JsonResponse({'error': str(e)}, status=400)
 
+    filter_fields = extract_fields_params(request.GET)
+    res['cases'] = [
+        filter_fields(case) if 'error' not in case else case
+        for case in res['cases']
+    ]
     return JsonResponse(res)
 
 
@@ -146,7 +152,8 @@ def _get_single_case(request, case_id):
         return JsonResponse({'error': f"Case '{case_id}' not found"}, status=404)
     except PermissionDenied:
         return JsonResponse({'error': f"Insufficent permission for Case '{case_id}'"}, status=403)
-    return JsonResponse(serialize_es_case(case))
+    filter_fields = extract_fields_params(request.GET)
+    return JsonResponse(filter_fields(serialize_es_case(case)))
 
 
 def _handle_ext_get(request, external_id):
@@ -184,7 +191,8 @@ def _handle_ext_get(request, external_id):
             {'error': f"Insufficent permission for Case '{case.case_id}'"},
             status=403,
         )
-    return JsonResponse(serialize_case(case))
+    filter_fields = extract_fields_params(request.GET)
+    return JsonResponse(filter_fields(serialize_case(case)))
 
 
 def _handle_bulk_fetch(request):
@@ -206,6 +214,9 @@ def _handle_list_view(request):
         res = get_list(request.domain, request.couch_user, request.GET)
     except UserError as e:
         return JsonResponse({'error': str(e)}, status=400)
+
+    filter_fields = extract_fields_params(request.GET)
+    res['cases'] = [filter_fields(case) for case in res['cases']]
 
     if 'next' in res:
         res['next'] = reverse('case_api', args=[request.domain], params=res['next'], absolute=True)
@@ -288,12 +299,13 @@ def _handle_case_update(request, data, is_creation):
             'form_id': e.form_id,
         }, status=400)
 
+    filter_fields = extract_fields_params(request.GET)
     if isinstance(case_or_cases, list):
         return JsonResponse({
             'form_id': xform.form_id,
-            'cases': [serialize_case(case) for case in case_or_cases],
+            'cases': [filter_fields(serialize_case(case)) for case in case_or_cases],
         })
     return JsonResponse({
         'form_id': xform.form_id,
-        'case': serialize_case(case_or_cases),
+        'case': filter_fields(serialize_case(case_or_cases)),
     })

--- a/docs/api/cases-v2.rst
+++ b/docs/api/cases-v2.rst
@@ -386,8 +386,10 @@ Interface -
 * ``GET /a/<domain>/api/case/v2/ext/<ext_id>/``
 
 
-This API takes no additional parameters.  The return value is a single
-case serialized as described in "`Single Case Serialization Format`_".
+This API takes no filter parameters.  The ``fields`` and ``exclude``
+parameters described in "`Limiting Response Fields`_" are supported.
+The return value is a single case serialized as described in
+"`Single Case Serialization Format`_".
 
 .. WARNING::
 

--- a/docs/api/cases-v2.rst
+++ b/docs/api/cases-v2.rst
@@ -386,10 +386,10 @@ Interface -
 * ``GET /a/<domain>/api/case/v2/ext/<ext_id>/``
 
 
-This API takes no filter parameters.  The ``fields`` and ``exclude``
-parameters described in "`Limiting Response Fields`_" are supported.
-The return value is a single case serialized as described in
-"`Single Case Serialization Format`_".
+This API takes no filter parameters, though you can control which fields are
+returned using the ``fields`` and ``exclude`` parameters as described in
+"`Limiting Response Fields`_". The return value is a single case serialized as
+described in "`Single Case Serialization Format`_".
 
 .. WARNING::
 

--- a/docs/api/cases-v2.rst
+++ b/docs/api/cases-v2.rst
@@ -295,6 +295,73 @@ Return value is a list of cases, each serialized as described in
 "`Single Case Serialization Format`_".
 
 
+Limiting Response Fields
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Two optional, mutually exclusive query parameters allow you to control which
+fields appear in the response:
+
+``fields``
+    A comma-separated list of field names to include. Only specified fields
+    will appear in the response. Use dot notation for nested fields.
+
+``exclude``
+    A comma-separated list of field names to remove from the response. Use
+    dot notation for nested fields.
+
+Using both ``fields`` and ``exclude`` in the same request will return an
+error.
+
+**Dot-param syntax** for grouping sub-fields under a parent:
+
+.. code-block:: text
+
+    ?fields=case_id,external_id&fields.properties=edd,lmp,age
+
+This is equivalent to:
+
+.. code-block:: text
+
+    ?fields=case_id,external_id,properties.edd,properties.lmp,properties.age
+
+Examples
+^^^^^^^^
+
+Include only specific fields:
+
+.. code-block:: text
+
+    GET /a/<domain>/api/case/v2/?case_type=patient&fields=case_id&fields.properties=edd,age
+
+.. code-block:: json
+
+    {
+        "matching_records": 1,
+        "cases": [
+            {
+                "case_id": "abc123",
+                "properties": {
+                    "edd": "2013-12-09",
+                    "age": "22"
+                }
+            }
+        ]
+    }
+
+Exclude specific fields:
+
+.. code-block:: text
+
+    GET /a/<domain>/api/case/v2/<case_id>?exclude=case_name&exclude.properties=husband_name
+
+These parameters work on all GET endpoints and on the case object returned
+by POST/PUT (create/update) endpoints. For list and bulk responses, the
+filtering applies to each individual case object; envelope fields
+(``matching_records``, ``next``) are not affected.
+
+Field filtering is preserved across paginated requests.
+
+
 Pagination
 ~~~~~~~~~~
 


### PR DESCRIPTION
## Product Description

Adds `fields` and `exclude` query parameters to Case API v2, allowing consumers to request only the fields they need. Supports nested fields via dot notation (e.g. `fields=case_id&fields.properties=edd,age`). Works on all GET endpoints and on create/update responses.

## Technical Summary

[Design doc](https://docs.google.com/document/d/1T1L_lM9HCHGwiv7Il18cfWnBjTq_OxBhpyblluB0eH0/edit?tab=t.0#heading=h.ipgou4bu0qoj) | [Iteration notes](https://github.com/dimagi/scratchpad/blob/main/case-api-field-filtering-design.md) | [USH-6393](https://dimagi.atlassian.net/browse/USH-6393)

New `field_filters.py` module builds a tree from dot-separated field paths and uses it to whitelist or blacklist fields from serialized case dicts. Field filtering is applied inside `get_list()` so it works correctly across cursor-paginated requests (where the original query params are encoded in the cursor). For non-list endpoints, filtering is applied in the view layer.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Field filtering is a post-processing step on already-serialized dicts — it cannot affect queries, data writes, or case storage. If neither `fields` nor `exclude` is passed, the identity function is used and behavior is unchanged.

### Automated test coverage

- 36 unit tests covering tree building, `_limit_fields`, `_exclude_fields`, and param extraction
- Integration tests verifying field filtering works across paginated cursor requests (ES-backed)
- Pipeline tests simulating envelope, error-stub, and update response patterns

### QA Plan


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[USH-6393]: https://dimagi.atlassian.net/browse/USH-6393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ