### PR TITLE
Update formplayer docs: commcare-core uses single master branch

### DIFF
--- a/docs/formplayer.rst
+++ b/docs/formplayer.rst
@@ -22,7 +22,7 @@ Repository Overview
 .. image:: images/formplayer_repo_overview.png
 
 * `commcare-android <https://github.com/dimagi/commcare-android>`_: The UI layer of CommCare mobile.
-* `commcare-core <https://github.com/dimagi/commcare-core>`_: The CommCare engine, this powers both CommCare mobile and formplayer. Mobile uses the ``master`` branch, while formplayer uses the ``formplayer`` branch. The two branches have a fairly small diff.
+* `commcare-core <https://github.com/dimagi/commcare-core>`_: The CommCare engine, this powers both CommCare mobile and formplayer. Both use the ``master`` branch.
 * `formplayer <https://github.com/dimagi/formplayer>`__
 * `commcare-hq <https://github.com/dimagi/commcare-hq>`_: HQ hosts web apps and the processes that run SMS forms.
 


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-19426

## Product Description
Documentation-only change. The commcare-core `formplayer` branch has been eliminated — both commcare-android and formplayer now use commcare-core's `master` branch. This updates `docs/formplayer.rst` to reflect that.

## Technical Summary
The `formplayer` branch in commcare-core was deleted as part of a branch consolidation effort. This PR updates the repository overview in the formplayer docs to remove the outdated reference to separate branches.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Documentation-only change with no code impact.

### Automated test coverage
N/A — docs only.

### QA Plan
N/A — docs only.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change