### PR TITLE
Increase expiration time for mobile worker email invites to 72 hours

### DIFF
--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1526,7 +1526,7 @@ class CommCareUserConfirmAccountViewByEmailView(CommCareUserConfirmAccountView):
 
     @property
     def _expiration_time_in_hours(self):
-        return 24
+        return 72
 
 
 @location_safe


### PR DESCRIPTION
## Product Description
Mobile worker email confirmation invites will now expire after 72 hours instead of 24 hours. This gives mobile workers in field deployments more time to access their email and confirm their accounts, reducing the need for project administrators to resend invitations.

## Technical Summary
https://dimagi.atlassian.net/browse/SUPPORT-26853

Follows the same pattern as [#37037](https://github.com/dimagi/commcare-hq/pull/37037) (SAAS-18588), which increased this value from 1 hour to 24 hours. This change extends it further to 72 hours based on continued feedback from field teams.

Single-line change to `CommCareUserConfirmAccountViewByEmailView._expiration_time_in_hours` in `corehq/apps/users/views/mobile/users.py`.

## Feature Flag
N/A — affects all domains using the Two Stage Mobile Worker Account Creation privilege.

## Safety Assurance

### Safety story
This is a single constant change (24 → 72) with no structural code modifications. The security implications are minimal — this only affects email-based account confirmation links for mobile workers, not password reset links or other sensitive tokens. A 72-hour window is still a conservative expiration for an account confirmation flow.

### Automated test coverage
Existing test `TestMobileWorkerConfirmAccountView::test_invite_expired_message` validates the expiration mechanism by mocking `_expiration_time_in_hours`. The test does not assert a specific expiration value, so no test changes are required.

### QA Plan
Not planned — same justification as #37037. The change is a single constant with no behavioral logic change.

### Migrations
- [x] This PR does not include any migrations.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change