### PR TITLE
Handle percent-encoded patches from Vellum emoji fix

### DIFF
--- a/corehq/apps/app_manager/tests/views/test_apply_patch.py
+++ b/corehq/apps/app_manager/tests/views/test_apply_patch.py
@@ -60,42 +60,44 @@ openrosa.org/formdesigner/03D5F750-13D0-4F08-A1CF-E5D9E6239E7F\" uiVersion=\"1\
 
 PATCHED_FORM = FORM_XML.replace("test", "text")
 
-PATCH = """@@ -558,17 +558,17 @@
- %09%09%09%09%09%3Cte
+# Patch is double-encoded: Vellum encodeURIs before diffing, then
+# patch_toText encodes again. See Vellum core.js for details.
+PATCH = """@@ -724,17 +724,17 @@
+ %2509%253Cte
 -s
 +x
- t /%3E%0A%09%09%09
-@@ -624,17 +624,17 @@
+ t%2520/%253E
+@@ -830,25 +830,25 @@
+ =%2522#form/te
+-s
++x
+ t%2522%2520nodes
+@@ -857,25 +857,25 @@
+ =%2522/data/te
+-s
++x
+ t%2522%2520type=
+@@ -1021,17 +1021,17 @@
+ id=%2522te
+-s
++x
+ t-label%25
+@@ -1069,17 +1069,17 @@
+ lue%253Ete
+-s
++x
+ t%253C/val
+@@ -1269,17 +1269,17 @@
  #form/te
 -s
 +x
- t%22 nodes
-@@ -645,17 +645,17 @@
+ t%2522%2520r
+@@ -1292,17 +1292,17 @@
  /data/te
 -s
 +x
- t%22 type=
-@@ -737,17 +737,17 @@
- t id=%22te
--s
-+x
- t-label%22
-@@ -763,17 +763,17 @@
- value%3Ete
--s
-+x
- t%3C/value
-@@ -879,17 +879,17 @@
- #form/te
--s
-+x
- t%22 ref=%22
-@@ -896,17 +896,17 @@
- /data/te
--s
-+x
- t%22%3E%0A%09%09%09%3C
-@@ -928,17 +928,17 @@
+ t%2522%253E%25
+@@ -1342,17 +1342,17 @@
  text('te
 -s
 +x

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -549,8 +549,14 @@ def patch_xform(request, domain, app_id, form_unique_id):
 
 
 def apply_patch(patch, text):
+    from urllib.parse import quote, unquote
     dmp = diff_match_patch()
-    return dmp.patch_apply(dmp.patch_fromText(patch), text)[0]
+    # JS pre-encodes text with encodeURI before diffing to avoid emoji
+    # breaking the diff (see core.js). Encode source the same way before
+    # applying, then decode. safe= matches JS encodeURI's preserved chars.
+    encoded_text = quote(text, safe="!#$&'()*+,-./:;=?@_~")
+    encoded_result = dmp.patch_apply(dmp.patch_fromText(patch), encoded_text)[0]
+    return unquote(encoded_result)
 
 
 def _get_case_mapping_diff(request, form):

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -26,6 +26,7 @@ from text_unidecode import unidecode
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import json_response
+from urllib.parse import quote, unquote
 
 from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
@@ -555,7 +556,6 @@ ENCODE_URI_SAFE = "!#$&'()*+,-./:;=?@_~"
 
 
 def apply_patch(patch, text):
-    from urllib.parse import quote, unquote
     dmp = diff_match_patch()
     # JS pre-encodes text with encodeURI before diffing to avoid emoji
     # breaking the diff (see core.js). Encode source the same way before

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -1,8 +1,13 @@
 import hashlib
 import json
 import logging
+from urllib.parse import quote, unquote
 from xml.sax.saxutils import escape
 
+from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
+from diff_match_patch import diff_match_patch
+from dimagi.utils.logging import notify_exception
+from dimagi.utils.web import json_response
 from django.conf import settings
 from django.contrib import messages
 from django.http import (
@@ -17,16 +22,9 @@ from django.utils.translation import gettext as _
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
-
-from diff_match_patch import diff_match_patch
 from lxml import etree
 from no_exceptions.exceptions import Http400
 from text_unidecode import unidecode
-
-from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
-from dimagi.utils.logging import notify_exception
-from dimagi.utils.web import json_response
-from urllib.parse import quote, unquote
 
 from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
@@ -52,10 +50,10 @@ from corehq.apps.app_manager.decorators import (
 from corehq.apps.app_manager.exceptions import (
     AppInDifferentDomainException,
     AppMisconfigurationError,
+    FormActionsDiffException,
     FormNotFoundException,
     ModuleNotFoundException,
     XFormValidationFailed,
-    FormActionsDiffException,
 )
 from corehq.apps.app_manager.helpers.validators import load_case_reserved_words
 from corehq.apps.app_manager.models import (
@@ -69,12 +67,12 @@ from corehq.apps.app_manager.models import (
     DeleteFormRecord,
     Form,
     FormActionCondition,
+    FormActionsDiff,
     FormDatum,
     FormLink,
     IncompatibleFormTypeException,
     OpenCaseAction,
     UpdateCaseAction,
-    FormActionsDiff,
 )
 from corehq.apps.app_manager.templatetags.xforms_extras import (
     clean_trans,
@@ -106,9 +104,9 @@ from corehq.apps.app_manager.xform import (
     XFormValidationError,
 )
 from corehq.apps.data_dictionary.util import (
+    get_case_property_count,
     get_case_property_deprecated_dict,
     get_case_property_description_dict,
-    get_case_property_count,
 )
 from corehq.apps.domain.decorators import (
     LoginAndDomainMixin,
@@ -120,7 +118,10 @@ from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.programs.models import Program
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
-from corehq.project_limits.const import CASE_PROP_LIMIT_PER_CASE_TYPE_KEY, DEFAULT_CASE_PROPS_PER_CASE_TYPE
+from corehq.project_limits.const import (
+    CASE_PROP_LIMIT_PER_CASE_TYPE_KEY,
+    DEFAULT_CASE_PROPS_PER_CASE_TYPE,
+)
 from corehq.project_limits.models import SystemLimit
 from corehq.util.view_utils import set_file_download
 
@@ -1009,7 +1010,9 @@ def get_form_datums(request, domain, app_id):
 
 
 def _get_form_datums(domain, app_id, form_id):
-    from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
+    from corehq.apps.app_manager.suite_xml.sections.entries import (
+        EntriesHelper,
+    )
     try:
         app = get_app(domain, app_id)
     except AppInDifferentDomainException as e:

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -548,13 +548,19 @@ def patch_xform(request, domain, app_id, form_unique_id):
     return JsonResponse(response_json)
 
 
+# Characters that JS encodeURI preserves (beyond letters/digits which
+# Python's quote already preserves). Used to match encodeURI behavior
+# so patch coordinates align between JS and Python.
+ENCODE_URI_SAFE = "!#$&'()*+,-./:;=?@_~"
+
+
 def apply_patch(patch, text):
     from urllib.parse import quote, unquote
     dmp = diff_match_patch()
     # JS pre-encodes text with encodeURI before diffing to avoid emoji
     # breaking the diff (see core.js). Encode source the same way before
-    # applying, then decode. safe= matches JS encodeURI's preserved chars.
-    encoded_text = quote(text, safe="!#$&'()*+,-./:;=?@_~")
+    # applying, then decode.
+    encoded_text = quote(text, safe=ENCODE_URI_SAFE)
     encoded_result = dmp.patch_apply(dmp.patch_fromText(patch), encoded_text)[0]
     return unquote(encoded_result)
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -441,7 +441,7 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
         set_session_endpoint(form, raw_endpoint_id, app)
 
     if should_edit('access_hidden_forms'):
-        form.respect_relevancy = not ('true' in request.POST.getlist('access_hidden_forms'))
+        form.respect_relevancy = 'true' not in request.POST.getlist('access_hidden_forms')
 
     if should_edit('function_datum_endpoints'):
         if request.POST['function_datum_endpoints']:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Forms with emoji fail to save when reordering question lists. This is the server-side companion to the Vellum fix.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19502
Vellum now pre-encodes form text with `encodeURI` before computing diff patches, so that emoji become ASCII percent-encoded sequences. This avoids both a URIError in JavaScript and a character-count mismatch between JS (UTF-16) and Python (Unicode code points) that caused patches to apply at wrong positions.                                                                                                       
                                                            
On the Python side, `apply_patch` must encode the source text the same way before applying the patch, then decode the result. This is done with `urllib.parse.quote` (using safe= matching JS encodeURI's preserved characters) and `urllib.parse.unquote`.
                                                                                                                                                                                                               
On performance/payload size: `quote()` and `unquote()` are called once each per patch save — they are fast string operations on text that is mostly ASCII (XML tags, attributes). The overhead is negligible compared to the XML parsing and form validation that follows.
                                                                                                                                                                                                               
Vellum Pr: https://github.com/dimagi/Vellum/pull/1212  
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
  - Only `apply_patch` is changed, which is only called from `patch_xform`. Full saves are unaffected.
  - The encoding round-trips correctly: `unquote(patch_apply(patches, quote(text)))` returns the same result as before for ASCII-only content, since quote doesn't encode most XML characters.
  - The sha1 conflict check happens before `apply_patch` and is unaffected.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Updated `test_vellum_xml_patch` in `test_apply_patch.py` with a double-encoded patch matching what new Vellum produces. The `test_empty_patch` test continues to pass unchanged.                                   

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations
Note: if this is reverted, the companion Vellum PR should also be reverted.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
