### PR TITLE
Detect additional_case_types in update_case_search_toggles

### DIFF
--- a/corehq/apps/domain/management/commands/update_case_search_toggles.py
+++ b/corehq/apps/domain/management/commands/update_case_search_toggles.py
@@ -103,6 +103,9 @@ class Command(BaseCommand):
             # Custom search input instance name
             if search_config.get('instance_name'):
                 reasons.append(f"module '{mod}': instance_name")
+            # Additional Case List and Case Search Types
+            if search_config.get('additional_case_types'):
+                reasons.append(f"module '{mod}': additional_case_types")
             # Custom Search Sort Properties
             if search_config.get('custom_sort_properties'):
                 reasons.append(f"module '{mod}': custom_sort_properties")


### PR DESCRIPTION
## Product Description

The additional_case_types feature is gated by CASE_SEARCH_ADVANCED in both the UI (module_view_settings.html) and suite generation (remote_requests.py), but the migration command wasn't checking for it. This could result in domains using additional case types not getting CASE_SEARCH_ADVANCED set, silently dropping those types from search results.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6502

## Feature Flag

CASE_SEARCH_ADVANCED

## Safety Assurance

Tested locally

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
