### PR TITLE
Add GitHub Action for rebuilding staging branch

### DIFF
--- a/.github/workflows/rebuild-staging.yml
+++ b/.github/workflows/rebuild-staging.yml
@@ -1,0 +1,24 @@
+name: Rebuild staging branch
+on:
+  workflow_dispatch:
+
+jobs:
+  rebuild-staging:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        # Full history needed for branch manipulation
+        fetch-depth: 0
+    - uses: astral-sh/setup-uv@v7
+    - name: Install git-build-branch
+      run: uv tool install git-build-branch
+    - name: Configure git
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+    - name: Rebuild staging
+      run: ./scripts/rebuildstaging


### PR DESCRIPTION
## Product Description

N/A — infrastructure change only.

## Technical Summary

Adds a `workflow_dispatch` GitHub Action that runs `./scripts/rebuildstaging` to rebuild the `autostaging` branch from the [staging-branches YAML config](https://github.com/dimagi/staging-branches/blob/main/commcare-hq-staging.yml).

This can be triggered manually from the Actions tab or via `gh workflow run rebuild-staging.yml`. A `repository_dispatch` trigger can be added later to automate it when the YAML config changes.

## Feature Flag

N/A

## Safety Assurance

### Safety story

This is a new workflow that only runs on manual trigger (`workflow_dispatch`). It uses `contents: write` permission scoped to this repo only, which is required to push the rebuilt staging branch. Since it's manually triggered, only users with write access to the repo can invoke it.

### Automated test coverage

The workflow can be validated by triggering it from the Actions tab.

### QA Plan

- Trigger the workflow manually and verify the autostaging branch is rebuilt correctly.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change