### PR TITLE
Skip default command_label in deprecated feature detection

### DIFF
--- a/corehq/apps/domain/management/commands/update_case_search_toggles.py
+++ b/corehq/apps/domain/management/commands/update_case_search_toggles.py
@@ -134,7 +134,9 @@ class Command(BaseCommand):
             # Normal Navigation / See More - only if case search is actually configured
             if bool(search_config.get('properties')) and not auto_launch:
                 reasons.append(f"module '{mod}': not auto_launch (See More / Normal Case List)")
-            if search_config.get('command_label'):  # Label for searching
+            # Label for searching
+            command_label = search_config.get('command_label', {})
+            if command_label and command_label != {'en': 'Search All Cases'}:
                 reasons.append(f"module '{mod}': command_label")
             if search_config.get('additional_relevant'):  # Claim condition
                 reasons.append(f"module '{mod}': additional_relevant (claim condition)")


### PR DESCRIPTION
## Product Description

- The `command_label` field defaults to `{'en': 'Search All Cases'}` which is always serialized to CouchDB, causing the `update_case_search_toggles` management command to flag nearly every domain for `CASE_SEARCH_DEPRECATED`
- Only flag domains that have customized the label away from the default
## Technical Summary

https://dimagi.atlassian.net/browse/USH-6502

## Feature Flag

CASE_SEARCH_ADVANCED

## Safety Assurance

Tested locally.

### Safety story

Run `manage.py update_case_search_toggles --dry-run --verbose` and verify `command_label` no longer appears for domains that haven't customized it

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
