### PR TITLE
Fix UserDomainsResource domain filtering and pagination

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1114,8 +1114,14 @@ class UserDomainsResource(ApiVersioningMixin, CorsResourceMixin, Resource):
         can_view_reports = request.GET.get("can_view_reports")
         couch_user = CouchUser.from_django_user(request.user)
         username = request.user.username
+
+        api_key = getattr(request, 'api_key', None)
+        api_key_domain = getattr(api_key, 'domain', '') if api_key else ''
+
         results = []
         for domain in couch_user.get_domains():
+            if api_key_domain and domain != api_key_domain:
+                continue
             domain_object = Domain.get_by_name(domain)
             if feature_flag and feature_flag not in toggles.toggles_dict(username=username, domain=domain):
                 continue

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1116,13 +1116,12 @@ class UserDomainsResource(ApiVersioningMixin, CorsResourceMixin, Resource):
         couch_user = CouchUser.from_django_user(request.user)
         username = request.user.username
 
-        api_key = getattr(request, 'api_key', None)
-        api_key_domain = getattr(api_key, 'domain', '') if api_key else ''
+        api_key = getattr(request, 'api_key', None)  # HQApiKey set by HQApiKeyAuthentication
+        api_key_domain = getattr(api_key, 'domain', '')
 
         results = []
-        for domain in couch_user.get_domains():
-            if api_key_domain and domain != api_key_domain:
-                continue
+        domains = [api_key_domain] if api_key_domain else couch_user.get_domains()
+        for domain in domains:
             domain_object = Domain.get_by_name(domain)
             if feature_flag and feature_flag not in toggles.toggles_dict(username=username, domain=domain):
                 continue

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1089,6 +1089,7 @@ class UserDomainsResource(ApiVersioningMixin, CorsResourceMixin, Resource):
         authentication = LoginAuthentication(allow_session_auth=True)
         object_class = UserDomain
         include_resource_uri = False
+        paginator_class = DoesNothingPaginator
 
     def dispatch_list(self, request, **kwargs):
         try:

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -1136,9 +1136,9 @@ class TestUserDomainsResourcePagination(TestCase):
         resource = UserDomainsResource()
         with patch.object(resource, 'get_object_list', return_value=mock_domains):
             response = resource.get_list(request)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         data = json.loads(response.content)
-        self.assertEqual(len(data['objects']), 25)
+        assert len(data['objects']) == 25
 
 
 class TestUserDomainsResourceApiKeyFiltering(TestCase):
@@ -1169,7 +1169,7 @@ class TestUserDomainsResourceApiKeyFiltering(TestCase):
     def test_all_domains_returned_without_api_key(self, _):
         resp = UserDomainsResource().obj_get_list(self._make_bundle())
         domain_names = [d.domain_name for d in resp]
-        self.assertCountEqual([self.domain, self.domain2], domain_names)
+        assert set(domain_names) == {self.domain, self.domain2}
 
     @patch('corehq.apps.api.resources.v0_5.domain_has_privilege', return_value=True)
     def test_all_domains_returned_with_unrestricted_api_key(self, _):
@@ -1177,7 +1177,7 @@ class TestUserDomainsResourceApiKeyFiltering(TestCase):
         api_key.domain = ''
         resp = UserDomainsResource().obj_get_list(self._make_bundle(api_key=api_key))
         domain_names = [d.domain_name for d in resp]
-        self.assertCountEqual([self.domain, self.domain2], domain_names)
+        assert set(domain_names) == {self.domain, self.domain2}
 
     @patch('corehq.apps.api.resources.v0_5.domain_has_privilege', return_value=True)
     def test_only_key_domain_returned_with_domain_scoped_api_key(self, _):
@@ -1185,7 +1185,7 @@ class TestUserDomainsResourceApiKeyFiltering(TestCase):
         api_key.domain = self.domain
         resp = UserDomainsResource().obj_get_list(self._make_bundle(api_key=api_key))
         domain_names = [d.domain_name for d in resp]
-        self.assertEqual([self.domain], domain_names)
+        assert domain_names == [self.domain]
 
     @patch('corehq.apps.api.resources.v0_5.domain_has_privilege', return_value=True)
     def test_only_key_domain2_returned_with_domain_scoped_api_key(self, _):
@@ -1193,7 +1193,7 @@ class TestUserDomainsResourceApiKeyFiltering(TestCase):
         api_key.domain = self.domain2
         resp = UserDomainsResource().obj_get_list(self._make_bundle(api_key=api_key))
         domain_names = [d.domain_name for d in resp]
-        self.assertEqual([self.domain2], domain_names)
+        assert domain_names == [self.domain2]
 
 
 class TestCommCareAnalyticsUserResource(APIResourceTest):

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -43,7 +43,7 @@ from corehq.const import USER_CHANGE_VIA_API
 from corehq.util.es.testing import sync_users_to_es
 from corehq.util.test_utils import flag_enabled, privilege_enabled
 
-from ..resources.v0_5 import BadRequest, UserDomainsResource
+from ..resources.v0_5 import BadRequest, UserDomain, UserDomainsResource
 from .utils import APIResourceTest
 
 
@@ -1120,6 +1120,25 @@ class TestUserDomainsResource(TestCase):
         bundle.request.api_key = None
         resp = UserDomainsResource().obj_get_list(bundle)
         self.assertEqual(0, len(resp))
+
+
+class TestUserDomainsResourcePagination(TestCase):
+
+    def test_all_domains_returned_when_more_than_default_page_size(self):
+        domain_names = [f'domain-{i}' for i in range(25)]
+        mock_domains = [
+            UserDomain(domain_name=name, project_name=name)
+            for name in domain_names
+        ]
+        request = Mock()
+        request.GET = {}
+        request.META = {}
+        resource = UserDomainsResource()
+        with patch.object(resource, 'get_object_list', return_value=mock_domains):
+            response = resource.get_list(request)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEqual(len(data['objects']), 25)
 
 
 class TestUserDomainsResourceApiKeyFiltering(TestCase):

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -1083,6 +1083,7 @@ class TestUserDomainsResource(TestCase):
         bundle.request = Mock()
         bundle.request.GET = {}
         bundle.request.user = self.user
+        bundle.request.api_key = None
         resp = UserDomainsResource().obj_get_list(bundle)
         self.assertListEqual([self.domain], [d.domain_name for d in resp])
 
@@ -1093,6 +1094,7 @@ class TestUserDomainsResource(TestCase):
         bundle.request = Mock()
         bundle.request.GET = {"feature_flag": "its_a_feature_not_bug"}
         bundle.request.user = self.user
+        bundle.request.api_key = None
         with self.assertRaises(BadRequest):
             UserDomainsResource().obj_get_list(bundle)
 
@@ -1104,6 +1106,7 @@ class TestUserDomainsResource(TestCase):
         bundle.request = Mock()
         bundle.request.GET = {"feature_flag": "superset-analytics"}
         bundle.request.user = self.user
+        bundle.request.api_key = None
         resp = UserDomainsResource().obj_get_list(bundle)
         self.assertListEqual([self.domain], [d.domain_name for d in resp])
 
@@ -1114,8 +1117,64 @@ class TestUserDomainsResource(TestCase):
         bundle.request = Mock()
         bundle.request.GET = {"feature_flag": "superset-analytics"}
         bundle.request.user = self.user
+        bundle.request.api_key = None
         resp = UserDomainsResource().obj_get_list(bundle)
         self.assertEqual(0, len(resp))
+
+
+class TestUserDomainsResourceApiKeyFiltering(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'test-domain'
+        cls.domain2 = 'test-domain-2'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+        cls.domain_obj2 = create_domain(cls.domain2)
+        cls.addClassCleanup(cls.domain_obj2.delete)
+        cls.user = WebUser.create(cls.domain, 'api-key-test@example.com', 'testpass', None, None)
+        cls.user.add_domain_membership(cls.domain2)
+        cls.user.save()
+        cls.addClassCleanup(cls.user.delete, cls.domain, deleted_by=None)
+
+    def _make_bundle(self, api_key=None):
+        bundle = Bundle()
+        bundle.request = Mock()
+        bundle.request.GET = {}
+        bundle.request.user = self.user.get_django_user()
+        bundle.request.api_key = api_key
+        return bundle
+
+    @patch('corehq.apps.api.resources.v0_5.domain_has_privilege', return_value=True)
+    def test_all_domains_returned_without_api_key(self, _):
+        resp = UserDomainsResource().obj_get_list(self._make_bundle())
+        domain_names = [d.domain_name for d in resp]
+        self.assertCountEqual([self.domain, self.domain2], domain_names)
+
+    @patch('corehq.apps.api.resources.v0_5.domain_has_privilege', return_value=True)
+    def test_all_domains_returned_with_unrestricted_api_key(self, _):
+        api_key = Mock()
+        api_key.domain = ''
+        resp = UserDomainsResource().obj_get_list(self._make_bundle(api_key=api_key))
+        domain_names = [d.domain_name for d in resp]
+        self.assertCountEqual([self.domain, self.domain2], domain_names)
+
+    @patch('corehq.apps.api.resources.v0_5.domain_has_privilege', return_value=True)
+    def test_only_key_domain_returned_with_domain_scoped_api_key(self, _):
+        api_key = Mock()
+        api_key.domain = self.domain
+        resp = UserDomainsResource().obj_get_list(self._make_bundle(api_key=api_key))
+        domain_names = [d.domain_name for d in resp]
+        self.assertEqual([self.domain], domain_names)
+
+    @patch('corehq.apps.api.resources.v0_5.domain_has_privilege', return_value=True)
+    def test_only_key_domain2_returned_with_domain_scoped_api_key(self, _):
+        api_key = Mock()
+        api_key.domain = self.domain2
+        resp = UserDomainsResource().obj_get_list(self._make_bundle(api_key=api_key))
+        domain_names = [d.domain_name for d in resp]
+        self.assertEqual([self.domain2], domain_names)
 
 
 class TestCommCareAnalyticsUserResource(APIResourceTest):


### PR DESCRIPTION
## Product Description

Fixes two bugs in the `/api/v0.5/user_domains/` endpoint:

1. **Domain-scoped API keys were ignored** — all user domains were returned instead of just the key's domain.
2. **Pagination capped results at 20** — users with more domains saw the rest silently truncated.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Additive bug fixes only. Uses existing `request.api_key` from auth and `DoesNothingPaginator` already used by other resources in the file.

### Automated test coverage

- `TestUserDomainsResourceApiKeyFiltering` — domain-scoped vs unrestricted keys
- `TestUserDomainsResourcePagination` — verifies >20 domains all returned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change