### PR TITLE
Add command to reset case search FFs

### DIFF
--- a/corehq/apps/domain/management/commands/reset_case_search_toggles.py
+++ b/corehq/apps/domain/management/commands/reset_case_search_toggles.py
@@ -1,0 +1,40 @@
+
+from django.core.management.base import BaseCommand
+
+from corehq import toggles
+from corehq.toggles import NAMESPACE_DOMAIN
+
+class Command(BaseCommand):
+    help = "Reset migrated to new Case Search toggles"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            help="Show what would be done without actually setting toggles",
+            action='store_true',
+        )
+        parser.add_argument(
+            '--domains',
+            help="Comma-separated list of domains to process instead of all SYNC_SEARCH_CASE_CLAIM domains",
+            type=lambda s: [d.strip() for d in s.split(',')],
+        )
+
+
+    def reset_toggle(self, domain_name, toggle, dry_run):
+        if toggle.enabled(domain_name, namespace=NAMESPACE_DOMAIN):
+            self.stdout.write(f"  {toggle.slug}")
+            if not dry_run:
+                toggle.set(domain_name, False, NAMESPACE_DOMAIN)
+
+    def handle(self, **options):
+        dry_run = options.get('dry_run', False)
+        if dry_run:
+            self.stdout.write("DRY RUN - No toggles will be reset\n")
+
+        domains = options['domains'] or toggles.SYNC_SEARCH_CASE_CLAIM.get_enabled_domains()
+        for domain_name in domains:
+            self.stdout.write(f"for domain '{domain_name}' reset:")
+            self.reset_toggle(domain_name, toggles.CASE_SEARCH_ADVANCED, dry_run)
+            self.reset_toggle(domain_name, toggles.CASE_SEARCH_DEPRECATED, dry_run)
+            self.reset_toggle(domain_name, toggles.CASE_SEARCH_RELATED_LOOKUPS, dry_run)
+            self.stdout.write("\n")


### PR DESCRIPTION
## Product Description

A previous version of the update_case_search_toggles command applied the
case search deprecated FF to too many projects. This command let's you
remove the case search advanced, deprecated and related lookups FFs from
all projects that also have the simple case search FF set.

A subsequent run of update_case_search_toggles should fix the situation

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6502

## Feature Flag

All the case search FFs

## Safety Assurance

Tested locally and on staging

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
