### PR TITLE
send existing case types to vellum

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -50,7 +50,7 @@ from corehq.apps.app_manager.views.utils import (
     set_lang_cookie,
 )
 from corehq.apps.cloudcare.utils import should_show_preview_app
-from corehq.apps.data_dictionary.util import get_case_properties
+from corehq.apps.data_dictionary.util import get_case_properties, get_data_dict_case_types
 from corehq.apps.domain.decorators import track_domain_request
 from corehq.apps.fixtures.fixturegenerators import item_lists_by_domain
 from corehq.apps.users.permissions import SUBMISSION_HISTORY_PERMISSION, has_permission_to_view_report
@@ -259,6 +259,11 @@ def _get_base_vellum_options(request, domain, form, displayLang):
             'properties': sorted(get_case_properties(domain, case_type).values_list('name', flat=True)),
             'view_form_url': reverse('view_form', args=[domain, app.id, form.unique_id]),
             'reserved_words': load_case_reserved_words(),
+        }
+
+    if toggles.VELLUM_SAVE_TO_CASE.enabled(domain):
+        options['saveToCase'] = {
+            'existingCaseTypes': sorted(get_data_dict_case_types(domain, is_deprecated=False)),
         }
 
     return options


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Save to case question will have a dropdown to select an existing case type. This PR is to send the data to Vellum to prepare for that change.
<img width="1002" height="490" alt="image" src="https://github.com/user-attachments/assets/64d987a6-8fc1-4359-a990-2db078afcfb9" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19459
`get_data_dict_case_types` is the same function used in Creating New Case List modal

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`VELLUM_SAVE_TO_CASE`
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
