### PR TITLE
Add admin UI option to Offboard Staff User

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -130,9 +130,10 @@
             <ul>
               {% if web_user.domain_memberships %}
                 <li>
-                  {% blocktrans with count=web_user.domain_memberships|length %}
-                    {{ count }}
-                    domain membership(s)
+                  {% blocktrans count count=web_user.domain_memberships|length %}
+                    {{ count }} domain membership
+                  {% plural %}
+                    {{ count }} domain memberships
                   {% endblocktrans %}
                 </li>
               {% endif %}

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -59,11 +59,14 @@
         href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}"
         >Temporarily Disable Two-Factor Authentication</a
       >
-      {% if web_user.domain_memberships or web_user.is_superuser or is_accounting_admin %}
+      {% if web_user.is_staff %}
         <button
           class="btn btn-danger"
           data-toggle="modal"
           data-target="#remove-all-access-modal"
+          {% if not web_user.domain_memberships and not web_user.is_superuser and not is_accounting_admin %}
+            disabled
+          {% endif %}
         >
           {% trans "Remove All Access" %}
         </button>
@@ -102,7 +105,7 @@
 
 {% block modals %}
   {{ block.super }}
-  {% if web_user.domain_memberships or web_user.is_superuser or is_accounting_admin %}
+  {% if web_user.is_staff %}
     <div
       class="modal fade"
       id="remove-all-access-modal"

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -25,39 +25,12 @@
       <a class="btn btn-default" href="{{ audit_report_url }}?username={{ web_user.username|urlencode }}">View User Audit Report</a>
       <a class="btn btn-default" href="{% url 'disable_user' %}?username={{ web_user.username|urlencode }}">Disable/Enable User Account</a>
       <a class="btn btn-default {% if not has_two_factor %}disabled{% endif %}" href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}">Temporarily Disable Two-Factor Authentication</a>
-      {% if web_user.domain_memberships %}
-        <button class="btn btn-danger" data-toggle="modal" data-target="#remove-domains-modal">
-          {% trans "Remove All Domain Memberships" %}
+      {% if web_user.domain_memberships or web_user.is_superuser or is_accounting_admin %}
+        <button class="btn btn-danger" data-toggle="modal" data-target="#remove-all-access-modal">
+          {% trans "Remove All Access" %}
         </button>
       {% endif %}
     </div>
-    {% if web_user.domain_memberships %}
-      <div class="modal fade" id="remove-domains-modal" tabindex="-1" role="dialog">
-        <div class="modal-dialog" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal">&times;</button>
-              <h4 class="modal-title">{% trans "Remove All Domain Memberships" %}</h4>
-            </div>
-            <div class="modal-body">
-              <p>
-                {% blocktrans with count=web_user.domain_memberships|length user_name=web_user.username %}
-                  Are you sure you want to remove all {{ count }} domain membership(s) from <strong>{{ user_name }}</strong>?
-                {% endblocktrans %}
-              </p>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
-              <form method="POST" action="{% url 'remove_web_user_domains' %}" style="display:inline">
-                {% csrf_token %}
-                <input type="hidden" name="username" value="{{ web_user.username }}">
-                <button type="submit" class="btn btn-danger">{% trans "Remove All" %}</button>
-              </form>
-            </div>
-          </div>
-        </div>
-      </div>
-    {% endif %}
     <h3>{% trans "Domains" %}</h3>
     <div class="col-md-6">
       <table class="table table-striped table-bordered">
@@ -75,3 +48,49 @@
     </div>
   {% endif %}
 {% endblock %}
+
+{% block modals %}
+  {{ block.super }}
+  {% if web_user.domain_memberships or web_user.is_superuser or is_accounting_admin %}
+    <div class="modal fade" id="remove-all-access-modal" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+            <h4 class="modal-title">{% trans "Remove All Access" %}</h4>
+          </div>
+          <div class="modal-body">
+            <p>
+              {% blocktrans with user_name=web_user.username %}
+                The following will be removed from <strong>{{ user_name }}</strong>:
+              {% endblocktrans %}
+            </p>
+            <ul>
+              {% if web_user.domain_memberships %}
+                <li>
+                  {% blocktrans with count=web_user.domain_memberships|length %}
+                    {{ count }} domain membership(s)
+                  {% endblocktrans %}
+                </li>
+              {% endif %}
+              {% if web_user.is_superuser %}
+                <li>{% trans "Superuser access" %}</li>
+              {% endif %}
+              {% if is_accounting_admin %}
+                <li>{% trans "Accounting admin access" %}</li>
+              {% endif %}
+            </ul>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
+            <form method="POST" action="{% url 'remove_all_web_user_access' %}" style="display:inline">
+              {% csrf_token %}
+              <input type="hidden" name="username" value="{{ web_user.username }}">
+              <button type="submit" class="btn btn-danger">{% trans "Remove All Access" %}</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endblock modals%}

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -2,31 +2,69 @@
 {% load i18n %}
 
 {% block page_content %}
-  <p>{% trans "See a user's projects by entering their email address below." %}</p>
+  <p>
+    {% trans "See a user's projects by entering their email address below." %}
+  </p>
   <form class="form-inline" method="GET" action="">
-    <input name="q" type="text" class="form-control" placeholder="you@example.com"/>
-    <input class="btn btn-primary" type="submit"/>
+    <input
+      name="q"
+      type="text"
+      class="form-control"
+      placeholder="you@example.com"
+    />
+    <input class="btn btn-primary" type="submit" />
   </form>
   {% if web_user %}
-    <hr>
-    <h1>{% blocktrans with user_name=web_user.human_friendly_name %}{{ user_name }}'s Information{% endblocktrans %}</h1>
+    <hr />
+    <h1>
+      {% blocktrans with user_name=web_user.human_friendly_name %}{{ user_name }}'s
+      Information{% endblocktrans %}
+    </h1>
     {% if not web_user.is_active %}
-      <div class="alert alert-warning" role="alert">{% trans "This account is disabled." %}</div>
+      <div class="alert alert-warning" role="alert">
+        {% trans "This account is disabled." %}
+      </div>
     {% endif %}
     <dl>
-      <div><b>{% trans "ID" %}:</b>
+      <div>
+        <b>{% trans "ID" %}:</b>
         {{ web_user.get_id }}
-        <small><a href="{% url 'raw_doc' %}?id={{ web_user.get_id }}">{% trans "couch doc" %}</a></small> |
-        <small><a href="{% url 'doc_in_es' %}?id={{ web_user.get_id }}">{% trans "elasticsearch lookup" %}</a></small>
+        <small
+          ><a href="{% url 'raw_doc' %}?id={{ web_user.get_id }}"
+            >{% trans "couch doc" %}</a
+          ></small
+        >
+        |
+        <small
+          ><a href="{% url 'doc_in_es' %}?id={{ web_user.get_id }}"
+            >{% trans "elasticsearch lookup" %}</a
+          ></small
+        >
       </div>
       <div><b>{% trans "Is Superuser" %}:</b> {{ web_user.is_superuser }}</div>
     </dl>
     <div class="btn-toolbar">
-      <a class="btn btn-default" href="{{ audit_report_url }}?username={{ web_user.username|urlencode }}">View User Audit Report</a>
-      <a class="btn btn-default" href="{% url 'disable_user' %}?username={{ web_user.username|urlencode }}">Disable/Enable User Account</a>
-      <a class="btn btn-default {% if not has_two_factor %}disabled{% endif %}" href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}">Temporarily Disable Two-Factor Authentication</a>
+      <a
+        class="btn btn-default"
+        href="{{ audit_report_url }}?username={{ web_user.username|urlencode }}"
+        >View User Audit Report</a
+      >
+      <a
+        class="btn btn-default"
+        href="{% url 'disable_user' %}?username={{ web_user.username|urlencode }}"
+        >Disable/Enable User Account</a
+      >
+      <a
+        class="btn btn-default {% if not has_two_factor %}disabled{% endif %}"
+        href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}"
+        >Temporarily Disable Two-Factor Authentication</a
+      >
       {% if web_user.domain_memberships or web_user.is_superuser or is_accounting_admin %}
-        <button class="btn btn-danger" data-toggle="modal" data-target="#remove-all-access-modal">
+        <button
+          class="btn btn-danger"
+          data-toggle="modal"
+          data-target="#remove-all-access-modal"
+        >
           {% trans "Remove All Access" %}
         </button>
       {% endif %}
@@ -40,7 +78,11 @@
         </tr>
         {% for membership in web_user.domain_memberships %}
           <tr>
-            <td><a href="{% url 'dashboard_default' membership.domain %}">{{ membership.domain  }}</a></td>
+            <td>
+              <a href="{% url 'dashboard_default' membership.domain %}"
+                >{{ membership.domain }}</a
+              >
+            </td>
             <td>{{ membership.role.name|default:'Unknown' }}</td>
           </tr>
         {% endfor %}
@@ -61,24 +103,33 @@
 {% block modals %}
   {{ block.super }}
   {% if web_user.domain_memberships or web_user.is_superuser or is_accounting_admin %}
-    <div class="modal fade" id="remove-all-access-modal" tabindex="-1" role="dialog">
+    <div
+      class="modal fade"
+      id="remove-all-access-modal"
+      tabindex="-1"
+      role="dialog"
+    >
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal">&times;</button>
+            <button type="button" class="close" data-dismiss="modal">
+              &times;
+            </button>
             <h4 class="modal-title">{% trans "Remove All Access" %}</h4>
           </div>
           <div class="modal-body">
             <p>
               {% blocktrans with user_name=web_user.username %}
-                The following will be removed from <strong>{{ user_name }}</strong>:
+                The following will be removed from
+                <strong>{{ user_name }}</strong>:
               {% endblocktrans %}
             </p>
             <ul>
               {% if web_user.domain_memberships %}
                 <li>
                   {% blocktrans with count=web_user.domain_memberships|length %}
-                    {{ count }} domain membership(s)
+                    {{ count }}
+                    domain membership(s)
                   {% endblocktrans %}
                 </li>
               {% endif %}
@@ -90,16 +141,40 @@
               {% endif %}
             </ul>
             <div class="form-group">
-              <label for="confirm-remove-access">{% trans 'Type <strong>REMOVE ACCESS</strong> to confirm' %}</label>
-              <input type="text" class="form-control" id="confirm-remove-access" autocomplete="off">
+              <label for="confirm-remove-access"
+                >{% trans 'Type <strong>REMOVE ACCESS</strong> to confirm' %}</label
+              >
+              <input
+                type="text"
+                class="form-control"
+                id="confirm-remove-access"
+                autocomplete="off"
+              />
             </div>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
-            <form method="POST" action="{% url 'remove_all_web_user_access' %}" style="display:inline">
+            <button type="button" class="btn btn-default" data-dismiss="modal">
+              {% trans "Cancel" %}
+            </button>
+            <form
+              method="POST"
+              action="{% url 'remove_all_web_user_access' %}"
+              style="display:inline"
+            >
               {% csrf_token %}
-              <input type="hidden" name="username" value="{{ web_user.username }}">
-              <button type="submit" class="btn btn-danger" id="remove-access-btn" disabled>{% trans "Remove All Access" %}</button>
+              <input
+                type="hidden"
+                name="username"
+                value="{{ web_user.username }}"
+              />
+              <button
+                type="submit"
+                class="btn btn-danger"
+                id="remove-access-btn"
+                disabled
+              >
+                {% trans "Remove All Access" %}
+              </button>
             </form>
           </div>
         </div>

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -63,12 +63,12 @@
         <button
           class="btn btn-danger"
           data-toggle="modal"
-          data-target="#remove-all-access-modal"
+          data-target="#offboard-staff-user-modal"
           {% if not web_user.domain_memberships and not web_user.is_superuser and not is_accounting_admin %}
             disabled
           {% endif %}
         >
-          {% trans "Remove All Access" %}
+          {% trans "Offboard Staff User" %}
         </button>
       {% endif %}
     </div>
@@ -97,8 +97,8 @@
 {% block js-inline %}
   {{ block.super }}
   <script>
-    document.getElementById("confirm-remove-access").addEventListener("input", function () {
-        document.getElementById("remove-access-btn").disabled = this.value !== "REMOVE ACCESS";
+    document.getElementById("confirm-offboard-user").addEventListener("input", function () {
+        document.getElementById("offboard-user-btn").disabled = this.value !== "OFFBOARD USER";
     });
   </script>
 {% endblock js-inline %}
@@ -108,7 +108,7 @@
   {% if web_user.is_staff %}
     <div
       class="modal fade"
-      id="remove-all-access-modal"
+      id="offboard-staff-user-modal"
       tabindex="-1"
       role="dialog"
     >
@@ -118,7 +118,7 @@
             <button type="button" class="close" data-dismiss="modal">
               &times;
             </button>
-            <h4 class="modal-title">{% trans "Remove All Access" %}</h4>
+            <h4 class="modal-title">{% trans "Offboard Staff User" %}</h4>
           </div>
           <div class="modal-body">
             <p>
@@ -145,13 +145,13 @@
               {% endif %}
             </ul>
             <div class="form-group">
-              <label for="confirm-remove-access"
-                >{% trans 'Type <strong>REMOVE ACCESS</strong> to confirm' %}</label
+              <label for="confirm-offboard-user"
+                >{% trans 'Type <strong>OFFBOARD USER</strong> to confirm' %}</label
               >
               <input
                 type="text"
                 class="form-control"
-                id="confirm-remove-access"
+                id="confirm-offboard-user"
                 autocomplete="off"
               />
             </div>
@@ -162,7 +162,7 @@
             </button>
             <form
               method="POST"
-              action="{% url 'remove_all_web_user_access' %}"
+              action="{% url 'offboard_staff_user' %}"
               style="display:inline"
             >
               {% csrf_token %}
@@ -174,10 +174,10 @@
               <button
                 type="submit"
                 class="btn btn-danger"
-                id="remove-access-btn"
+                id="offboard-user-btn"
                 disabled
               >
-                {% trans "Remove All Access" %}
+                {% trans "Offboard Staff User" %}
               </button>
             </form>
           </div>

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -2,30 +2,126 @@
 {% load i18n %}
 
 {% block page_content %}
-  <p>{% trans "See a user's projects by entering their email address below." %}</p>
+  <p>
+    {% trans "See a user's projects by entering their email address below." %}
+  </p>
   <form class="form-inline" method="GET" action="">
-    <input name="q" type="text" class="form-control" placeholder="you@example.com"/>
-    <input class="btn btn-primary" type="submit"/>
+    <input
+      name="q"
+      type="text"
+      class="form-control"
+      placeholder="you@example.com"
+    />
+    <input class="btn btn-primary" type="submit" />
   </form>
   {% if web_user %}
-    <hr>
-    <h1>{% blocktrans with user_name=web_user.human_friendly_name %}{{ user_name }}'s Information{% endblocktrans %}</h1>
+    <hr />
+    <h1>
+      {% blocktrans with user_name=web_user.human_friendly_name %}{{ user_name }}'s
+      Information{% endblocktrans %}
+    </h1>
     {% if not web_user.is_active %}
-      <div class="alert alert-warning" role="alert">{% trans "This account is disabled." %}</div>
+      <div class="alert alert-warning" role="alert">
+        {% trans "This account is disabled." %}
+      </div>
     {% endif %}
     <dl>
-      <div><b>{% trans "ID" %}:</b>
+      <div>
+        <b>{% trans "ID" %}:</b>
         {{ web_user.get_id }}
-        <small><a href="{% url 'raw_doc' %}?id={{ web_user.get_id }}">{% trans "couch doc" %}</a></small> |
-        <small><a href="{% url 'doc_in_es' %}?id={{ web_user.get_id }}">{% trans "elasticsearch lookup" %}</a></small>
+        <small
+          ><a href="{% url 'raw_doc' %}?id={{ web_user.get_id }}"
+            >{% trans "couch doc" %}</a
+          ></small
+        >
+        |
+        <small
+          ><a href="{% url 'doc_in_es' %}?id={{ web_user.get_id }}"
+            >{% trans "elasticsearch lookup" %}</a
+          ></small
+        >
       </div>
       <div><b>{% trans "Is Superuser" %}:</b> {{ web_user.is_superuser }}</div>
     </dl>
     <div class="btn-toolbar">
-      <a class="btn btn-default" href="{{ audit_report_url }}?username={{ web_user.username|urlencode }}">View User Audit Report</a>
-      <a class="btn btn-default" href="{% url 'disable_user' %}?username={{ web_user.username|urlencode }}">Disable/Enable User Account</a>
-      <a class="btn btn-default {% if not has_two_factor %}disabled{% endif %}" href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}">Temporarily Disable Two-Factor Authentication</a>
+      <a
+        class="btn btn-default"
+        href="{{ audit_report_url }}?username={{ web_user.username|urlencode }}"
+        >View User Audit Report</a
+      >
+      <a
+        class="btn btn-default"
+        href="{% url 'disable_user' %}?username={{ web_user.username|urlencode }}"
+        >Disable/Enable User Account</a
+      >
+      <a
+        class="btn btn-default {% if not has_two_factor %}disabled{% endif %}"
+        href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}"
+        >Temporarily Disable Two-Factor Authentication</a
+      >
+      {% if web_user.domain_memberships %}
+        <button
+          class="btn btn-danger"
+          data-toggle="modal"
+          data-target="#remove-domains-modal"
+        >
+          {% trans "Remove All Domain Memberships" %}
+        </button>
+      {% endif %}
     </div>
+    {% if web_user.domain_memberships %}
+      <div
+        class="modal fade"
+        id="remove-domains-modal"
+        tabindex="-1"
+        role="dialog"
+      >
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal">
+                &times;
+              </button>
+              <h4 class="modal-title">
+                {% trans "Remove All Domain Memberships" %}
+              </h4>
+            </div>
+            <div class="modal-body">
+              <p>
+                {% blocktrans with count=web_user.domain_memberships|length user_name=web_user.username %}
+                  Are you sure you want to remove all {{ count }} domain
+                  membership(s) from <strong>{{ user_name }}</strong>?
+                {% endblocktrans %}
+              </p>
+            </div>
+            <div class="modal-footer">
+              <button
+                type="button"
+                class="btn btn-default"
+                data-dismiss="modal"
+              >
+                {% trans "Cancel" %}
+              </button>
+              <form
+                method="POST"
+                action="{% url 'remove_web_user_domains' %}"
+                style="display:inline"
+              >
+                {% csrf_token %}
+                <input
+                  type="hidden"
+                  name="username"
+                  value="{{ web_user.username }}"
+                />
+                <button type="submit" class="btn btn-danger">
+                  {% trans "Remove All" %}
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endif %}
     <h3>{% trans "Domains" %}</h3>
     <div class="col-md-6">
       <table class="table table-striped table-bordered">
@@ -35,7 +131,11 @@
         </tr>
         {% for membership in web_user.domain_memberships %}
           <tr>
-            <td><a href="{% url 'dashboard_default' membership.domain %}">{{ membership.domain  }}</a></td>
+            <td>
+              <a href="{% url 'dashboard_default' membership.domain %}"
+                >{{ membership.domain }}</a
+              >
+            </td>
             <td>{{ membership.role.name|default:'Unknown' }}</td>
           </tr>
         {% endfor %}

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -97,9 +97,12 @@
 {% block js-inline %}
   {{ block.super }}
   <script>
-    document.getElementById("confirm-offboard-user").addEventListener("input", function () {
-        document.getElementById("offboard-user-btn").disabled = this.value !== "OFFBOARD USER";
-    });
+    const confirmOffboardEl = document.getElementById("confirm-offboard-user");
+    if (confirmOffboardEl) {
+        confirmOffboardEl.addEventListener("input", function () {
+            document.getElementById("offboard-user-btn").disabled = this.value !== "OFFBOARD USER";
+        });
+    }
   </script>
 {% endblock js-inline %}
 

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -148,9 +148,11 @@
               {% endif %}
             </ul>
             <div class="form-group">
-              <label for="confirm-offboard-user"
-                >{% trans 'Type <strong>OFFBOARD USER</strong> to confirm' %}</label
-              >
+              <label for="confirm-offboard-user">
+                {% blocktrans with confirm_text="OFFBOARD USER" %}
+                  Type <strong>{{ confirm_text }}</strong> to confirm
+                {% endblocktrans %}
+              </label>
               <input
                 type="text"
                 class="form-control"

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -49,6 +49,15 @@
   {% endif %}
 {% endblock %}
 
+{% block js-inline %}
+  {{ block.super }}
+  <script>
+    document.getElementById("confirm-remove-access").addEventListener("input", function () {
+        document.getElementById("remove-access-btn").disabled = this.value !== "REMOVE ACCESS";
+    });
+  </script>
+{% endblock js-inline %}
+
 {% block modals %}
   {{ block.super }}
   {% if web_user.domain_memberships or web_user.is_superuser or is_accounting_admin %}
@@ -80,17 +89,21 @@
                 <li>{% trans "Accounting admin access" %}</li>
               {% endif %}
             </ul>
+            <div class="form-group">
+              <label for="confirm-remove-access">{% trans 'Type <strong>REMOVE ACCESS</strong> to confirm' %}</label>
+              <input type="text" class="form-control" id="confirm-remove-access" autocomplete="off">
+            </div>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
             <form method="POST" action="{% url 'remove_all_web_user_access' %}" style="display:inline">
               {% csrf_token %}
               <input type="hidden" name="username" value="{{ web_user.username }}">
-              <button type="submit" class="btn btn-danger">{% trans "Remove All Access" %}</button>
+              <button type="submit" class="btn btn-danger" id="remove-access-btn" disabled>{% trans "Remove All Access" %}</button>
             </form>
           </div>
         </div>
       </div>
     </div>
   {% endif %}
-{% endblock modals%}
+{% endblock modals %}

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -2,120 +2,56 @@
 {% load i18n %}
 
 {% block page_content %}
-  <p>
-    {% trans "See a user's projects by entering their email address below." %}
-  </p>
+  <p>{% trans "See a user's projects by entering their email address below." %}</p>
   <form class="form-inline" method="GET" action="">
-    <input
-      name="q"
-      type="text"
-      class="form-control"
-      placeholder="you@example.com"
-    />
-    <input class="btn btn-primary" type="submit" />
+    <input name="q" type="text" class="form-control" placeholder="you@example.com"/>
+    <input class="btn btn-primary" type="submit"/>
   </form>
   {% if web_user %}
-    <hr />
-    <h1>
-      {% blocktrans with user_name=web_user.human_friendly_name %}{{ user_name }}'s
-      Information{% endblocktrans %}
-    </h1>
+    <hr>
+    <h1>{% blocktrans with user_name=web_user.human_friendly_name %}{{ user_name }}'s Information{% endblocktrans %}</h1>
     {% if not web_user.is_active %}
-      <div class="alert alert-warning" role="alert">
-        {% trans "This account is disabled." %}
-      </div>
+      <div class="alert alert-warning" role="alert">{% trans "This account is disabled." %}</div>
     {% endif %}
     <dl>
-      <div>
-        <b>{% trans "ID" %}:</b>
+      <div><b>{% trans "ID" %}:</b>
         {{ web_user.get_id }}
-        <small
-          ><a href="{% url 'raw_doc' %}?id={{ web_user.get_id }}"
-            >{% trans "couch doc" %}</a
-          ></small
-        >
-        |
-        <small
-          ><a href="{% url 'doc_in_es' %}?id={{ web_user.get_id }}"
-            >{% trans "elasticsearch lookup" %}</a
-          ></small
-        >
+        <small><a href="{% url 'raw_doc' %}?id={{ web_user.get_id }}">{% trans "couch doc" %}</a></small> |
+        <small><a href="{% url 'doc_in_es' %}?id={{ web_user.get_id }}">{% trans "elasticsearch lookup" %}</a></small>
       </div>
       <div><b>{% trans "Is Superuser" %}:</b> {{ web_user.is_superuser }}</div>
     </dl>
     <div class="btn-toolbar">
-      <a
-        class="btn btn-default"
-        href="{{ audit_report_url }}?username={{ web_user.username|urlencode }}"
-        >View User Audit Report</a
-      >
-      <a
-        class="btn btn-default"
-        href="{% url 'disable_user' %}?username={{ web_user.username|urlencode }}"
-        >Disable/Enable User Account</a
-      >
-      <a
-        class="btn btn-default {% if not has_two_factor %}disabled{% endif %}"
-        href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}"
-        >Temporarily Disable Two-Factor Authentication</a
-      >
+      <a class="btn btn-default" href="{{ audit_report_url }}?username={{ web_user.username|urlencode }}">View User Audit Report</a>
+      <a class="btn btn-default" href="{% url 'disable_user' %}?username={{ web_user.username|urlencode }}">Disable/Enable User Account</a>
+      <a class="btn btn-default {% if not has_two_factor %}disabled{% endif %}" href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}">Temporarily Disable Two-Factor Authentication</a>
       {% if web_user.domain_memberships %}
-        <button
-          class="btn btn-danger"
-          data-toggle="modal"
-          data-target="#remove-domains-modal"
-        >
+        <button class="btn btn-danger" data-toggle="modal" data-target="#remove-domains-modal">
           {% trans "Remove All Domain Memberships" %}
         </button>
       {% endif %}
     </div>
     {% if web_user.domain_memberships %}
-      <div
-        class="modal fade"
-        id="remove-domains-modal"
-        tabindex="-1"
-        role="dialog"
-      >
+      <div class="modal fade" id="remove-domains-modal" tabindex="-1" role="dialog">
         <div class="modal-dialog" role="document">
           <div class="modal-content">
             <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal">
-                &times;
-              </button>
-              <h4 class="modal-title">
-                {% trans "Remove All Domain Memberships" %}
-              </h4>
+              <button type="button" class="close" data-dismiss="modal">&times;</button>
+              <h4 class="modal-title">{% trans "Remove All Domain Memberships" %}</h4>
             </div>
             <div class="modal-body">
               <p>
                 {% blocktrans with count=web_user.domain_memberships|length user_name=web_user.username %}
-                  Are you sure you want to remove all {{ count }} domain
-                  membership(s) from <strong>{{ user_name }}</strong>?
+                  Are you sure you want to remove all {{ count }} domain membership(s) from <strong>{{ user_name }}</strong>?
                 {% endblocktrans %}
               </p>
             </div>
             <div class="modal-footer">
-              <button
-                type="button"
-                class="btn btn-default"
-                data-dismiss="modal"
-              >
-                {% trans "Cancel" %}
-              </button>
-              <form
-                method="POST"
-                action="{% url 'remove_web_user_domains' %}"
-                style="display:inline"
-              >
+              <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
+              <form method="POST" action="{% url 'remove_web_user_domains' %}" style="display:inline">
                 {% csrf_token %}
-                <input
-                  type="hidden"
-                  name="username"
-                  value="{{ web_user.username }}"
-                />
-                <button type="submit" class="btn btn-danger">
-                  {% trans "Remove All" %}
-                </button>
+                <input type="hidden" name="username" value="{{ web_user.username }}">
+                <button type="submit" class="btn btn-danger">{% trans "Remove All" %}</button>
               </form>
             </div>
           </div>
@@ -131,11 +67,7 @@
         </tr>
         {% for membership in web_user.domain_memberships %}
           <tr>
-            <td>
-              <a href="{% url 'dashboard_default' membership.domain %}"
-                >{{ membership.domain }}</a
-              >
-            </td>
+            <td><a href="{% url 'dashboard_default' membership.domain %}">{{ membership.domain  }}</a></td>
             <td>{{ membership.role.name|default:'Unknown' }}</td>
           </tr>
         {% endfor %}

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -174,7 +174,7 @@ class TestRemoveAllWebUserAccess(TestCase):
             None, "admin@dimagi.com", "password", None, None, is_superuser=True
         )
         cls.addClassCleanup(cls.superuser.delete, None, None)
-        cls.url = reverse('remove_all_web_user_access')
+        cls.url = reverse('offboard_staff_user')
 
     def setUp(self):
         self.client.login(username=self.superuser.username, password='password')

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -165,7 +165,7 @@ class TestSuperuserManagementView(TestCase):
             self.assertIn(user.username, permission.enabled_users)
 
 
-class TestRemoveAllWebUserAccess(TestCase):
+class TestOffboardStaffUser(TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -186,9 +186,11 @@ class TestRemoveAllWebUserAccess(TestCase):
 
     def _make_accounting_admin(self, django_user):
         # privileges.ACCOUNTING_ADMIN is applied via OPERATIONS_TEAM role
-        ops_role = Role.objects.create(slug=privileges.OPERATIONS_TEAM, name='Ops')
-        accounting_role = Role.objects.create(slug=privileges.ACCOUNTING_ADMIN, name='Accounting')
-        Grant.objects.create(from_role=ops_role, to_role=accounting_role)
+        ops_role, _ = Role.objects.get_or_create(slug=privileges.OPERATIONS_TEAM, defaults={'name': 'Ops'})
+        accounting_role, _ = Role.objects.get_or_create(
+            slug=privileges.ACCOUNTING_ADMIN, defaults={'name': 'Accounting'}
+        )
+        Grant.objects.get_or_create(from_role=ops_role, to_role=accounting_role)
         user_privs = Role.objects.create(slug=f"{django_user.username}_privs", name="Test user privileges")
         UserRole.objects.create(user=django_user, role=user_privs)
         Grant.objects.create(from_role=user_privs, to_role=ops_role)
@@ -224,7 +226,7 @@ class TestRemoveAllWebUserAccess(TestCase):
         user = self._create_user()
         django_user = user.get_django_user()
         self._make_accounting_admin(django_user)
-
+        assert is_accounting_admin(django_user)
         self.client.post(self.url, {'username': user.username})
 
         Role.update_cache()

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -194,6 +194,7 @@ class TestOffboardStaffUser(TestCase):
         user_privs = Role.objects.create(slug=f"{django_user.username}_privs", name="Test user privileges")
         UserRole.objects.create(user=django_user, role=user_privs)
         Grant.objects.create(from_role=user_privs, to_role=ops_role)
+        Role.update_cache()
 
     def test_removes_domain_memberships(self):
         domain_a = create_domain('domain-a')
@@ -227,6 +228,7 @@ class TestOffboardStaffUser(TestCase):
         django_user = user.get_django_user()
         self._make_accounting_admin(django_user)
         assert is_accounting_admin(django_user)
+
         self.client.post(self.url, {'username': user.username})
 
         Role.update_cache()

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -231,6 +231,5 @@ class TestOffboardStaffUser(TestCase):
 
         self.client.post(self.url, {'username': user.username})
 
-        Role.update_cache()
         django_user.refresh_from_db()
         assert not is_accounting_admin(django_user)

--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -5,10 +5,14 @@ from django.http import HttpResponse
 from django.test import SimpleTestCase, TestCase
 from django.urls import reverse
 
+from django_prbac.models import Grant, Role, UserRole
 from lxml import etree
 from unittest.mock import Mock, patch
 
+from corehq import privileges
+from corehq.apps.accounting.utils import is_accounting_admin
 from corehq.apps.app_manager.tests.util import TestXmlMixin
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.hqadmin.views.users import AdminRestoreView, DisableUserView
 from corehq.apps.users.models import WebUser
 from corehq.toggles import TAG_RELEASE, TAG_GA_PATH
@@ -159,3 +163,70 @@ class TestSuperuserManagementView(TestCase):
         for tag_slug in [TAG_GA_PATH.slug, TAG_RELEASE.slug]:
             permission = ToggleEditPermission.objects.get_by_tag_slug(tag_slug)
             self.assertIn(user.username, permission.enabled_users)
+
+
+class TestRemoveAllWebUserAccess(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.superuser = WebUser.create(
+            None, "admin@dimagi.com", "password", None, None, is_superuser=True
+        )
+        cls.addClassCleanup(cls.superuser.delete, None, None)
+        cls.url = reverse('remove_all_web_user_access')
+
+    def setUp(self):
+        self.client.login(username=self.superuser.username, password='password')
+
+    def _create_user(self):
+        user = WebUser.create(None, "testuser@dimagi.com", "password", None, None)
+        self.addCleanup(user.delete, None, None)
+        return user
+
+    def _make_accounting_admin(self, django_user):
+        # privileges.ACCOUNTING_ADMIN is applied via OPERATIONS_TEAM role
+        ops_role = Role.objects.create(slug=privileges.OPERATIONS_TEAM, name='Ops')
+        accounting_role = Role.objects.create(slug=privileges.ACCOUNTING_ADMIN, name='Accounting')
+        Grant.objects.create(from_role=ops_role, to_role=accounting_role)
+        user_privs = Role.objects.create(slug=f"{django_user.username}_privs", name="Test user privileges")
+        UserRole.objects.create(user=django_user, role=user_privs)
+        Grant.objects.create(from_role=user_privs, to_role=ops_role)
+
+    def test_removes_domain_memberships(self):
+        domain_a = create_domain('domain-a')
+        domain_b = create_domain('domain-b')
+        self.addCleanup(domain_a.delete)
+        self.addCleanup(domain_b.delete)
+        user = self._create_user()
+        user.add_domain_membership('domain-a')
+        user.add_domain_membership('domain-b')
+        user.save()
+
+        self.client.post(self.url, {'username': user.username})
+
+        user = WebUser.get_by_username(user.username)
+        assert user.domains == []
+        assert user.domain_memberships == []
+
+    def test_removes_superuser(self):
+        user = self._create_user()
+        django_user = user.get_django_user()
+        django_user.is_superuser = True
+        django_user.save()
+
+        self.client.post(self.url, {'username': user.username})
+
+        django_user.refresh_from_db()
+        assert not django_user.is_superuser
+
+    def test_removes_accounting_admin(self):
+        user = self._create_user()
+        django_user = user.get_django_user()
+        self._make_accounting_admin(django_user)
+
+        self.client.post(self.url, {'username': user.username})
+
+        Role.update_cache()
+        django_user.refresh_from_db()
+        assert not is_accounting_admin(django_user)

--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -28,7 +28,7 @@ from corehq.apps.hqadmin.views.users import (
     OffboardingUserList,
     WebUserDataView,
     email_status,
-    remove_web_user_domains,
+    remove_all_web_user_access,
     superuser_table,
     web_user_lookup,
 )
@@ -57,7 +57,7 @@ urlpatterns = [
     url(r'^app_build_timings/$', AppBuildTimingsView.as_view(), name="app_build_timings"),
     url(r'^do_pillow_op/$', pillow_operation_api, name="pillow_operation_api"),
     url(r'^web_user_lookup/$', web_user_lookup, name='web_user_lookup'),
-    url(r'^remove_web_user_domains/$', remove_web_user_domains, name='remove_web_user_domains'),
+    url(r'^remove_all_web_user_access/$', remove_all_web_user_access, name='remove_all_web_user_access'),
     url(r'^disable_two_factor/$', DisableTwoFactorView.as_view(), name=DisableTwoFactorView.urlname),
     url(r'^disable_account/$', DisableUserView.as_view(), name=DisableUserView.urlname),
     url(r'^doc_in_es/$', doc_in_es, name='doc_in_es'),

--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -28,7 +28,7 @@ from corehq.apps.hqadmin.views.users import (
     OffboardingUserList,
     WebUserDataView,
     email_status,
-    remove_all_web_user_access,
+    offboard_staff_user,
     superuser_table,
     web_user_lookup,
 )
@@ -57,7 +57,7 @@ urlpatterns = [
     url(r'^app_build_timings/$', AppBuildTimingsView.as_view(), name="app_build_timings"),
     url(r'^do_pillow_op/$', pillow_operation_api, name="pillow_operation_api"),
     url(r'^web_user_lookup/$', web_user_lookup, name='web_user_lookup'),
-    url(r'^remove_all_web_user_access/$', remove_all_web_user_access, name='remove_all_web_user_access'),
+    url(r'^offboard_staff_user/$', offboard_staff_user, name='offboard_staff_user'),
     url(r'^disable_two_factor/$', DisableTwoFactorView.as_view(), name=DisableTwoFactorView.urlname),
     url(r'^disable_account/$', DisableUserView.as_view(), name=DisableUserView.urlname),
     url(r'^doc_in_es/$', doc_in_es, name='doc_in_es'),

--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -28,6 +28,7 @@ from corehq.apps.hqadmin.views.users import (
     OffboardingUserList,
     WebUserDataView,
     email_status,
+    remove_web_user_domains,
     superuser_table,
     web_user_lookup,
 )
@@ -56,6 +57,7 @@ urlpatterns = [
     url(r'^app_build_timings/$', AppBuildTimingsView.as_view(), name="app_build_timings"),
     url(r'^do_pillow_op/$', pillow_operation_api, name="pillow_operation_api"),
     url(r'^web_user_lookup/$', web_user_lookup, name='web_user_lookup'),
+    url(r'^remove_web_user_domains/$', remove_web_user_domains, name='remove_web_user_domains'),
     url(r'^disable_two_factor/$', DisableTwoFactorView.as_view(), name=DisableTwoFactorView.urlname),
     url(r'^disable_account/$', DisableUserView.as_view(), name=DisableUserView.urlname),
     url(r'^doc_in_es/$', doc_in_es, name='doc_in_es'),

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -546,69 +546,71 @@ def offboard_staff_user(request):
     if not username:
         return HttpResponseBadRequest("Missing username")
 
+    base_url = reverse("web_user_lookup")
     web_user = WebUser.get_by_username(username)
     if web_user is None:
         messages.error(request, _("User '{username}' not found.").format(username=username))
-    else:
-        removed = []
-        fields_changed = {}
-        django_user = web_user.get_django_user()
+        return redirect(base_url)
 
-        if web_user.domains:
-            count = len(web_user.domains)
-            for domain in list(web_user.domains):
-                web_user.delete_domain_membership(domain)
-                log_user_change(
-                    by_domain=None, for_domain=domain, couch_user=web_user,
-                    changed_by_user=request.couch_user,
-                    changed_via=USER_CHANGE_VIA_WEB,
-                    change_messages=UserChangeMessage.domain_removal(domain),
-                    by_domain_required_for_log=False,
-                )
-            web_user.save()
-            removed.append(ngettext(
-                "{count} domain membership",
-                "{count} domain memberships",
-                count,
-            ).format(count=count))
+    removed = []
+    fields_changed = {}
+    django_user = web_user.get_django_user()
 
-        if django_user.is_superuser:
-            django_user.is_superuser = False
-            django_user.save()
-            fields_changed['is_superuser'] = False
-            removed.append(_("superuser access"))
-
-        if is_accounting_admin(django_user):
-            ops_role = Role.objects.get(slug=privileges.OPERATIONS_TEAM)
-            Grant.objects.filter(
-                from_role=django_user.prbac_role.role,
-                to_role=ops_role,
-            ).delete()
-            Role.update_cache()
-            fields_changed['is_accounting_admin'] = False
-            removed.append(_("accounting admin access"))
-
-        if fields_changed:
+    if web_user.domains:
+        count = len(web_user.domains)
+        for domain in list(web_user.domains):
+            web_user.delete_domain_membership(domain)
             log_user_change(
-                by_domain=None, for_domain=None, couch_user=web_user,
+                by_domain=None, for_domain=domain, couch_user=web_user,
                 changed_by_user=request.couch_user,
                 changed_via=USER_CHANGE_VIA_WEB,
-                fields_changed=fields_changed,
+                change_messages=UserChangeMessage.domain_removal(domain),
                 by_domain_required_for_log=False,
-                for_domain_required_for_log=False,
             )
+        web_user.save()
+        removed.append(ngettext(
+            "{count} domain membership",
+            "{count} domain memberships",
+            count,
+        ).format(count=count))
 
-        if removed:
-            messages.success(
-                request,
-                _("Removed {items} from user '{username}'.").format(items=", ".join(removed), username=username)
-            )
-        else:
-            messages.info(
-                request, _("User '{username}' has no access to remove.").format(username=username)
-            )
+    if django_user.is_superuser:
+        django_user.is_superuser = False
+        django_user.save()
+        fields_changed['is_superuser'] = False
+        removed.append(_("superuser access"))
 
-    redirect_url = '{}?{}'.format(reverse('web_user_lookup'), urllib.parse.urlencode({'q': username}))
+    if is_accounting_admin(django_user):
+        ops_role = Role.objects.get(slug=privileges.OPERATIONS_TEAM)
+        Grant.objects.filter(
+            from_role=django_user.prbac_role.role,
+            to_role=ops_role,
+        ).delete()
+        Role.update_cache()
+        fields_changed['is_accounting_admin'] = False
+        removed.append(_("accounting admin access"))
+
+    if fields_changed:
+        log_user_change(
+            by_domain=None, for_domain=None, couch_user=web_user,
+            changed_by_user=request.couch_user,
+            changed_via=USER_CHANGE_VIA_WEB,
+            fields_changed=fields_changed,
+            by_domain_required_for_log=False,
+            for_domain_required_for_log=False,
+        )
+
+    if removed:
+        messages.success(
+            request,
+            _("Removed {items} from user '{username}'.").format(items=", ".join(removed), username=username)
+        )
+    else:
+        messages.info(
+            request, _("User '{username}' has no access to remove.").format(username=username)
+        )
+
+    redirect_url = '{}?{}'.format(base_url, urllib.parse.urlencode({'q': web_user.username}))
     return redirect(redirect_url)
 
 

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -541,7 +541,7 @@ def web_user_lookup(request):
 
 
 @require_superuser
-def remove_all_web_user_access(request):
+def offboard_staff_user(request):
     username = request.POST.get("username")
     if not username:
         return HttpResponseBadRequest("Missing username")

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -537,6 +537,32 @@ def web_user_lookup(request):
     return render(request, template, context)
 
 
+@require_superuser
+def remove_web_user_domains(request):
+    username = request.POST.get("username")
+    if not username:
+        return HttpResponseBadRequest("Missing username")
+
+    web_user = WebUser.get_by_username(username)
+    if web_user is None:
+        messages.error(request, _("User '%(username)s' not found.") % {'username': username})
+    elif not web_user.domains:
+        messages.info(request, _("User '%(username)s' has no domain memberships.") % {'username': username})
+    else:
+        domains = list(web_user.domains)
+        for domain in domains:
+            web_user.delete_domain_membership(domain)
+        web_user.save()
+        messages.success(
+            request,
+            _("Removed %(count)d domain membership(s) from user '%(username)s'.")
+            % {'count': len(domains), 'username': username},
+        )
+
+    redirect_url = '{}?q={}'.format(reverse('web_user_lookup'), urllib.parse.quote(username))
+    return redirect(redirect_url)
+
+
 @method_decorator(require_superuser, name='dispatch')
 class DisableUserView(FormView):
     template_name = 'hqadmin/disable_user.html'

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -607,7 +607,7 @@ def remove_all_web_user_access(request):
                 request, _("User '{username}' has no access to remove.").format(username=username)
             )
 
-    redirect_url = '{}?q={}'.format(reverse('web_user_lookup'), urllib.parse.quote(username))
+    redirect_url = '{}?{}'.format(reverse('web_user_lookup'), urllib.parse.urlencode({'q': username}))
     return redirect(redirect_url)
 
 
@@ -639,8 +639,7 @@ class DisableUserView(FormView):
     def redirect_url(self):
         base_url = reverse('web_user_lookup')
         if self.username:
-            encoded_username = urllib.parse.quote(self.username) if self.username else None
-            return '{}?q={}'.format(base_url, encoded_username)
+            return '{}?{}'.format(base_url, urllib.parse.urlencode({'q': self.username}))
 
         return base_url
 
@@ -746,7 +745,7 @@ class DisableTwoFactorView(FormView):
         from django_otp import user_has_device
 
         username = request.GET.get("q")
-        redirect_url = '{}?q={}'.format(reverse('web_user_lookup'), username)
+        redirect_url = '{}?{}'.format(reverse('web_user_lookup'), urllib.parse.urlencode({'q': username}))
         try:
             user = User.objects.get(username__iexact=username)
         except User.DoesNotExist:
@@ -816,7 +815,7 @@ class DisableTwoFactorView(FormView):
         )
 
         messages.success(self.request, _('Two-Factor Auth successfully disabled.'))
-        return redirect('{}?q={}'.format(reverse('web_user_lookup'), username))
+        return redirect('{}?{}'.format(reverse('web_user_lookup'), urllib.parse.urlencode({'q': username})))
 
 
 class WebUserDataView(View):

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -28,6 +28,7 @@ from django.utils.translation import gettext_lazy
 from django.views.generic import FormView, TemplateView, View
 
 from couchdbkit.exceptions import ResourceNotFound
+from django_prbac.models import Grant, Role
 from lxml import etree
 from lxml.builder import E
 from two_factor.utils import default_device
@@ -38,6 +39,7 @@ from couchexport.models import Format
 from couchforms.openrosa_response import RESPONSE_XMLNS
 from dimagi.utils.django.email import send_HTML_email
 
+from corehq import privileges
 from corehq.apps.accounting.utils import is_accounting_admin
 from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.auth import basicauth
@@ -534,11 +536,12 @@ def web_user_lookup(request):
         context['web_user'] = web_user
         django_user = web_user.get_django_user()
         context['has_two_factor'] = user_has_device(django_user)
+        context['is_accounting_admin'] = is_accounting_admin(django_user)
     return render(request, template, context)
 
 
 @require_superuser
-def remove_web_user_domains(request):
+def remove_all_web_user_access(request):
     username = request.POST.get("username")
     if not username:
         return HttpResponseBadRequest("Missing username")
@@ -546,18 +549,40 @@ def remove_web_user_domains(request):
     web_user = WebUser.get_by_username(username)
     if web_user is None:
         messages.error(request, _("User '%(username)s' not found.") % {'username': username})
-    elif not web_user.domains:
-        messages.info(request, _("User '%(username)s' has no domain memberships.") % {'username': username})
     else:
-        domains = list(web_user.domains)
-        for domain in domains:
-            web_user.delete_domain_membership(domain)
-        web_user.save()
-        messages.success(
-            request,
-            _("Removed %(count)d domain membership(s) from user '%(username)s'.")
-            % {'count': len(domains), 'username': username},
-        )
+        removed = []
+        django_user = web_user.get_django_user()
+
+        if web_user.domains:
+            count = len(web_user.domains)
+            for domain in list(web_user.domains):
+                web_user.delete_domain_membership(domain)
+            web_user.save()
+            removed.append(_("%(count)d domain membership(s)") % {'count': count})
+
+        if django_user.is_superuser:
+            django_user.is_superuser = False
+            django_user.save()
+            removed.append(_("superuser access"))
+
+        if is_accounting_admin(django_user):
+            ops_role = Role.objects.get(slug=privileges.OPERATIONS_TEAM)
+            Grant.objects.filter(
+                from_role=django_user.prbac_role.role,
+                to_role=ops_role,
+            ).delete()
+            removed.append(_("accounting admin access"))
+
+        if removed:
+            messages.success(
+                request,
+                _("Removed %(items)s from user '%(username)s'.")
+                % {'items': ', '.join(removed), 'username': username},
+            )
+        else:
+            messages.info(
+                request, _("User '%(username)s' has no access to remove.") % {'username': username}
+            )
 
     redirect_url = '{}?q={}'.format(reverse('web_user_lookup'), urllib.parse.quote(username))
     return redirect(redirect_url)

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -551,18 +551,27 @@ def remove_all_web_user_access(request):
         messages.error(request, _("User '%(username)s' not found.") % {'username': username})
     else:
         removed = []
+        fields_changed = {}
         django_user = web_user.get_django_user()
 
         if web_user.domains:
             count = len(web_user.domains)
             for domain in list(web_user.domains):
                 web_user.delete_domain_membership(domain)
+                log_user_change(
+                    by_domain=None, for_domain=domain, couch_user=web_user,
+                    changed_by_user=request.couch_user,
+                    changed_via=USER_CHANGE_VIA_WEB,
+                    change_messages=UserChangeMessage.domain_removal(domain),
+                    by_domain_required_for_log=False,
+                )
             web_user.save()
             removed.append(_("%(count)d domain membership(s)") % {'count': count})
 
         if django_user.is_superuser:
             django_user.is_superuser = False
             django_user.save()
+            fields_changed['is_superuser'] = False
             removed.append(_("superuser access"))
 
         if is_accounting_admin(django_user):
@@ -571,7 +580,18 @@ def remove_all_web_user_access(request):
                 from_role=django_user.prbac_role.role,
                 to_role=ops_role,
             ).delete()
+            fields_changed['is_accounting_admin'] = False
             removed.append(_("accounting admin access"))
+
+        if fields_changed:
+            log_user_change(
+                by_domain=None, for_domain=None, couch_user=web_user,
+                changed_by_user=request.couch_user,
+                changed_via=USER_CHANGE_VIA_WEB,
+                fields_changed=fields_changed,
+                by_domain_required_for_log=False,
+                for_domain_required_for_log=False,
+            )
 
         if removed:
             messages.success(

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -24,7 +24,7 @@ from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
-from django.utils.translation import gettext_lazy
+from django.utils.translation import gettext_lazy, ngettext
 from django.views.generic import FormView, TemplateView, View
 
 from couchdbkit.exceptions import ResourceNotFound
@@ -548,7 +548,7 @@ def remove_all_web_user_access(request):
 
     web_user = WebUser.get_by_username(username)
     if web_user is None:
-        messages.error(request, _("User '%(username)s' not found.") % {'username': username})
+        messages.error(request, _("User '{username}' not found.").format(username=username))
     else:
         removed = []
         fields_changed = {}
@@ -566,7 +566,11 @@ def remove_all_web_user_access(request):
                     by_domain_required_for_log=False,
                 )
             web_user.save()
-            removed.append(_("%(count)d domain membership(s)") % {'count': count})
+            removed.append(ngettext(
+                "{count} domain membership",
+                "{count} domain memberships",
+                count,
+            ).format(count=count))
 
         if django_user.is_superuser:
             django_user.is_superuser = False
@@ -596,12 +600,11 @@ def remove_all_web_user_access(request):
         if removed:
             messages.success(
                 request,
-                _("Removed %(items)s from user '%(username)s'.")
-                % {'items': ', '.join(removed), 'username': username},
+                _("Removed {items} from user '{username}'.").format(items=", ".join(removed), username=username)
             )
         else:
             messages.info(
-                request, _("User '%(username)s' has no access to remove.") % {'username': username}
+                request, _("User '{username}' has no access to remove.").format(username=username)
             )
 
     redirect_url = '{}?q={}'.format(reverse('web_user_lookup'), urllib.parse.quote(username))

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -584,6 +584,7 @@ def offboard_staff_user(request):
                 from_role=django_user.prbac_role.role,
                 to_role=ops_role,
             ).delete()
+            Role.update_cache()
             fields_changed['is_accounting_admin'] = False
             removed.append(_("accounting admin access"))
 


### PR DESCRIPTION
## Product Description
Adds "Offboard Staff User" to the web user lookup screen, which launches a modal showing which access will be removed and requiring explicit confirmation to do so.
<img width="773" height="135" alt="image" src="https://github.com/user-attachments/assets/61eba3ab-739e-45af-a0be-e86e5cc758ab" />
 
<img width="602" height="302" alt="image" src="https://github.com/user-attachments/assets/a08009f7-4dc1-42e3-b609-6597437395e9" />



## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19517
Adds functionality, UI, and tests to remove a user (with `is_staff=True`) from all project spaces and remove superuser and accounting admin access all at once.

## Safety Assurance

### Safety story
This page is only accessible to superusers and only shows up in limited circumstances (specifically if the user looked up is marked as a staff user). Requiring textbox confirmation prevents accidental clicks, and automated tests are added here to ensure functionality works. Tested locally and checked appearance on staging.

### Automated test coverage
Added TestOffboardStaffUser

### QA Plan
Not planning it.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
