### PR TITLE
Upgrade readthedocs Ubuntu and Python versions

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,9 @@ sphinx:
   configuration: docs/conf.py
 formats: all
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.13"
   jobs:
     create_environment:
       - pip install uv


### PR DESCRIPTION
## Product Description
No user-facing changes

## Technical Summary
https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/

Upgrade readthedocs Ubuntu and Python versions

## Feature Flag


## Safety Assurance
Only affects docs build

### Safety story


### Automated test coverage


### QA Plan
Spot check after docs build

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
