### PR TITLE
Update dev setup docs

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -172,12 +172,12 @@ git-hooks/install.sh
     For convenience, you can create an alias to activate virtual environments in
     ".venv" and "venv" directories. To do that, add the following to your
     `.bashrc` or `.zshrc` file:
-    ```shell
+    ```sh
     alias venv='if [[ -d .venv ]] ; then source .venv/bin/activate ; elif [[ -d venv ]] ; then source venv/bin/activate ; fi'
     ```
     Then you can activate virtual environments with
-    ```shell
-    $ venv
+    ```sh
+    venv
     ```
 
     - Recommended for developers or others with custom requirements: create a
@@ -382,14 +382,14 @@ If you want to use a partitioned database, change
 You will also need to create the additional databases manually:
 
 ```sh
-$ psql -h localhost -p 5432 -U commcarehq
+psql -h localhost -p 5432 -U commcarehq
 ```
 
 (assuming that "commcarehq" is the username in `DATABASES` in
 `localsettings.py`). When prompted, use the password associated with the
 username, of course.
 
-```sh
+```sql
 commcarehq=# CREATE DATABASE commcarehq_proxy;
 CREATE DATABASE
 commcarehq=# CREATE DATABASE commcarehq_p1;
@@ -401,24 +401,24 @@ commcarehq=# \q
 If you are running formplayer through docker, you will need to create the
 database for the service
 
-```sh
+```sql
 commcarehq=# CREATE DATABASE formplayer;
 CREATE DATABASE
 ```
 Populate your database:
 
 ```sh
-$ ./manage.py sync_couch_views
-$ ./manage.py create_kafka_topics
-$ env CCHQ_IS_FRESH_INSTALL=1 ./manage.py migrate --noinput
+./manage.py sync_couch_views
+./manage.py create_kafka_topics
+env CCHQ_IS_FRESH_INSTALL=1 ./manage.py migrate --noinput
 ```
 
 If you are using a partitioned database, populate the additional
 databases too, and configure PL/Proxy:
 
 ```sh
-$ env CCHQ_IS_FRESH_INSTALL=1 ./manage.py migrate_multi --noinput
-$ ./manage.py configure_pl_proxy_cluster --create_only
+env CCHQ_IS_FRESH_INSTALL=1 ./manage.py migrate_multi --noinput
+./manage.py configure_pl_proxy_cluster --create_only
 ```
 
 You should run `./manage.py migrate` frequently, but only use the environment
@@ -435,8 +435,8 @@ you do not expect to be using the global changes feed. You can use
 `curl` to create the databases:
 
 ```sh
-$ curl -X PUT http://username:password@127.0.0.1:5984/_users
-$ curl -X PUT http://username:password@127.0.0.1:5984/_replicator
+curl -X PUT http://username:password@127.0.0.1:5984/_users
+curl -X PUT http://username:password@127.0.0.1:5984/_replicator
 ```
 
 where "username" and "password" are the values of "COUCH_USERNAME"
@@ -447,7 +447,7 @@ and "COUCH_PASSWORD" given in `COUCH_DATABASES` set in
 
 **Mac OS M1 Users:** If you see the following error, check the [Supplementary Guide](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP_MAC.md).
 ```sh
-ImportError: failed to find libmagic.  Check your installation
+> ImportError: failed to find libmagic.  Check your installation
 ```
 
 #### Troubleshooting Issues with `migrate`
@@ -556,10 +556,10 @@ have locally, you might run into issues. Here are minimum version requirements
 for these packages.
 
 ```sh
-$ npm --version
-11.6.2
-$ node --version
-v24.11.1
+npm --version
+> 11.6.2
+node --version
+> v24.11.1
 ```
 
 On a clean Ubuntu 22.04 LTS install, the packaged nodejs version is expected to be v12. The
@@ -582,7 +582,7 @@ compile SASS, we need Dart Sass. There is a `sass` npm package that can be insta
 `npm install -g sass`, however this installs the pure javascript version without a binary. For speed in a
 development environment, it is recommended to install `sass` with homebrew:
 
-```shell
+```sh
 brew install sass/sass/sass
 ```
 

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -302,8 +302,8 @@ needs of most developers.
     ./scripts/docker up -d postgres couch redis elasticsearch6 zookeeper kafka minio formplayer
     ```
 
-   **Mac OS:** Note that you will encounter many issues at this stage.
-   We recommend visiting the Docker section in the [Supplementary Guide](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP_MAC.md).
+   **Mac OS:** You may encounter issues with formplayer and elasticsearch at this stage.
+   We recommend visiting the Docker section in the [Supplementary Guide](DEV_SETUP_MAC.md#Docker).
 
 
 5. If you are planning on running Formplayer from a binary or source, stop the

--- a/DEV_SETUP_MAC.md
+++ b/DEV_SETUP_MAC.md
@@ -84,7 +84,7 @@
 
 ## Issues With `uv sync`
 
-- `psycopg2` will complain
+- `psycopg2` may complain
 
   As of Mac OS 11.x Big Sur, the solution for this is:
   ```sh
@@ -101,7 +101,7 @@
 
 - `uv pip install xmlsec` gives `ImportError`
 
-  Due to issues with recent versions of `libxmlsec1` (v1.3 and after) `uv pip install xmlsec` is currently broken.
+  Due to issues with recent versions of `libxmlsec1` (v1.3 and after) `uv pip install xmlsec` may be broken.
   This is a workaround. This solution also assumes your `homebrew` version is greater than `4.0.13`*:
 
 1. run `brew unlink libxmlsec1`
@@ -118,8 +118,6 @@ and [thread](https://github.com/xmlsec/python-xmlsec/issues/254) are good starti
 
 ### M1 Issues
 
-- `gevent` may present errors when installing with Python <3.9. For this reason, you should avoid using an older version of Python unless it is required.
-
 - `pynacl` will likely install but may throw an error `symbol not found in flat namespace '_ffi_prep_closure'` when attempting to run, particularly when setting up CommCare-Cloud.
 
   This can be fixed by installing a version of `pynacl` specific to the system architecture:
@@ -134,7 +132,7 @@ Docker images that will not run on Mac OS (Intel or M1):
 
 - `formplayer` (See section on Running Formplayer Outside of Docker in the [Main Developer Setup Guide](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md))
 
-Docker images that will not run on Mac OS (as of 11.x Big Sur and above):
+Docker images that may not run on Mac OS (as of 11.x Big Sur and above):
 
 - `elasticsearch6` (Image is not optimized for arm but can run on apple silicon)
 

--- a/DEV_SETUP_MAC.md
+++ b/DEV_SETUP_MAC.md
@@ -160,7 +160,7 @@ curl https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.8.23.t
 
 Un-tar and put the folder somewhere you can find it. Take note of that path (`pwd`) and add the following to your `~/.zshrc`:
 
-```
+```sh
 tar -xvzf elasticsearch-6.8.23.tar.gz
 ```
 
@@ -174,19 +174,19 @@ You would need to update couple of setting in order to make elasticsearch run on
 
 Change into elasticsearch directory
 
-```
+```sh
 cd /path/to/elasticsearch-6.8.23
 ```
 
 - In `config/jvm.options`, comment out `10-:-XX:UseAVX=2`
 
-```
+```sh
 sed -i '' '/10-:-XX:UseAVX=2/ s/^/# /' config/jvm.options
 ```
 
 - In `config/elasticsearch.yml`, add xpack.ml.enabled: false
 
-```
+```sh
 echo "xpack.ml.enabled: false" | sudo tee -a config/elasticsearch.yml
 ```
 
@@ -199,8 +199,8 @@ Now that you have Elasticsearch running you will need to install the necessary p
 
 1. Install the plugin
 
-    ```shell
-    $ elasticsearch-plugin install analysis-phonetic
+    ```sh
+    elasticsearch-plugin install analysis-phonetic
     ```
 
     (If the `plugin` command is not found you will need to use the full path `<es home>/bin/plugin`).
@@ -209,8 +209,8 @@ Now that you have Elasticsearch running you will need to install the necessary p
 
 3. Verify the plugin was correctly installed
 
-    ```shell
-    $ curl "localhost:9200/_cat/plugins?s=component&h=component,version"
+    ```sh
+    curl "localhost:9200/_cat/plugins?s=component&h=component,version"
     > analysis-phonetic 6.8.23
     ```
 


### PR DESCRIPTION
## Technical Summary
Updates setup docs with softer language for Mac issues, as many are no longer an issue on the newest systems, and removes a note about Python <3.9 which we no longer support. Also consistently uses `sh` for shell code blocks, removes `$` to make commands copyable, and adds a couple `>` to indicate shell output.

## Safety Assurance

### Safety story
No functional code, just updates docs.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
n/a

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
