### PR TITLE
Update sign-up prompt and description in login_full.html

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/partials/bootstrap3/login_full.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/bootstrap3/login_full.html
@@ -20,7 +20,7 @@
                     team with powerful service delivery apps that work where
                     you work, even offline. No coding required.
                   {% endblocktrans %}
-                  <a href="https://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
+                  <a target="_blank" href="https://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
               </p>
             {% endif %}
             <p class="text-center">

--- a/corehq/apps/domain/templates/login_and_password/partials/bootstrap3/login_full.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/bootstrap3/login_full.html
@@ -10,13 +10,17 @@
           <div class="well sign-up-bubble form-bubble-purple">
             <h2>
               {% blocktrans %}
-                No account? Sign up today, it's free!
+                No account? Get started for free.
               {% endblocktrans %}
             </h2>
             {% if not allow_domain_requests %}
               <p class="lead">
-                <strong><a href="http://www.dimagi.com/commcare/">{% trans "Learn more" %}</a></strong>
-                {% blocktrans %}about how CommCare can be your mobile solution for your frontline workforce.{% endblocktrans %}
+                 {% blocktrans %}
+                    Data collection is just the start. Equip your frontline
+                    team with powerful service delivery apps that work where
+                    you work, even offline. No coding required.
+                  {% endblocktrans %}
+                  <a href="https://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
               </p>
             {% endif %}
             <p class="text-center">

--- a/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/login_full.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/login_full.html
@@ -21,7 +21,7 @@
                     team with powerful service delivery apps that work where
                     you work, even offline. No coding required.
                   {% endblocktrans %}
-                  <a href="https://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
+                  <a class="text-decoration-underline" href="https://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
                 </p>
               {% endif %}
               <p class="text-center">

--- a/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/login_full.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/login_full.html
@@ -11,13 +11,13 @@
             <div class="card-body mt-3">
               <h2>
                 {% blocktrans %}
-                  No account? Sign up today, it's free!
+                  No account? Get started for free.
                 {% endblocktrans %}
               </h2>
               {% if not allow_domain_requests %}
-                <p class="lead">
-                  <strong><a href="http://www.dimagi.com/commcare/">{% trans "Learn more" %}</a></strong>
-                  {% blocktrans %}about how CommCare can be your mobile solution for your frontline workforce.{% endblocktrans %}
+              <p class="lead">
+                  {% blocktrans %}Data collection is just the start. Equip your frontline team with powerful service delivery apps that work where you work, even offline. No coding required.{% endblocktrans %}
+                  <a href="http://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
                 </p>
               {% endif %}
               <p class="text-center">

--- a/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/login_full.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/login_full.html
@@ -15,9 +15,13 @@
                 {% endblocktrans %}
               </h2>
               {% if not allow_domain_requests %}
-              <p class="lead">
-                  {% blocktrans %}Data collection is just the start. Equip your frontline team with powerful service delivery apps that work where you work, even offline. No coding required.{% endblocktrans %}
-                  <a href="http://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
+                <p class="lead">
+                  {% blocktrans %}
+                    Data collection is just the start. Equip your frontline
+                    team with powerful service delivery apps that work where
+                    you work, even offline. No coding required.
+                  {% endblocktrans %}
+                  <a href="https://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
                 </p>
               {% endif %}
               <p class="text-center">

--- a/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/login_full.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/bootstrap5/login_full.html
@@ -21,7 +21,7 @@
                     team with powerful service delivery apps that work where
                     you work, even offline. No coding required.
                   {% endblocktrans %}
-                  <a class="text-decoration-underline" href="https://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
+                  <a class="text-decoration-underline" target="_blank" href="https://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
                 </p>
               {% endif %}
               <p class="text-center">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/login_and_password/partials/login_full.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/login_and_password/partials/login_full.html.diff.txt
@@ -35,7 +35,8 @@
                      team with powerful service delivery apps that work where
                      you work, even offline. No coding required.
                    {% endblocktrans %}
-                   <a href="https://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
+-                  <a target="_blank" href="https://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
++                  <a class="text-decoration-underline" target="_blank" href="https://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
 +                </p>
 +              {% endif %}
 +              <p class="text-center">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/login_and_password/partials/login_full.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/login_and_password/partials/login_full.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -1,39 +1,41 @@
+@@ -1,43 +1,45 @@
  {% load i18n %}
  <div class="container-fluid">
    <div class="row">
@@ -15,24 +15,27 @@
 -          <div class="well sign-up-bubble form-bubble-purple">
 -            <h2>
 -              {% blocktrans %}
--                No account? Sign up today, it's free!
+-                No account? Get started for free.
 -              {% endblocktrans %}
 -            </h2>
 -            {% if not allow_domain_requests %}
 -              <p class="lead">
--                <strong><a href="http://www.dimagi.com/commcare/">{% trans "Learn more" %}</a></strong>
--                {% blocktrans %}about how CommCare can be your mobile solution for your frontline workforce.{% endblocktrans %}
+-                 {% blocktrans %}
 +          <div class="card sign-up-bubble form-bubble-purple">
 +            <div class="card-body mt-3">
 +              <h2>
 +                {% blocktrans %}
-+                  No account? Sign up today, it's free!
++                  No account? Get started for free.
 +                {% endblocktrans %}
 +              </h2>
 +              {% if not allow_domain_requests %}
 +                <p class="lead">
-+                  <strong><a href="http://www.dimagi.com/commcare/">{% trans "Learn more" %}</a></strong>
-+                  {% blocktrans %}about how CommCare can be your mobile solution for your frontline workforce.{% endblocktrans %}
++                  {% blocktrans %}
+                     Data collection is just the start. Equip your frontline
+                     team with powerful service delivery apps that work where
+                     you work, even offline. No coding required.
+                   {% endblocktrans %}
+                   <a href="https://www.dimagi.com/commcare/">{% trans "Learn more about CommCare." %}</a>
 +                </p>
 +              {% endif %}
 +              <p class="text-center">


### PR DESCRIPTION

## Product Description
Updates to the copy on the bottom of the CommCareHQ login screen to refresh our messaging for people who may not already have an account. Existing copy has been there for a long time and feels dated in terms of how we are positioning CommCare today.
<img width="627" height="293" alt="Screenshot 2026-04-07 at 4 18 34 PM" src="https://github.com/user-attachments/assets/a51e407c-ceda-4daf-bee4-0b5464fe357c" />


## Technical Summary
Text-only change to the sign-up callout on the login page. No logic or functionality changes.

## Feature Flag
N/A

## Safety Assurance

### Safety story
This is a copy-only change to a single HTML template. No code, data, or functionality is affected.

### Automated test coverage
N/A — text-only change

### QA Plan
Visual review of the login page at /accounts/login/


### Rollback instructions
- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
