### PR TITLE
Add case type validation for save to case

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -1159,13 +1159,13 @@ class IndexedFormBaseValidator(FormBaseValidator):
                     errors.append({'type': 'save_to_case_missing_case_type', 'case_tag': save_ref.path})
                 if 'case_name' not in save_ref.properties:
                     errors.append({'type': 'save_to_case_missing_case_name', 'case_tag': save_ref.path})
-            case_type = save_ref.case_type
-            if case_type and not is_valid_case_type(case_type):
-                errors.append({
-                    'type': 'save_to_case_invalid_case_type',
-                    'case_tag': save_ref.path,
-                    'case_type': case_type,
-                })
+                case_type = save_ref.case_type
+                if case_type and not is_valid_case_type(case_type):
+                    errors.append({
+                        'type': 'save_to_case_invalid_case_type',
+                        'case_tag': save_ref.path,
+                        'case_type': case_type,
+                    })
             if case_type == 'commcare-user' and (save_ref.create or save_ref.close):
                 errors.append({
                     'type': 'save_to_case_commcare_user_not_update_only',

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -1154,12 +1154,12 @@ class IndexedFormBaseValidator(FormBaseValidator):
         errors = []
         save_references = self.form.case_references_data.get_save_references()
         for save_ref in save_references:
+            case_type = save_ref.case_type
             if save_ref.create:
                 if 'case_type' not in save_ref.properties:
                     errors.append({'type': 'save_to_case_missing_case_type', 'case_tag': save_ref.path})
                 if 'case_name' not in save_ref.properties:
                     errors.append({'type': 'save_to_case_missing_case_name', 'case_tag': save_ref.path})
-                case_type = save_ref.case_type
                 if case_type and not is_valid_case_type(case_type):
                     errors.append({
                         'type': 'save_to_case_invalid_case_type',

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -44,6 +44,7 @@ from corehq.apps.app_manager.suite_xml.features.case_tiles import CUSTOM, case_t
 from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
 from corehq.apps.app_manager.util import (
     app_callout_templates,
+    is_valid_case_type,
     module_case_hierarchy_has_circular_reference,
     module_loads_registry_case,
     module_uses_inline_search,
@@ -1158,6 +1159,18 @@ class IndexedFormBaseValidator(FormBaseValidator):
                     errors.append({'type': 'save_to_case_missing_case_type', 'case_tag': save_ref.path})
                 if 'case_name' not in save_ref.properties:
                     errors.append({'type': 'save_to_case_missing_case_name', 'case_tag': save_ref.path})
+            case_type = save_ref.case_type
+            if case_type and not is_valid_case_type(case_type):
+                errors.append({
+                    'type': 'save_to_case_invalid_case_type',
+                    'case_tag': save_ref.path,
+                    'case_type': case_type,
+                })
+            if case_type == 'commcare-user' and (save_ref.create or save_ref.close):
+                errors.append({
+                    'type': 'save_to_case_commcare_user_not_update_only',
+                    'case_tag': save_ref.path,
+                })
 
         return errors
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap3/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap3/build_errors.html
@@ -467,6 +467,22 @@
             {% if not not_actual_build %}
               in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
+            {% case "save_to_case_invalid_case_type" %}
+            {% blocktrans with case_tag=error.case_tag case_type=error.case_type %}
+              <strong>Save to Case question "{{ case_tag }}" has an invalid case type "{{ case_type }}".</strong>
+              Case types can only include the characters a-z, 0-9, '-' and '_'.
+            {% endblocktrans %}
+            {% if not not_actual_build %}
+              in {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
+            {% case "save_to_case_commcare_user_not_update_only" %}
+            {% blocktrans with case_tag=error.case_tag %}
+              <strong>Save to Case question "{{ case_tag }}" has an invalid action for 'commcare-user' cases.</strong>
+              'commcare-user' cases are managed by the system and can only be updated, not created or closed.
+            {% endblocktrans %}
+            {% if not not_actual_build %}
+              in {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "path error" %}
             {% if error.path %}
               The case management

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/build_errors.html
@@ -467,6 +467,22 @@
             {% if not not_actual_build %}
               in {% include "app_manager/partials/form_error_message.html" %}
             {% endif %}
+            {% case "save_to_case_invalid_case_type" %}
+            {% blocktrans with case_tag=error.case_tag case_type=error.case_type %}
+              <strong>Save to Case question "{{ case_tag }}" has an invalid case type "{{ case_type }}".</strong>
+              Case types can only include the characters a-z, 0-9, '-' and '_'.
+            {% endblocktrans %}
+            {% if not not_actual_build %}
+              in {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
+            {% case "save_to_case_commcare_user_not_update_only" %}
+            {% blocktrans with case_tag=error.case_tag %}
+              <strong>Save to Case question "{{ case_tag }}" has an invalid action for 'commcare-user' cases.</strong>
+              'commcare-user' cases are managed by the system and can only be updated, not created or closed.
+            {% endblocktrans %}
+            {% if not not_actual_build %}
+              in {% include "app_manager/partials/form_error_message.html" %}
+            {% endif %}
             {% case "path error" %}
             {% if error.path %}
               The case management

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -102,6 +102,97 @@ class BuildErrorsTest(TestCase):
             for error in errors
         ))
 
+    def test_save_to_case_invalid_case_type(self, *args):
+        factory = AppFactory()
+        _, form = factory.new_basic_module('save_to_case', 'household')
+        form.source = get_simple_form()
+        form.case_references_data = CaseReferences(
+            load={},
+            save={
+                '/data/save_to_case': CaseSaveReference(
+                    case_type='invalid case type!',
+                    properties=['case_type', 'case_name'],
+                    create=True,
+                    close=False,
+                )
+            },
+        )
+
+        errors = form.validate_for_build()
+        self.assertTrue(any(
+            error.get('type') == 'save_to_case_invalid_case_type'
+            and error.get('case_tag') == '/data/save_to_case'
+            for error in errors
+        ))
+
+    def test_save_to_case_commcare_user_not_update_only(self, *args):
+        factory = AppFactory()
+        _, form = factory.new_basic_module('save_to_case', 'household')
+        form.source = get_simple_form()
+        form.case_references_data = CaseReferences(
+            load={},
+            save={
+                '/data/save_to_case': CaseSaveReference(
+                    case_type='commcare-user',
+                    properties=['case_type', 'case_name'],
+                    create=True,
+                    close=False,
+                )
+            },
+        )
+
+        errors = form.validate_for_build()
+        self.assertTrue(any(
+            error.get('type') == 'save_to_case_commcare_user_not_update_only'
+            and error.get('case_tag') == '/data/save_to_case'
+            for error in errors
+        ))
+
+    def test_save_to_case_commcare_user_close(self, *args):
+        factory = AppFactory()
+        _, form = factory.new_basic_module('save_to_case', 'household')
+        form.source = get_simple_form()
+        form.case_references_data = CaseReferences(
+            load={},
+            save={
+                '/data/save_to_case': CaseSaveReference(
+                    case_type='commcare-user',
+                    properties=[],
+                    create=False,
+                    close=True,
+                )
+            },
+        )
+
+        errors = form.validate_for_build()
+        self.assertTrue(any(
+            error.get('type') == 'save_to_case_commcare_user_not_update_only'
+            and error.get('case_tag') == '/data/save_to_case'
+            for error in errors
+        ))
+
+    def test_save_to_case_commcare_user_update_is_allowed(self, *args):
+        factory = AppFactory()
+        _, form = factory.new_basic_module('save_to_case', 'household')
+        form.source = get_simple_form()
+        form.case_references_data = CaseReferences(
+            load={},
+            save={
+                '/data/save_to_case': CaseSaveReference(
+                    case_type='commcare-user',
+                    properties=[],
+                    create=False,
+                    close=False,
+                )
+            },
+        )
+
+        errors = form.validate_for_build()
+        self.assertFalse(any(
+            error.get('type') == 'save_to_case_commcare_user_not_update_only'
+            for error in errors
+        ))
+
     def test_empty_module_errors(self, *args):
         factory = AppFactory(build_version='2.24.0')
         app = factory.app

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -12,7 +12,7 @@ from corehq.apps.app_manager.tests.util import (
     patch_validate_xform,
     SuiteMixin,
 )
-from corehq.apps.app_manager.util import split_path, does_app_have_mobile_ucr_v1_refs
+from corehq.apps.app_manager.util import is_valid_case_type, split_path, does_app_have_mobile_ucr_v1_refs
 from corehq.apps.app_manager.views.utils import get_default_followup_form_xml
 from corehq.apps.domain.models import Domain
 
@@ -159,6 +159,19 @@ class TestGlobalAppConfig(TestCase):
         config = GlobalAppConfig.by_app_id(self.domain, app_id)
         config.app_prompt = 'on'
         return config
+
+
+class TestIsValidCaseType(SimpleTestCase):
+
+    def test_valid_case_types(self):
+        for value in ('foo', 'foo-bar', 'case_type_1', 'CaseType123'):
+            with self.subTest(value=value):
+                self.assertTrue(is_valid_case_type(value))
+
+    def test_invalid_case_types(self):
+        for value in ('foo bar', '', None, 'foo\tbar', '!special-char'):
+            with self.subTest(value=value):
+                self.assertFalse(is_valid_case_type(value))
 
 
 class TestSplitPath(SimpleTestCase):

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -1,6 +1,8 @@
 from django.http import Http404
 from django.test.testcases import TestCase, SimpleTestCase
 
+import pytest
+
 from corehq.apps.app_manager.models import (
     AdvancedModule,
     Application,
@@ -12,7 +14,11 @@ from corehq.apps.app_manager.tests.util import (
     patch_validate_xform,
     SuiteMixin,
 )
-from corehq.apps.app_manager.util import is_valid_case_type, split_path, does_app_have_mobile_ucr_v1_refs
+from corehq.apps.app_manager.util import (
+    is_valid_case_type,
+    split_path,
+    does_app_have_mobile_ucr_v1_refs,
+)
 from corehq.apps.app_manager.views.utils import get_default_followup_form_xml
 from corehq.apps.domain.models import Domain
 
@@ -161,17 +167,18 @@ class TestGlobalAppConfig(TestCase):
         return config
 
 
-class TestIsValidCaseType(SimpleTestCase):
+@pytest.mark.parametrize(
+    'value', ('foo', 'foo-bar', 'case_type_1', 'CaseType123')
+)
+def test_valid_case_types(value):
+    assert is_valid_case_type(value)
 
-    def test_valid_case_types(self):
-        for value in ('foo', 'foo-bar', 'case_type_1', 'CaseType123'):
-            with self.subTest(value=value):
-                self.assertTrue(is_valid_case_type(value))
 
-    def test_invalid_case_types(self):
-        for value in ('foo bar', '', None, 'foo\tbar', '!special-char'):
-            with self.subTest(value=value):
-                self.assertFalse(is_valid_case_type(value))
+@pytest.mark.parametrize(
+    'value', ('foo bar', '', None, 'foo\tbar', '!special-char')
+)
+def test_invalid_case_types(value):
+    assert not is_valid_case_type(value)
 
 
 class TestSplitPath(SimpleTestCase):

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -208,21 +208,6 @@ _case_type_regex = re.compile(CASE_TYPE_REGEX)
 
 
 def is_valid_case_type(case_type):
-    """
-    Returns ``True`` if ``case_type`` is valid for ``module``
-
-    >>> from corehq.apps.app_manager.models import Module, AdvancedModule
-    >>> is_valid_case_type('foo', Module())
-    True
-    >>> is_valid_case_type('foo-bar', Module())
-    True
-    >>> is_valid_case_type('foo bar', Module())
-    False
-    >>> is_valid_case_type('', Module())
-    False
-    >>> is_valid_case_type(None, Module())
-    False
-    """
     matches_regex = bool(_case_type_regex.match(case_type or ''))
     return matches_regex
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/build_errors.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/build_errors.html.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -482,7 +482,7 @@
+@@ -498,7 +498,7 @@
                in the
                form{% include "app_manager/partials/form_error_message.html" with no_form="." %}
                is missing a question. Please choose a question from the dropdown
@@ -9,7 +9,7 @@
              {% endif %}
              {% case "multimedia case property not supported" %}
              {% blocktrans with path=error.path %}
-@@ -552,8 +552,9 @@
+@@ -568,8 +568,9 @@
                  but cases are not available for this form. Please either remove
                  the case reference or (1) make sure that the case list is set to
                  display the case list first and then form, and (2) make sure
@@ -21,7 +21,7 @@
                {% endblocktrans %}
              {% else %}
                {% blocktrans %}
-@@ -561,8 +562,9 @@
+@@ -577,8 +578,9 @@
                  are not available. Please either remove the case reference or
                  (1) make sure that the case list is set to display the case list
                  first and then form, and (2) make sure that all forms in this


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Though in vellum we add validation warnings, but user can still save the form and publish the changes, add build-time validation for case types in Save to Case question can strictly prevent those scenario.

<img width="867" height="415" alt="Screenshot 2026-04-01 at 3 48 13 PM" src="https://github.com/user-attachments/assets/50a74154-5f9c-4dac-8b43-c4d14e147041" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

Added validation in `check_save_to_case_references()`:
  - Invalid case type format: Rejects case types not matching `^[\w-]+$` (the same `is_valid_case_type()` check used for module-level case types)
  - `commcare-user` restriction: Rejects create or close actions on `commcare-user` cases.

Note: `commcare-user` with index action is not validated here because `CaseSaveReference` doesn't have an index field. This is currently only guarded by a Vellum-side UI warning.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`VELLUM_SAVE_TO_CASE`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
 - Validation only runs at build time — no impact on existing published apps
 - Uses the same is_valid_case_type() regex already used for module case type validation

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
new test added in corehq/apps/app_manager/tests/test_build_errors.py

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
- Create a Save to Case form with a valid case type — verify build succeeds
- Create a Save to Case form with a invalid case type — verify build succeeds
- Attempt to build with `commcare-user` as case type with Create action — verify build error
- Attempt to build with `commcare-user` as case type with Close action — verify build error
- Build with `commcare-user` as case type with Update only — verify build succeeds

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
