### PR TITLE
Remove Case Search Index Management from Config UI

### DIFF
--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -374,23 +374,16 @@ def case_search_sync_cases_on_form_entry_enabled_for_domain(domain):
 
 
 def enable_case_search(domain):
-    from corehq.apps.case_search.tasks import reindex_case_search_for_domain
-
     config, created = CaseSearchConfig.objects.get_or_create(pk=domain)
     if not config.enabled:
         config.enabled = True
         config.save()
         case_search_enabled_for_domain.clear(domain)
-        reindex_case_search_for_domain.delay(domain)
         case_search_sync_cases_on_form_entry_enabled_for_domain.clear(domain)
     return config
 
 
 def disable_case_search(domain):
-    from corehq.apps.case_search.tasks import (
-        delete_case_search_cases_for_domain,
-    )
-
     try:
         config = CaseSearchConfig.objects.get(pk=domain)
     except CaseSearchConfig.DoesNotExist:
@@ -400,7 +393,6 @@ def disable_case_search(domain):
         config.enabled = False
         config.save()
         case_search_enabled_for_domain.clear(domain)
-        delete_case_search_cases_for_domain.delay(domain)
         case_search_sync_cases_on_form_entry_enabled_for_domain.clear(domain)
     return config
 

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -405,12 +405,6 @@ def disable_case_search(domain):
     return config
 
 
-def case_search_enabled_domains():
-    """Returns a list of all domains that have case search enabled
-    """
-    return CaseSearchConfig.objects.filter(enabled=True).values_list('domain', flat=True)
-
-
 class DomainsNotInCaseSearchIndex(models.Model):
     """
     NOTE: This is a temporary "migration" model.

--- a/corehq/apps/case_search/tasks.py
+++ b/corehq/apps/case_search/tasks.py
@@ -1,15 +1,7 @@
 from corehq.apps.celery import task
-from corehq.pillows.case_search import (
-    CaseSearchReindexerFactory,
-    delete_case_search_cases,
-)
+from corehq.pillows.case_search import CaseSearchReindexerFactory
 
 
 @task
 def reindex_case_search_for_domain(domain):
     CaseSearchReindexerFactory(domain=domain).build().reindex()
-
-
-@task
-def delete_case_search_cases_for_domain(domain):
-    delete_case_search_cases(domain)

--- a/corehq/apps/case_search/tests/test_models.py
+++ b/corehq/apps/case_search/tests/test_models.py
@@ -1,49 +1,20 @@
-from unittest.mock import call, patch
-
-from django.test import TestCase
-
 from testil import assert_raises, eq
 
 from corehq.apps.case_search.exceptions import CaseSearchUserError
 from corehq.apps.case_search.filter_dsl import CaseFilterError
 from corehq.apps.case_search.models import (
+    CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
+    CASE_SEARCH_CASE_TYPE_KEY,
     CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY,
-    CASE_SEARCH_REGISTRY_ID_KEY,
     CASE_SEARCH_INCLUDE_ALL_RELATED_CASES_KEY,
-    CASE_SEARCH_SORT_KEY,
     CASE_SEARCH_MODULE_NAME_TAG_KEY,
+    CASE_SEARCH_REGISTRY_ID_KEY,
+    CASE_SEARCH_SORT_KEY,
     CaseSearchRequestConfig,
-    disable_case_search,
-    enable_case_search,
+    SearchCriteria,
     extract_search_request_config,
-    CASE_SEARCH_CASE_TYPE_KEY, SearchCriteria, CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
 )
 from corehq.util.test_utils import generate_cases
-
-
-class TestCaseSearch(TestCase):
-    domain = "meereen"
-
-    @patch('corehq.apps.case_search.tasks.CaseSearchReindexerFactory')
-    def test_enable_case_search_reindex(self, fake_factor):
-        """
-        When case search is enabled, reindex that domains cases
-        """
-        enable_case_search(self.domain)
-        self.assertEqual(fake_factor.call_args, call(domain=self.domain))
-        self.assertTrue(fake_factor().build.called)
-        self.assertTrue(fake_factor().build().reindex.called)
-
-    @patch('corehq.apps.case_search.tasks.delete_case_search_cases')
-    def test_disable_case_search_reindex(self, fake_deleter):
-        """
-        When case search is disabled, delete that domains cases
-        """
-        with patch('corehq.apps.case_search.tasks.CaseSearchReindexerFactory'):
-            enable_case_search(self.domain)
-
-        disable_case_search(self.domain)
-        self.assertEqual(fake_deleter.call_args, call(self.domain))
 
 
 @generate_cases([

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -16,8 +16,7 @@ from corehq.apps.change_feed.consumer.feed import (
     KafkaCheckpointEventHandler,
 )
 from corehq.apps.data_dictionary.util import get_gps_properties
-from corehq.apps.es.case_search import CaseSearchES, case_search_adapter
-from corehq.apps.es.client import manager
+from corehq.apps.es.case_search import case_search_adapter
 from corehq.apps.geospatial.utils import get_geo_case_property
 from corehq.form_processor.backends.sql.dbaccessors import CaseReindexAccessor
 from corehq.util.doc_processor.sql import SqlDocumentProvider
@@ -249,12 +248,3 @@ class ResumableCaseSearchReindexerFactory(ReindexerFactory):
             adapter=case_search_adapter,
             **self.options
         )
-
-
-def delete_case_search_cases(domain):
-    if domain is None or isinstance(domain, dict):
-        raise TypeError("Domain attribute is required")
-
-    manager.index_refresh(case_search_adapter.index_name)
-    case_ids = CaseSearchES().domain(domain).values_list('_id', flat=True)
-    case_search_adapter.bulk_delete(case_ids)

--- a/testapps/test_pillowtop/tests/test_case_search_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_search_pillow.py
@@ -19,10 +19,7 @@ from corehq.apps.es.client import manager
 from corehq.apps.es.tests.utils import es_test
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.case import get_case_pillow
-from corehq.pillows.case_search import (
-    CaseSearchReindexerFactory,
-    delete_case_search_cases,
-)
+from corehq.pillows.case_search import CaseSearchReindexerFactory
 from corehq.util.test_utils import create_and_save_a_case, privilege_enabled
 
 
@@ -48,31 +45,6 @@ class CaseSearchPillowTest(TestCase):
         case = self._make_case(domain=self.domain)
         CaseSearchReindexerFactory(domain=self.domain).build().reindex()
         self._assert_case_in_es(self.domain, case)
-
-    def test_delete_case_search_cases(self):
-        """
-        Tests that cases are correctly removed from the es index
-        """
-        other_domain = "braavos"
-        self._bootstrap_cases_in_es_for_domain(self.domain)
-        case = self._bootstrap_cases_in_es_for_domain(other_domain)
-
-        with self.assertRaises(TypeError):
-            delete_case_search_cases(None)
-        with self.assertRaises(TypeError):
-            delete_case_search_cases({})
-
-        # delete cases from one domain
-        delete_case_search_cases(self.domain)
-
-        # make sure the other domain's cases are still there
-        self._assert_case_in_es(other_domain, case)
-
-        # delete other domains cases
-        delete_case_search_cases(other_domain)
-
-        # make sure nothing is left
-        self._assert_index_empty()
 
     def test_sql_case_search_pillow(self):
         consumer = get_test_kafka_consumer(topics.CASE_SQL)


### PR DESCRIPTION
## Product Description


## Technical Summary
Probably not a good idea to have a button that lets projects delete their entire case search index :fearful: 
I believe this is a holdover from before we turned on the case search index for all projects.  I checked and confirmed that there are no `DomainsNotInCaseSearchIndex` remaining on prod (didn't check other envs).  There's a lot of other code related to that transition that can probably be removed as well now, but for the moment I'll leave it at getting rid of this destructive action.

Shout to @MartinRiese for identifying in https://github.com/dimagi/commcare-hq/pull/37534

## Feature Flag
Simple Case Search

## Safety Assurance


### Safety story
This code is only executed when projects enable or disable case search, which is an infrequent action, so I don't believe this PR can affect day-to-day usage.

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
