### PR TITLE
Restrict which domains get new case search FFs

### DIFF
--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -121,7 +121,8 @@ def build_filter_from_ast(node, context):
 
         if is_ancestor_comparison(node):
             # this node represents a filter on a property for a related case
-            _require_related_lookups_flag(context)
+            if serialize(node.left.right) != '@case_id':
+                _require_related_lookups_flag(context)
             return ancestor_comparison_query(context, node)
 
         if _is_subcase_count(node):

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -521,3 +521,8 @@ def test_subcase_query_logging():
         with flag_enabled('CASE_SEARCH_RELATED_LOOKUPS'):
             build_filter_from_ast(parsed, SearchFilterContext("mydomain"))
         notify.assert_not_called()
+
+    parsed = parse_xpath("parent/@case_id = '123abc'")
+    with patch('corehq.apps.case_search.filter_dsl.notify_exception') as notify:
+        build_filter_from_ast(parsed, SearchFilterContext("mydomain"))
+        notify.assert_not_called()

--- a/corehq/apps/domain/management/commands/update_case_search_toggles.py
+++ b/corehq/apps/domain/management/commands/update_case_search_toggles.py
@@ -162,6 +162,9 @@ class Command(BaseCommand):
             "parent/"           # Related properties
         ]
 
+        def is_parent_reference(prop):
+            return prop.startswith('parent/') and prop.removeprefix('parent/') != '@case_id'
+
         for m in Command._get_case_list_modules(app):
             search_config = m.get('search_config', {})
             properties = search_config.get('properties', [])
@@ -180,10 +183,10 @@ class Command(BaseCommand):
                     reasons.append(f"module '{mod}': xpath_query default with {matched}")
 
             # Related properties
-            if any(p['name'].startswith('parent/') for p in properties):
+            if any(is_parent_reference(p['name']) for p in properties):
                 reasons.append(f"module '{mod}': parent/ search property")
             # Related properties
-            if any(p.get('property', '').startswith('parent/') for p in default_properties):
+            if any(is_parent_reference(p.get('property', '')) for p in default_properties):
                 reasons.append(f"module '{mod}': parent/ default property")
             # Include related cases in search results
             if search_config.get('include_all_related_cases', False):

--- a/corehq/apps/domain/management/commands/update_case_search_toggles.py
+++ b/corehq/apps/domain/management/commands/update_case_search_toggles.py
@@ -119,13 +119,6 @@ class Command(BaseCommand):
         return reasons
 
     @staticmethod
-    def _domain_uses_deprecated_feature(domain_name):
-        reasons = []
-        if toggles.WEBAPPS_STICKY_SEARCH.enabled(domain_name):  # Sticky Search
-            reasons.append("toggle WEBAPPS_STICKY_SEARCH")
-        return reasons
-
-    @staticmethod
     def _app_uses_deprecated_feature(app):
         reasons = []
 
@@ -209,12 +202,8 @@ class Command(BaseCommand):
             if advanced_reasons:
                 advanced_reasons = [f"domain: {r}" for r in advanced_reasons]
 
-            deprecated_reasons = Command._domain_uses_deprecated_feature(domain_name)
-            if deprecated_reasons:
-                deprecated_reasons = [f"domain: {r}" for r in deprecated_reasons]
-
+            deprecated_reasons = []
             related_lookup_reasons = []
-
             for app_id in get_app_ids_in_domain(domain_name):
                 if advanced_reasons and deprecated_reasons and related_lookup_reasons:
                     break


### PR DESCRIPTION
## Product Description


## Technical Summary
https://dimagi.atlassian.net/browse/USH-6509
Each commit should be self-explanatory.  These are a few follow-ups from testing the logic around which flags to enable for each domain.

## Feature Flag
Case Search

## Safety Assurance


### Safety story
The test and management command changes can't affect normal web server operation, and the other change should be safe based on the comment I added in-line.


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
