### PR TITLE
[Couch to SQL]Remove blob from CommCareBuild

### DIFF
--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -17,8 +17,6 @@ from dimagi.ext.couchdbkit import (
 
 from corehq.apps.app_manager.const import APP_V2
 from corehq.apps.builds.fixtures import commcare_build_config
-from corehq.blobs import CODES as BLOB_CODES
-from corehq.blobs.mixin import BlobMixin
 from corehq.util.quickcache import quickcache
 
 
@@ -38,11 +36,10 @@ class SemanticVersionProperty(StringProperty):
         return value
 
 
-class CommCareBuild(BlobMixin, Document):
+class CommCareBuild(Document):
     build_number = IntegerProperty()
     version = SemanticVersionProperty()
     time = DateTimeProperty()
-    _blobdb_type_code = BLOB_CODES.commcarebuild
 
     @classmethod
     def create_without_artifacts(cls, version, build_number):

--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -44,15 +44,6 @@ class CommCareBuild(BlobMixin, Document):
     time = DateTimeProperty()
     _blobdb_type_code = BLOB_CODES.commcarebuild
 
-    def fetch_file(self, path, filename=None):
-        if filename:
-            path = '/'.join([path, filename])
-        attachment = self.fetch_attachment(path)
-        try:
-            return attachment.decode('utf-8')
-        except UnicodeDecodeError:
-            return attachment
-
     @classmethod
     def create_without_artifacts(cls, version, build_number):
         self = cls(build_number=build_number, version=version,

--- a/corehq/apps/builds/urls.py
+++ b/corehq/apps/builds/urls.py
@@ -1,11 +1,10 @@
 from django.urls import re_path as url
 
-from .views import EditMenuView, get, get_all, import_build, post
+from .views import EditMenuView, get_all, import_build, post
 
 urlpatterns = [
     url(r'^edit_menu/$', EditMenuView.as_view(), name=EditMenuView.urlname),
     url(r'^import/$', import_build, name='import_build'),
     url(r'^post/$', post),
-    url(r'^(?P<version>.+)/(?P<build_number>\d+)/(?P<path>.+)$', get),
     url(r'^$', get_all),
 ]

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
 
-from couchdbkit import BadValueError, ResourceNotFound
+from couchdbkit import BadValueError
 
 from dimagi.utils.web import json_request, json_response
 

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -37,19 +37,6 @@ def post(request):
 
 
 @require_GET
-def get(request, version, build_number, path):
-    build = CommCareBuild.get_build(version, build_number)
-    try:
-        file = build.fetch_file(path)
-    except ResourceNotFound:
-        raise Http404()
-
-    response = HttpResponse(file)
-    response['Content-Disposition'] = 'attachment; filename="%s"' % path.split("/")[-1]
-    return response
-
-
-@require_GET
 @require_superuser
 def get_all(request):
     builds = sorted(CommCareBuild.all_builds(), key=lambda build: build.time)

--- a/corehq/blobs/__init__.py
+++ b/corehq/blobs/__init__.py
@@ -75,7 +75,7 @@ class CODES:
     domain = 4          # Domain
     application = 5     # Application, Application-Deleted, LinkedApplication
     multimedia = 6      # CommCareMultimedia
-    commcarebuild = 7   # CommCareBuild
+    commcarebuild = 7   # CommCareBuild - No longer in use
     data_import = 8     # case_importer
 
     data_export = 9     # FormExportInstance, CaseExportInstance

--- a/corehq/blobs/migrate_metadata.py
+++ b/corehq/blobs/migrate_metadata.py
@@ -13,7 +13,6 @@ from corehq.util.doc_processor.sql import SqlDocumentProvider
 import corehq.apps.accounting.models as acct
 import corehq.apps.app_manager.models as apps
 import corehq.apps.hqmedia.models as hqmedia
-from corehq.apps.builds.models import CommCareBuild
 from corehq.apps.case_importer.tracking.models import CaseUploadFileMeta, CaseUploadRecord
 from corehq.apps.domain.models import Domain
 from corehq.apps.export import models as exports
@@ -297,7 +296,6 @@ migrate_metadata = lambda: MultiDbMigrator("migrate_metadata",
         ("Application-Deleted", apps.Application),
         ("RemoteApp-Deleted", apps.RemoteApp),
         apps.SavedAppBuild,
-        CommCareBuild,
         Domain,
         acct.InvoicePdf,
         hqmedia.CommCareAudio,

--- a/corehq/blobs/tests/test_migrate_metadata.py
+++ b/corehq/blobs/tests/test_migrate_metadata.py
@@ -25,7 +25,6 @@ class TestMigrateBackend(TestCase):
         "Application-Deleted": mod.apps.Application,
         "RemoteApp-Deleted": mod.apps.RemoteApp,
         "SavedAppBuild": mod.apps.SavedAppBuild,
-        "CommCareBuild": mod.CommCareBuild,
         "Domain": mod.Domain,
         "InvoicePdf": mod.acct.InvoicePdf,
         "CommCareAudio": mod.hqmedia.CommCareAudio,
@@ -37,7 +36,6 @@ class TestMigrateBackend(TestCase):
         "SMSExportInstance": mod.exports.SMSExportInstance,
     }
     shared_domain_doc_types = {
-        "CommCareBuild",
         "CommCareAudio",
         "CommCareImage",
         "CommCareVideo",


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing effects.                                                                                                                                                                                      

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
We are planning a Couch-to-SQL migration for `CommCareBuild` using the `SyncCouchToSQLMixin`/`SyncSQLToCouchMixin` pattern. As a preparatory step, this PR removes blob-related code (`BlobMixin`, `fetch_file`, and the `/builds/<version>/<build_number>/<path>` endpoint) from `CommCareBuild` that has not been used for several years. We stopped adding external files at least from 2023 according to [this PR](https://github.com/dimagi/commcare-hq/pull/32845).                                                                                                              
                  
This simplifies the `CommCareBuild` Python interface so that the migration tooling (which examines the Couch model to determine what fields to sync to SQL) sees only the fields that actually matter: `build_number`, `version`, and `time`. Without this cleanup, the blob-related code would add noise and require investigation during migration scoping.
                                                                                                                                                                                                               
Old `CommCareBuild` documents in Couch that still have `external_blobs` data are unaffected — `external_blobs` is stored as a JSON field on the document itself, so removing the Python `BlobMixin` does not alter or lose any data. Since we're migrating `CommCareBuild` to SQL, the blobs will be cleaned up when we delete the couch docs.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Checked logs and `fetch_file` and the associated URL endpoint do not appear to be in use. ( Also to use it you have to provide a `build_number`)
- Old `CommCareBuild` documents in Couch retain their external_blobs JSON data — only the Python mixin is removed. We verified through a private release that a old `CommCareBuild` that has blobs can still be wrapped.
- This is a pure code removal with no data migration or schema change  

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
