### PR TITLE
Exit with error when rebuild-staging fails

### DIFF
--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -68,4 +68,5 @@ if rebuildstaging $args ; then
 else
     echo "You can edit the branch build configuration here:"
     echo "  https://github.com/dimagi/staging-branches/blob/main/commcare-hq-staging.yml"
+    exit 1
 fi


### PR DESCRIPTION
## Product Description

N/A — internal tooling fix.

## Technical Summary

The `scripts/rebuildstaging` bash script uses an `if/else` to handle failure from the `rebuildstaging` function. The `else` branch prints a helpful message but never exits non-zero — the `echo` succeeds, so the script exits 0. This causes the [rebuild-staging GitHub Actions workflow](https://github.com/dimagi/commcare-hq/actions/runs/23929669187/job/69793970212) to report success even when the rebuild fails.

Fix: add `exit 1` to the `else` branch.

## Feature Flag

N/A

## Safety Assurance

### Safety story

One-line change in a bash script that only runs in CI. The only behavioral change is that a previously-silent failure now correctly fails the workflow.

### Automated test coverage

N/A — bash script executed by GitHub Actions.

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change