### PR TITLE
Add missing dependency to docs build after ubuntu upgrade

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,7 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Doc builds are generated automatically from the master branch
+# There is a hidden doc build also generated from the readthedocs branch
+# This can be used to test the readthedocs build itself before merging
 
 version: 2
 sphinx:
@@ -6,6 +9,8 @@ sphinx:
 formats: all
 build:
   os: ubuntu-24.04
+  apt_packages:
+    - libmagic1
   tools:
     python: "3.13"
   jobs:


### PR DESCRIPTION
## Product Description


## Technical Summary
https://github.com/dimagi/commcare-hq/pull/37541 [broke the docs build](https://app.readthedocs.org/projects/commcare-hq/builds/32131722/).  This fixes it.

## Feature Flag


## Safety Assurance
Tested on a separate docs build before merging this time (and documented that process)

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
