### PR TITLE
feat: add import app API endpoints

### DIFF
--- a/corehq/apps/app_manager/tests/test_app_import_api.py
+++ b/corehq/apps/app_manager/tests/test_app_import_api.py
@@ -1,0 +1,249 @@
+import json
+import zipfile
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory, SimpleTestCase
+
+from couchdbkit.exceptions import ResourceNotFound
+from soil.exceptions import TaskFailedError
+
+from corehq.apps.app_manager.views.app_import_api import (
+    _handle_import_app as import_app_api,
+    _handle_multimedia_status as multimedia_status_api,
+    _handle_upload_multimedia as upload_multimedia_api,
+)
+
+
+class TestImportAppAPI(SimpleTestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.domain = 'test-domain'
+
+    def _make_request(self, app_name=None, app_file_content=None):
+        data = {}
+        if app_name:
+            data['app_name'] = app_name
+        if app_file_content is not None:
+            f = BytesIO(app_file_content)
+            f.name = 'app.json'
+            data['app_file'] = f
+
+        request = self.factory.post('/fake-url/', data=data)
+        request.couch_user = MagicMock()
+        request.couch_user.username = 'testuser'
+        setattr(request, 'session', 'session')
+        messages = FallbackStorage(request)
+        setattr(request, '_messages', messages)
+        return request
+
+    def test_missing_app_name(self):
+        request = self._make_request(
+            app_file_content=json.dumps({'doc_type': 'Application'}).encode()
+        )
+        response = import_app_api(request, self.domain)
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content)
+        self.assertIn('app_name', data['error'])
+
+    def test_missing_app_file(self):
+        request = self._make_request(app_name='My App')
+        response = import_app_api(request, self.domain)
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content)
+        self.assertIn('app_file', data['error'])
+
+    def test_invalid_json_file(self):
+        request = self._make_request(
+            app_name='My App',
+            app_file_content=b'not json at all',
+        )
+        response = import_app_api(request, self.domain)
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content)
+        self.assertIn('JSON', data['error'])
+
+    @patch('corehq.apps.app_manager.views.app_import_api.import_app_util')
+    def test_successful_import(self, mock_import):
+        mock_app = MagicMock()
+        mock_app._id = 'abc123'
+        mock_import.return_value = mock_app
+
+        request = self._make_request(
+            app_name='My App',
+            app_file_content=json.dumps({'doc_type': 'Application'}).encode(),
+        )
+        response = import_app_api(request, self.domain)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.content)
+        self.assertTrue(data['success'])
+        self.assertEqual(data['app_id'], 'abc123')
+
+        mock_import.assert_called_once()
+        call_args = mock_import.call_args
+        self.assertEqual(call_args[0][1], self.domain)
+        self.assertEqual(call_args[0][2], {'name': 'My App'})
+
+    @patch('corehq.apps.app_manager.views.app_import_api.import_app_util')
+    def test_successful_import_with_warnings(self, mock_import):
+        mock_app = MagicMock()
+        mock_app._id = 'abc123'
+
+        def import_with_warning(source, domain, extra, request=None):
+            from django.contrib import messages
+            messages.warning(request, "Missing multimedia file(s).")
+            return mock_app
+
+        mock_import.side_effect = import_with_warning
+
+        request = self._make_request(
+            app_name='My App',
+            app_file_content=json.dumps({'doc_type': 'Application'}).encode(),
+        )
+        response = import_app_api(request, self.domain)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.content)
+        self.assertTrue(data['success'])
+        self.assertEqual(data['app_id'], 'abc123')
+        self.assertIn('warnings', data)
+        self.assertEqual(len(data['warnings']), 1)
+        self.assertIn('Missing multimedia', data['warnings'][0])
+
+
+class TestUploadMultimediaAPI(SimpleTestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.domain = 'test-domain'
+
+    def _make_zip_file(self):
+        buf = BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zf:
+            zf.writestr('images/icon.png', b'\x89PNG fake data')
+        buf.seek(0)
+        buf.name = 'multimedia.zip'
+        return buf
+
+    def _make_request(self, upload_file=None):
+        data = {}
+        if upload_file is not None:
+            data['bulk_upload_file'] = upload_file
+        request = self.factory.post('/fake-url/', data=data)
+        request.couch_user = MagicMock()
+        request.couch_user.username = 'testuser'
+        return request
+
+    def test_missing_file(self):
+        request = self._make_request()
+        with patch('corehq.apps.app_manager.views.app_import_api.get_app'):
+            response = upload_multimedia_api(request, self.domain, 'app123')
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content)
+        self.assertIn('bulk_upload_file', data['error'])
+
+    def test_invalid_zip(self):
+        bad_file = BytesIO(b'not a zip')
+        bad_file.name = 'bad.zip'
+        request = self._make_request(upload_file=bad_file)
+        with patch('corehq.apps.app_manager.views.app_import_api.get_app'):
+            response = upload_multimedia_api(request, self.domain, 'app123')
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content)
+        self.assertIn('ZIP', data['error'])
+
+    @patch('corehq.apps.app_manager.views.app_import_api.save_multimedia_upload')
+    @patch('corehq.apps.app_manager.views.app_import_api.process_bulk_upload_zip')
+    @patch('corehq.apps.app_manager.views.app_import_api.get_app')
+    def test_successful_upload(self, mock_get_app, mock_task, mock_save):
+        mock_get_app.return_value = MagicMock()
+        mock_task.delay = MagicMock()
+        mock_save.return_value = ('proc-abc123', MagicMock())
+
+        zip_file = self._make_zip_file()
+        request = self._make_request(upload_file=zip_file)
+        response = upload_multimedia_api(request, self.domain, 'app123')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertTrue(data['success'])
+        self.assertEqual(data['processing_id'], 'proc-abc123')
+        mock_save.assert_called_once()
+        mock_task.delay.assert_called_once()
+
+    @patch('corehq.apps.app_manager.views.app_import_api.get_app')
+    def test_app_not_found(self, mock_get_app):
+        mock_get_app.side_effect = ResourceNotFound()
+
+        zip_file = self._make_zip_file()
+        request = self._make_request(upload_file=zip_file)
+        response = upload_multimedia_api(request, self.domain, 'app123')
+        self.assertEqual(response.status_code, 404)
+
+
+class TestMultimediaStatusAPI(SimpleTestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.domain = 'test-domain'
+
+    def _make_request(self):
+        request = self.factory.get('/fake-url/')
+        request.couch_user = MagicMock()
+        return request
+
+    @patch('corehq.apps.app_manager.views.app_import_api.get_app')
+    @patch('corehq.apps.app_manager.views.app_import_api.get_download_context')
+    @patch('corehq.apps.app_manager.views.app_import_api.BulkMultimediaStatusCache')
+    def test_successful_status(self, mock_cache_cls, mock_download_ctx, mock_get_app):
+        mock_get_app.return_value = MagicMock()
+        mock_download_ctx.return_value = {}
+        mock_status = MagicMock()
+        mock_status.get_response.return_value = {
+            'complete': False,
+            'in_celery': True,
+            'progress': {'percent': 50, 'current': 5, 'total': 10},
+            'errors': [],
+            'processing_id': 'proc123',
+        }
+        mock_cache_cls.get.return_value = mock_status
+
+        request = self._make_request()
+        response = multimedia_status_api(request, self.domain, 'app123', 'proc123')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertTrue(data['success'])
+        self.assertFalse(data['complete'])
+        self.assertEqual(data['progress']['current'], 5)
+
+    @patch('corehq.apps.app_manager.views.app_import_api.get_app')
+    @patch('corehq.apps.app_manager.views.app_import_api.get_download_context')
+    @patch('corehq.apps.app_manager.views.app_import_api.BulkMultimediaStatusCache')
+    def test_expired_processing_id(self, mock_cache_cls, mock_download_ctx, mock_get_app):
+        mock_get_app.return_value = MagicMock()
+        mock_download_ctx.return_value = {}
+        mock_cache_cls.get.return_value = None
+
+        request = self._make_request()
+        response = multimedia_status_api(request, self.domain, 'app123', 'proc123')
+        self.assertEqual(response.status_code, 404)
+
+    @patch('corehq.apps.app_manager.views.app_import_api.get_app')
+    @patch('corehq.apps.app_manager.views.app_import_api.get_download_context')
+    def test_task_failed(self, mock_download_ctx, mock_get_app):
+        mock_get_app.return_value = MagicMock()
+        mock_download_ctx.side_effect = TaskFailedError()
+
+        request = self._make_request()
+        response = multimedia_status_api(request, self.domain, 'app123', 'proc123')
+        self.assertEqual(response.status_code, 500)
+        data = json.loads(response.content)
+        self.assertIn('error', data)
+
+    @patch('corehq.apps.app_manager.views.app_import_api.get_app')
+    def test_app_not_found(self, mock_get_app):
+        mock_get_app.side_effect = ResourceNotFound()
+
+        request = self._make_request()
+        response = multimedia_status_api(request, self.domain, 'app123', 'proc123')
+        self.assertEqual(response.status_code, 404)

--- a/corehq/apps/app_manager/tests/test_app_import_api.py
+++ b/corehq/apps/app_manager/tests/test_app_import_api.py
@@ -3,247 +3,226 @@ import zipfile
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.contrib.messages.storage.fallback import FallbackStorage
-from django.test import RequestFactory, SimpleTestCase
+from django.test import RequestFactory
 
 from couchdbkit.exceptions import ResourceNotFound
 from soil.exceptions import TaskFailedError
 
 from corehq.apps.app_manager.views.app_import_api import (
-    _handle_import_app as import_app_api,
-    _handle_multimedia_status as multimedia_status_api,
-    _handle_upload_multimedia as upload_multimedia_api,
+    _handle_import_app,
+    _handle_multimedia_status,
+    _handle_upload_multimedia,
 )
 
-
-class TestImportAppAPI(SimpleTestCase):
-
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.domain = 'test-domain'
-
-    def _make_request(self, app_name=None, app_file_content=None):
-        data = {}
-        if app_name:
-            data['app_name'] = app_name
-        if app_file_content is not None:
-            f = BytesIO(app_file_content)
-            f.name = 'app.json'
-            data['app_file'] = f
-
-        request = self.factory.post('/fake-url/', data=data)
-        request.couch_user = MagicMock()
-        request.couch_user.username = 'testuser'
-        setattr(request, 'session', 'session')
-        messages = FallbackStorage(request)
-        setattr(request, '_messages', messages)
-        return request
-
-    def test_missing_app_name(self):
-        request = self._make_request(
-            app_file_content=json.dumps({'doc_type': 'Application'}).encode()
-        )
-        response = import_app_api(request, self.domain)
-        self.assertEqual(response.status_code, 400)
-        data = json.loads(response.content)
-        self.assertIn('app_name', data['error'])
-
-    def test_missing_app_file(self):
-        request = self._make_request(app_name='My App')
-        response = import_app_api(request, self.domain)
-        self.assertEqual(response.status_code, 400)
-        data = json.loads(response.content)
-        self.assertIn('app_file', data['error'])
-
-    def test_invalid_json_file(self):
-        request = self._make_request(
-            app_name='My App',
-            app_file_content=b'not json at all',
-        )
-        response = import_app_api(request, self.domain)
-        self.assertEqual(response.status_code, 400)
-        data = json.loads(response.content)
-        self.assertIn('JSON', data['error'])
-
-    @patch('corehq.apps.app_manager.views.app_import_api.import_app_util')
-    def test_successful_import(self, mock_import):
-        mock_app = MagicMock()
-        mock_app._id = 'abc123'
-        mock_import.return_value = mock_app
-
-        request = self._make_request(
-            app_name='My App',
-            app_file_content=json.dumps({'doc_type': 'Application'}).encode(),
-        )
-        response = import_app_api(request, self.domain)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.content)
-        self.assertTrue(data['success'])
-        self.assertEqual(data['app_id'], 'abc123')
-
-        mock_import.assert_called_once()
-        call_args = mock_import.call_args
-        self.assertEqual(call_args[0][1], self.domain)
-        self.assertEqual(call_args[0][2], {'name': 'My App'})
-
-    @patch('corehq.apps.app_manager.views.app_import_api.import_app_util')
-    def test_successful_import_with_warnings(self, mock_import):
-        mock_app = MagicMock()
-        mock_app._id = 'abc123'
-
-        def import_with_warning(source, domain, extra, request=None):
-            from django.contrib import messages
-            messages.warning(request, "Missing multimedia file(s).")
-            return mock_app
-
-        mock_import.side_effect = import_with_warning
-
-        request = self._make_request(
-            app_name='My App',
-            app_file_content=json.dumps({'doc_type': 'Application'}).encode(),
-        )
-        response = import_app_api(request, self.domain)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.content)
-        self.assertTrue(data['success'])
-        self.assertEqual(data['app_id'], 'abc123')
-        self.assertIn('warnings', data)
-        self.assertEqual(len(data['warnings']), 1)
-        self.assertIn('Missing multimedia', data['warnings'][0])
+DOMAIN = 'test-domain'
+MODULE = 'corehq.apps.app_manager.views.app_import_api'
 
 
-class TestUploadMultimediaAPI(SimpleTestCase):
+def _make_import_request(app_name=None, app_file_content=None):
+    data = {}
+    if app_name:
+        data['app_name'] = app_name
+    if app_file_content is not None:
+        f = BytesIO(app_file_content)
+        f.name = 'app.json'
+        data['app_file'] = f
 
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.domain = 'test-domain'
-
-    def _make_zip_file(self):
-        buf = BytesIO()
-        with zipfile.ZipFile(buf, 'w') as zf:
-            zf.writestr('images/icon.png', b'\x89PNG fake data')
-        buf.seek(0)
-        buf.name = 'multimedia.zip'
-        return buf
-
-    def _make_request(self, upload_file=None):
-        data = {}
-        if upload_file is not None:
-            data['bulk_upload_file'] = upload_file
-        request = self.factory.post('/fake-url/', data=data)
-        request.couch_user = MagicMock()
-        request.couch_user.username = 'testuser'
-        return request
-
-    def test_missing_file(self):
-        request = self._make_request()
-        with patch('corehq.apps.app_manager.views.app_import_api.get_app'):
-            response = upload_multimedia_api(request, self.domain, 'app123')
-        self.assertEqual(response.status_code, 400)
-        data = json.loads(response.content)
-        self.assertIn('bulk_upload_file', data['error'])
-
-    def test_invalid_zip(self):
-        bad_file = BytesIO(b'not a zip')
-        bad_file.name = 'bad.zip'
-        request = self._make_request(upload_file=bad_file)
-        with patch('corehq.apps.app_manager.views.app_import_api.get_app'):
-            response = upload_multimedia_api(request, self.domain, 'app123')
-        self.assertEqual(response.status_code, 400)
-        data = json.loads(response.content)
-        self.assertIn('ZIP', data['error'])
-
-    @patch('corehq.apps.app_manager.views.app_import_api.save_multimedia_upload')
-    @patch('corehq.apps.app_manager.views.app_import_api.process_bulk_upload_zip')
-    @patch('corehq.apps.app_manager.views.app_import_api.get_app')
-    def test_successful_upload(self, mock_get_app, mock_task, mock_save):
-        mock_get_app.return_value = MagicMock()
-        mock_task.delay = MagicMock()
-        mock_save.return_value = ('proc-abc123', MagicMock())
-
-        zip_file = self._make_zip_file()
-        request = self._make_request(upload_file=zip_file)
-        response = upload_multimedia_api(request, self.domain, 'app123')
-        self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
-        self.assertTrue(data['success'])
-        self.assertEqual(data['processing_id'], 'proc-abc123')
-        mock_save.assert_called_once()
-        mock_task.delay.assert_called_once()
-
-    @patch('corehq.apps.app_manager.views.app_import_api.get_app')
-    def test_app_not_found(self, mock_get_app):
-        mock_get_app.side_effect = ResourceNotFound()
-
-        zip_file = self._make_zip_file()
-        request = self._make_request(upload_file=zip_file)
-        response = upload_multimedia_api(request, self.domain, 'app123')
-        self.assertEqual(response.status_code, 404)
+    request = RequestFactory().post('/fake-url/', data=data)
+    request.couch_user = MagicMock()
+    request.couch_user.username = 'testuser'
+    request.session = 'session'
+    request._messages = FallbackStorage(request)
+    return request
 
 
-class TestMultimediaStatusAPI(SimpleTestCase):
+def _make_upload_request(upload_file=None):
+    data = {}
+    if upload_file is not None:
+        data['bulk_upload_file'] = upload_file
+    request = RequestFactory().post('/fake-url/', data=data)
+    request.couch_user = MagicMock()
+    request.couch_user.username = 'testuser'
+    return request
 
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.domain = 'test-domain'
 
-    def _make_request(self):
-        request = self.factory.get('/fake-url/')
-        request.couch_user = MagicMock()
-        return request
+def _make_zip_file():
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr('images/icon.png', b'\x89PNG fake data')
+    buf.seek(0)
+    buf.name = 'multimedia.zip'
+    return buf
 
-    @patch('corehq.apps.app_manager.views.app_import_api.get_app')
-    @patch('corehq.apps.app_manager.views.app_import_api.get_download_context')
-    @patch('corehq.apps.app_manager.views.app_import_api.BulkMultimediaStatusCache')
-    def test_successful_status(self, mock_cache_cls, mock_download_ctx, mock_get_app):
-        mock_get_app.return_value = MagicMock()
-        mock_download_ctx.return_value = {}
-        mock_status = MagicMock()
-        mock_status.get_response.return_value = {
-            'complete': False,
-            'in_celery': True,
-            'progress': {'percent': 50, 'current': 5, 'total': 10},
-            'errors': [],
-            'processing_id': 'proc123',
-        }
-        mock_cache_cls.get.return_value = mock_status
 
-        request = self._make_request()
-        response = multimedia_status_api(request, self.domain, 'app123', 'proc123')
-        self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
-        self.assertTrue(data['success'])
-        self.assertFalse(data['complete'])
-        self.assertEqual(data['progress']['current'], 5)
+def _json(response):
+    return json.loads(response.content)
 
-    @patch('corehq.apps.app_manager.views.app_import_api.get_app')
-    @patch('corehq.apps.app_manager.views.app_import_api.get_download_context')
-    @patch('corehq.apps.app_manager.views.app_import_api.BulkMultimediaStatusCache')
-    def test_expired_processing_id(self, mock_cache_cls, mock_download_ctx, mock_get_app):
-        mock_get_app.return_value = MagicMock()
-        mock_download_ctx.return_value = {}
-        mock_cache_cls.get.return_value = None
 
-        request = self._make_request()
-        response = multimedia_status_api(request, self.domain, 'app123', 'proc123')
-        self.assertEqual(response.status_code, 404)
+def _app_json():
+    return json.dumps({'doc_type': 'Application'}).encode()
 
-    @patch('corehq.apps.app_manager.views.app_import_api.get_app')
-    @patch('corehq.apps.app_manager.views.app_import_api.get_download_context')
-    def test_task_failed(self, mock_download_ctx, mock_get_app):
-        mock_get_app.return_value = MagicMock()
-        mock_download_ctx.side_effect = TaskFailedError()
 
-        request = self._make_request()
-        response = multimedia_status_api(request, self.domain, 'app123', 'proc123')
-        self.assertEqual(response.status_code, 500)
-        data = json.loads(response.content)
-        self.assertIn('error', data)
+# --- import_app_api ---
 
-    @patch('corehq.apps.app_manager.views.app_import_api.get_app')
-    def test_app_not_found(self, mock_get_app):
-        mock_get_app.side_effect = ResourceNotFound()
 
-        request = self._make_request()
-        response = multimedia_status_api(request, self.domain, 'app123', 'proc123')
-        self.assertEqual(response.status_code, 404)
+@pytest.mark.parametrize('app_name, app_file_content, expected_error', [
+    (None, _app_json(), 'app_name'),
+    ('My App', None, 'app_file'),
+    ('My App', b'not json at all', 'JSON'),
+])
+def test_import_app_validation_errors(app_name, app_file_content, expected_error):
+    request = _make_import_request(app_name=app_name, app_file_content=app_file_content)
+    response = _handle_import_app(request, DOMAIN)
+    assert response.status_code == 400
+    assert expected_error in _json(response)['error']
+
+
+@patch(f'{MODULE}.import_app_util')
+def test_import_app_success(mock_import):
+    mock_app = MagicMock()
+    mock_app._id = 'abc123'
+    mock_import.return_value = mock_app
+
+    request = _make_import_request(app_name='My App', app_file_content=_app_json())
+    response = _handle_import_app(request, DOMAIN)
+
+    assert response.status_code == 201
+    data = _json(response)
+    assert data['success'] is True
+    assert data['app_id'] == 'abc123'
+    mock_import.assert_called_once()
+    assert mock_import.call_args[0][1] == DOMAIN
+    assert mock_import.call_args[0][2] == {'name': 'My App'}
+
+
+@patch(f'{MODULE}.import_app_util')
+def test_import_app_captures_warnings(mock_import):
+    mock_app = MagicMock()
+    mock_app._id = 'abc123'
+
+    def import_with_warning(source, domain, extra, request=None):
+        from django.contrib import messages
+        messages.warning(request, "Missing multimedia file(s).")
+        return mock_app
+
+    mock_import.side_effect = import_with_warning
+
+    request = _make_import_request(app_name='My App', app_file_content=_app_json())
+    response = _handle_import_app(request, DOMAIN)
+
+    assert response.status_code == 201
+    data = _json(response)
+    assert data['success'] is True
+    assert len(data['warnings']) == 1
+    assert 'Missing multimedia' in data['warnings'][0]
+
+
+# --- upload_multimedia_api ---
+
+
+def test_upload_multimedia_missing_file():
+    request = _make_upload_request()
+    with patch(f'{MODULE}.get_app'):
+        response = _handle_upload_multimedia(request, DOMAIN, 'app123')
+    assert response.status_code == 400
+    assert 'bulk_upload_file' in _json(response)['error']
+
+
+def test_upload_multimedia_invalid_zip():
+    bad_file = BytesIO(b'not a zip')
+    bad_file.name = 'bad.zip'
+    request = _make_upload_request(upload_file=bad_file)
+    with patch(f'{MODULE}.get_app'):
+        response = _handle_upload_multimedia(request, DOMAIN, 'app123')
+    assert response.status_code == 400
+    assert 'ZIP' in _json(response)['error']
+
+
+@patch(f'{MODULE}.save_multimedia_upload')
+@patch(f'{MODULE}.process_bulk_upload_zip')
+@patch(f'{MODULE}.get_app')
+def test_upload_multimedia_success(mock_get_app, mock_task, mock_save):
+    mock_get_app.return_value = MagicMock()
+    mock_task.delay = MagicMock()
+    mock_save.return_value = ('proc-abc123', MagicMock())
+
+    request = _make_upload_request(upload_file=_make_zip_file())
+    response = _handle_upload_multimedia(request, DOMAIN, 'app123')
+
+    assert response.status_code == 200
+    data = _json(response)
+    assert data['success'] is True
+    assert data['processing_id'] == 'proc-abc123'
+    mock_save.assert_called_once()
+    mock_task.delay.assert_called_once()
+
+
+@patch(f'{MODULE}.get_app', side_effect=ResourceNotFound())
+def test_upload_multimedia_app_not_found(_mock_get_app):
+    request = _make_upload_request(upload_file=_make_zip_file())
+    response = _handle_upload_multimedia(request, DOMAIN, 'app123')
+    assert response.status_code == 404
+
+
+# --- multimedia_status_api ---
+
+
+def _make_status_request():
+    request = RequestFactory().get('/fake-url/')
+    request.couch_user = MagicMock()
+    return request
+
+
+@patch(f'{MODULE}.get_app')
+@patch(f'{MODULE}.get_download_context')
+@patch(f'{MODULE}.BulkMultimediaStatusCache')
+def test_multimedia_status_success(mock_cache_cls, mock_download_ctx, mock_get_app):
+    mock_get_app.return_value = MagicMock()
+    mock_download_ctx.return_value = {}
+    mock_status = MagicMock()
+    mock_status.get_response.return_value = {
+        'complete': False,
+        'in_celery': True,
+        'progress': {'percent': 50, 'current': 5, 'total': 10},
+        'errors': [],
+        'processing_id': 'proc123',
+    }
+    mock_cache_cls.get.return_value = mock_status
+
+    response = _handle_multimedia_status(_make_status_request(), DOMAIN, 'app123', 'proc123')
+
+    assert response.status_code == 200
+    data = _json(response)
+    assert data['success'] is True
+    assert data['complete'] is False
+    assert data['progress']['current'] == 5
+
+
+@patch(f'{MODULE}.get_app')
+@patch(f'{MODULE}.get_download_context')
+@patch(f'{MODULE}.BulkMultimediaStatusCache')
+def test_multimedia_status_expired_processing_id(mock_cache_cls, mock_download_ctx, mock_get_app):
+    mock_get_app.return_value = MagicMock()
+    mock_download_ctx.return_value = {}
+    mock_cache_cls.get.return_value = None
+
+    response = _handle_multimedia_status(_make_status_request(), DOMAIN, 'app123', 'proc123')
+    assert response.status_code == 404
+
+
+@patch(f'{MODULE}.get_download_context', side_effect=TaskFailedError())
+@patch(f'{MODULE}.get_app')
+def test_multimedia_status_task_failed(mock_get_app, _mock_download_ctx):
+    mock_get_app.return_value = MagicMock()
+
+    response = _handle_multimedia_status(_make_status_request(), DOMAIN, 'app123', 'proc123')
+    assert response.status_code == 500
+    assert 'error' in _json(response)
+
+
+@patch(f'{MODULE}.get_app', side_effect=ResourceNotFound())
+def test_multimedia_status_app_not_found(_mock_get_app):
+    response = _handle_multimedia_status(_make_status_request(), DOMAIN, 'app123', 'proc123')
+    assert response.status_code == 404

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -85,6 +85,11 @@ from corehq.apps.app_manager.views import (
     view_module,
     view_module_legacy,
 )
+from corehq.apps.app_manager.views.app_import_api import (
+    import_app_api,
+    multimedia_status_api,
+    upload_multimedia_api,
+)
 from corehq.apps.app_manager.views.apps import move_child_modules_after_parents
 from corehq.apps.app_manager.views.modules import ExistingCaseTypesView, AllCaseTypesView
 from corehq.apps.hqmedia.urls import application_urls as hqmedia_urls
@@ -255,6 +260,10 @@ urlpatterns = [
 
     url(r'^api/list_apps/$', list_apps, name='list_apps'),
     url(r'^api/download_ccz/$', direct_ccz, name='direct_ccz'),
+    url(r'^api/import_app/$', import_app_api, name='import_app_api'),
+    url(r'^api/(?P<app_id>[\w-]+)/multimedia/$', upload_multimedia_api, name='upload_multimedia_api'),
+    url(r'^api/(?P<app_id>[\w-]+)/multimedia/status/(?P<processing_id>[\w-]+)/$',
+        multimedia_status_api, name='multimedia_status_api'),
     url(r'^download/(?P<app_id>[\w-]+)/$', download_index, name='download_index'),
     # the order of these download urls is important
     url(r'^download/(?P<app_id>[\w-]+)/CommCare.ccz$', DownloadCCZ.as_view(),

--- a/corehq/apps/app_manager/views/app_import_api.py
+++ b/corehq/apps/app_manager/views/app_import_api.py
@@ -1,0 +1,136 @@
+import json
+import zipfile
+
+from django.contrib.messages import get_messages
+from django.http import JsonResponse
+from django.views.decorators.http import require_GET, require_POST
+
+from couchdbkit.exceptions import ResourceNotFound
+
+from soil.exceptions import TaskFailedError
+from soil.util import get_download_context
+
+from corehq.apps.api.decorators import api_throttle
+from corehq.apps.app_manager.dbaccessors import get_app
+from corehq.apps.app_manager.models import import_app as import_app_util
+from corehq.apps.domain.decorators import api_auth
+from corehq.apps.hqmedia.cache import BulkMultimediaStatusCache
+from corehq.apps.hqmedia.tasks import process_bulk_upload_zip
+from corehq.apps.hqmedia.utils import save_multimedia_upload
+from corehq.apps.users.decorators import require_permission
+from corehq.apps.users.models import HqPermissions
+from corehq.util.view_utils import json_error
+
+
+def _handle_import_app(request, domain):
+    app_name = request.POST.get('app_name')
+    if not app_name:
+        return JsonResponse({'success': False, 'error': 'app_name is required'}, status=400)
+
+    app_file = request.FILES.get('app_file')
+    if not app_file:
+        return JsonResponse({'success': False, 'error': 'app_file is required'}, status=400)
+
+    try:
+        source = json.load(app_file)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JsonResponse({'success': False, 'error': 'Invalid JSON file'}, status=400)
+
+    if not source:
+        return JsonResponse({'success': False, 'error': 'Invalid JSON file'}, status=400)
+
+    app = import_app_util(source, domain, {'name': app_name}, request=request)
+
+    response = {'success': True, 'app_id': app._id}
+    warnings = [str(m) for m in get_messages(request)]
+    if warnings:
+        response['warnings'] = warnings
+    return JsonResponse(response, status=201)
+
+
+@json_error
+@require_permission(HqPermissions.edit_apps, login_decorator=api_auth())
+@api_throttle
+@require_POST
+def import_app_api(request, domain):
+    return _handle_import_app(request, domain)
+
+
+def _handle_upload_multimedia(request, domain, app_id):
+    try:
+        get_app(domain, app_id)
+    except ResourceNotFound:
+        return JsonResponse(
+            {'success': False, 'error': 'Application not found'}, status=404
+        )
+
+    uploaded_file = request.FILES.get('bulk_upload_file')
+    if not uploaded_file:
+        return JsonResponse(
+            {'success': False, 'error': 'bulk_upload_file is required'}, status=400
+        )
+
+    try:
+        with zipfile.ZipFile(uploaded_file) as zf:
+            if zf.testzip() is not None:
+                return JsonResponse(
+                    {'success': False, 'error': 'ZIP file is corrupt'}, status=400
+                )
+    except zipfile.BadZipFile:
+        return JsonResponse(
+            {'success': False, 'error': 'Uploaded file is not a valid ZIP file'}, status=400
+        )
+
+    uploaded_file.seek(0)
+    processing_id, _ = save_multimedia_upload(uploaded_file)
+
+    username = request.couch_user.username if request.couch_user else None
+    process_bulk_upload_zip.delay(
+        processing_id, domain, app_id, username=username
+    )
+
+    return JsonResponse({'success': True, 'processing_id': processing_id})
+
+
+@json_error
+@require_permission(HqPermissions.edit_apps, login_decorator=api_auth())
+@api_throttle
+@require_POST
+def upload_multimedia_api(request, domain, app_id):
+    return _handle_upload_multimedia(request, domain, app_id)
+
+
+def _handle_multimedia_status(request, domain, app_id, processing_id):
+    try:
+        get_app(domain, app_id)
+    except ResourceNotFound:
+        return JsonResponse(
+            {'success': False, 'error': 'Application not found'}, status=404
+        )
+
+    try:
+        get_download_context(processing_id)
+    except TaskFailedError:
+        return JsonResponse(
+            {'success': False, 'error': 'Multimedia processing task failed'},
+            status=500
+        )
+
+    status = BulkMultimediaStatusCache.get(processing_id)
+    if status is None:
+        return JsonResponse(
+            {'success': False, 'error': 'Processing ID not found or expired'},
+            status=404
+        )
+
+    response_data = status.get_response()
+    response_data['success'] = True
+    return JsonResponse(response_data)
+
+
+@json_error
+@require_permission(HqPermissions.edit_apps, login_decorator=api_auth())
+@api_throttle
+@require_GET
+def multimedia_status_api(request, domain, app_id, processing_id):
+    return _handle_multimedia_status(request, domain, app_id, processing_id)

--- a/corehq/apps/app_manager/views/app_import_api.py
+++ b/corehq/apps/app_manager/views/app_import_api.py
@@ -22,6 +22,14 @@ from corehq.apps.users.models import HqPermissions
 from corehq.util.view_utils import json_error
 
 
+@json_error
+@require_permission(HqPermissions.edit_apps, login_decorator=api_auth())
+@api_throttle
+@require_POST
+def import_app_api(request, domain):
+    return _handle_import_app(request, domain)
+
+
 def _handle_import_app(request, domain):
     app_name = request.POST.get('app_name')
     if not app_name:
@@ -52,8 +60,8 @@ def _handle_import_app(request, domain):
 @require_permission(HqPermissions.edit_apps, login_decorator=api_auth())
 @api_throttle
 @require_POST
-def import_app_api(request, domain):
-    return _handle_import_app(request, domain)
+def upload_multimedia_api(request, domain, app_id):
+    return _handle_upload_multimedia(request, domain, app_id)
 
 
 def _handle_upload_multimedia(request, domain, app_id):
@@ -95,9 +103,9 @@ def _handle_upload_multimedia(request, domain, app_id):
 @json_error
 @require_permission(HqPermissions.edit_apps, login_decorator=api_auth())
 @api_throttle
-@require_POST
-def upload_multimedia_api(request, domain, app_id):
-    return _handle_upload_multimedia(request, domain, app_id)
+@require_GET
+def multimedia_status_api(request, domain, app_id, processing_id):
+    return _handle_multimedia_status(request, domain, app_id, processing_id)
 
 
 def _handle_multimedia_status(request, domain, app_id, processing_id):
@@ -126,11 +134,3 @@ def _handle_multimedia_status(request, domain, app_id, processing_id):
     response_data = status.get_response()
     response_data['success'] = True
     return JsonResponse(response_data)
-
-
-@json_error
-@require_permission(HqPermissions.edit_apps, login_decorator=api_auth())
-@api_throttle
-@require_GET
-def multimedia_status_api(request, domain, app_id, processing_id):
-    return _handle_multimedia_status(request, domain, app_id, processing_id)

--- a/corehq/apps/hqmedia/tests/test_utils.py
+++ b/corehq/apps/hqmedia/tests/test_utils.py
@@ -2,41 +2,40 @@ import zipfile
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
-from django.test import SimpleTestCase
-
 from corehq.apps.hqmedia.utils import save_multimedia_upload
 
 
-class TestSaveMultimediaUpload(SimpleTestCase):
+def _make_zip_file():
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr('images/icon.png', b'\x89PNG fake data')
+    buf.seek(0)
+    buf.name = 'multimedia.zip'
+    return buf
 
-    def _make_zip_file(self):
-        buf = BytesIO()
-        with zipfile.ZipFile(buf, 'w') as zf:
-            zf.writestr('images/icon.png', b'\x89PNG fake data')
-        buf.seek(0)
-        buf.name = 'multimedia.zip'
-        return buf
 
-    @patch('corehq.apps.hqmedia.utils.expose_cached_download')
-    def test_returns_processing_id(self, mock_expose):
-        mock_saved = MagicMock()
-        mock_saved.download_id = 'dl-abc123'
-        mock_expose.return_value = mock_saved
+@patch('corehq.apps.hqmedia.utils.BulkMultimediaStatusCache')
+@patch('corehq.apps.hqmedia.utils.expose_cached_download')
+def test_save_multimedia_upload_returns_processing_id(mock_expose, mock_cache_cls):
+    mock_saved = MagicMock()
+    mock_saved.download_id = 'dl-abc123'
+    mock_expose.return_value = mock_saved
 
-        uploaded_file = self._make_zip_file()
-        processing_id, status = save_multimedia_upload(uploaded_file)
-        self.assertEqual(processing_id, 'dl-abc123')
-        self.assertIsNotNone(status)
-        mock_expose.assert_called_once()
+    processing_id, status = save_multimedia_upload(_make_zip_file())
 
-    @patch('corehq.apps.hqmedia.utils.expose_cached_download')
-    def test_reads_file_content(self, mock_expose):
-        mock_saved = MagicMock()
-        mock_saved.download_id = 'dl-abc123'
-        mock_expose.return_value = mock_saved
+    assert processing_id == 'dl-abc123'
+    assert status is not None
+    mock_expose.assert_called_once()
 
-        uploaded_file = self._make_zip_file()
-        save_multimedia_upload(uploaded_file)
 
-        call_args = mock_expose.call_args
-        self.assertIsInstance(call_args[0][0], bytes)
+@patch('corehq.apps.hqmedia.utils.BulkMultimediaStatusCache')
+@patch('corehq.apps.hqmedia.utils.expose_cached_download')
+def test_save_multimedia_upload_reads_file_content(mock_expose, _mock_cache_cls):
+    mock_saved = MagicMock()
+    mock_saved.download_id = 'dl-abc123'
+    mock_expose.return_value = mock_saved
+
+    save_multimedia_upload(_make_zip_file())
+
+    content = mock_expose.call_args[0][0]
+    assert isinstance(content, bytes)

--- a/corehq/apps/hqmedia/tests/test_utils.py
+++ b/corehq/apps/hqmedia/tests/test_utils.py
@@ -1,0 +1,42 @@
+import zipfile
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from corehq.apps.hqmedia.utils import save_multimedia_upload
+
+
+class TestSaveMultimediaUpload(SimpleTestCase):
+
+    def _make_zip_file(self):
+        buf = BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zf:
+            zf.writestr('images/icon.png', b'\x89PNG fake data')
+        buf.seek(0)
+        buf.name = 'multimedia.zip'
+        return buf
+
+    @patch('corehq.apps.hqmedia.utils.expose_cached_download')
+    def test_returns_processing_id(self, mock_expose):
+        mock_saved = MagicMock()
+        mock_saved.download_id = 'dl-abc123'
+        mock_expose.return_value = mock_saved
+
+        uploaded_file = self._make_zip_file()
+        processing_id, status = save_multimedia_upload(uploaded_file)
+        self.assertEqual(processing_id, 'dl-abc123')
+        self.assertIsNotNone(status)
+        mock_expose.assert_called_once()
+
+    @patch('corehq.apps.hqmedia.utils.expose_cached_download')
+    def test_reads_file_content(self, mock_expose):
+        mock_saved = MagicMock()
+        mock_saved.download_id = 'dl-abc123'
+        mock_expose.return_value = mock_saved
+
+        uploaded_file = self._make_zip_file()
+        save_multimedia_upload(uploaded_file)
+
+        call_args = mock_expose.call_args
+        self.assertIsInstance(call_args[0][0], bytes)

--- a/corehq/apps/hqmedia/utils.py
+++ b/corehq/apps/hqmedia/utils.py
@@ -1,4 +1,49 @@
+import shutil
+import uuid
+
+from django.conf import settings
+
+from soil import DownloadBase
+from soil.util import expose_cached_download
+
+from corehq.apps.hqmedia.cache import (
+    BulkMultimediaStatusCache,
+    BulkMultimediaStatusCacheNfs,
+)
+from corehq.util.files import file_extention_from_filename
+
 MULTIMEDIA_PREFIX = "jr://file/"
 IMAGE_MIMETYPES = ["image/jpeg", "image/gif", "image/png"]
 AUDIO_MIMETYPES = ["audio/mpeg", "audio/mpeg3", "audio/wav", "audio/x-wav"]
 ZIP_MIMETYPES = ["application/zip"]
+
+
+def save_multimedia_upload(uploaded_file):
+    """Save an uploaded multimedia ZIP file and return a processing_id.
+
+    Handles both NFS-backed (temporary_file_path) and in-memory uploads.
+    Creates a BulkMultimediaStatusCache entry for tracking.
+
+    Returns a (processing_id, status) tuple. The processing_id is passed
+    to process_bulk_upload_zip; the status object can be used to get the
+    initial response without a cache re-fetch.
+    """
+    if hasattr(uploaded_file, 'temporary_file_path') and settings.SHARED_DRIVE_CONF.temp_dir:
+        prefix = DownloadBase.new_id_prefix
+        processing_id = prefix + uuid.uuid4().hex
+        path = settings.SHARED_DRIVE_CONF.get_temp_file(suffix='.upload')
+        shutil.move(uploaded_file.temporary_file_path(), path)
+        status = BulkMultimediaStatusCacheNfs(processing_id, path)
+        status.save()
+    else:
+        uploaded_file.seek(0)
+        saved_file = expose_cached_download(
+            uploaded_file.read(),
+            expiry=BulkMultimediaStatusCache.cache_expiry,
+            file_extension=file_extention_from_filename(uploaded_file.name),
+        )
+        processing_id = saved_file.download_id
+        status = BulkMultimediaStatusCache(processing_id)
+        status.save()
+
+    return processing_id, status

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -2,13 +2,10 @@ import io
 import itertools
 import json
 import os
-import shutil
-import uuid
 import zipfile
 from datetime import datetime
 from mimetypes import guess_all_extensions, guess_type
 
-from django.conf import settings
 from django.contrib import messages
 from django.http import (
     Http404,
@@ -35,7 +32,7 @@ from couchexport.models import Format
 from couchexport.shortcuts import export_response
 from soil import DownloadBase
 from soil.exceptions import TaskFailedError
-from soil.util import expose_cached_download, get_download_context
+from soil.util import get_download_context
 
 from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
@@ -55,7 +52,6 @@ from corehq.apps.case_importer.util import (
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.hqmedia.cache import (
     BulkMultimediaStatusCache,
-    BulkMultimediaStatusCacheNfs,
 )
 from corehq.apps.hqmedia.controller import (
     MultimediaAudioUploadController,
@@ -74,13 +70,13 @@ from corehq.apps.hqmedia.tasks import (
     build_application_zip,
     process_bulk_upload_zip,
 )
+from corehq.apps.hqmedia.utils import save_multimedia_upload
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.hqwebapp.views import BaseSectionPageView
 from corehq.apps.translations.utils import get_file_content_from_workbook
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
 from corehq.middleware import always_allow_browser_caching
-from corehq.util.files import file_extention_from_filename
 from corehq.util.workbook_reading import valid_extensions, SpreadsheetFileExtError
 
 transient_file_store = TransientFileStore("hqmedia_upload_paths", timeout=1 * 60 * 60)
@@ -629,23 +625,7 @@ class ProcessBulkUploadView(BaseProcessUploadedView):
             raise BadMediaFileException(_("Unable to extract the ZIP file."))
 
     def process_upload(self):
-        if hasattr(self.uploaded_file, 'temporary_file_path') and settings.SHARED_DRIVE_CONF.temp_dir:
-            prefix = DownloadBase.new_id_prefix
-            processing_id = prefix + uuid.uuid4().hex
-            path = settings.SHARED_DRIVE_CONF.get_temp_file(suffix='.upload')
-            shutil.move(self.uploaded_file.temporary_file_path(), path)
-            status = BulkMultimediaStatusCacheNfs(processing_id, path)
-            status.save()
-        else:
-            self.uploaded_file.file.seek(0)
-            saved_file = expose_cached_download(
-                self.uploaded_file.file.read(),
-                expiry=BulkMultimediaStatusCache.cache_expiry,
-                file_extension=file_extention_from_filename(self.uploaded_file.name),
-            )
-            processing_id = saved_file.download_id
-            status = BulkMultimediaStatusCache(processing_id)
-            status.save()
+        processing_id, status = save_multimedia_upload(self.uploaded_file)
 
         process_bulk_upload_zip.delay(processing_id, self.domain, self.app_id,
                                       username=self.username,


### PR DESCRIPTION
Connect was looking for a way to programatically add the applications created by our new app building tools (nova and forge), rather than having to manually upload them through the UI. To accomplish this, I added API views for each of the steps in the existing process, reusing all the processing code, but wrapping them in API specific decorators. Claude summary below, and claude artifacts available [here](https://github.com/dimagi/commcare-hq/commit/ade0e3d5f6e440db0205b0aa0c420f02a93f90b1). The history got really messy so I ended up squashing all the commits, hopefully its still reviewable, but happy to play with the history if it will help. I also didn't know who to tag for review so just picked a bunch of commcare people, let me know if I am missing someone who should review it.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

Add three API endpoints for programmatic app import and multimedia upload, alongside existing app manager API views (list_apps, direct_ccz):

- POST /apps/api/import_app/ - Upload app JSON, returns new app_id
- POST /apps/api/{app_id}/multimedia/ - Upload multimedia ZIP (async)
- GET /apps/api/{app_id}/multimedia/status/{processing_id}/ - Poll status

Extract save_multimedia_upload() utility from ProcessBulkUploadView to share file storage logic between the existing view and the new API.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is all new work (with one minor refactor to an existing view) and is heavily tested.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
The new views are heavily tested for both happy path and different error conditions

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
N/A

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
