### PR TITLE
USH_INLINE_SEARCH only sets advanced when case search is enabled

### DIFF
--- a/corehq/apps/domain/management/commands/update_case_search_toggles.py
+++ b/corehq/apps/domain/management/commands/update_case_search_toggles.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
         reasons = []
         csc = CaseSearchConfig.objects.get_or_none(pk=domain_name)
         # USH Specific toggle to making case search user input available to other parts of the app.
-        if toggles.USH_INLINE_SEARCH.enabled(domain_name):
+        if csc and csc.enabled and toggles.USH_INLINE_SEARCH.enabled(domain_name):
             reasons.append("toggle USH_INLINE_SEARCH")
         if csc and csc.synchronous_web_apps:  # Synchronous Web Apps Submissions
             reasons.append("synchronous_web_apps")


### PR DESCRIPTION
## Product Description

Previously it did not matter if case search was actually enabled. Inline
search caused the advanced FF to be set regardless.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6507?focusedCommentId=455589

## Feature Flag
USH_INLINE_SEARCH

## Safety Assurance

Tested locally

### Safety story

* Create new project
* Set basic case search FF and inline FF
* Enable case search
* Run ./manage.py update_case_search_toggles --dry-run --verbose
  * Advanced FF is listed as being set
* Disabled case search
* Run ./manage.py update_case_search_toggles --dry-run --verbose
  * Advanced FF is NOT listed as being set

### Automated test coverage

None

### QA Plan

None
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
