### PR TITLE
PostgreSQL 18

### DIFF
--- a/corehq/apps/api/tests/audit_resources.py
+++ b/corehq/apps/api/tests/audit_resources.py
@@ -127,7 +127,7 @@ class TestNavigationEventAuditResource(APIResourceTest):
         self.assertEqual(result_objects, self.domain1_audits.expected_response_objects[:limit])
 
     def test_request_with_timezone_param(self):
-        timezone = 'US/Eastern'
+        timezone = 'America/New_York'
 
         params = {'local_timezone': timezone}
         list_endpoint = f'{self.list_endpoint}?{urlencode(params)}'

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -75,7 +75,7 @@ services:
       interval: 10s
       retries: 10
     volumes:
-      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-postgresql:}/var/lib/postgresql/data
+      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-postgresql:}/var/lib/postgresql
 
   couch:
     build:

--- a/scripts/docker
+++ b/scripts/docker
@@ -254,7 +254,7 @@ export TRAVIS_PULL_REQUEST_SHA="$TRAVIS_PULL_REQUEST_SHA"
 export TRAVIS_REPO_SLUG="$TRAVIS_REPO_SLUG"
 
 # Check pinned service versions
-pg_version=14
+pg_version=18
 export DOCKER_HQ_POSTGRES_VERSION="${DOCKER_HQ_POSTGRES_VERSION:-$pg_version}"
 if (( "$DOCKER_HQ_POSTGRES_VERSION" < "$pg_version" )); then
     echo "WARNING postgres is pinned with DOCKER_HQ_POSTGRES_VERSION=$DOCKER_HQ_POSTGRES_VERSION"


### PR DESCRIPTION
## Product Description

No user-facing effects. This changes only the test infrastructure.

## Technical Summary

https://dimagi.atlassian.net/browse/SAAS-19448

Bumps the pinned Docker PostgreSQL version from 14 to 18 so that CI runs the full test suite against PostgreSQL 18.3. This is preparation for upgrading PostgreSQL in production environments.

- The `dimagi/docker-postgresql:18` image has been built and pushed to Docker Hub with plproxy and pghashlib extensions compiled against PG 18.
- Follows the same approach as #32120 (10 → 14).

https://dimagi.atlassian.net/browse/SAAS-19448

## Feature Flag

N/A

## Safety Assurance

### Safety story

PostgreSQL has very high standards for backward compatibility. The primary risk is that new code could be introduced that depends on PG 18 features while production environments are still running PG 14. CI running against PG 18 will surface any incompatibilities in existing code.

### Automated test coverage

The entire test suite runs against PostgreSQL — this PR validates that all existing tests pass on PG 18.

### QA Plan

CI test suite passing on PG 18 is the QA plan.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change