### PR TITLE
Add role_permission_history management command

### DIFF
--- a/corehq/apps/users/management/commands/role_permission_history.py
+++ b/corehq/apps/users/management/commands/role_permission_history.py
@@ -1,0 +1,229 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from field_audit.models import AuditEvent
+
+from corehq.apps.users.models_role import (
+    Permission,
+    RoleAssignableBy,
+    RolePermission,
+    UserRole,
+)
+
+
+class Command(BaseCommand):
+    help = """Show chronological history of permission changes on a user role.
+
+    Usage:
+        # List all roles in a domain
+        ./manage.py role_permission_history my-domain --list
+
+        # By role name
+        ./manage.py role_permission_history my-domain --role-name "Field Worker"
+
+        # By role ID
+        ./manage.py role_permission_history my-domain --role-id 123
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("domain")
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument("--role-name", help="Name of the role")
+        group.add_argument("--role-id", type=int, help="Database ID of the role")
+        group.add_argument("--list", action="store_true", dest="list_roles",
+                           help="List all roles in the domain")
+
+    def handle(self, domain, role_name, role_id, list_roles, **options):
+        if list_roles:
+            self._list_roles(domain)
+            return
+
+        role = self._get_role(domain, role_name, role_id)
+        perm_map = {p.id: p.value for p in Permission.objects.all()}
+        entries = self._collect_events(role)
+
+        if not entries:
+            self.stdout.write("No audit events found for this role.")
+            return
+
+        self.stdout.write(
+            f"\n=== Permission History for Role: '{role.name}' "
+            f"(id={role.id}, domain={role.domain}) ===\n"
+        )
+        for entry_type, event in entries:
+            self._print_event(entry_type, event, perm_map)
+
+    def _list_roles(self, domain):
+        roles = UserRole.objects.get_by_domain(domain, include_archived=True)
+        if not roles:
+            self.stdout.write(f"No roles found in domain '{domain}'")
+            return
+        self.stdout.write(f"Roles in domain '{domain}':")
+        for r in roles:
+            archived = " (archived)" if r.is_archived else ""
+            self.stdout.write(f"  {r.name} (id={r.id}){archived}")
+
+    def _get_role(self, domain, role_name, role_id):
+        if role_id:
+            try:
+                return UserRole.objects.get(id=role_id)
+            except UserRole.DoesNotExist:
+                raise CommandError(f"No role found with id={role_id}")
+
+        roles = UserRole.objects.filter(domain=domain, name=role_name)
+        if roles.count() == 0:
+            raise CommandError(
+                f"No role found with name '{role_name}' in domain '{domain}'. "
+                f"Use --list to see available roles."
+            )
+        if roles.count() > 1:
+            matches = ", ".join(
+                f"id={r.id} (archived={r.is_archived})" for r in roles
+            )
+            raise CommandError(
+                f"Multiple roles found with name '{role_name}': {matches}. "
+                f"Use --role-id to specify one."
+            )
+        return roles.first()
+
+    def _collect_events(self, role):
+        entries = []
+
+        for event in (AuditEvent.objects.by_model(UserRole)
+                      .filter(object_pk=role.id)
+                      .order_by("event_date")):
+            entries.append(("role", event))
+
+        # Collect RolePermission PKs that belong to this role from audit history,
+        # since update events may not include the role field in their delta.
+        rp_pks = self._get_role_permission_pks(role)
+        for event in (AuditEvent.objects.by_model(RolePermission)
+                      .filter(object_pk__in=rp_pks)
+                      .order_by("event_date")):
+            entries.append(("permission", event))
+
+        rab_pks = self._get_role_assignable_by_pks(role)
+        for event in (AuditEvent.objects.by_model(RoleAssignableBy)
+                      .filter(object_pk__in=rab_pks)
+                      .order_by("event_date")):
+            entries.append(("assignable_by", event))
+
+        entries.sort(key=lambda x: x[1].event_date)
+        return entries
+
+    def _get_role_permission_pks(self, role):
+        """Get all RolePermission PKs for this role, including deleted ones."""
+        pks = set(role.rolepermission_set.values_list("pk", flat=True))
+        for event in (AuditEvent.objects.by_model(RolePermission)
+                      .order_by("event_date")):
+            role_ref = event.delta.get("role", {})
+            if role_ref.get("new", role_ref.get("old")) == role.id:
+                pks.add(event.object_pk)
+        return pks
+
+    def _get_role_assignable_by_pks(self, role):
+        """Get all RoleAssignableBy PKs for this role, including deleted ones."""
+        pks = set(role.roleassignableby_set.values_list("pk", flat=True))
+        for event in (AuditEvent.objects.by_model(RoleAssignableBy)
+                      .order_by("event_date")):
+            role_ref = event.delta.get("role", {})
+            if role_ref.get("new", role_ref.get("old")) == role.id:
+                pks.add(event.object_pk)
+        return pks
+
+    def _print_event(self, entry_type, event, perm_map):
+        prefix = self._event_prefix(event)
+
+        if entry_type == "role":
+            for line in self._role_lines(event, event.delta):
+                self.stdout.write(f"{prefix} {line}")
+        elif entry_type == "permission":
+            self.stdout.write(
+                f"{prefix} {self._permission_line(event, event.delta, perm_map)}"
+            )
+        elif entry_type == "assignable_by":
+            self.stdout.write(
+                f"{prefix} {self._assignable_by_line(event, event.delta)}"
+            )
+
+    def _event_prefix(self, event):
+        ts = event.event_date.strftime("%Y-%m-%d %H:%M:%S.%f UTC")
+        return f"[{ts}] by {self._who(event)}"
+
+    def _role_lines(self, event, delta):
+        interesting = {
+            k: v for k, v in delta.items() if k not in ("couch_id", "domain")
+        }
+        if event.is_create:
+            fields = ", ".join(
+                f"{field}: {change['new']}"
+                for field, change in interesting.items()
+                if change.get("new") is not None
+                and change["new"] != ""
+                and change["new"] is not False
+            )
+            yield f"Role CREATED: {fields}" if fields else "Role CREATED"
+        else:
+            for field, change in interesting.items():
+                old = change.get("old", "\u2014")
+                new = change.get("new", "\u2014")
+                yield f"Role {field}: {old} \u2192 {new}"
+
+    def _permission_line(self, event, delta, perm_map):
+        perm_fk = delta.get("permission_fk", {})
+        perm_id = perm_fk.get("new", perm_fk.get("old"))
+        pname = perm_map.get(perm_id, f"unknown(id={perm_id})")
+
+        if event.is_create:
+            allow_all = delta.get("allow_all", {}).get("new", True)
+            items = delta.get("allowed_items", {}).get("new")
+            if allow_all:
+                return f"Permission GRANTED: {pname} (allow all)"
+            return f"Permission GRANTED: {pname} (items: {self._format_items(items)})"
+        elif event.is_delete:
+            return f"Permission REVOKED: {pname}"
+        else:
+            changes = []
+            if "allow_all" in delta:
+                old_aa = delta["allow_all"].get("old")
+                new_aa = delta["allow_all"].get("new")
+                if old_aa != new_aa:
+                    changes.append(f"allow_all: {old_aa} \u2192 {new_aa}")
+            if "allowed_items" in delta:
+                old_items = delta["allowed_items"].get("old")
+                new_items = delta["allowed_items"].get("new")
+                changes.append(
+                    f"items: {self._format_items(old_items)} "
+                    f"\u2192 {self._format_items(new_items)}"
+                )
+            return f"Permission CHANGED: {pname} ({', '.join(changes)})"
+
+    def _assignable_by_line(self, event, delta):
+        ab_ref = delta.get("assignable_by_role", {})
+        ab_id = ab_ref.get("new", ab_ref.get("old"))
+        try:
+            ab_name = UserRole.objects.get(id=ab_id).name
+        except UserRole.DoesNotExist:
+            ab_name = f"deleted role (id={ab_id})"
+
+        if event.is_create:
+            return f"Assignable by ADDED: {ab_name}"
+        elif event.is_delete:
+            return f"Assignable by REMOVED: {ab_name}"
+        return f"Assignable by CHANGED: {ab_name}"
+
+    @staticmethod
+    def _who(event):
+        ctx = event.change_context or {}
+        username = ctx.get("username", "unknown")
+        user_type = ctx.get("user_type", "")
+        if user_type and user_type != "RequestUser":
+            return f"{username} ({user_type})"
+        return username
+
+    @staticmethod
+    def _format_items(items):
+        if not items:
+            return "none"
+        if len(items) <= 5:
+            return ", ".join(str(i) for i in items)
+        return f"{', '.join(str(i) for i in items[:5])}... ({len(items)} total)"

--- a/corehq/apps/users/management/commands/role_permission_history.py
+++ b/corehq/apps/users/management/commands/role_permission_history.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
 
 from field_audit.models import AuditEvent
 
@@ -117,24 +118,29 @@ class Command(BaseCommand):
         entries.sort(key=lambda x: x[1].event_date)
         return entries
 
+    def _get_related_pks_from_audit(self, model_class, role):
+        """Get all PKs for a related model from audit events where role matches.
+
+        The role field only appears in the delta for create and delete events
+        (since it doesn't change during updates), but that's sufficient to
+        discover all PKs that ever belonged to this role.
+        """
+        return set(
+            AuditEvent.objects.by_model(model_class)
+            .filter(Q(delta__role__new=role.id) | Q(delta__role__old=role.id))
+            .values_list("object_pk", flat=True)
+        )
+
     def _get_role_permission_pks(self, role):
         """Get all RolePermission PKs for this role, including deleted ones."""
         pks = set(role.rolepermission_set.values_list("pk", flat=True))
-        for event in (AuditEvent.objects.by_model(RolePermission)
-                      .order_by("event_date")):
-            role_ref = event.delta.get("role", {})
-            if role_ref.get("new", role_ref.get("old")) == role.id:
-                pks.add(event.object_pk)
+        pks.update(self._get_related_pks_from_audit(RolePermission, role))
         return pks
 
     def _get_role_assignable_by_pks(self, role):
         """Get all RoleAssignableBy PKs for this role, including deleted ones."""
         pks = set(role.roleassignableby_set.values_list("pk", flat=True))
-        for event in (AuditEvent.objects.by_model(RoleAssignableBy)
-                      .order_by("event_date")):
-            role_ref = event.delta.get("role", {})
-            if role_ref.get("new", role_ref.get("old")) == role.id:
-                pks.add(event.object_pk)
+        pks.update(self._get_related_pks_from_audit(RoleAssignableBy, role))
         return pks
 
     def _print_event(self, entry_type, event, perm_map):

--- a/corehq/apps/users/management/commands/role_permission_history.py
+++ b/corehq/apps/users/management/commands/role_permission_history.py
@@ -193,7 +193,11 @@ class Command(BaseCommand):
                 return f"Permission GRANTED: {pname} (allow all)"
             return f"Permission GRANTED: {pname} (items: {self._format_items(items)})"
         elif event.is_delete:
-            return f"Permission REVOKED: {pname}"
+            allow_all = delta.get("allow_all", {}).get("old", True)
+            items = delta.get("allowed_items", {}).get("old")
+            if allow_all:
+                return f"Permission REVOKED: {pname} (was allow all)"
+            return f"Permission REVOKED: {pname} (was items: {self._format_items(items)})"
         else:
             changes = []
             if "allow_all" in delta:

--- a/corehq/apps/users/management/commands/role_permission_history.py
+++ b/corehq/apps/users/management/commands/role_permission_history.py
@@ -68,14 +68,14 @@ class Command(BaseCommand):
         if role_id:
             if role_id.isdigit():
                 try:
-                    return UserRole.objects.get(id=int(role_id))
+                    return UserRole.objects.get(domain=domain, id=int(role_id))
                 except UserRole.DoesNotExist:
-                    raise CommandError(f"No role found with id={role_id}")
+                    raise CommandError(f"No role found with id={role_id} in domain '{domain}'")
             else:
                 try:
-                    return UserRole.objects.get(couch_id=role_id)
+                    return UserRole.objects.get(domain=domain, couch_id=role_id)
                 except UserRole.DoesNotExist:
-                    raise CommandError(f"No role found with couch_id='{role_id}'")
+                    raise CommandError(f"No role found with couch_id='{role_id}' in domain '{domain}'")
 
         roles = UserRole.objects.filter(domain=domain, name=role_name)
         if roles.count() == 0:

--- a/corehq/apps/users/management/commands/role_permission_history.py
+++ b/corehq/apps/users/management/commands/role_permission_history.py
@@ -20,15 +20,16 @@ class Command(BaseCommand):
         # By role name
         ./manage.py role_permission_history my-domain --role-name "Field Worker"
 
-        # By role ID
+        # By database ID or couch_id
         ./manage.py role_permission_history my-domain --role-id 123
+        ./manage.py role_permission_history my-domain --role-id abc123def456
     """
 
     def add_arguments(self, parser):
         parser.add_argument("domain")
         group = parser.add_mutually_exclusive_group(required=True)
         group.add_argument("--role-name", help="Name of the role")
-        group.add_argument("--role-id", type=int, help="Database ID of the role")
+        group.add_argument("--role-id", help="Database ID or couch_id of the role")
         group.add_argument("--list", action="store_true", dest="list_roles",
                            help="List all roles in the domain")
 
@@ -60,14 +61,20 @@ class Command(BaseCommand):
         self.stdout.write(f"Roles in domain '{domain}':")
         for r in roles:
             archived = " (archived)" if r.is_archived else ""
-            self.stdout.write(f"  {r.name} (id={r.id}){archived}")
+            self.stdout.write(f"  {r.name} (id={r.id}, couch_id={r.couch_id}){archived}")
 
     def _get_role(self, domain, role_name, role_id):
         if role_id:
-            try:
-                return UserRole.objects.get(id=role_id)
-            except UserRole.DoesNotExist:
-                raise CommandError(f"No role found with id={role_id}")
+            if role_id.isdigit():
+                try:
+                    return UserRole.objects.get(id=int(role_id))
+                except UserRole.DoesNotExist:
+                    raise CommandError(f"No role found with id={role_id}")
+            else:
+                try:
+                    return UserRole.objects.get(couch_id=role_id)
+                except UserRole.DoesNotExist:
+                    raise CommandError(f"No role found with couch_id='{role_id}'")
 
         roles = UserRole.objects.filter(domain=domain, name=role_name)
         if roles.count() == 0:

--- a/corehq/apps/users/management/commands/role_permission_history.py
+++ b/corehq/apps/users/management/commands/role_permission_history.py
@@ -198,13 +198,13 @@ class Command(BaseCommand):
             allow_all = delta.get("allow_all", {}).get("new", True)
             items = delta.get("allowed_items", {}).get("new")
             if allow_all:
-                return f"Permission GRANTED: {pname} (allow all)"
+                return f"Permission GRANTED: {pname}"
             return f"Permission GRANTED: {pname} (items: {self._format_items(items)})"
         elif event.is_delete:
             allow_all = delta.get("allow_all", {}).get("old", True)
             items = delta.get("allowed_items", {}).get("old")
             if allow_all:
-                return f"Permission REVOKED: {pname} (was allow all)"
+                return f"Permission REVOKED: {pname}"
             return f"Permission REVOKED: {pname} (was items: {self._format_items(items)})"
         else:
             changes = []

--- a/corehq/apps/users/management/commands/role_permission_history.py
+++ b/corehq/apps/users/management/commands/role_permission_history.py
@@ -184,6 +184,14 @@ class Command(BaseCommand):
     def _permission_line(self, event, delta, perm_map):
         perm_fk = delta.get("permission_fk", {})
         perm_id = perm_fk.get("new", perm_fk.get("old"))
+        if perm_id is None:
+            # Update events don't include permission_fk in the delta since it
+            # didn't change. Look it up from the RolePermission row directly.
+            try:
+                perm_id = (RolePermission.objects.values_list("permission_fk", flat=True)
+                           .get(pk=event.object_pk))
+            except RolePermission.DoesNotExist:
+                pass
         pname = perm_map.get(perm_id, f"unknown(id={perm_id})")
 
         if event.is_create:

--- a/corehq/apps/users/tests/test_role_permission_history.py
+++ b/corehq/apps/users/tests/test_role_permission_history.py
@@ -32,24 +32,21 @@ class BaseRoleHistoryTest(TestCase):
         call_command("role_permission_history", *args, stdout=out, stderr=err, **kwargs)
         return out.getvalue()
 
-    def setUp(self):
-        super().setUp()
-        AuditEvent.objects.all().delete()
+
 
 
 class TestListRoles(BaseRoleHistoryTest):
 
     def test_list_roles(self):
         role = UserRole.create(self.domain_name, "Supervisor")
-        self.addCleanup(role.delete)
+
         output = self._call_command(self.domain_name, "--list")
         assert "Supervisor" in output
         assert f"id={role.id}" in output
         assert f"couch_id={role.couch_id}" in output
 
     def test_list_roles_shows_archived(self):
-        role = UserRole.create(self.domain_name, "Old Role", is_archived=True)
-        self.addCleanup(role.delete)
+        UserRole.create(self.domain_name, "Old Role", is_archived=True)
         output = self._call_command(self.domain_name, "--list")
         assert "Old Role" in output
         assert "(archived)" in output
@@ -77,27 +74,25 @@ class TestGetRoleErrors(BaseRoleHistoryTest):
 
     def test_lookup_by_couch_id(self):
         role = UserRole.create(self.domain_name, "Couch Lookup")
-        self.addCleanup(role.delete)
+
         output = self._call_command(self.domain_name, "--role-id", role.couch_id)
         assert "Couch Lookup" in output
 
     def test_role_id_wrong_domain(self):
         role = UserRole.create(self.domain_name, "Wrong Domain")
-        self.addCleanup(role.delete)
+
         with pytest.raises(CommandError, match="No role found"):
             self._call_command("other-domain", "--role-id", str(role.id))
 
     def test_couch_id_wrong_domain(self):
         role = UserRole.create(self.domain_name, "Wrong Domain Couch")
-        self.addCleanup(role.delete)
+
         with pytest.raises(CommandError, match="No role found"):
             self._call_command("other-domain", "--role-id", role.couch_id)
 
     def test_ambiguous_role_name(self):
-        role1 = UserRole.create(self.domain_name, "Duplicate")
-        role2 = UserRole.create(self.domain_name, "Duplicate")
-        self.addCleanup(role1.delete)
-        self.addCleanup(role2.delete)
+        UserRole.create(self.domain_name, "Duplicate")
+        UserRole.create(self.domain_name, "Duplicate")
         with pytest.raises(CommandError, match="Multiple roles found") as exc_info:
             self._call_command(self.domain_name, "--role-name", "Duplicate")
         assert "--role-id" in str(exc_info.value)
@@ -107,14 +102,14 @@ class TestRoleCreatedEvent(BaseRoleHistoryTest):
 
     def test_shows_role_created(self):
         role = UserRole.create(self.domain_name, "New Role")
-        self.addCleanup(role.delete)
+
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
         assert "Role CREATED" in output
         assert "name: New Role" in output
 
     def test_shows_role_metadata_change(self):
         role = UserRole.create(self.domain_name, "Editable Role")
-        self.addCleanup(role.delete)
+
         role.is_non_admin_editable = True
         role.save()
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
@@ -125,7 +120,7 @@ class TestPermissionEvents(BaseRoleHistoryTest):
 
     def test_permission_granted(self):
         role = UserRole.create(self.domain_name, "Grant Test")
-        self.addCleanup(role.delete)
+
         perm = Permission.objects.first()
         role.set_permissions([PermissionInfo(perm.value)])
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
@@ -135,7 +130,7 @@ class TestPermissionEvents(BaseRoleHistoryTest):
 
     def test_permission_granted_with_items(self):
         role = UserRole.create(self.domain_name, "Items Test")
-        self.addCleanup(role.delete)
+
         perm = Permission.objects.get(value="view_reports")
         role.set_permissions([PermissionInfo(perm.value, allow=["item_a", "item_b"])])
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
@@ -145,7 +140,7 @@ class TestPermissionEvents(BaseRoleHistoryTest):
 
     def test_permission_revoked(self):
         role = UserRole.create(self.domain_name, "Revoke Test")
-        self.addCleanup(role.delete)
+
         perm = Permission.objects.first()
         role.set_permissions([PermissionInfo(perm.value)])
         role.set_permissions([])
@@ -155,7 +150,7 @@ class TestPermissionEvents(BaseRoleHistoryTest):
 
     def test_permission_changed(self):
         role = UserRole.create(self.domain_name, "Change Test")
-        self.addCleanup(role.delete)
+
         perm = Permission.objects.get(value="view_reports")
         role.set_permissions([PermissionInfo(perm.value)])
         # Re-fetch the RolePermission after set_permissions (which deletes and recreates)
@@ -172,7 +167,7 @@ class TestAssignableByEvents(BaseRoleHistoryTest):
 
     def test_assignable_by_added(self):
         role = UserRole.create(self.domain_name, "Assign Test")
-        self.addCleanup(role.delete)
+
         role.set_assignable_by([role.id])
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
         assert "Assignable by ADDED" in output
@@ -180,7 +175,7 @@ class TestAssignableByEvents(BaseRoleHistoryTest):
 
     def test_assignable_by_removed(self):
         role = UserRole.create(self.domain_name, "Unassign Test")
-        self.addCleanup(role.delete)
+
         role.set_assignable_by([role.id])
         role.set_assignable_by([])
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
@@ -191,7 +186,7 @@ class TestNoEvents(BaseRoleHistoryTest):
 
     def test_no_events(self):
         role = UserRole.create(self.domain_name, "Empty Test")
-        self.addCleanup(role.delete)
+
         # Clear all events including the create event
         AuditEvent.objects.all().delete()
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
@@ -202,7 +197,7 @@ class TestChronologicalOrder(BaseRoleHistoryTest):
 
     def test_events_in_chronological_order(self):
         role = UserRole.create(self.domain_name, "Chrono Test")
-        self.addCleanup(role.delete)
+
         perm = Permission.objects.first()
         role.set_permissions([PermissionInfo(perm.value)])
         role.set_permissions([])

--- a/corehq/apps/users/tests/test_role_permission_history.py
+++ b/corehq/apps/users/tests/test_role_permission_history.py
@@ -136,7 +136,7 @@ class TestPermissionEvents(BaseRoleHistoryTest):
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
         self.assertIn("Permission GRANTED", output)
         self.assertIn(perm.value, output)
-        self.assertIn("allow all", output)
+        self.assertNotIn("items:", output)
 
     def test_permission_granted_with_items(self):
         role = UserRole.create(self.domain_name, "Items Test")

--- a/corehq/apps/users/tests/test_role_permission_history.py
+++ b/corehq/apps/users/tests/test_role_permission_history.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 
 from field_audit.models import AuditEvent
 
-from corehq.apps.domain.models import Domain
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import PermissionInfo
 from corehq.apps.users.models_role import Permission, UserRole
 
@@ -20,10 +20,7 @@ class BaseRoleHistoryTest(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         AuditEvent.objects.all().delete()
-        cls.domain = Domain.get_or_create_with_name(
-            name=cls.domain_name, is_active=True,
-        )
-        cls.domain.save()
+        cls.domain = create_domain(cls.domain_name)
         cls.addClassCleanup(cls.domain.delete)
 
     def _call_command(self, *args, **kwargs):

--- a/corehq/apps/users/tests/test_role_permission_history.py
+++ b/corehq/apps/users/tests/test_role_permission_history.py
@@ -168,8 +168,9 @@ class TestPermissionEvents(BaseRoleHistoryTest):
         rp.allow_all = False
         rp.save()
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
-        self.assertIn("Permission CHANGED", output)
+        self.assertIn("Permission CHANGED: view_reports", output)
         self.assertIn("allow_all: True \u2192 False", output)
+        self.assertNotIn("unknown", output)
 
 
 class TestAssignableByEvents(BaseRoleHistoryTest):

--- a/corehq/apps/users/tests/test_role_permission_history.py
+++ b/corehq/apps/users/tests/test_role_permission_history.py
@@ -1,0 +1,191 @@
+from io import StringIO
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from field_audit.models import AuditEvent
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.users.models import PermissionInfo
+from corehq.apps.users.models_role import Permission, UserRole
+
+
+class BaseRoleHistoryTest(TestCase):
+
+    domain_name = "test-role-history"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        AuditEvent.objects.all().delete()
+        cls.domain = Domain.get_or_create_with_name(
+            name=cls.domain_name, is_active=True,
+        )
+        cls.domain.save()
+        cls.addClassCleanup(cls.domain.delete)
+
+    def _call_command(self, *args, **kwargs):
+        out = StringIO()
+        err = StringIO()
+        call_command("role_permission_history", *args, stdout=out, stderr=err, **kwargs)
+        return out.getvalue()
+
+    def setUp(self):
+        super().setUp()
+        AuditEvent.objects.all().delete()
+
+
+class TestListRoles(BaseRoleHistoryTest):
+
+    def test_list_roles(self):
+        role = UserRole.create(self.domain_name, "Supervisor")
+        self.addCleanup(role.delete)
+        output = self._call_command(self.domain_name, "--list")
+        self.assertIn("Supervisor", output)
+        self.assertIn(f"id={role.id}", output)
+
+    def test_list_roles_shows_archived(self):
+        role = UserRole.create(self.domain_name, "Old Role", is_archived=True)
+        self.addCleanup(role.delete)
+        output = self._call_command(self.domain_name, "--list")
+        self.assertIn("Old Role", output)
+        self.assertIn("(archived)", output)
+
+    def test_list_roles_empty_domain(self):
+        output = self._call_command("nonexistent-domain", "--list")
+        self.assertIn("No roles found", output)
+
+
+class TestGetRoleErrors(BaseRoleHistoryTest):
+
+    def test_nonexistent_role_name(self):
+        with self.assertRaises(CommandError) as ctx:
+            self._call_command(self.domain_name, "--role-name", "Nonexistent")
+        self.assertIn("No role found", str(ctx.exception))
+        self.assertIn("--list", str(ctx.exception))
+
+    def test_nonexistent_role_id(self):
+        with self.assertRaises(CommandError) as ctx:
+            self._call_command(self.domain_name, "--role-id", "999999")
+        self.assertIn("No role found", str(ctx.exception))
+
+    def test_ambiguous_role_name(self):
+        role1 = UserRole.create(self.domain_name, "Duplicate")
+        role2 = UserRole.create(self.domain_name, "Duplicate")
+        self.addCleanup(role1.delete)
+        self.addCleanup(role2.delete)
+        with self.assertRaises(CommandError) as ctx:
+            self._call_command(self.domain_name, "--role-name", "Duplicate")
+        self.assertIn("Multiple roles found", str(ctx.exception))
+        self.assertIn("--role-id", str(ctx.exception))
+
+
+class TestRoleCreatedEvent(BaseRoleHistoryTest):
+
+    def test_shows_role_created(self):
+        role = UserRole.create(self.domain_name, "New Role")
+        self.addCleanup(role.delete)
+        output = self._call_command(self.domain_name, "--role-id", str(role.id))
+        self.assertIn("Role CREATED", output)
+        self.assertIn("name: New Role", output)
+
+    def test_shows_role_metadata_change(self):
+        role = UserRole.create(self.domain_name, "Editable Role")
+        self.addCleanup(role.delete)
+        role.is_non_admin_editable = True
+        role.save()
+        output = self._call_command(self.domain_name, "--role-id", str(role.id))
+        self.assertIn("is_non_admin_editable: False \u2192 True", output)
+
+
+class TestPermissionEvents(BaseRoleHistoryTest):
+
+    def test_permission_granted(self):
+        role = UserRole.create(self.domain_name, "Grant Test")
+        self.addCleanup(role.delete)
+        perm = Permission.objects.first()
+        role.set_permissions([PermissionInfo(perm.value)])
+        output = self._call_command(self.domain_name, "--role-id", str(role.id))
+        self.assertIn("Permission GRANTED", output)
+        self.assertIn(perm.value, output)
+        self.assertIn("allow all", output)
+
+    def test_permission_granted_with_items(self):
+        role = UserRole.create(self.domain_name, "Items Test")
+        self.addCleanup(role.delete)
+        perm = Permission.objects.get(value="view_reports")
+        role.set_permissions([PermissionInfo(perm.value, allow=["item_a", "item_b"])])
+        output = self._call_command(self.domain_name, "--role-id", str(role.id))
+        self.assertIn("Permission GRANTED", output)
+        self.assertIn("item_a", output)
+        self.assertIn("item_b", output)
+
+    def test_permission_revoked(self):
+        role = UserRole.create(self.domain_name, "Revoke Test")
+        self.addCleanup(role.delete)
+        perm = Permission.objects.first()
+        role.set_permissions([PermissionInfo(perm.value)])
+        role.set_permissions([])
+        output = self._call_command(self.domain_name, "--role-id", str(role.id))
+        self.assertIn("Permission REVOKED", output)
+        self.assertIn(perm.value, output)
+
+    def test_permission_changed(self):
+        role = UserRole.create(self.domain_name, "Change Test")
+        self.addCleanup(role.delete)
+        perm = Permission.objects.get(value="view_reports")
+        role.set_permissions([PermissionInfo(perm.value)])
+        # Re-fetch the RolePermission after set_permissions (which deletes and recreates)
+        rp = role.rolepermission_set.get(permission_fk=perm)
+        rp.allow_all = False
+        rp.save()
+        output = self._call_command(self.domain_name, "--role-id", str(role.id))
+        self.assertIn("Permission CHANGED", output)
+        self.assertIn("allow_all: True \u2192 False", output)
+
+
+class TestAssignableByEvents(BaseRoleHistoryTest):
+
+    def test_assignable_by_added(self):
+        role = UserRole.create(self.domain_name, "Assign Test")
+        self.addCleanup(role.delete)
+        role.set_assignable_by([role.id])
+        output = self._call_command(self.domain_name, "--role-id", str(role.id))
+        self.assertIn("Assignable by ADDED", output)
+        self.assertIn("Assign Test", output)
+
+    def test_assignable_by_removed(self):
+        role = UserRole.create(self.domain_name, "Unassign Test")
+        self.addCleanup(role.delete)
+        role.set_assignable_by([role.id])
+        role.set_assignable_by([])
+        output = self._call_command(self.domain_name, "--role-id", str(role.id))
+        self.assertIn("Assignable by REMOVED", output)
+
+
+class TestNoEvents(BaseRoleHistoryTest):
+
+    def test_no_events(self):
+        role = UserRole.create(self.domain_name, "Empty Test")
+        self.addCleanup(role.delete)
+        # Clear all events including the create event
+        AuditEvent.objects.all().delete()
+        output = self._call_command(self.domain_name, "--role-id", str(role.id))
+        self.assertIn("No audit events found", output)
+
+
+class TestChronologicalOrder(BaseRoleHistoryTest):
+
+    def test_events_in_chronological_order(self):
+        role = UserRole.create(self.domain_name, "Chrono Test")
+        self.addCleanup(role.delete)
+        perm = Permission.objects.first()
+        role.set_permissions([PermissionInfo(perm.value)])
+        role.set_permissions([])
+        output = self._call_command(self.domain_name, "--role-id", str(role.id))
+        created_pos = output.index("Role CREATED")
+        granted_pos = output.index("Permission GRANTED")
+        revoked_pos = output.index("Permission REVOKED")
+        self.assertLess(created_pos, granted_pos)
+        self.assertLess(granted_pos, revoked_pos)

--- a/corehq/apps/users/tests/test_role_permission_history.py
+++ b/corehq/apps/users/tests/test_role_permission_history.py
@@ -1,5 +1,6 @@
 from io import StringIO
 
+import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
@@ -42,70 +43,64 @@ class TestListRoles(BaseRoleHistoryTest):
         role = UserRole.create(self.domain_name, "Supervisor")
         self.addCleanup(role.delete)
         output = self._call_command(self.domain_name, "--list")
-        self.assertIn("Supervisor", output)
-        self.assertIn(f"id={role.id}", output)
-        self.assertIn(f"couch_id={role.couch_id}", output)
+        assert "Supervisor" in output
+        assert f"id={role.id}" in output
+        assert f"couch_id={role.couch_id}" in output
 
     def test_list_roles_shows_archived(self):
         role = UserRole.create(self.domain_name, "Old Role", is_archived=True)
         self.addCleanup(role.delete)
         output = self._call_command(self.domain_name, "--list")
-        self.assertIn("Old Role", output)
-        self.assertIn("(archived)", output)
+        assert "Old Role" in output
+        assert "(archived)" in output
 
     def test_list_roles_empty_domain(self):
         output = self._call_command("nonexistent-domain", "--list")
-        self.assertIn("No roles found", output)
+        assert "No roles found" in output
 
 
 class TestGetRoleErrors(BaseRoleHistoryTest):
 
     def test_nonexistent_role_name(self):
-        with self.assertRaises(CommandError) as ctx:
+        with pytest.raises(CommandError, match="No role found") as exc_info:
             self._call_command(self.domain_name, "--role-name", "Nonexistent")
-        self.assertIn("No role found", str(ctx.exception))
-        self.assertIn("--list", str(ctx.exception))
+        assert "--list" in str(exc_info.value)
 
     def test_nonexistent_role_id(self):
-        with self.assertRaises(CommandError) as ctx:
+        with pytest.raises(CommandError, match="No role found"):
             self._call_command(self.domain_name, "--role-id", "999999")
-        self.assertIn("No role found", str(ctx.exception))
 
     def test_nonexistent_couch_id(self):
-        with self.assertRaises(CommandError) as ctx:
+        with pytest.raises(CommandError, match="No role found") as exc_info:
             self._call_command(self.domain_name, "--role-id", "abc123def456")
-        self.assertIn("No role found", str(ctx.exception))
-        self.assertIn("couch_id", str(ctx.exception))
+        assert "couch_id" in str(exc_info.value)
 
     def test_lookup_by_couch_id(self):
         role = UserRole.create(self.domain_name, "Couch Lookup")
         self.addCleanup(role.delete)
         output = self._call_command(self.domain_name, "--role-id", role.couch_id)
-        self.assertIn("Couch Lookup", output)
+        assert "Couch Lookup" in output
 
     def test_role_id_wrong_domain(self):
         role = UserRole.create(self.domain_name, "Wrong Domain")
         self.addCleanup(role.delete)
-        with self.assertRaises(CommandError) as ctx:
+        with pytest.raises(CommandError, match="No role found"):
             self._call_command("other-domain", "--role-id", str(role.id))
-        self.assertIn("No role found", str(ctx.exception))
 
     def test_couch_id_wrong_domain(self):
         role = UserRole.create(self.domain_name, "Wrong Domain Couch")
         self.addCleanup(role.delete)
-        with self.assertRaises(CommandError) as ctx:
+        with pytest.raises(CommandError, match="No role found"):
             self._call_command("other-domain", "--role-id", role.couch_id)
-        self.assertIn("No role found", str(ctx.exception))
 
     def test_ambiguous_role_name(self):
         role1 = UserRole.create(self.domain_name, "Duplicate")
         role2 = UserRole.create(self.domain_name, "Duplicate")
         self.addCleanup(role1.delete)
         self.addCleanup(role2.delete)
-        with self.assertRaises(CommandError) as ctx:
+        with pytest.raises(CommandError, match="Multiple roles found") as exc_info:
             self._call_command(self.domain_name, "--role-name", "Duplicate")
-        self.assertIn("Multiple roles found", str(ctx.exception))
-        self.assertIn("--role-id", str(ctx.exception))
+        assert "--role-id" in str(exc_info.value)
 
 
 class TestRoleCreatedEvent(BaseRoleHistoryTest):
@@ -114,8 +109,8 @@ class TestRoleCreatedEvent(BaseRoleHistoryTest):
         role = UserRole.create(self.domain_name, "New Role")
         self.addCleanup(role.delete)
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
-        self.assertIn("Role CREATED", output)
-        self.assertIn("name: New Role", output)
+        assert "Role CREATED" in output
+        assert "name: New Role" in output
 
     def test_shows_role_metadata_change(self):
         role = UserRole.create(self.domain_name, "Editable Role")
@@ -123,7 +118,7 @@ class TestRoleCreatedEvent(BaseRoleHistoryTest):
         role.is_non_admin_editable = True
         role.save()
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
-        self.assertIn("is_non_admin_editable: False \u2192 True", output)
+        assert "is_non_admin_editable: False \u2192 True" in output
 
 
 class TestPermissionEvents(BaseRoleHistoryTest):
@@ -134,9 +129,9 @@ class TestPermissionEvents(BaseRoleHistoryTest):
         perm = Permission.objects.first()
         role.set_permissions([PermissionInfo(perm.value)])
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
-        self.assertIn("Permission GRANTED", output)
-        self.assertIn(perm.value, output)
-        self.assertNotIn("items:", output)
+        assert "Permission GRANTED" in output
+        assert perm.value in output
+        assert "items:" not in output
 
     def test_permission_granted_with_items(self):
         role = UserRole.create(self.domain_name, "Items Test")
@@ -144,9 +139,9 @@ class TestPermissionEvents(BaseRoleHistoryTest):
         perm = Permission.objects.get(value="view_reports")
         role.set_permissions([PermissionInfo(perm.value, allow=["item_a", "item_b"])])
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
-        self.assertIn("Permission GRANTED", output)
-        self.assertIn("item_a", output)
-        self.assertIn("item_b", output)
+        assert "Permission GRANTED" in output
+        assert "item_a" in output
+        assert "item_b" in output
 
     def test_permission_revoked(self):
         role = UserRole.create(self.domain_name, "Revoke Test")
@@ -155,8 +150,8 @@ class TestPermissionEvents(BaseRoleHistoryTest):
         role.set_permissions([PermissionInfo(perm.value)])
         role.set_permissions([])
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
-        self.assertIn("Permission REVOKED", output)
-        self.assertIn(perm.value, output)
+        assert "Permission REVOKED" in output
+        assert perm.value in output
 
     def test_permission_changed(self):
         role = UserRole.create(self.domain_name, "Change Test")
@@ -168,9 +163,9 @@ class TestPermissionEvents(BaseRoleHistoryTest):
         rp.allow_all = False
         rp.save()
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
-        self.assertIn("Permission CHANGED: view_reports", output)
-        self.assertIn("allow_all: True \u2192 False", output)
-        self.assertNotIn("unknown", output)
+        assert "Permission CHANGED: view_reports" in output
+        assert "allow_all: True \u2192 False" in output
+        assert "unknown" not in output
 
 
 class TestAssignableByEvents(BaseRoleHistoryTest):
@@ -180,8 +175,8 @@ class TestAssignableByEvents(BaseRoleHistoryTest):
         self.addCleanup(role.delete)
         role.set_assignable_by([role.id])
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
-        self.assertIn("Assignable by ADDED", output)
-        self.assertIn("Assign Test", output)
+        assert "Assignable by ADDED" in output
+        assert "Assign Test" in output
 
     def test_assignable_by_removed(self):
         role = UserRole.create(self.domain_name, "Unassign Test")
@@ -189,7 +184,7 @@ class TestAssignableByEvents(BaseRoleHistoryTest):
         role.set_assignable_by([role.id])
         role.set_assignable_by([])
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
-        self.assertIn("Assignable by REMOVED", output)
+        assert "Assignable by REMOVED" in output
 
 
 class TestNoEvents(BaseRoleHistoryTest):
@@ -200,7 +195,7 @@ class TestNoEvents(BaseRoleHistoryTest):
         # Clear all events including the create event
         AuditEvent.objects.all().delete()
         output = self._call_command(self.domain_name, "--role-id", str(role.id))
-        self.assertIn("No audit events found", output)
+        assert "No audit events found" in output
 
 
 class TestChronologicalOrder(BaseRoleHistoryTest):
@@ -215,5 +210,4 @@ class TestChronologicalOrder(BaseRoleHistoryTest):
         created_pos = output.index("Role CREATED")
         granted_pos = output.index("Permission GRANTED")
         revoked_pos = output.index("Permission REVOKED")
-        self.assertLess(created_pos, granted_pos)
-        self.assertLess(granted_pos, revoked_pos)
+        assert created_pos < granted_pos < revoked_pos

--- a/corehq/apps/users/tests/test_role_permission_history.py
+++ b/corehq/apps/users/tests/test_role_permission_history.py
@@ -44,6 +44,7 @@ class TestListRoles(BaseRoleHistoryTest):
         output = self._call_command(self.domain_name, "--list")
         self.assertIn("Supervisor", output)
         self.assertIn(f"id={role.id}", output)
+        self.assertIn(f"couch_id={role.couch_id}", output)
 
     def test_list_roles_shows_archived(self):
         role = UserRole.create(self.domain_name, "Old Role", is_archived=True)
@@ -69,6 +70,18 @@ class TestGetRoleErrors(BaseRoleHistoryTest):
         with self.assertRaises(CommandError) as ctx:
             self._call_command(self.domain_name, "--role-id", "999999")
         self.assertIn("No role found", str(ctx.exception))
+
+    def test_nonexistent_couch_id(self):
+        with self.assertRaises(CommandError) as ctx:
+            self._call_command(self.domain_name, "--role-id", "abc123def456")
+        self.assertIn("No role found", str(ctx.exception))
+        self.assertIn("couch_id", str(ctx.exception))
+
+    def test_lookup_by_couch_id(self):
+        role = UserRole.create(self.domain_name, "Couch Lookup")
+        self.addCleanup(role.delete)
+        output = self._call_command(self.domain_name, "--role-id", role.couch_id)
+        self.assertIn("Couch Lookup", output)
 
     def test_ambiguous_role_name(self):
         role1 = UserRole.create(self.domain_name, "Duplicate")

--- a/corehq/apps/users/tests/test_role_permission_history.py
+++ b/corehq/apps/users/tests/test_role_permission_history.py
@@ -83,6 +83,20 @@ class TestGetRoleErrors(BaseRoleHistoryTest):
         output = self._call_command(self.domain_name, "--role-id", role.couch_id)
         self.assertIn("Couch Lookup", output)
 
+    def test_role_id_wrong_domain(self):
+        role = UserRole.create(self.domain_name, "Wrong Domain")
+        self.addCleanup(role.delete)
+        with self.assertRaises(CommandError) as ctx:
+            self._call_command("other-domain", "--role-id", str(role.id))
+        self.assertIn("No role found", str(ctx.exception))
+
+    def test_couch_id_wrong_domain(self):
+        role = UserRole.create(self.domain_name, "Wrong Domain Couch")
+        self.addCleanup(role.delete)
+        with self.assertRaises(CommandError) as ctx:
+            self._call_command("other-domain", "--role-id", role.couch_id)
+        self.assertIn("No role found", str(ctx.exception))
+
     def test_ambiguous_role_name(self):
         role1 = UserRole.create(self.domain_name, "Duplicate")
         role2 = UserRole.create(self.domain_name, "Duplicate")


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-19560

## Product Description

N/A — internal tooling only, no user-facing effects.

## Technical Summary

Adds a `role_permission_history` management command that displays a chronological
audit trail of all permission changes on a `UserRole`, using `field_audit`
`AuditEvent` records.

Supports three modes:
- `--list` — list all roles in a domain
- `--role-name` — look up by name
- `--role-id` — look up by database ID or couch_id (auto-detected, validated against domain)

Output includes role creation/metadata changes, permission grants/revocations/modifications,
and assignable-by relationship changes, with timestamps and actor info. Each event
is printed on a single line for easy scanning and grepping.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Read-only management command that queries existing audit data. No data modifications.

### Automated test coverage

20 tests in `corehq/apps/users/tests/test_role_permission_history.py` covering:
- `--list` output (including archived roles and empty domains)
- Error cases (nonexistent role, ambiguous name, nonexistent couch_id, wrong domain)
- Lookup by database ID and couch_id
- Role creation and metadata change events
- Permission granted (allow all and with items), revoked, and changed events
- Assignable-by added/removed events
- Empty history
- Chronological ordering

### QA Plan

Run the command against a domain with known role history and verify output matches expectations.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)