### PR TITLE
Fix vellum-to-hq scripts

### DIFF
--- a/scripts/vellum-to-hq
+++ b/scripts/vellum-to-hq
@@ -189,8 +189,10 @@ def update_hq(path, branch, base_branch, vellum_dir, vellum_rev, push, target, d
 
     if push:
         print(f"Pushing HQ origin/{hq_branch}")
-        maybe_force = "" if branch == "master" else "-f"
-        get_git(path, foreground=True).push("origin", hq_branch, maybe_force)
+        push_args = ["origin", hq_branch]
+        if branch != "master":
+            push_args.append("-f")
+        get_git(path, foreground=True).push(*push_args)
         # push output will print instructions for creating a PR
     elif branch == "master":
         print(f"\nPush '{hq_branch}' to Github, then create a PR:\n")

--- a/scripts/vellum-to-hq
+++ b/scripts/vellum-to-hq
@@ -151,7 +151,7 @@ def update_hq(path, branch, base_branch, vellum_dir, vellum_rev, push, target, d
             git.reset("--hard", "origin/" + base_branch)
             assert hq_vellum.startswith(path), (path, hq_vellum)
         else:
-            git.checkout("-B", hq_branch, "origin/master")
+            git.checkout("-B", hq_branch, "--no-track", "origin/master")
     old_vellum_rev = get_old_vellum_rev(hq_vellum)
 
     print("Overwriting HQ Vellum with new build")


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Something I want to fix for a long time...

Fix two bugs in `scripts/vellum-to-hq` that cause `--push` to fail in master mode:                                                                                                                               
 
1. Empty `refspec` passed to `git push`: `maybe_force` was set to `""` for master mode, and the `sh` library passed it as a literal empty argument, causing `fatal: invalid refspec ''`.                                 
2. Branch created with wrong upstream: `git checkout -B vellum-XXX origin/master` automatically sets `origin/master` as the tracking branch. If the push in (1) fails and the user retries with `git push`, it pushes to `origin/master` instead of `origin/vellum-XXX`. Added `--no-track` to prevent this.  
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is for a developer only script. Tested locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
