### PR TITLE
Clarify pytest assert convention in CODE_STANDARDS

### DIFF
--- a/CODE_STANDARDS.md
+++ b/CODE_STANDARDS.md
@@ -45,8 +45,11 @@ writing code, or making changes to the project.
 - **Coverage**: Changes must be covered by appropriate tests. Tests need
   to cover edge cases and failure scenarios.
 
-- **pytest conventions**: Use pytest features like Pythonic `assert`
-  statements and parametrized tests for repetitive test cases.
+- **pytest conventions**: Use plain `assert` statements instead of
+  unittest-style assertion methods. For example, use `assert x == y`
+  instead of `self.assertEqual(x, y)`, `assert x in y` instead of
+  `self.assertIn(x, y)`, etc. Use parametrized tests for repetitive
+  test cases.
 
 - **Explicit fixtures**: Use [pytest-unmagic](https://github.com/dimagi/pytest-unmagic/)
   for explicit test fixtures.


### PR DESCRIPTION
## Product Description

No user-facing effects. Updates developer documentation.

## Technical Summary
I don't know that this will actually solve some recent issues we've seen with claude not respecting this rule (it might just be that we still need to manually call out looking at the code standards readme), but seems worth a shot.

Makes the pytest assert convention in CODE_STANDARDS.md more explicit. The previous wording ("Pythonic assert statements") was too vague — AI coding assistants were still generating unittest-style assertions (`self.assertEqual`, `self.assertIn`, etc.) instead of plain `assert` statements.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Documentation-only change.

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change