### PR TITLE
User Audit Report: address review feedback

### DIFF
--- a/corehq/apps/auditcare/README.md
+++ b/corehq/apps/auditcare/README.md
@@ -31,16 +31,16 @@ all users (requires a domain filter).
   starting with `10.`.
 - Comma-separated for multiple: `10.0.0.0/8, 192.168.1.0/24`
 
-**URL Include** — One URL path pattern per line. Choose **contains** or
+**URL Path Include** — One URL path pattern per line. Choose **contains** or
 **starts with** mode. Rows matching any pattern are included. Leave blank to
-include all URLs.
+include all paths.
 
 When using "starts with" with a domain filter, the report shows a hint if your
-patterns don't start with `/a/<domain>/`, since most domain-scoped URLs follow
-that convention.
+patterns don't start with `/a/<domain>/`, since most domain-scoped URL paths
+follow that convention.
 
-**URL Exclude** — Same format as URL Include. Rows matching any pattern are
-excluded. Has its own independent contains/starts-with toggle.
+**URL Path Exclude** — Same format as URL Path Include. Rows matching any
+pattern are excluded. Has its own independent contains/starts-with toggle.
 
 **Status Code** — Comma-separated HTTP status codes, e.g. `200, 403, 500`. When
 active, only `NavigationEventAudit` rows with a matching status code are shown

--- a/corehq/apps/auditcare/README.md
+++ b/corehq/apps/auditcare/README.md
@@ -73,6 +73,10 @@ events:
 4. An info message explains the adjustment and suggests setting the start time
    to the displayed cutoff to page forward.
 
+If the minute boundary drops a large number of rows (more than 500), the
+message notes how many were excluded and suggests adding filters to narrow
+results.
+
 If all 5,001 rows fall within the same minute (making minute-boundary trimming
 impossible), the report shows the first 5,000 rows with a warning that
 additional events in that minute are not displayed.

--- a/corehq/apps/auditcare/tests/test_export.py
+++ b/corehq/apps/auditcare/tests/test_export.py
@@ -15,8 +15,8 @@ from ..utils.export import (
     AuditWindowQuery,
     ForeignKeyAccessError,
     build_ip_filter,
-    build_url_exclude_filter,
-    build_url_include_filter,
+    build_path_exclude_filter,
+    build_path_include_filter,
     get_all_log_events,
     get_date_range_where,
     get_domain_first_access_times,
@@ -334,38 +334,38 @@ class TestBuildIPFilter(AuditcareTest):
         self.assertIsNone(q)
 
 
-class TestBuildURLFilters(AuditcareTest):
+class TestBuildPathFilters(AuditcareTest):
 
     def test_include_contains(self):
-        q = build_url_include_filter(["/api/v1/"], "contains")
+        q = build_path_include_filter(["/api/v1/"], "contains")
         self.assertEqual(q, Q(path__contains="/api/v1/"))
 
     def test_include_startswith(self):
-        q = build_url_include_filter(["/a/test/"], "startswith")
+        q = build_path_include_filter(["/a/test/"], "startswith")
         self.assertEqual(q, Q(path__startswith="/a/test/"))
 
     def test_include_multiple_or(self):
-        q = build_url_include_filter(["/api/", "/dashboard/"], "contains")
+        q = build_path_include_filter(["/api/", "/dashboard/"], "contains")
         self.assertEqual(q, Q(path__contains="/api/") | Q(path__contains="/dashboard/"))
 
     def test_include_empty_returns_none(self):
-        q = build_url_include_filter([], "contains")
+        q = build_path_include_filter([], "contains")
         self.assertIsNone(q)
 
     def test_exclude_contains(self):
-        q = build_url_exclude_filter(["/heartbeat/"], "contains")
+        q = build_path_exclude_filter(["/heartbeat/"], "contains")
         self.assertEqual(q, ~Q(path__contains="/heartbeat/"))
 
     def test_exclude_startswith(self):
-        q = build_url_exclude_filter(["/a/test/heartbeat/"], "startswith")
+        q = build_path_exclude_filter(["/a/test/heartbeat/"], "startswith")
         self.assertEqual(q, ~Q(path__startswith="/a/test/heartbeat/"))
 
     def test_exclude_multiple_and_not(self):
-        q = build_url_exclude_filter(["/heartbeat/", "/ping/"], "contains")
+        q = build_path_exclude_filter(["/heartbeat/", "/ping/"], "contains")
         self.assertEqual(q, ~Q(path__contains="/heartbeat/") & ~Q(path__contains="/ping/"))
 
     def test_exclude_empty_returns_none(self):
-        q = build_url_exclude_filter([], "contains")
+        q = build_path_exclude_filter([], "contains")
         self.assertIsNone(q)
 
 

--- a/corehq/apps/auditcare/utils/export.py
+++ b/corehq/apps/auditcare/utils/export.py
@@ -321,14 +321,14 @@ def _q_for_path(pattern, mode):
     elif mode == "startswith":
         return Q(path__startswith=pattern)
     else:
-        raise ValueError(f"Invalid URL filter mode: {mode!r}")
+        raise ValueError(f"Invalid path filter mode: {mode!r}")
 
 
-def build_url_include_filter(patterns, mode):
-    """Build a Q object for URL include filtering.
+def build_path_include_filter(patterns, mode):
+    """Build a Q object for path include filtering.
 
     Args:
-        patterns: list of URL pattern strings
+        patterns: list of URL path pattern strings
         mode: "contains" or "startswith"
 
     Returns:
@@ -342,11 +342,11 @@ def build_url_include_filter(patterns, mode):
     return q
 
 
-def build_url_exclude_filter(patterns, mode):
-    """Build a Q object for URL exclude filtering.
+def build_path_exclude_filter(patterns, mode):
+    """Build a Q object for path exclude filtering.
 
     Args:
-        patterns: list of URL pattern strings
+        patterns: list of URL path pattern strings
         mode: "contains" or "startswith"
 
     Returns:

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -16,8 +16,8 @@ from corehq.apps.accounting.models import SoftwarePlanEdition, Subscription
 from corehq.apps.auditcare.utils.export import (
     all_audit_events_by_user,
     build_ip_filter,
-    build_url_exclude_filter,
-    build_url_include_filter,
+    build_path_exclude_filter,
+    build_path_include_filter,
     get_generic_log_event_row,
 )
 from corehq.apps.es.aggregations import TermsAggregation
@@ -172,8 +172,8 @@ class UserAuditReport(AdminReport, DatespanMixin):
         'corehq.apps.reports.filters.simple.SimpleOptionalDomain',
         'corehq.apps.reports.filters.select.UserAuditActionFilter',
         'corehq.apps.reports.filters.simple.IPAddressFilter',
-        'corehq.apps.reports.filters.simple.URLIncludeFilter',
-        'corehq.apps.reports.filters.simple.URLExcludeFilter',
+        'corehq.apps.reports.filters.simple.PathIncludeFilter',
+        'corehq.apps.reports.filters.simple.PathExcludeFilter',
         'corehq.apps.reports.filters.simple.StatusCodeFilter',
     ]
     emailable = False
@@ -201,23 +201,23 @@ class UserAuditReport(AdminReport, DatespanMixin):
         return IPAddressFilter.parse_ip_input(raw)
 
     @property
-    def selected_url_include_patterns(self):
-        raw = self.request.GET.get('url_include', '')
+    def selected_path_include_patterns(self):
+        raw = self.request.GET.get('path_include', '')
         return [line.strip() for line in raw.splitlines() if line.strip()]
 
     @property
-    def selected_url_include_mode(self):
-        mode = self.request.GET.get('url_include_mode', 'contains')
+    def selected_path_include_mode(self):
+        mode = self.request.GET.get('path_include_mode', 'contains')
         return mode if mode in ('contains', 'startswith') else 'contains'
 
     @property
-    def selected_url_exclude_patterns(self):
-        raw = self.request.GET.get('url_exclude', '')
+    def selected_path_exclude_patterns(self):
+        raw = self.request.GET.get('path_exclude', '')
         return [line.strip() for line in raw.splitlines() if line.strip()]
 
     @property
-    def selected_url_exclude_mode(self):
-        mode = self.request.GET.get('url_exclude_mode', 'contains')
+    def selected_path_exclude_mode(self):
+        mode = self.request.GET.get('path_exclude_mode', 'contains')
         return mode if mode in ('contains', 'startswith') else 'contains'
 
     @property
@@ -341,17 +341,17 @@ class UserAuditReport(AdminReport, DatespanMixin):
             if ip_q:
                 filters &= ip_q
 
-        url_include = build_url_include_filter(
-            self.selected_url_include_patterns, self.selected_url_include_mode
+        path_include = build_path_include_filter(
+            self.selected_path_include_patterns, self.selected_path_include_mode
         )
-        if url_include:
-            filters &= url_include
+        if path_include:
+            filters &= path_include
 
-        url_exclude = build_url_exclude_filter(
-            self.selected_url_exclude_patterns, self.selected_url_exclude_mode
+        path_exclude = build_path_exclude_filter(
+            self.selected_path_exclude_patterns, self.selected_path_exclude_mode
         )
-        if url_exclude:
-            filters &= url_exclude
+        if path_exclude:
+            filters &= path_exclude
 
         return filters if filters != Q() else None
 
@@ -403,15 +403,15 @@ class UserAuditReport(AdminReport, DatespanMixin):
                 "Invalid status code filter. Use comma-separated integers (e.g. 200, 403, 500)."
             )
 
-        # URL domain hint
-        if (self.selected_url_include_mode == 'startswith'
+        # Path domain hint
+        if (self.selected_path_include_mode == 'startswith'
                 and self.selected_domain
-                and self.selected_url_include_patterns):
+                and self.selected_path_include_patterns):
             domain_prefix = f'/a/{self.selected_domain}/'
-            if not any(p.startswith(domain_prefix) for p in self.selected_url_include_patterns):
+            if not any(p.startswith(domain_prefix) for p in self.selected_path_include_patterns):
                 context.setdefault('info_message', '')
                 context['info_message'] += _(
-                    'Note: URLs for this domain typically start with "{domain_prefix}".'
+                    'Note: URL paths for this domain typically start with "{domain_prefix}".'
                 ).format(domain_prefix=domain_prefix)
 
         if self._truncation_same_minute:

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -287,13 +287,12 @@ class UserAuditReport(AdminReport, DatespanMixin):
     # paginating through results by adjusting the date range.
     MAX_RECORDS = 5000
 
-    @property
     @memoized
-    def rows(self):
+    def _compute_rows(self):
         if not (self.selected_domain or self.selected_users):
-            return []
+            return [], None, False
         if self.selected_ip_addresses is None or self.selected_status_codes is None:
-            return []
+            return [], None, False
 
         nav_filters = self._build_nav_filters()
         access_filters = self._build_access_filters()
@@ -316,10 +315,22 @@ class UserAuditReport(AdminReport, DatespanMixin):
             if count > self.MAX_RECORDS:
                 break
 
-        truncated_rows, cutoff_dt = truncate_rows_to_minute_boundary(rows, self.MAX_RECORDS)
-        self._truncation_cutoff = cutoff_dt
-        self._truncation_same_minute = (len(rows) > self.MAX_RECORDS and cutoff_dt is None)
-        return truncated_rows
+        sorted_rows = sorted(rows, key=lambda x: x[0])
+        truncated_rows, cutoff_dt = truncate_rows_to_minute_boundary(sorted_rows, self.MAX_RECORDS)
+        same_minute = len(rows) > self.MAX_RECORDS and cutoff_dt is None
+        return truncated_rows, cutoff_dt, same_minute
+
+    @property
+    def rows(self):
+        return self._compute_rows()[0]
+
+    @property
+    def _truncation_cutoff(self):
+        return self._compute_rows()[1]
+
+    @property
+    def _truncation_same_minute(self):
+        return self._compute_rows()[2]
 
     def _build_common_filters(self):
         filters = Q()
@@ -403,17 +414,14 @@ class UserAuditReport(AdminReport, DatespanMixin):
                     'Note: URLs for this domain typically start with "{domain_prefix}".'
                 ).format(domain_prefix=domain_prefix)
 
-        # Truncation messages (set by rows property)
-        # Access rows to trigger the query and truncation logic
-        _rows = self.rows  # noqa: F841
-        if getattr(self, '_truncation_same_minute', False):
+        if self._truncation_same_minute:
             context['truncation_message'] = _(
                 "Showing {max_records} results, but there are additional events within the "
                 "same minute that are not shown. Try narrowing by username, domain, IP address, "
                 "or other filters to see all results."
             ).format(max_records=self.MAX_RECORDS)
             context['truncation_level'] = 'warning'
-        elif getattr(self, '_truncation_cutoff', None):
+        elif self._truncation_cutoff:
             cutoff = self._truncation_cutoff
             context['truncation_message'] = _(
                 "Showing events through {cutoff_time}. Your query returned more than "

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -80,10 +80,7 @@ def truncate_rows_to_minute_boundary(rows, max_records):
 
     cutoff = overflow_minute
     trimmed = [r for r in rows if parse_date(r[0]) < cutoff]
-
-    # Guard: if trimmed still exceeds (shouldn't normally happen)
-    if len(trimmed) > max_records:
-        return truncate_rows_to_minute_boundary(trimmed, max_records)
+    assert len(trimmed) <= max_records, (len(trimmed), max_records)
 
     return trimmed, cutoff
 

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -70,18 +70,14 @@ def truncate_rows_to_minute_boundary(rows, max_records):
     def floor_to_minute(dt):
         return dt.replace(second=0, microsecond=0)
 
-    # Find the minute of the row that pushed us over the limit
     overflow_date = parse_date(rows[max_records][0])
     overflow_minute = floor_to_minute(overflow_date)
 
-    # Find the minute of the first row
     first_minute = floor_to_minute(parse_date(rows[0][0]))
 
-    # If all rows are in the same minute, we can't trim
     if overflow_minute == first_minute:
         return rows[:max_records], None
 
-    # Trim to rows with event_date < overflow_minute
     cutoff = overflow_minute
     trimmed = [r for r in rows if parse_date(r[0]) < cutoff]
 

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -423,14 +423,24 @@ class UserAuditReport(AdminReport, DatespanMixin):
             context['truncation_level'] = 'warning'
         elif self._truncation_cutoff:
             cutoff = self._truncation_cutoff
-            context['truncation_message'] = _(
-                "Showing events through {cutoff_time}. Your query returned more than "
+            num_rows = len(self.rows)
+            message = _(
+                "Showing {num_rows} events through {cutoff_time}. Your query returned more than "
                 "{max_records} results; the end date/time has been adjusted. "
                 "To see later events, set the start time to {cutoff_time}."
             ).format(
+                num_rows=num_rows,
                 cutoff_time=cutoff.strftime("%Y-%m-%d %H:%M UTC"),
                 max_records=self.MAX_RECORDS,
             )
+            dropped = self.MAX_RECORDS - num_rows
+            if dropped > 500:
+                message += " " + _(
+                    "Note: {dropped} additional results within the cutoff minute were excluded "
+                    "to align with a clean minute boundary. Adding filters (IP address, "
+                    "URL path, status code) may help narrow results."
+                ).format(dropped=dropped)
+            context['truncation_message'] = message
             context['truncation_level'] = 'info'
             context['adjusted_end_date'] = cutoff.strftime("%Y-%m-%d")
             context['adjusted_end_time'] = cutoff.strftime("%H:%M")

--- a/corehq/apps/hqadmin/tests/test_user_audit_report.py
+++ b/corehq/apps/hqadmin/tests/test_user_audit_report.py
@@ -228,47 +228,47 @@ class TestUserAuditReportFilters(AuditcareTest):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0][7], 404)
 
-    def test_url_include_contains(self):
+    def test_path_include_contains(self):
         report = self._get_report({
             'username': 'admin@test.com',
             'startdate': '2026-03-27',
             'enddate': '2026-03-27',
-            'url_include': '/api/',
-            'url_include_mode': 'contains',
+            'path_include': '/api/',
+            'path_include_mode': 'contains',
         })
         rows = report.rows
         self.assertEqual(len(rows), 1)
 
-    def test_url_exclude_contains(self):
+    def test_path_exclude_contains(self):
         report = self._get_report({
             'username': 'admin@test.com',
             'startdate': '2026-03-27',
             'enddate': '2026-03-27',
-            'url_exclude': '/dashboard/',
-            'url_exclude_mode': 'contains',
+            'path_exclude': '/dashboard/',
+            'path_exclude_mode': 'contains',
         })
         rows = report.rows
         # API row + AccessAudit login row (neither contains /dashboard/)
         nav_rows = [r for r in rows if r[1] == 'NavigationEventAudit']
         self.assertEqual(len(nav_rows), 1)
 
-    def test_url_include_mode_defaults_for_invalid_input(self):
+    def test_path_include_mode_defaults_for_invalid_input(self):
         report = self._get_report({
             'username': 'admin@test.com',
             'startdate': '2026-03-27',
             'enddate': '2026-03-27',
-            'url_include_mode': 'iregex',
+            'path_include_mode': 'iregex',
         })
-        self.assertEqual(report.selected_url_include_mode, 'contains')
+        self.assertEqual(report.selected_path_include_mode, 'contains')
 
-    def test_url_exclude_mode_defaults_for_invalid_input(self):
+    def test_path_exclude_mode_defaults_for_invalid_input(self):
         report = self._get_report({
             'username': 'admin@test.com',
             'startdate': '2026-03-27',
             'enddate': '2026-03-27',
-            'url_exclude_mode': 'regex',
+            'path_exclude_mode': 'regex',
         })
-        self.assertEqual(report.selected_url_exclude_mode, 'contains')
+        self.assertEqual(report.selected_path_exclude_mode, 'contains')
 
     def test_status_code_filter_excludes_access_events(self):
         report = self._get_report({
@@ -292,16 +292,16 @@ class TestUserAuditReportFilters(AuditcareTest):
         self.assertIn('AccessAudit', doc_types)
         self.assertIn('NavigationEventAudit', doc_types)
 
-    def test_url_include_and_exclude_combined(self):
-        """Include URLs containing /a/test-domain/ but exclude /dashboard/"""
+    def test_path_include_and_exclude_combined(self):
+        """Include paths containing /a/test-domain/ but exclude /dashboard/"""
         report = self._get_report({
             'username': 'admin@test.com',
             'startdate': '2026-03-27',
             'enddate': '2026-03-27',
-            'url_include': '/a/test-domain/',
-            'url_include_mode': 'contains',
-            'url_exclude': '/dashboard/',
-            'url_exclude_mode': 'contains',
+            'path_include': '/a/test-domain/',
+            'path_include_mode': 'contains',
+            'path_exclude': '/dashboard/',
+            'path_exclude_mode': 'contains',
         })
         rows = report.rows
         # Should get the API row and the AccessAudit login row
@@ -309,13 +309,13 @@ class TestUserAuditReportFilters(AuditcareTest):
         self.assertEqual(len(nav_rows), 1)
         self.assertIn('/api/', nav_rows[0][6])
 
-    def test_url_include_startswith(self):
+    def test_path_include_startswith(self):
         report = self._get_report({
             'username': 'admin@test.com',
             'startdate': '2026-03-27',
             'enddate': '2026-03-27',
-            'url_include': '/a/test-domain/api/',
-            'url_include_mode': 'startswith',
+            'path_include': '/a/test-domain/api/',
+            'path_include_mode': 'startswith',
         })
         rows = report.rows
         nav_rows = [r for r in rows if r[1] == 'NavigationEventAudit']

--- a/corehq/apps/reports/filters/simple.py
+++ b/corehq/apps/reports/filters/simple.py
@@ -138,7 +138,7 @@ class PathIncludeFilter(BasePathFilter):
     slug = 'path_include'
     label = gettext_lazy("URL Path Include")
     mode_slug = 'path_include_mode'
-    placeholder = '/a/domain/api/v1/'
+    placeholder = '/a/domain/api/v0.5/'
     help_inline = gettext_lazy(
         "One URL path pattern per line. Patterns are OR'd together. "
         "Leave blank to include all paths."
@@ -149,7 +149,7 @@ class PathExcludeFilter(BasePathFilter):
     slug = 'path_exclude'
     label = gettext_lazy("URL Path Exclude")
     mode_slug = 'path_exclude_mode'
-    placeholder = '/a/domain/heartbeat/'
+    placeholder = '/a/domain/phone/heartbeat/'
     help_inline = gettext_lazy(
         "One URL path pattern per line. Matching rows are excluded. "
         "Patterns are OR'd (any match excludes the row)."

--- a/corehq/apps/reports/filters/simple.py
+++ b/corehq/apps/reports/filters/simple.py
@@ -111,10 +111,10 @@ class IPAddressFilter(BaseSimpleFilter):
         return results
 
 
-class BaseURLFilter(BaseSimpleFilter):
+class BasePathFilter(BaseSimpleFilter):
     template = "reports/filters/bootstrap3/textarea_with_select.html"
     placeholder = ''
-    mode_slug = None  # override in subclass: e.g. 'url_include_mode'
+    mode_slug = None  # override in subclass: e.g. 'path_include_mode'
 
     @property
     def selected_mode(self):
@@ -134,24 +134,24 @@ class BaseURLFilter(BaseSimpleFilter):
         }
 
 
-class URLIncludeFilter(BaseURLFilter):
-    slug = 'url_include'
-    label = gettext_lazy("URL Include")
-    mode_slug = 'url_include_mode'
+class PathIncludeFilter(BasePathFilter):
+    slug = 'path_include'
+    label = gettext_lazy("URL Path Include")
+    mode_slug = 'path_include_mode'
     placeholder = '/a/domain/api/v1/'
     help_inline = gettext_lazy(
-        "One URL pattern per line. Patterns are OR'd together. "
-        "Leave blank to include all URLs."
+        "One URL path pattern per line. Patterns are OR'd together. "
+        "Leave blank to include all paths."
     )
 
 
-class URLExcludeFilter(BaseURLFilter):
-    slug = 'url_exclude'
-    label = gettext_lazy("URL Exclude")
-    mode_slug = 'url_exclude_mode'
+class PathExcludeFilter(BasePathFilter):
+    slug = 'path_exclude'
+    label = gettext_lazy("URL Path Exclude")
+    mode_slug = 'path_exclude_mode'
     placeholder = '/a/domain/heartbeat/'
     help_inline = gettext_lazy(
-        "One URL pattern per line. Matching rows are excluded. "
+        "One URL path pattern per line. Matching rows are excluded. "
         "Patterns are OR'd (any match excludes the row)."
     )
 


### PR DESCRIPTION
## Summary
Address review feedback from dimagi/commcare-hq#37555

- Rename URL filters to "URL Path" (user-facing) / `path` (code)
  - This straight rename accounts for **most of the PR diff**
- Eliminate side effects from `rows` property via `_compute_rows()`
- Replace unreachable recursive guard with assert, remove obvious comments
- Improve truncation UX messaging when many rows are dropped
- Fix path filter placeholders to match real routes

## Test plan
- [x] Existing tests pass (`pytest corehq/apps/hqadmin/tests/test_user_audit_report.py corehq/apps/auditcare/tests/test_export.py`)
- [x] Verify filters work at `/hq/admin/user_audit_report/` with path_include/path_exclude params

🤖 Generated with [Claude Code](https://claude.com/claude-code)