### PR TITLE
Remove unused `create_copy` method

### DIFF
--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -351,16 +351,6 @@ class Event(ContentForeignKeyMixin):
     class Meta(object):
         abstract = True
 
-    def create_copy(self):
-        """
-        The point of this method is to create a copy of this object with no
-        primary keys set or references to other objects. It's used in the
-        process of copying schedules to a different project in the copy
-        conditional alert workflow, so there should also not be any
-        unresolved project-specific references in the returned copy.
-        """
-        raise NotImplementedError()
-
 
 class Content(models.Model):
     # If this content is being invoked in the context of a case,
@@ -378,16 +368,6 @@ class Content(models.Model):
 
     class Meta(object):
         abstract = True
-
-    def create_copy(self):
-        """
-        The point of this method is to create a copy of this object with no
-        primary keys set or references to other objects. It's used in the
-        process of copying schedules to a different project in the copy
-        conditional alert workflow, so there should also not be any
-        unresolved project-specific references in the returned copy.
-        """
-        raise NotImplementedError()
 
     def set_context(self, case=None, schedule_instance=None, critical_section_already_acquired=False):
         if case:

--- a/corehq/messaging/scheduling/models/alert_schedule.py
+++ b/corehq/messaging/scheduling/models/alert_schedule.py
@@ -114,14 +114,6 @@ class AlertEvent(Event):
     schedule = models.ForeignKey('scheduling.AlertSchedule', on_delete=models.CASCADE)
     minutes_to_wait = models.IntegerField()
 
-    def create_copy(self):
-        """
-        See Event.create_copy() for docstring.
-        """
-        return AlertEvent(
-            minutes_to_wait=self.minutes_to_wait,
-        )
-
 
 class ImmediateBroadcast(Broadcast):
     schedule = models.ForeignKey('scheduling.AlertSchedule', on_delete=models.CASCADE)

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from datetime import datetime, timezone
 
 from django.conf import settings
@@ -44,14 +43,6 @@ from corehq.util.view_utils import absolute_reverse
 class SMSContent(Content):
     message = old_jsonfield.JSONField(default=dict)
 
-    def create_copy(self):
-        """
-        See Content.create_copy() for docstring
-        """
-        return SMSContent(
-            message=deepcopy(self.message),
-        )
-
     def render_message(self, message, recipient, logged_subevent):
         if not message:
             logged_subevent.error(MessagingEvent.ERROR_NO_MESSAGE)
@@ -94,16 +85,6 @@ class EmailContent(Content):
     html_message = NullJsonField(default=dict)
 
     TRIAL_MAX_EMAILS = 50
-
-    def create_copy(self):
-        """
-        See Content.create_copy() for docstring
-        """
-        return EmailContent(
-            subject=deepcopy(self.subject),
-            message=deepcopy(self.message),
-            html_message=deepcopy(self.html_message),
-        )
 
     def render_subject_and_message(self, subject, message, html_message, recipient):
         renderer = self.get_template_renderer(recipient)
@@ -218,19 +199,6 @@ class EmailContent(Content):
 
 
 class SMSSurveyContent(SurveyContent):
-
-    def create_copy(self):
-        """
-        See Content.create_copy() for docstring
-        """
-        return SMSSurveyContent(
-            app_id=None,
-            form_unique_id=None,
-            expire_after=self.expire_after,
-            reminder_intervals=deepcopy(self.reminder_intervals),
-            submit_partially_completed_forms=self.submit_partially_completed_forms,
-            include_case_updates_in_partial_submissions=self.include_case_updates_in_partial_submissions,
-        )
 
     def phone_has_opted_out(self, phone_entry_or_number):
         if isinstance(phone_entry_or_number, PhoneNumber):
@@ -384,14 +352,6 @@ class CustomContent(Content):
     # messsages to send to the recipient.
     custom_content_id = models.CharField(max_length=126)
 
-    def create_copy(self):
-        """
-        See Content.create_copy() for docstring
-        """
-        return CustomContent(
-            custom_content_id=self.custom_content_id,
-        )
-
     def get_list_of_messages(self, recipient):
         if not self.schedule_instance:
             raise ValueError(
@@ -454,17 +414,6 @@ class FCMNotificationContent(Content):
     message = old_jsonfield.JSONField(default=dict)
     action = models.CharField(null=True, choices=ACTION_CHOICES, max_length=25)
     message_type = models.CharField(choices=MESSAGE_TYPES, max_length=25)
-
-    def create_copy(self):
-        """
-        See Content.create_copy() for docstring
-        """
-        return FCMNotificationContent(
-            subject=deepcopy(self.subject),
-            message=deepcopy(self.message),
-            action=self.action,
-            message_type=self.message_type
-        )
 
     def render_subject_and_message(self, subject, message, recipient):
         renderer = self.get_template_renderer(recipient)
@@ -608,11 +557,6 @@ class EmailImage(object):
 class ConnectMessageContent(Content):
     message = old_jsonfield.JSONField(default=dict)
 
-    def create_copy(self):
-        return ConnectMessageContent(
-            message=deepcopy(self.message),
-        )
-
     def send(self, recipient, logged_event, phone_entry=None):
         domain = logged_event.domain
         domain_obj = Domain.get_by_name(domain)
@@ -641,19 +585,6 @@ class ConnectMessageContent(Content):
 
 
 class ConnectMessageSurveyContent(SurveyContent):
-
-    def create_copy(self):
-        """
-        See Content.create_copy() for docstring
-        """
-        return ConnectMessageSurveyContent(
-            app_id=None,
-            form_unique_id=None,
-            expire_after=self.expire_after,
-            reminder_intervals=deepcopy(self.reminder_intervals),
-            submit_partially_completed_forms=self.submit_partially_completed_forms,
-            include_case_updates_in_partial_submissions=self.include_case_updates_in_partial_submissions,
-        )
 
     def send(self, recipient, logged_event, phone_entry=None):
         app, module, form, requires_input = self.get_memoized_app_module_form(logged_event.domain)

--- a/corehq/messaging/scheduling/models/timed_schedule.py
+++ b/corehq/messaging/scheduling/models/timed_schedule.py
@@ -3,7 +3,6 @@ import hashlib
 import json
 import random
 import re
-from copy import deepcopy
 
 from django.db import models, transaction
 
@@ -566,15 +565,6 @@ class AbstractTimedEvent(Event):
 class TimedEvent(AbstractTimedEvent):
     time = models.TimeField()
 
-    def create_copy(self):
-        """
-        See Event.create_copy() for docstring.
-        """
-        return TimedEvent(
-            day=self.day,
-            time=deepcopy(self.time),
-        )
-
     def get_time(self, case=None):
         return self.time, 0
 
@@ -592,16 +582,6 @@ class RandomTimedEvent(AbstractTimedEvent):
     """
     time = models.TimeField()
     window_length = models.PositiveIntegerField()
-
-    def create_copy(self):
-        """
-        See Event.create_copy() for docstring.
-        """
-        return RandomTimedEvent(
-            day=self.day,
-            time=deepcopy(self.time),
-            window_length=self.window_length,
-        )
 
     def get_time(self, case=None):
         choices = list(range(self.window_length))
@@ -622,15 +602,6 @@ class CasePropertyTimedEvent(AbstractTimedEvent):
     content based on the value in a case property.
     """
     case_property_name = models.CharField(max_length=126)
-
-    def create_copy(self):
-        """
-        See Event.create_copy() for docstring.
-        """
-        return CasePropertyTimedEvent(
-            day=self.day,
-            case_property_name=self.case_property_name,
-        )
 
     def get_time(self, case=None):
         if not case:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
None

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
References to this appear to have been removed in https://github.com/dimagi/commcare-hq/commit/88fa31e5738a629f8a7d0b6d129d20468a810681. There are no references other than method definitions in event and content classes. No calls are being made to these methods from what I can tell. The docstring says the purpose of this method

> The point of this method is to create a copy of this object with no
primary keys set or references to other objects. It's used in the
process of copying schedules to a different project in the copy
conditional alert workflow, so there should also not be any
unresolved project-specific references in the returned copy.

So I'd expect to see it in use if that was still a relevant feature.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Unused

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
