### PR TITLE
Auto-rebuild staging on branch push

### DIFF
--- a/.github/workflows/rebuild-staging.yml
+++ b/.github/workflows/rebuild-staging.yml
@@ -1,9 +1,39 @@
 name: Rebuild staging branch
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - '**'
+
+concurrency:
+  group: rebuild-staging
+  cancel-in-progress: false
 
 jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      should-rebuild: >-
+        ${{ github.event_name == 'workflow_dispatch'
+            || steps.check.outputs.found == 'true' }}
+    steps:
+    - name: Check if branch is in staging config
+      id: check
+      if: github.event_name == 'push'
+      env:
+        BRANCH: ${{ github.ref_name }}
+      run: |
+        curl -sf https://raw.githubusercontent.com/dimagi/staging-branches/main/commcare-hq-staging.yml \
+          -o staging.yml
+        if grep -qF "$BRANCH" staging.yml; then
+          echo "found=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "Branch '$BRANCH' not found in staging config, skipping rebuild"
+        fi
+
   rebuild-staging:
+    needs: check-branch
+    if: needs.check-branch.outputs.should-rebuild == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -11,6 +41,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
+        ref: master
         # Full history needed for branch manipulation
         fetch-depth: 0
     - uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Product Description

N/A — infrastructure change, no user-facing effects.

## Technical Summary

With this change, `autostaging` will always be up to date (with a short delay): merges to `master` and pushes to any commcare-hq branch already listed in the staging config will automatically trigger a rebuild. The only remaining edge case where `autostaging` can go stale is when new commits are pushed to a branch that's declared in a submodule's staging config.

Docs updated in the other repo: https://github.com/dimagi/staging-branches/pull/5

### How it works

- Pushing to any branch triggers `rebuild-staging.yml`
- A lightweight `check-branch` job fetches `commcare-hq-staging.yml` and skips the rebuild if the pushed branch isn't listed. (Occasional false positives are cheap, so it just does a grep.)
- Manually triggered / `workflow_dispatch` jobs always proceed, skipping the above check
- Global concurrency group with `cancel-in-progress: false` debounces rapid pushes (there will always be at most 1 running and 1 queued)
- Checkout always uses `ref: master` since the rebuild script runs against master regardless of which branch triggered it

## Feature Flag

N/A

## Safety Assurance

### Safety story

The rebuild-staging job itself is unchanged — only the trigger conditions are new. The skip logic is conservative: branches not in the staging config are ignored. The concurrency group prevents redundant runs. `workflow_dispatch` behavior is unaffected.

### Automated test coverage

N/A — GHA workflow, not application code.

### QA Plan

- Verify `workflow_dispatch` still works as before
- Push to a branch listed in `commcare-hq-staging.yml` and confirm the rebuild triggers
- Push to an unlisted branch and confirm the workflow skips

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change