### PR TITLE
Set source on apps created via API import

### DIFF
--- a/corehq/apps/app_manager/tests/test_app_import_api.py
+++ b/corehq/apps/app_manager/tests/test_app_import_api.py
@@ -94,7 +94,10 @@ def test_import_app_success(mock_import):
     assert data['app_id'] == 'abc123'
     mock_import.assert_called_once()
     assert mock_import.call_args[0][1] == DOMAIN
-    assert mock_import.call_args[0][2] == {'name': 'My App'}
+    assert mock_import.call_args[0][2] == {
+        'name': 'My App',
+        'created_from_template': 'import_app_api',
+    }
 
 
 @patch(f'{MODULE}.import_app_util')

--- a/corehq/apps/app_manager/views/app_import_api.py
+++ b/corehq/apps/app_manager/views/app_import_api.py
@@ -47,7 +47,8 @@ def _handle_import_app(request, domain):
     if not source:
         return JsonResponse({'success': False, 'error': 'Invalid JSON file'}, status=400)
 
-    app = import_app_util(source, domain, {'name': app_name}, request=request)
+    extra = {'name': app_name, 'created_from_template': 'import_app_api'}
+    app = import_app_util(source, domain, extra, request=request)
 
     response = {'success': True, 'app_id': app._id}
     warnings = [str(m) for m in get_messages(request)]

--- a/corehq/apps/domain/views/import_apps.py
+++ b/corehq/apps/domain/views/import_apps.py
@@ -74,7 +74,8 @@ class ImportAppStepsView(LoginAndDomainMixin, DomainViewMixin, HqHtmxActionMixin
             file = form.cleaned_data.get('app_file')
             file.seek(0)  # rewind to the beginning becaues the file has already been read once when validating
             source = json.load(file)
-            app = import_app_util(source, self.domain, {'name': name}, request=request)
+            extra = {'name': name, 'created_from_template': 'import_app'}
+            app = import_app_util(source, self.domain, extra, request=request)
             source_server = form.cleaned_data.get('source_server')
             source_domain = form.cleaned_data.get('source_domain')
             source_app_id = form.cleaned_data.get('app_id')


### PR DESCRIPTION
## Product Description


## Technical Summary
From https://github.com/dimagi/commcare-hq/pull/37559

There are few constraints on apps created this way - it may be handy in the future to be able to conclusively identify them.

I thought about glibly setting `slop = True`, but `created_from_template` already exists (for template apps), and is indexed in elasticsearch, so it seemed prudent to just use that.

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
