### PR TITLE
Copy GitHub gist on upgrading postgres to HQ

### DIFF
--- a/docker/postgres-upgrade.md
+++ b/docker/postgres-upgrade.md
@@ -1,0 +1,78 @@
+# Upgrade to new version of Postgres in Docker
+
+This example upgrades PostgreSQL 9.4 to 9.6. Substitute the versions you're upgrading to/from as needed below.
+
+## Dump all databases to a file
+
+Run the following command to make a backup of all postgres data in a local file:
+
+```sh
+docker exec -i hqservice_postgres_1 pg_dumpall -U commcarehq | gzip > pg-backup.sql.gz
+```
+
+Open the file with vim (or any editor that will automatically decompress the contents) and verify that it contains the expected content:
+
+```sh
+vim pg-backup.sql.gz
+```
+
+The first lines in the file should be something like
+
+```sql
+--
+-- PostgreSQL database cluster dump
+--
+```
+
+## Move the old data directory out of the way
+
+Failing to do this step will prevent the new version of postgres from starting. A new data directory will be created automatically when the new version starts.
+
+First, stop the postgresql service in docker:
+
+```sh
+# this uses the commcare-hq docker script
+./scripts/docker stop postgres
+```
+
+Adjust `DATA_DIR` as needed to point to the place where docker stores data for postgres.
+
+```sh
+DATA_DIR=~/.local/share/dockerhq/postgresql
+sudo mv $DATA_DIR ${DATA_DIR}9.4
+```
+
+The old data directory can be deleted when you're confident you will no longer need it.
+
+## Optional: tag old docker image so we can get it back if needed
+
+```sh
+docker tag dimagi/docker-postgresql dimagi/postgresql9.4
+```
+
+## Upgrade docker image and start it
+
+```sh
+docker pull dimagi/docker-postgresql
+
+# this uses the commcare-hq docker script
+./scripts/docker up -d postgres  # --> Recreating hqservice_postgres_1
+```
+
+## Verify new database version
+
+```sh
+sudo cat $DATA_DIR/PG_VERSION  # --> 9.6
+```
+
+## Finally, restore the dumped databases
+
+```sh
+gzip -cd pg-backup.sql.gz | docker exec -i hqservice_postgres_1 psql -U commcarehq
+# should see a lot of output here as databases are created, etc.
+```
+
+Reset commcarehq user password (adjust this command to set the password you use locally). This may only be necessary for some major version upgrades.
+```sh
+docker exec -i hqservice_postgres_1 psql -U commcarehq -c "ALTER USER commcarehq WITH PASSWORD 'commcarehq';"
+```


### PR DESCRIPTION
Copied this gist
https://gist.githubusercontent.com/millerdev/547bac773483402554797e578fbd238f/raw/d1a3be8879ea5ef2bb9f2a4da9d2375fb874cf50/steps.md with the intention of updating this doc over time to make any minor adjustments needed for each postgres upgrade we perform.

## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
None

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Wanted to do this in a separate PR from when I actually update these instructions for postgres 18 (these were last used for postgres 14). I'll make the necessary changes to this doc in the same PR that actually upgrades to the postgres 18 container. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just copying text verbatim from a gist.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
no
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
