### PR TITLE
Remove references to FCMNotificationContent from code

### DIFF
--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1392,7 +1392,6 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
             ConnectMessageSurveyContent,
             CustomContent,
             EmailContent,
-            FCMNotificationContent,
             SMSContent,
             SMSSurveyContent,
         )
@@ -1405,8 +1404,6 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
             return cls.CONTENT_SMS_SURVEY, content.app_id, content.form_unique_id, form_name
         elif isinstance(content, EmailContent):
             return cls.CONTENT_EMAIL, None, None, None
-        elif isinstance(content, FCMNotificationContent):
-            return cls.CONTENT_FCM_Notification, None, None, None
         elif isinstance(content, ConnectMessageContent):
             return cls.CONTENT_CONNECT, None, None, None
         elif isinstance(content, ConnectMessageSurveyContent):

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -90,7 +90,6 @@ from corehq.messaging.scheduling.models import (
     ConnectMessageSurveyContent,
     CustomContent,
     EmailContent,
-    FCMNotificationContent,
     ImmediateBroadcast,
     IVRSurveyContent,
     RandomTimedEvent,
@@ -634,9 +633,6 @@ class ContentForm(Form):
         elif isinstance(content, SMSCallbackContent):
             result['message'] = content.message
             result['sms_callback_intervals'] = ', '.join(str(i) for i in content.reminder_intervals)
-        elif isinstance(content, FCMNotificationContent):
-            result['subject'] = content.subject
-            result['message'] = content.message
         elif isinstance(content, ConnectMessageContent):
             result['message'] = content.message
         elif isinstance(content, ConnectMessageSurveyContent):
@@ -1129,7 +1125,6 @@ class ScheduleForm(Form):
     CONTENT_IVR_SURVEY = 'ivr_survey'
     CONTENT_SMS_CALLBACK = 'sms_callback'
     CONTENT_CUSTOM_SMS = 'custom_sms'
-    CONTENT_FCM_NOTIFICATION = 'fcm_notification'
     CONTENT_CONNECT_MESSAGE = 'connect_message'
     CONTENT_CONNECT_SURVEY = 'connect_survey'
 
@@ -1538,8 +1533,6 @@ class ScheduleForm(Form):
                 content.include_case_updates_in_partial_submissions
         elif isinstance(content, SMSCallbackContent):
             initial['content'] = self.CONTENT_SMS_CALLBACK
-        elif isinstance(content, FCMNotificationContent):
-            initial['content'] = self.CONTENT_FCM_NOTIFICATION
         elif isinstance(content, ConnectMessageContent):
             initial['content'] = self.CONTENT_CONNECT_MESSAGE
         elif isinstance(content, ConnectMessageSurveyContent):
@@ -3195,10 +3188,6 @@ class ConditionalAlertScheduleForm(ScheduleForm):
                 (self.CONTENT_CUSTOM_SMS, _("Custom SMS")),
             ]
 
-        if self.initial.get('content') == self.CONTENT_FCM_NOTIFICATION:
-            self.fields['content'].choices += [
-                (self.CONTENT_FCM_NOTIFICATION, _("Push Notification"))
-            ]
 
     @property
     def current_visit_scheduler_form(self):
@@ -3792,10 +3781,6 @@ class ConditionalAlertScheduleForm(ScheduleForm):
             if self.cleaned_data.get('content') != self.CONTENT_EMAIL:
                 raise ValidationError(_("Email case property can only be used with Email content"))
 
-        if self.cleaned_data.get('content') == self.CONTENT_FCM_NOTIFICATION:
-            raise ValidationError(
-                _("Push Notifications is no longer available. Please contact Administrator.")
-            )
 
     def distill_start_offset(self):
         send_frequency = self.cleaned_data.get('send_frequency')

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -1,29 +1,42 @@
-import jsonfield
 import uuid
 from contextlib import contextmanager
-from memoized import memoized
+
 from django.conf import settings
 from django.db import models, transaction
 from django.http import Http404
+from django.utils.functional import cached_property
+
+import jsonfield
+from memoized import memoized
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_latest_released_app
-from corehq.apps.app_manager.exceptions import AppInDifferentDomainException, FormNotFoundException
+from corehq.apps.app_manager.exceptions import (
+    AppInDifferentDomainException,
+    FormNotFoundException,
+)
 from corehq.apps.data_interfaces.utils import property_references_parent
 from corehq.apps.formplayer_api.smsforms.api import TouchformsError
-from corehq.apps.reminders.util import get_one_way_number_for_recipient, get_two_way_number_for_recipient
-from corehq.apps.sms.api import MessageMetadata, send_sms, send_message_to_verified_number
+from corehq.apps.reminders.util import (
+    get_one_way_number_for_recipient,
+    get_two_way_number_for_recipient,
+)
+from corehq.apps.sms.api import (
+    MessageMetadata,
+    send_message_to_verified_number,
+    send_sms,
+)
 from corehq.apps.sms.forms import (
+    LANGUAGE_FALLBACK_DOMAIN,
     LANGUAGE_FALLBACK_NONE,
     LANGUAGE_FALLBACK_SCHEDULE,
-    LANGUAGE_FALLBACK_DOMAIN,
 )
 from corehq.apps.sms.models import (
+    WORKFLOW_BROADCAST,
+    WORKFLOW_KEYWORD,
+    WORKFLOW_REMINDER,
     MessagingEvent,
     PhoneNumber,
-    WORKFLOW_REMINDER,
-    WORKFLOW_KEYWORD,
-    WORKFLOW_BROADCAST,
 )
 from corehq.apps.sms.util import (
     get_formplayer_exception,
@@ -31,21 +44,23 @@ from corehq.apps.sms.util import (
 )
 from corehq.apps.smsforms.app import start_session
 from corehq.apps.smsforms.models import SQLXFormsSession
-from corehq.apps.smsforms.util import critical_section_for_smsforms_sessions, form_requires_input
+from corehq.apps.smsforms.util import (
+    critical_section_for_smsforms_sessions,
+    form_requires_input,
+)
 from corehq.apps.translations.models import SMSTranslations
 from corehq.apps.users.models import CommCareUser
+from corehq.messaging.scheduling import util
 from corehq.messaging.scheduling.exceptions import (
     NoAvailableContent,
     UnknownContentType,
 )
-from corehq.messaging.scheduling import util
 from corehq.messaging.templating import (
-    _get_obj_template_info,
+    CaseMessagingTemplateParam,
     MessagingTemplateRenderer,
     SimpleDictTemplateParam,
-    CaseMessagingTemplateParam,
+    _get_obj_template_info,
 )
-from django.utils.functional import cached_property
 
 
 @contextmanager
@@ -181,7 +196,10 @@ class Schedule(models.Model):
     @memoized
     def memoized_language_set(self):
         from corehq.messaging.scheduling.models import (
-            ConnectMessageContent, SMSContent, EmailContent, SMSCallbackContent
+            ConnectMessageContent,
+            EmailContent,
+            SMSCallbackContent,
+            SMSContent,
         )
 
         result = set()
@@ -287,8 +305,6 @@ class ContentForeignKeyMixin(models.Model):
             return self.custom_content
         elif self.sms_callback_content_id:
             return self.sms_callback_content
-        elif self.fcm_notification_content:
-            return self.fcm_notification_content
         elif self.connect_message_content:
             return self.connect_message_content
         elif self.connect_survey_content:
@@ -307,9 +323,16 @@ class ContentForeignKeyMixin(models.Model):
 
     @content.setter
     def content(self, value):
-        from corehq.messaging.scheduling.models import (SMSContent, EmailContent, SMSSurveyContent,
-            IVRSurveyContent, CustomContent, SMSCallbackContent, FCMNotificationContent,
-            ConnectMessageContent, ConnectMessageSurveyContent)
+        from corehq.messaging.scheduling.models import (
+            ConnectMessageContent,
+            ConnectMessageSurveyContent,
+            CustomContent,
+            EmailContent,
+            IVRSurveyContent,
+            SMSCallbackContent,
+            SMSContent,
+            SMSSurveyContent,
+        )
 
         self.sms_content = None
         self.email_content = None
@@ -332,8 +355,6 @@ class ContentForeignKeyMixin(models.Model):
             self.custom_content = value
         elif isinstance(value, SMSCallbackContent):
             self.sms_callback_content = value
-        elif isinstance(value, FCMNotificationContent):
-            self.fcm_notification_content = value
         elif isinstance(value, ConnectMessageContent):
             self.connect_message_content = value
         elif isinstance(value, ConnectMessageSurveyContent):


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

https://github.com/dimagi/commcare-hq/pull/37415 was reverted over the concern that for the brief time during deploy there would be chances of the code path being hit that references the model fields directly which could cause a 500. 

The PR picks changes from https://github.com/dimagi/commcare-hq/pull/37415 which were error prone and removes them from the codebase. 

Thing to note is that all the entries of FCMNotificationContent have been removed from the database on all environments. So it is not possible for codepath to fail because the checks are removed.




## Safety Assurance
Should be pretty safe, affects the features that has already been removed from HQ.
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
N/A
### QA Plan
N/A
<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
