### PR TITLE
Add metrics for case property mapping changes

### DIFF
--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -15,6 +15,7 @@ from ..form_action_diff import (
 from ..models import (
     FormActions, UpdateCaseAction, OpenCaseAction
 )
+from ..views.forms import _case_mapping_diff_has_changes
 
 
 class OpenCaseActionApplyDiffTests(SimpleTestCase):
@@ -662,6 +663,44 @@ class FormActionsTests(SimpleTestCase):
         update_form_actions(form_actions, close_case_update, {})
 
         assert form_actions.close_case.condition.type == 'never'
+
+
+class CaseMappingDiffHasChangesTests(SimpleTestCase):
+
+    def test_none(self):
+        assert not _case_mapping_diff_has_changes(None)
+
+    def test_empty(self):
+        assert not _case_mapping_diff_has_changes({})
+
+    def test_empty_open_case(self):
+        assert not _case_mapping_diff_has_changes({"open_case": {}})
+
+    def test_empty_update_case(self):
+        assert not _case_mapping_diff_has_changes({"update_case": {}})
+
+    def test_both_empty(self):
+        assert not _case_mapping_diff_has_changes({"open_case": {}, "update_case": {}})
+
+    def test_empty_actions(self):
+        assert not _case_mapping_diff_has_changes({
+            "open_case": {"add": [], "delete": []},
+            "update_case": {"add": {}, "delete": {}},
+        })
+
+    def test_has_changes(self):
+        diff = {
+            'open_case': {
+                'delete': [{'question_path': 'old_name'}],
+                'add': [{'question_path': 'new_name'}],
+            },
+            'update_case': {
+                'delete': {'one': [{'question_path': 'one'}]},
+                'add': {'two': [{'question_path': 'two'}]},
+            }
+        }
+
+        assert _case_mapping_diff_has_changes(diff)
 
 
 class ConvertUpdateToAddPlusDeleteTests(SimpleTestCase):

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -28,6 +28,7 @@ from text_unidecode import unidecode
 
 from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.analytics.tasks import record_google_analytics_event
 from corehq.apps.app_manager.app_schemas.case_properties import (
     get_all_case_properties,
     get_usercase_properties,
@@ -254,6 +255,13 @@ def edit_form_actions(request, domain, app_id, form_unique_id):
 
     response_json = {}
     app.save(response_json)
+
+    if _case_mapping_diff_has_changes(diff):
+        record_google_analytics_event(
+            METRICS_UPDATE_CASE_PROPERTIES,
+            request.couch_user,
+            {'source': UPDATE_CASE_SOURCE_CASE_MANAGEMENT},
+        )
     response_json['actions'] = make_multi(form.actions.to_json())
     response_json['propertiesMap'] = get_all_case_properties(app)
     response_json['usercasePropertiesMap'] = get_usercase_properties(app)
@@ -344,6 +352,14 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
                     xform = xform.encode('utf-8')
                 case_mapping_diff = _get_case_mapping_diff(request, form)
                 save_xform(app, form, xform, case_mapping_diff)
+                if _case_mapping_diff_has_changes(case_mapping_diff):
+                    # form builder is the only client that submits
+                    # mapping_diff at time of writing, but that could change.
+                    record_google_analytics_event(
+                        METRICS_UPDATE_CASE_PROPERTIES,
+                        request.couch_user,
+                        {'source': UPDATE_CASE_SOURCE_FORM_BUILDER},
+                    )
             else:
                 raise Exception("You didn't select a form to upload")
         except Exception as e:
@@ -552,9 +568,21 @@ def patch_xform(request, domain, app_id, form_unique_id):
         'sha1': hashlib.sha1(xml).hexdigest()
     }
     app.save(response_json)
+
+    if _case_mapping_diff_has_changes(case_mapping_diff):
+        record_google_analytics_event(
+            METRICS_UPDATE_CASE_PROPERTIES,
+            request.couch_user,
+            {'source': UPDATE_CASE_SOURCE_FORM_BUILDER},
+        )
+
     _add_case_management_data(response_json, form, request)
     return JsonResponse(response_json)
 
+
+METRICS_UPDATE_CASE_PROPERTIES = 'update_case_properties'
+UPDATE_CASE_SOURCE_FORM_BUILDER = 'formbuilder'
+UPDATE_CASE_SOURCE_CASE_MANAGEMENT = 'casemanagement'
 
 # Characters that JS encodeURI preserves (beyond letters/digits which
 # Python's quote already preserves). Used to match encodeURI behavior
@@ -581,6 +609,10 @@ def _get_case_mapping_diff(request, form):
             is_registration=form.is_registration_form(),
         )
     return case_mapping_diff
+
+
+def _case_mapping_diff_has_changes(diff):
+    return diff and any(any(v.values()) for v in diff.values())
 
 
 def _get_xform_conflict_response(form, sha1_checksum):


### PR DESCRIPTION
## Product Description
Track when users modify case property mappings in an app form, distinguishing between edits made via the form builder and edits made via the case management UI. This gives the product team visibility into how case property mappings are being configured.

https://dimagi.atlassian.net/browse/SAAS-17605

## Feature Flag
`FORMBUILDER_SAVE_TO_CASE`

## Safety Assurance

### Safety story
Analytics-only change. The new code path is gated behind `_case_mapping_diff_has_changes`, runs after the app has already been saved, and only issues a Google Analytics event — it cannot affect form save behavior or app data. Risk is low.

### Automated test coverage
Yes

### QA Plan
No QA

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations
