### PR TITLE
Add Locked Admin Questions feature flags for development

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -325,6 +325,9 @@ def _get_vellum_plugins(domain, form, module, options):
         vellum_plugins.append("saveToCase")
     if toggles.COMMCARE_CONNECT.enabled(domain):
         vellum_plugins.append("commcareConnect")
+    if toggles.LOCKED_ADMIN_QUESTIONS.enabled(domain, namespace=toggles.NAMESPACE_DOMAIN):
+        # replace with privilege check once added to appropriate software plan(s)
+        vellum_plugins.append("lock")
 
     form_uses_case = (
         (module and module.case_type and form.requires_case())

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1200,6 +1200,15 @@ VELLUM_ALLOW_BULK_FORM_ACTIONS = StaticToggle(
                 "the Form Builder's main dropdown menu.",
 )
 
+LOCKED_ADMIN_QUESTIONS = FeatureRelease(
+    'locked_admin_questions',
+    "Locked Admin Questions",
+    TAG_RELEASE,
+    [NAMESPACE_DOMAIN],
+    owner="Evan Joseph-Pinero",
+    description="Enables Locked Admin Questions workflows in HQ and the form builder.",
+)
+
 CACHE_AND_INDEX = StaticToggle(
     'cache_and_index',
     'REC: Enable the "Cache and Index" format option when choosing sort properties '

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1209,6 +1209,15 @@ LOCKED_ADMIN_QUESTIONS = FeatureRelease(
     description="Enables Locked Admin Questions workflows in HQ and the form builder.",
 )
 
+EDIT_LOCKED_QUESTIONS = FeatureRelease(
+    'edit_locked_questions',
+    "Edit Locked Admin Questions",
+    TAG_RELEASE,
+    [NAMESPACE_USER],
+    owner="Evan Joseph-Pinero",
+    description="Allows locking and unlocking questions in forms."
+)
+
 CACHE_AND_INDEX = StaticToggle(
     'cache_and_index',
     'REC: Enable the "Cache and Index" format option when choosing sort properties '


### PR DESCRIPTION
## Product Description
Allows access to the in-development Locked Admin Questions feature when the appropriate feature flag(s) are enabled.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19546
Adds two feature flags, domain-level and user-level, to enable Locked Admin Questions functionality in the form builder (Vellum) while this feature is in development. The `edit_locked_questions` flag requires nothing additional to pass into Vellum, as feature flags are already passed in from HQ as `vellum_features`: https://github.com/dimagi/commcare-hq/blob/a271aca99c143e8ba008df5d1a0b2ab07cc8ed88/corehq/apps/app_manager/views/formdesigner.py#L347-L348

## Feature Flag
LOCKED_ADMIN_QUESTIONS, EDIT_LOCKED_QUESTIONS

## Safety Assurance

### Safety story
Checked these feature flags have the intended effects when working in the form builder locally.

### Automated test coverage
n/a

### QA Plan
Not for this change.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
