### PR TITLE
Remove server-side case name auto-assignment on form save

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -188,7 +188,9 @@ def save_xform(app, form, xml, case_mapping_diff=None):
     form.source = xml.decode('utf-8')
 
     from corehq.apps.app_manager.models import ConditionalCaseUpdate
-    if form.is_registration_form():
+    if form.is_registration_form() and case_mapping_diff is None:
+        # Except for AdvancedForms, this is now handled by
+        # Case Management in the Form Builder.
         # For registration forms, assume that the first question is the
         # case name unless something else has been specified
         questions = form.get_questions([app.default_language])

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -260,6 +260,7 @@ def _get_base_vellum_options(request, domain, form, displayLang):
             'properties': sorted(get_case_properties(domain, case_type).values_list('name', flat=True)),
             'view_form_url': reverse('view_form', args=[domain, app.id, form.unique_id]),
             'reserved_words': load_case_reserved_words(),
+            'is_registration_form': form.is_registration_form(),
         }
 
     if toggles.VELLUM_SAVE_TO_CASE.enabled(domain):

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -601,14 +601,19 @@ def apply_patch(patch, text):
 
 
 def _get_case_mapping_diff(request, form):
-    case_mapping_diff = None
     has_vellum_case_mapping = toggles.FORMBUILDER_SAVE_TO_CASE.enabled_for_request(request)
-    if has_vellum_case_mapping and 'mapping_diff' in request.POST:
-        case_mapping_diff = from_combined_diff(
-            json.loads(request.POST['mapping_diff']),
-            is_registration=form.is_registration_form(),
-        )
-    return case_mapping_diff
+    is_advanced_form = isinstance(form, AdvancedForm)
+    if has_vellum_case_mapping and not is_advanced_form:
+        if 'case_mapping_diff' in request.POST:
+            return json.loads(request.POST['case_mapping_diff'])
+        if 'mapping_diff' in request.POST:
+            # Legacy, can be removed when Vellum always sends case_mapping_diff
+            return from_combined_diff(
+                json.loads(request.POST['mapping_diff']),
+                is_registration=form.is_registration_form(),
+            )
+        return {}  # not None, prevent name mapping in save_xform
+    return None
 
 
 def _case_mapping_diff_has_changes(diff):


### PR DESCRIPTION
## Product Description

When saving a registration form, HQ previously auto-assigned the first question to the case name if the case name had no mapping. This behavior is now [handled by the Form Builder](https://github.com/dimagi/Vellum/pull/1224) (Vellum) instead, giving form designers direct visibility and control over the case name mapping. The server-side auto-assignment is retained only for Advanced Forms, which are not yet managed by Vellum's case management.

## Technical Summary

- Stop auto-assigning case name in `save_xform` when a case mapping diff is provided, deferring to Vellum's case management
- Send the `is_registration_form` flag to Vellum so it can handle the case name default on its side
- Add support for a new `case_mapping_diff` POST parameter (standard format), with backward compatibility for the legacy `mapping_diff` format. A future enhancement to Vellum will use this new parameter to send the same diff format as that sent by `case_config_ui.js`, which is possible now that it has `is_registration_form`.

## Feature Flag

`FORMBUILDER_SAVE_TO_CASE`

## Safety Assurance

### Safety story

The auto-assignment behavior change only applies when the `FORMBUILDER_SAVE_TO_CASE` feature flag is enabled and the form is not an Advanced Form. Advanced Forms retain the existing behavior. The legacy `mapping_diff` format is still supported for backward compatibility during the Vellum transition.

### Automated test coverage

No.

### QA Plan

No QA.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
