### PR TITLE
Fix merge commit regex in rebuild-staging workflow

### DIFF
--- a/.github/workflows/rebuild-staging.yml
+++ b/.github/workflows/rebuild-staging.yml
@@ -45,7 +45,7 @@ jobs:
         # Extract branch name from the first line of the merge commit message
         # Format: "Merge pull request #NNN from owner/branch-name"
         FIRST_LINE="${COMMIT_MSG%%$'\n'*}"
-        if [[ "$FIRST_LINE" =~ ^Merge\ pull\ request\ \#[0-9]+\ from\ [^/]+/(\S+) ]]; then
+        if [[ "$FIRST_LINE" =~ ^Merge\ pull\ request\ \#[0-9]+\ from\ [^/]+/([^[:space:]]+) ]]; then
           MERGED_BRANCH="${BASH_REMATCH[1]}"
           echo "Detected merged branch: $MERGED_BRANCH"
 


### PR DESCRIPTION
## Product Description

No user-facing changes.

## Technical Summary

Bash regex uses POSIX ERE which doesn't support Perl shortcuts like `\S`.
Replace `\S+` with `[^[:space:]]+` in the merge commit parser so the
`check-merged` step actually captures the branch name.

This bug was introduced in #37598 and caused the `remove-merged-branch` job
to be silently skipped on merges to master. Verified in [run 24531987963](https://github.com/dimagi/commcare-hq/actions/runs/24531987963):
the commit message `Merge pull request #37598 from dimagi/dmr/auto-remove-merged-branches`
did not match the regex, so the workflow fell through to `rebuild-staging`
which then failed because the deleted branch was still in the config.

Tested locally on Ubuntu bash 5.2:
- `\S+` → NO MATCH
- `[^[:space:]]+` → MATCH: `dmr/auto-remove-merged-branches`

[SAAS-19618](https://dimagi.atlassian.net/browse/SAAS-19618)

## Feature Flag

N/A

## Safety Assurance

### Safety story

One-line change to a regex in a GitHub Actions workflow. Verified the fix
locally against bash 5.2 (matches the GHA runner's bash version).

### Automated test coverage

GitHub Actions workflows cannot be unit tested.

### QA Plan

After merging, the next PR merge of a staging-listed branch should trigger
the `remove-merged-branch` job instead of `rebuild-staging`.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SAAS-19618]: https://dimagi.atlassian.net/browse/SAAS-19618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ