### PR TITLE
Fix API key as PW for 2FA required users

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -239,7 +239,7 @@ class ApiKeyFallbackBackend(object):
             for key in keys_qs:
                 if key.plaintext_key == password:
                     request.api_key_authenticated = True
-                    request.skip_two_factor_check = True
+                    request.bypass_two_factor = True
                     return user
             return None
         except User.DoesNotExist:

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -520,7 +520,7 @@ def two_factor_check(view_func, api_key):
                 request.user.otp_device = otp_device
                 request.user.is_verified = lambda: True
                 return fn(request, domain, *args, **kwargs)
-            if api_key:
+            if api_key or getattr(request, 'skip_two_factor_check', False):
                 request.bypass_two_factor = True
             return fn(request, domain, *args, **kwargs)
         return _inner

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -500,7 +500,7 @@ def two_factor_check(view_func, api_key):
             _ensure_request_couch_user(request)
             if (
                 not api_key
-                and not getattr(request, 'skip_two_factor_check', False)
+                and not getattr(request, 'bypass_two_factor', False)
                 and domain_obj
                 and _two_factor_required(view_func, domain_obj, request)
             ):
@@ -520,7 +520,7 @@ def two_factor_check(view_func, api_key):
                 request.user.otp_device = otp_device
                 request.user.is_verified = lambda: True
                 return fn(request, domain, *args, **kwargs)
-            if api_key or getattr(request, 'skip_two_factor_check', False):
+            if api_key:
                 request.bypass_two_factor = True
             return fn(request, domain, *args, **kwargs)
         return _inner

--- a/corehq/apps/domain/tests/test_two_factor_check.py
+++ b/corehq/apps/domain/tests/test_two_factor_check.py
@@ -136,16 +136,12 @@ class TestApiKeyBasicAuthWithTwoFactor(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.domain = create_domain(cls.domain_name)
+        cls.addClassCleanup(cls.domain.delete)
         cls.domain.two_factor_auth = True
         cls.domain.save()
         cls.user = WebUser.create( cls.domain_name, 'test@dimagi.com', 'password', None, None, is_admin=True,)
+        cls.addClassCleanup(cls.user.delete, cls.domain_name, deleted_by=None)
         cls.api_key = HQApiKey.objects.create(user=cls.user.get_django_user()).plaintext_key
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete(cls.domain_name, deleted_by=None)
-        cls.domain.delete()
-        super().tearDownClass()
 
     def test_api_key_basic_auth_with_two_factor_domain(self):
         encoded_creds = base64.b64encode(f'test@dimagi.com:{self.api_key}'.encode()).decode()

--- a/corehq/apps/domain/tests/test_two_factor_check.py
+++ b/corehq/apps/domain/tests/test_two_factor_check.py
@@ -1,16 +1,20 @@
+import base64
 import json
 from unittest.mock import Mock, patch
 
+from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory, TestCase, override_settings
 
 from corehq.apps.domain.decorators import (
     OTP_AUTH_FAIL_RESPONSE,
     _two_factor_required,
+    api_auth,
     two_factor_check,
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.sso.tests.generator import create_request_session
-from corehq.apps.users.models import CouchUser
+from corehq.apps.users.decorators import require_permission
+from corehq.apps.users.models import CouchUser, HQApiKey, HqPermissions, WebUser
 
 
 class TestTwoFactorRequired(TestCase):
@@ -124,21 +128,38 @@ class TestTwoFactorCheck(TestCase):
             data = json.loads(response.content)
             self.assertDictEqual(data, OTP_AUTH_FAIL_RESPONSE)
 
-    @patch('corehq.apps.domain.decorators._ensure_request_couch_user')
-    @patch('corehq.apps.domain.decorators.Domain.get_by_name', new=lambda _: Mock(two_factor_auth=True))
-    def test_skip_two_factor_check_sets_bypass(self, mock_ensure_couch_user):
-        """When skip_two_factor_check is set (e.g. API key auth via basic auth),
-        two_factor_check should set bypass_two_factor
-        """
-        mock_ensure_couch_user.return_value = self.request.couch_user
-        self.request.skip_two_factor_check = True
 
-        @two_factor_check('dummy_view', api_key=False)
-        def view(request, domain):
-            return request
+class TestApiKeyBasicAuthWithTwoFactor(TestCase):
+    domain_name = 'two-factor-api-test'
 
-        request = view(self.request, 'test_domain')
-        self.assertTrue(
-            getattr(request, 'bypass_two_factor', False),
-            "bypass_two_factor should be set when skip_two_factor_check is True",
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = create_domain(cls.domain_name)
+        cls.domain.two_factor_auth = True
+        cls.domain.save()
+        cls.user = WebUser.create( cls.domain_name, 'test@dimagi.com', 'password', None, None, is_admin=True,)
+        cls.api_key = HQApiKey.objects.create(user=cls.user.get_django_user()).plaintext_key
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(cls.domain_name, deleted_by=None)
+        cls.domain.delete()
+        super().tearDownClass()
+
+    def test_api_key_basic_auth_with_two_factor_domain(self):
+        encoded_creds = base64.b64encode(f'test@dimagi.com:{self.api_key}'.encode()).decode()
+        request = RequestFactory().get(
+            f'/a/{self.domain_name}/api/case/v2/',
+            HTTP_AUTHORIZATION=f'Basic {encoded_creds}',
         )
+        request.user = AnonymousUser()  # User hasn't been established yet
+
+        @api_auth(allow_creds_in_data=False)
+        @require_permission(HqPermissions.edit_data)
+        def view(request, domain):
+            from django.http import HttpResponse
+            return HttpResponse('ok')
+
+        response = view(request, self.domain_name)
+        self.assertEqual(response.status_code, 200)

--- a/corehq/apps/domain/tests/test_two_factor_check.py
+++ b/corehq/apps/domain/tests/test_two_factor_check.py
@@ -123,3 +123,22 @@ class TestTwoFactorCheck(TestCase):
 
             data = json.loads(response.content)
             self.assertDictEqual(data, OTP_AUTH_FAIL_RESPONSE)
+
+    @patch('corehq.apps.domain.decorators._ensure_request_couch_user')
+    @patch('corehq.apps.domain.decorators.Domain.get_by_name', new=lambda _: Mock(two_factor_auth=True))
+    def test_skip_two_factor_check_sets_bypass(self, mock_ensure_couch_user):
+        """When skip_two_factor_check is set (e.g. API key auth via basic auth),
+        two_factor_check should set bypass_two_factor
+        """
+        mock_ensure_couch_user.return_value = self.request.couch_user
+        self.request.skip_two_factor_check = True
+
+        @two_factor_check('dummy_view', api_key=False)
+        def view(request, domain):
+            return request
+
+        request = view(self.request, 'test_domain')
+        self.assertTrue(
+            getattr(request, 'bypass_two_factor', False),
+            "bypass_two_factor should be set when skip_two_factor_check is True",
+        )


### PR DESCRIPTION

## Product Description
Fixes 500 error when making API requests with an API key via basic auth against a domain that requires two-factor authentication.

## Technical Summary
https://dimagi.sentry.io/issues/6902381816/?project=136860&query=is%3Aunresolved&referrer=issue-stream
Looks like it dates back to just after this functionality was enabled in https://github.com/dimagi/commcare-hq/pull/36864
Also feels adjacent to https://github.com/dimagi/commcare-hq/pull/37408 (though not directly related)

There core problem was that we had two different flags for skipping 2FA requirements, and there were some code paths that didn't account for both.  The more fundamental problem, IMO is that we have authentication happen in middleware most of the time, but sometimes in view decorators.  This makes everything around it just kinda messy.

## Feature Flag


## Safety Assurance


### Safety story
The footprint of the change is super small, local and automated testing should be sufficient.

### Automated test coverage
Included


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
