### PR TITLE
Remove outdated troubleshooting notes from DEV_SETUP

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -488,12 +488,6 @@ If you have trouble with your first run of `./manage.py sync_couch_views`:
 - If you encounter an authorization error related to CouchDB, try going to your
   `localsettings.py` file and change `COUCH_PASSWORD` to an empty string.
 
-- If you get errors saying "Segmentation fault (core dumped)", with a warning like
-  "RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility.
-  Expected 144 from C header, got 152 from PyObject" check that your Python version is correct (3.9).
-  Alternatively, you can try upgrading `gevent` (`uv pip install --upgrade gevent`) to fix this error
-  on Python 3.8, but you may run into other issues!
-
 ### Step 6: Populate Elasticsearch
 
 To set up elasticsearch indexes run the following:


### PR DESCRIPTION
## Product Description
None — developer documentation change.

## Technical Summary
Removes a stale troubleshooting note in `DEV_SETUP.md` about `greenlet`/`gevent` segfaults tied to Python 3.8/3.9. The project has since moved past those Python versions, so the guidance no longer applies and is misleading to new developers setting up their environment.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Documentation-only change with no runtime impact.

### Automated test coverage
N/A — documentation change.

### QA Plan
N/A — documentation change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change