### PR TITLE
Update case search feature flag links and descriptions

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -941,8 +941,9 @@ SYNC_SEARCH_CASE_CLAIM = StaticToggle(
     'search_claim',
     'Simple Case Search',
     TAG_FROZEN,
-    help_link='https://dimagi.atlassian.net/wiki/spaces/GS/pages/2146606528/Case+Search+and+Claim',
-    namespaces=[NAMESPACE_DOMAIN]
+    help_link='https://dimagi.atlassian.net/wiki/spaces/uss/pages/3675717639/Simple+Case+Search',
+    description="Basic case search functionality",
+    namespaces=[NAMESPACE_DOMAIN],
 )
 
 CASE_SEARCH_DEPRECATED = StaticToggle(
@@ -958,7 +959,8 @@ CASE_SEARCH_ADVANCED = StaticToggle(
     'case_search_advanced',
     'Advanced Case Search',
     TAG_FROZEN,
-    help_link='https://dimagi.atlassian.net/wiki/spaces/GS/pages/2146606528/Case+Search+and+Claim',
+    help_link='https://dimagi.atlassian.net/wiki/spaces/uss/pages/3676536837/Advanced+Case+Search',
+    description="Complex, fragile case search configuration for USS projects",
     namespaces=[NAMESPACE_DOMAIN],
     parent_toggles=[SYNC_SEARCH_CASE_CLAIM],
 )
@@ -967,7 +969,8 @@ CASE_SEARCH_RELATED_LOOKUPS = StaticToggle(
     'case_search_related_lookups',
     'Case Search: Related Lookups',
     TAG_FROZEN,
-    help_link='https://dimagi.atlassian.net/wiki/spaces/GS/pages/2146606528/Case+Search+and+Claim',
+    help_link='https://dimagi.atlassian.net/wiki/spaces/uss/pages/3676635261/Case+Search+Related+Lookups',
+    description="Allows access to less-performant, complex related lookups in case search. USS only.",
     namespaces=[NAMESPACE_DOMAIN],
     parent_toggles=[CASE_SEARCH_ADVANCED],
 )


### PR DESCRIPTION
## Product Description
Updates the help links and adds descriptions on the admin feature-flag edit pages for three case-search flags, so internal users see accurate pointers to the current USS wiki pages.

## Technical Summary
[USH-6514](https://dimagi.atlassian.net/browse/USH-6514). Old `help_link` URLs pointed to an outdated `GS` space page (`Case+Search+and+Claim`). Each flag now links to its dedicated `uss` space page and has a short `description` that shows up on the flag's edit page.

No logic or behavior changes; only metadata on `StaticToggle` declarations in `corehq/toggles/__init__.py`.

## Feature Flag
Changes metadata on existing flags.

- Simple Case Search (`search_claim`)
- Advanced Case Search (`case_search_advanced`)
- Case Search: Related Lookups (`case_search_related_lookups`)

## Safety Assurance

### Safety story
Strings-only change to feature-flag declarations. No code paths, data, or migrations are affected.

### Automated test coverage
Not applicable — no behavior to test.

### QA Plan
Visit the three flag edit pages and confirm the updated description and wiki link appear:
- `/hq/flags/edit/search_claim/`
- `/hq/flags/edit/case_search_advanced/`
- `/hq/flags/edit/case_search_related_lookups/`

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[USH-6514]: https://dimagi.atlassian.net/browse/USH-6514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ