### PR TITLE
Add feature flag to tell formplayer to use specific cache key.

### DIFF
--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -972,6 +972,17 @@ CASE_SEARCH_RELATED_LOOKUPS = StaticToggle(
     parent_toggles=[CASE_SEARCH_ADVANCED],
 )
 
+CASE_SEARCH_CACHE_KEY = StaticToggle(
+    'case_search_cache_key',
+    'Case Search: Formplayer cache key',
+    TAG_GA_PATH,
+    description="""
+        If set formplayer will use a more specific cache key. This is meant to fix a bug but the
+        perfomance implications are not clear. Hence the FF.""",
+    namespaces=[NAMESPACE_DOMAIN],
+    parent_toggles=[SYNC_SEARCH_CASE_CLAIM],
+)
+
 USH_CASE_LIST_MULTI_SELECT = StaticToggle(
     'ush_case_list_multi_select',
     'USH: Allow selecting multiple cases from the case list',


### PR DESCRIPTION
## Product Description

Add feature flag to be used in formplayer. We think there is a bug caused by
poluted caches. This will tell formplayer to use more specific keys.

The performance implications are not quite clear. So we are putting the
functionality behind a FF so we can test it

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6536

## Feature Flag

CASE_SEARCH_CACHE_KEY

## Safety Assurance

See: https://github.com/dimagi/formplayer/pull/1770

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
