### PR TITLE
Remove case search label configuration

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -375,7 +375,7 @@ def _create_case_search_app_strings(
         if toggles.SYNC_SEARCH_CASE_CLAIM.enabled(app.domain):
             yield (
                 id_strings.case_search_locale(module),
-                clean_trans({'en': 'Search All Cases'}, langs)
+                clean_trans(module.search_config.search_button_label, langs)
             )
 
             title_label = module.search_config.get_search_title_label(app, lang, for_default=for_default)
@@ -397,7 +397,7 @@ def _create_case_search_app_strings(
             )
             yield (
                 id_strings.case_search_locale(module),
-                clean_trans({'en': 'Search All Cases'}, langs)
+                clean_trans(module.search_config.search_button_label, langs)
             )
 
         for prop in module.search_config.properties:

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -373,25 +373,10 @@ def _create_case_search_app_strings(
         from corehq.apps.app_manager.models import CaseSearch
 
         if toggles.SYNC_SEARCH_CASE_CLAIM.enabled(app.domain):
-            # search label
             yield (
                 id_strings.case_search_locale(module),
-                clean_trans(module.search_config.search_label.label, langs)
+                clean_trans({'en': 'Search All Cases'}, langs)
             )
-            icon = module.search_config.search_label.icon_app_string(
-                lang,
-                for_default,
-                build_profile_id,
-            )
-            if icon:
-                yield id_strings.case_search_icon_locale(module), icon
-            audio = module.search_config.search_label.audio_app_string(
-                lang,
-                for_default,
-                build_profile_id,
-            )
-            if audio:
-                yield id_strings.case_search_audio_locale(module), audio
 
             title_label = module.search_config.get_search_title_label(app, lang, for_default=for_default)
             if app.enable_case_search_title_translation:
@@ -412,7 +397,7 @@ def _create_case_search_app_strings(
             )
             yield (
                 id_strings.case_search_locale(module),
-                clean_trans(CaseSearch.search_label.default().label, langs)
+                clean_trans({'en': 'Search All Cases'}, langs)
             )
 
         for prop in module.search_config.properties:

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -246,16 +246,6 @@ def case_search_locale(module):
     return "case_search.m{module.id}".format(module=module)
 
 
-@pattern('case_search.m%d.icon')
-def case_search_icon_locale(module):
-    return "case_search.m{module.id}.icon".format(module=module)
-
-
-@pattern('case_search.m%d.audio')
-def case_search_audio_locale(module):
-    return "case_search.m{module.id}.audio".format(module=module)
-
-
 @pattern('case_search.m%d.again')
 def case_search_again_locale(module):
     return "case_search.m{module.id}.again".format(module=module)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2240,7 +2240,6 @@ class CaseSearch(DocumentSchema):
     - search_label: Removed; search button always uses default label (Apr 2026)
       These fields may still exist in CouchDB documents but are no longer used.
     """
-    command_label = LabelProperty(default={'en': 'Search All Cases'})
     properties = SchemaListProperty(CaseSearchProperty)
     auto_launch = BooleanProperty(default=False)        # if true, skip the casedb case list
     default_search = BooleanProperty(default=False)     # if true, skip the search fields screen

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2240,6 +2240,7 @@ class CaseSearch(DocumentSchema):
     - search_label: Removed; search button always uses default label (Apr 2026)
       These fields may still exist in CouchDB documents but are no longer used.
     """
+    search_button_label = LabelProperty(default={'en': 'Search All Cases'})
     properties = SchemaListProperty(CaseSearchProperty)
     auto_launch = BooleanProperty(default=False)        # if true, skip the casedb case list
     default_search = BooleanProperty(default=False)     # if true, skip the search fields screen

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2228,15 +2228,6 @@ class CaseSearchCustomSortProperty(DocumentSchema):
     direction = StringProperty()
 
 
-class BaseCaseSearchLabel(NavMenuItemMediaMixin):
-    def get_app(self):
-        return self._module.get_app()
-
-
-class CaseSearchLabel(BaseCaseSearchLabel):
-    label = LabelProperty(default={'en': 'Search All Cases'})
-
-
 class CaseSearch(DocumentSchema):
     """
     Properties and search command label
@@ -2245,9 +2236,11 @@ class CaseSearch(DocumentSchema):
     - again_label: Removed with SSCS migration (Feb 2026)
     - search_again_label: Removed with SSCS migration (Feb 2026)
       These fields may still exist in CouchDB documents but are no longer used.
+    - command_label: Superseded by search_label (2021 migration)
+    - search_label: Removed; search button always uses default label (Apr 2026)
+      These fields may still exist in CouchDB documents but are no longer used.
     """
     command_label = LabelProperty(default={'en': 'Search All Cases'})
-    search_label = SchemaProperty(CaseSearchLabel)
     properties = SchemaListProperty(CaseSearchProperty)
     auto_launch = BooleanProperty(default=False)        # if true, skip the casedb case list
     default_search = BooleanProperty(default=False)     # if true, skip the search fields screen
@@ -2406,7 +2399,6 @@ class ModuleBase(IndexedSchema, ModuleMediaMixin, NavMenuItemMediaMixin, Comment
         if hasattr(self, 'case_list_form'):
             self.case_list_form._module = self
         if hasattr(self, 'search_config'):
-            self.search_config.search_label._module = self
             self.search_config.title_label._module = self
             self.search_config.description._module = self
 

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -204,7 +204,7 @@ var additionalRegistryCaseModel = function (xpath, saveButton) {
 
 var searchConfigKeys = [
     'auto_launch', 'blacklisted_owner_ids_expression', 'default_search',
-    'title_label', 'description', 'search_button_display_condition', 'search_label', 'search_filter',
+    'title_label', 'description', 'search_button_display_condition', 'search_filter',
     'additional_relevant', 'data_registry', 'data_registry_workflow', 'additional_registry_cases',
     'custom_related_case_property', 'inline_search', 'instance_name', 'include_all_related_cases',
     'search_on_clear',
@@ -212,7 +212,6 @@ var searchConfigKeys = [
 var searchConfigModel = function (options, lang, searchFilterObservable, saveButton) {
     assertProperties.assertRequired(options, searchConfigKeys);
 
-    options.search_label = options.search_label[lang] || "";
     options.title_label = options.title_label[lang] || "";
     options.description = options.description[lang] || "";
     var mapping = {
@@ -299,14 +298,6 @@ var searchConfigModel = function (options, lang, searchFilterObservable, saveBut
     self.serialize = function () {
         var data = ko.mapping.toJS(self);
         data.additional_registry_cases = data.data_registry_workflow === "load_case" ? _.pluck(data.additional_registry_cases, 'caseIdXpath') : [];
-        _.each(['search_label'], function (label) {
-            _.each(['image', 'audio'], function (media) {
-                var key = label + "_" + media,
-                    selector = "#case_search-" + label + "_media_media_" + media + " input[type='hidden']";
-                data[key] = $(selector + "[name='case_search-" + label + "_media_media_" + media + "']").val();
-                data[key + "_for_all"] = $(selector + "[name='case_search-" + label + "_media_use_default_" + media + "_for_all']").val();
-            });
-        });
         return data;
     };
 

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -408,12 +408,6 @@ class DetailContributor(SectionContributor):
                 menu_locale_id=(
                     id_strings.case_search_locale(module)
                 ),
-                image_locale_id=(
-                    id_strings.case_search_icon_locale(module)
-                ),
-                audio_locale_id=(
-                    id_strings.case_search_audio_locale(module)
-                ),
                 stack=Stack(),
                 for_action_menu=True,
                 **action_kwargs,

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -403,14 +403,13 @@ class DetailContributor(SectionContributor):
 
         action_kwargs = DetailContributor._get_action_kwargs(module, in_search)
 
-        search_label = module.search_config.search_label
         if module.get_app().enable_localized_menu_media:
             action = LocalizedAction(
                 menu_locale_id=(
                     id_strings.case_search_locale(module)
                 ),
-                media_image=search_label.uses_image(build_profile_id=build_profile_id),
-                media_audio=search_label.uses_audio(build_profile_id=build_profile_id),
+                media_image=False,
+                media_audio=False,
                 image_locale_id=(
                     id_strings.case_search_icon_locale(module)
                 ),
@@ -427,8 +426,6 @@ class DetailContributor(SectionContributor):
                     text=Text(locale_id=(
                         id_strings.case_search_locale(module)
                     )),
-                    media_image=search_label.default_media_image,
-                    media_audio=search_label.default_media_audio
                 ),
                 stack=Stack(),
                 **action_kwargs

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -408,8 +408,6 @@ class DetailContributor(SectionContributor):
                 menu_locale_id=(
                     id_strings.case_search_locale(module)
                 ),
-                media_image=False,
-                media_audio=False,
                 image_locale_id=(
                     id_strings.case_search_icon_locale(module)
                 ),

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_search_properties.html
@@ -311,36 +311,7 @@
               </div>
             </div>
           {% endif %}
-          {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
-            <div class="form-group" data-bind="hidden: inlineSearchActive">
-              <label
-                for="search_label"
-                class="{% css_label_class %} control-label"
-              >
-                {% trans "Label for Searching" %}
-                <span
-                  class="hq-help-template"
-                  data-title="{% trans "Label for Searching" %}"
-                  data-content="{% trans_html_attr "This text is for the button to enter case search. It is also the header on the search results screen." %}"
-                >
-                </span>
-              </label>
-              <div class="{% css_field_class %}">
-                {% input_trans module.search_config.search_label.label langs input_name='search_label' input_id='search_label' data_bind="value: search_label" %}
-              </div>
-            </div>
-          {% endif %}
           {% if request|toggle_enabled:'SYNC_SEARCH_CASE_CLAIM' %}
-            <div
-              class="case-search-multimedia-input"
-              data-bind="hidden: inlineSearchActive"
-            >
-              <!-- stopBinding to avoid conflicts with the binding of enclosing template to a different object 'search'-->
-              <!-- binding for this partial is done via app_manager/js/nav_menu_media-->
-              <!-- ko stopBinding: true -->
-              {% include "app_manager/partials/bootstrap3/nav_menu_media.html" with qualifier='case_search-search_label_media_' ICON_LABEL="Search Icon" AUDIO_LABEL="Search Audio" %}
-              <!-- /ko -->
-            </div>
             <div class="form-group">
               <label
                 for="search_screen_title"

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_search_properties.html
@@ -311,36 +311,7 @@
               </div>
             </div>
           {% endif %}
-          {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
-            <div class="form-group" data-bind="hidden: inlineSearchActive">  {# todo B5: css-form-group #}
-              <label
-                for="search_label"
-                class="{% css_label_class %} form-label"
-              >
-                {% trans "Label for Searching" %}
-                <span
-                  class="hq-help-template"
-                  data-title="{% trans "Label for Searching" %}"
-                  data-content="{% trans_html_attr "This text is for the button to enter case search. It is also the header on the search results screen." %}"
-                >
-                </span>
-              </label>
-              <div class="{% css_field_class %}">
-                {% input_trans module.search_config.search_label.label langs input_name='search_label' input_id='search_label' data_bind="value: search_label" %}
-              </div>
-            </div>
-          {% endif %}
           {% if request|toggle_enabled:'SYNC_SEARCH_CASE_CLAIM' %}
-            <div
-              class="case-search-multimedia-input"
-              data-bind="hidden: inlineSearchActive"
-            >
-              <!-- stopBinding to avoid conflicts with the binding of enclosing template to a different object 'search'-->
-              <!-- binding for this partial is done via app_manager/js/nav_menu_media-->
-              <!-- ko stopBinding: true -->
-              {% include "app_manager/partials/bootstrap5/nav_menu_media.html" with qualifier='case_search-search_label_media_' ICON_LABEL="Search Icon" AUDIO_LABEL="Search Audio" %}
-              <!-- /ko -->
-            </div>
             <div class="form-group">  {# todo B5: css-form-group #}
               <label
                 for="search_screen_title"

--- a/corehq/apps/app_manager/tests/app_factory.py
+++ b/corehq/apps/app_manager/tests/app_factory.py
@@ -225,9 +225,6 @@ class AppFactory(object):
         case_module.case_list_form.label = {
             'en': 'New Case',
         }
-        case_module.search_config.search_label.label = {
-            'en': 'Find a Mother',
-        }
         case_module.search_config.title_label = {
             'en': 'Find a Mom',
         }

--- a/corehq/apps/app_manager/tests/data/suite/case-search-with-action.xml
+++ b/corehq/apps/app_manager/tests/data/suite/case-search-with-action.xml
@@ -4,7 +4,6 @@
       <text>
         <locale id="case_search.m0"/>
       </text>
-      <media audio="jr://file/commcare/image/2.mp3" image="jr://file/commcare/image/1.png"/>
     </display>
     <stack>
       <push>

--- a/corehq/apps/app_manager/tests/data/suite/case-search-with-localized-action.xml
+++ b/corehq/apps/app_manager/tests/data/suite/case-search-with-localized-action.xml
@@ -4,12 +4,6 @@
       <text>
         <locale id="case_search.m0"/>
       </text>
-      <text form="image">
-        <locale id="case_search.m0.icon"/>
-      </text>
-      <text form="audio">
-        <locale id="case_search.m0.audio"/>
-      </text>
     </display>
     <stack>
       <push>

--- a/corehq/apps/app_manager/tests/test_app_strings.py
+++ b/corehq/apps/app_manager/tests/test_app_strings.py
@@ -14,7 +14,6 @@ from corehq.apps.app_manager.models import (
     Application,
     BuildProfile,
     CaseSearch,
-    CaseSearchLabel,
     CaseSearchProperty,
     MappingItem,
 )
@@ -166,14 +165,6 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
         })
         module, form = factory.new_basic_module('my_module', 'cases')
         module.search_config = CaseSearch(
-            search_label=CaseSearchLabel(
-                label={'en': 'Get them', 'es': 'Conseguirlos'},
-                media_image={
-                    'en': "jr://file/commcare/image/1.png",
-                    'es': "jr://file/commcare/image/1_es.png"
-                },
-                media_audio={'en': "jr://file/commcare/image/2.mp3"}
-            ),
             properties=[
                 CaseSearchProperty(is_group=True, name='group_header_0',
                                    group_key='group_header_0', label={'en': 'Personal Information'}),
@@ -188,8 +179,6 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
             self.assertEqual(app.default_language, 'en')
             en_app_strings = self._generate_app_strings(app, 'default', build_profile_id='en')
             self.assertEqual(en_app_strings['case_search.m0'], 'Search All Cases')
-            self.assertFalse('case_search.m0.icon' in en_app_strings)
-            self.assertFalse('case_search.m0.audio' in en_app_strings)
 
             # non-default language
             es_app_strings = self._generate_app_strings(app, 'es', build_profile_id='es')
@@ -198,16 +187,15 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
         with flag_enabled('SYNC_SEARCH_CASE_CLAIM'):
             # default language
             en_app_strings = self._generate_app_strings(app, 'default', build_profile_id='en')
-            self.assertEqual(en_app_strings['case_search.m0'], 'Get them')
-            self.assertEqual(en_app_strings['case_search.m0.icon'], 'jr://file/commcare/image/1.png')
-            self.assertEqual(en_app_strings['case_search.m0.audio'], 'jr://file/commcare/image/2.mp3')
+            self.assertEqual(en_app_strings['case_search.m0'], 'Search All Cases')
+            self.assertFalse('case_search.m0.icon' in en_app_strings)
+            self.assertFalse('case_search.m0.audio' in en_app_strings)
             self.assertEqual(en_app_strings['search_property.m0.name'], 'Name')
             self.assertEqual(en_app_strings['search_property.m0.group_header_0'], 'Personal Information')
 
             # non-default language
             es_app_strings = self._generate_app_strings(app, 'es', build_profile_id='es')
-            self.assertEqual(es_app_strings['case_search.m0'], 'Conseguirlos')
-            self.assertEqual(es_app_strings['case_search.m0.icon'], 'jr://file/commcare/image/1_es.png')
+            self.assertEqual(es_app_strings['case_search.m0'], 'Search All Cases')
 
     def test_dependencies_app_strings(self):
         app_id = 'callout.commcare.org.sendussd'

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -17,7 +17,6 @@ from corehq.apps.app_manager.models import (
     CaseReferences,
     CaseSaveReference,
     CaseSearch,
-    CaseSearchLabel,
     CaseSearchProperty,
     DetailColumn,
     DetailTab,
@@ -384,7 +383,6 @@ class BuildErrorsTest(TestCase):
 
         module.case_details.short.multi_select = True
         module.search_config = CaseSearch(
-            search_label=CaseSearchLabel(label={'en': 'Search'}),
             properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
             data_registry="so_many_cases",
             data_registry_workflow=REGISTRY_WORKFLOW_LOAD_CASE,
@@ -423,7 +421,6 @@ class BuildErrorsTest(TestCase):
             ))
         ])
         module.search_config = CaseSearch(
-            search_label=CaseSearchLabel(label={'en': 'Search'}),
             properties=[CaseSearchProperty(name='name')],
         )
 

--- a/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_build_errors_inline_search.py
@@ -6,7 +6,6 @@ from corehq.apps.app_manager.const import REGISTRY_WORKFLOW_SMART_LINK, WORKFLOW
 from corehq.apps.app_manager.models import (
     Application,
     CaseSearch,
-    CaseSearchLabel,
     CaseSearchProperty,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
@@ -25,7 +24,6 @@ class BuildErrorsInlineSearchTest(SimpleTestCase):
         m1, _ = factory.new_basic_module('second', 'case', parent_module=m0)
 
         m0.search_config = CaseSearch(
-            search_label=CaseSearchLabel(label={'en': 'Search'}),
             properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
             auto_launch=True,
             inline_search=True,
@@ -46,7 +44,6 @@ class BuildErrorsInlineSearchTest(SimpleTestCase):
         factory.form_requires_case(form, 'person')
 
         module.search_config = CaseSearch(
-            search_label=CaseSearchLabel(label={'en': 'Search'}),
             properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
             data_registry="so_many_cases",
             data_registry_workflow=REGISTRY_WORKFLOW_SMART_LINK,
@@ -63,7 +60,6 @@ class BuildErrorsInlineSearchTest(SimpleTestCase):
         m0.put_in_root = True
 
         m0.search_config = CaseSearch(
-            search_label=CaseSearchLabel(label={'en': 'Search'}),
             properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
             auto_launch=True,
             inline_search=True,
@@ -77,7 +73,6 @@ class BuildErrorsInlineSearchTest(SimpleTestCase):
         factory.form_requires_case(m0f0)
 
         m0.search_config = CaseSearch(
-            search_label=CaseSearchLabel(label={'en': 'Search'}),
             properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
             auto_launch=True,
             inline_search=True,

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -11,7 +11,6 @@ from corehq.apps.app_manager.models import (
     AutoSelectCase,
     CaseIndex,
     CaseSearch,
-    CaseSearchLabel,
     CaseSearchProperty,
     ConditionalCaseUpdate,
     DefaultCaseSearchProperty,
@@ -308,11 +307,6 @@ class OverwriteCaseSearchConfigTests(SimpleTestCase):
         self.app = Application.new_app('domain', "Untitled Application")
         self.src_module = self.app.add_module(Module.new_module('Src Module', lang='en'))
         self.case_search_config = CaseSearch(
-            search_label=CaseSearchLabel(
-                label={
-                    'en': 'Search Patients Nationally'
-                }
-            ),
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
                 CaseSearchProperty(name='dob', label={'en': 'Date of birth'})

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -6,7 +6,6 @@ from corehq.apps.app_manager.exceptions import SuiteValidationError
 from corehq.apps.app_manager.models import (
     Application,
     CaseSearch,
-    CaseSearchLabel,
     CaseSearchProperty,
     DetailColumn,
     GraphConfiguration,
@@ -41,11 +40,6 @@ class SuiteTest(SimpleTestCase, SuiteMixin):
     def test_case_search_action(self):
         app = Application.wrap(self.get_json('suite-advanced'))
         app.modules[0].search_config = CaseSearch(
-            search_label=CaseSearchLabel(
-                label={'en': 'Get them'},
-                media_image={'en': "jr://file/commcare/image/1.png"},
-                media_audio={'en': "jr://file/commcare/image/2.mp3"}
-            ),
             properties=[CaseSearchProperty(name='name', label={'en': 'Name'})],
         )
         # wrap to have assign_references called

--- a/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
+++ b/corehq/apps/app_manager/tests/test_suite_multi_select_case_list.py
@@ -18,7 +18,6 @@ from corehq.apps.app_manager.const import (
 from corehq.apps.app_manager.models import (
     Application,
     CaseSearch,
-    CaseSearchLabel,
     CaseSearchProperty,
     ConditionalCaseUpdate,
     FormDatum,
@@ -55,7 +54,6 @@ class MultiSelectCaseListTests(SimpleTestCase, TestXmlMixin):
 
         self.module.case_details.short.multi_select = True
         self.module.search_config = CaseSearch(
-            search_label=CaseSearchLabel(label={'en': 'Search'}),
             properties=[CaseSearchProperty(name=field) for field in ['name', 'greatest_fear']],
         )
         self.module.assign_references()

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -11,7 +11,6 @@ from corehq.apps.app_manager.models import (
     Assertion,
     CaseSearch,
     CaseSearchCustomSortProperty,
-    CaseSearchLabel,
     CaseSearchProperty,
     DefaultCaseSearchProperty,
     DetailColumn,
@@ -60,7 +59,6 @@ class RemoteRequestSmartLinkTest(SimpleTestCase, SuiteMixin):
         self.factory.form_requires_case(child_form, 'leaf')
 
         child_module.search_config = CaseSearch(
-            search_label=CaseSearchLabel(label={'en': 'Search'}),
             properties=[CaseSearchProperty(name=field) for field in ['name', 'shape']],
             data_registry="a_registry",
             data_registry_workflow=REGISTRY_WORKFLOW_SMART_LINK,
@@ -163,11 +161,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             ))
         )
         self.module.search_config = CaseSearch(
-            search_label=CaseSearchLabel(
-                label={
-                    'en': 'Search Patients Nationally'
-                }
-            ),
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
                 CaseSearchProperty(name='dob', label={'en': 'Date of birth'}, input_="date"),
@@ -268,11 +261,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         """
         # Regular and advanced modules should get the search detail
         search_config = CaseSearch(
-            search_label=CaseSearchLabel(
-                label={
-                    'en': 'Advanced Search'
-                }
-            ),
             properties=[CaseSearchProperty(name='name', label={'en': 'Name'})]
         )
         advanced_module = self.app.add_module(AdvancedModule.new_module("advanced", None))
@@ -344,11 +332,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
         shadow_module = self.app.add_module(ShadowModule.new_module("shadow", "en"))
         shadow_module.source_module_id = self.module.get_or_create_unique_id()
         shadow_module.search_config = CaseSearch(
-            search_label=CaseSearchLabel(
-                label={
-                    'en': 'Search from Shadow Module'
-                }
-            ),
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
             ],

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -30,7 +30,6 @@ from corehq.apps.app_manager.views.forms import (
     _get_linkable_forms_context,
     get_apps_modules,
 )
-from corehq.apps.app_manager.views.view_generic import _get_specific_media
 from corehq.apps.builds.models import BuildSpec
 from corehq.apps.domain.models import Domain
 from corehq.apps.es.apps import app_adapter

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -1050,20 +1050,6 @@ class TestGetSpecificMedia(SimpleTestCase):
     def _qualifiers(self, result):
         return [entry.get('qualifier') for entry in result]
 
-    def test_case_search_label_media_included_with_toggle(self):
-        factory = AppFactory(domain=self.domain)
-        module, _ = factory.new_basic_module('cases', 'case')
-        with flag_enabled('SYNC_SEARCH_CASE_CLAIM'):
-            result = _get_specific_media('user', self.domain, factory.app, module, None, 'en')
-        assert 'case_search-search_label_media_' in self._qualifiers(result)
-
-    def test_case_search_label_media_excluded_without_toggle(self):
-        factory = AppFactory(domain=self.domain)
-        module, _ = factory.new_basic_module('cases', 'case')
-        result = _get_specific_media('user', self.domain, factory.app, module, None, 'en')
-        assert 'case_search-search_label_media_' not in self._qualifiers(result)
-
-
 def test_doctests():
     import corehq.apps.app_manager.views.view_generic as module
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -265,8 +265,6 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
                 'blacklisted_owner_ids_expression': (
                     module.search_config.blacklisted_owner_ids_expression if module_offers_search(module) else ""),
                 # populate labels even if module_offers_search is false - search_config might just not exist yet
-                'search_label':
-                    module.search_config.search_label.label if hasattr(module, 'search_config') else "",
                 'title_label':
                     module.search_config.title_label if hasattr(module, 'search_config') else "",
                 'description':
@@ -1290,17 +1288,6 @@ def _gather_and_update_search_properties(params, app, module, lang):
         description = module.search_config.description
         description[lang] = search_properties.get('description', '')
 
-        search_label = module.search_config.search_label
-        search_label.label[lang] = search_properties.get('search_label', '')
-        if search_properties.get('search_label_image_for_all'):
-            search_label.use_default_image_for_all = (
-                search_properties.get('search_label_image_for_all') == 'true')
-        if search_properties.get('search_label_audio_for_all'):
-            search_label.use_default_audio_for_all = (
-                search_properties.get('search_label_audio_for_all') == 'true')
-        search_label.set_media("media_image", lang, search_properties.get('search_label_image'))
-        search_label.set_media("media_audio", lang, search_properties.get('search_label_audio'))
-
         try:
             properties = [
                 CaseSearchProperty.wrap(p)
@@ -1356,7 +1343,6 @@ def _gather_and_update_search_properties(params, app, module, lang):
             ).format(instance_name))
 
         module.search_config = CaseSearch(
-            search_label=search_label,
             title_label=title_label,
             description=description,
             properties=properties,

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -374,28 +374,6 @@ def _get_specific_media(
             'qualifier': 'case_list-menu_item_',
         })
         if (
-            module
-            and hasattr(module, 'search_config')
-            and module.uses_media()
-            and toggles.SYNC_SEARCH_CASE_CLAIM.enabled(domain)
-        ):
-            specific_media.extend([
-                {
-                    'menu_refs': app.get_case_search_label_media(
-                        module,
-                        module.search_config.search_label,
-                        to_language=lang,
-                    ),
-                    'default_file_name': _make_file_name(
-                        default_file_name,
-                        'case_search_label_item',
-                        lang,
-                    ),
-                    'qualifier': 'case_search-search_label_media_'
-                }
-            ])
-
-        if (
             toggles.CASE_LIST_LOOKUP.enabled(username)
             or toggles.CASE_LIST_LOOKUP.enabled(app.domain)
             or toggles.BIOMETRIC_INTEGRATION.enabled(app.domain)

--- a/corehq/apps/domain/management/commands/update_case_search_toggles.py
+++ b/corehq/apps/domain/management/commands/update_case_search_toggles.py
@@ -130,10 +130,6 @@ class Command(BaseCommand):
             # Normal Navigation / See More - only if case search is actually configured
             if bool(search_config.get('properties')) and not auto_launch:
                 reasons.append(f"module '{mod}': not auto_launch (See More / Normal Case List)")
-            # Label for searching
-            command_label = search_config.get('command_label', {})
-            if command_label and command_label != {'en': 'Search All Cases'}:
-                reasons.append(f"module '{mod}': command_label")
             if search_config.get('additional_relevant'):  # Claim condition
                 reasons.append(f"module '{mod}': additional_relevant (claim condition)")
             # USH Specific toggle to use Search Filter in case search options.

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -634,10 +634,6 @@ class ModuleMediaMixin(MediaMixin):
         if hasattr(self, 'case_list') and self.case_list.show:
             media.extend(self.menu_media(self.case_list, lang=lang))
 
-        # Case search and claim menu items
-        if hasattr(self, 'search_config'):
-            media.extend(self.menu_media(self.search_config.search_label, lang=lang))
-
         for name, details, display in self.get_details():
             # Case list lookup - not language-specific
             if display and details.display == 'short' and details.lookup_enabled and details.lookup_image:
@@ -667,10 +663,6 @@ class ModuleMediaMixin(MediaMixin):
         # Case list menu item
         if hasattr(self, 'case_list') and self.case_list.show:
             count += self.rename_menu_media(self.case_list, old_path, new_path)
-
-        # Case search and claim menu items
-        if hasattr(self, 'search_config'):
-            count += self.rename_menu_media(self.search_config.search_label, old_path, new_path)
 
         for name, details, display in self.get_details():
             # Case list lookup
@@ -827,11 +819,6 @@ class ApplicationMediaMixin(Document, MediaMixin):
         media_kwargs = self.get_media_ref_kwargs(module)
         media_kwargs.update(to_language=to_language or self.default_language)
         return self._get_item_media(module.case_list, media_kwargs)
-
-    def get_case_search_label_media(self, module, label, to_language=None):
-        media_kwargs = self.get_media_ref_kwargs(module)
-        media_kwargs.update(to_language=to_language or self.default_language)
-        return self._get_item_media(label, media_kwargs)
 
     def get_case_list_lookup_image(self, module, type='case'):
         if not module:

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_search_properties.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_search_properties.html.diff.txt
@@ -264,27 +264,10 @@
                  {% trans "Search Input Instance Name" %}
                  <span
                    class="hq-help-template"
-@@ -312,10 +312,10 @@
+@@ -312,16 +312,16 @@
              </div>
            {% endif %}
-           {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
--            <div class="form-group" data-bind="hidden: inlineSearchActive">
-+            <div class="form-group" data-bind="hidden: inlineSearchActive">  {# todo B5: css-form-group #}
-               <label
-                 for="search_label"
--                class="{% css_label_class %} control-label"
-+                class="{% css_label_class %} form-label"
-               >
-                 {% trans "Label for Searching" %}
-                 <span
-@@ -338,19 +338,19 @@
-               <!-- stopBinding to avoid conflicts with the binding of enclosing template to a different object 'search'-->
-               <!-- binding for this partial is done via app_manager/js/nav_menu_media-->
-               <!-- ko stopBinding: true -->
--              {% include "app_manager/partials/bootstrap3/nav_menu_media.html" with qualifier='case_search-search_label_media_' ICON_LABEL="Search Icon" AUDIO_LABEL="Search Audio" %}
-+              {% include "app_manager/partials/bootstrap5/nav_menu_media.html" with qualifier='case_search-search_label_media_' ICON_LABEL="Search Icon" AUDIO_LABEL="Search Audio" %}
-               <!-- /ko -->
-             </div>
+           {% if request|toggle_enabled:'SYNC_SEARCH_CASE_CLAIM' %}
 -            <div class="form-group">
 +            <div class="form-group">  {# todo B5: css-form-group #}
                <label
@@ -301,7 +284,7 @@
                  >
                  </span>
                </label>
-@@ -358,10 +358,10 @@
+@@ -329,10 +329,10 @@
                  {% input_trans module.search_config.title_label langs input_name='title_label' input_id='title_label' data_bind="value: title_label" %}
                </div>
              </div>
@@ -314,7 +297,7 @@
                >
                  {% trans "Search Screen Subtitle" %}
                  <span
-@@ -376,10 +376,10 @@
+@@ -347,10 +347,10 @@
                </div>
              </div>
            {% endif %}
@@ -327,7 +310,7 @@
              >
                {% trans "Display Condition" %}
                <span
-@@ -406,10 +406,10 @@
+@@ -377,10 +377,10 @@
              </div>
            </div>
            {% if request|toggle_enabled:'USH_SEARCH_FILTER' %}
@@ -340,7 +323,7 @@
                >
                  {% trans "Search Filter" %}
                  <span
-@@ -434,7 +434,7 @@
+@@ -405,7 +405,7 @@
                  ></textarea>
                  <p class="help-block">
                    <button
@@ -349,7 +332,7 @@
                      data-bind="visible: setSearchFilterVisible, enable: setSearchFilterEnabled, click: setSearchFilter"
                    >
                      <i class="fa-solid fa-reply"></i>
-@@ -446,10 +446,10 @@
+@@ -417,10 +417,10 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
@@ -362,7 +345,7 @@
              >
                {% trans "Claim Condition" %}
                <span
-@@ -475,10 +475,10 @@
+@@ -446,10 +446,10 @@
              </div>
            </div>
            {% endif %}
@@ -375,7 +358,7 @@
              >
                {% trans "Don't search cases owned by the following ids" %}
                <span
-@@ -511,10 +511,10 @@
+@@ -482,10 +482,10 @@
              </div>
            </div>
            {% if data_registry_enabled %}
@@ -388,7 +371,7 @@
                >
                  {% trans "Data Registry" %}
                  <span
-@@ -525,7 +525,7 @@
+@@ -496,7 +496,7 @@
                  </span>
                </label>
                <div class="{% css_field_class %}">
@@ -397,7 +380,7 @@
                    class="form-control"
                    id="data-registry"
                    data-bind="value: data_registry"
-@@ -539,15 +539,15 @@
+@@ -510,15 +510,15 @@
                  </select>
                </div>
              </div>
@@ -416,7 +399,7 @@
                    class="form-control"
                    data-bind="value: data_registry_workflow"
                  >
-@@ -558,12 +558,12 @@
+@@ -529,12 +529,12 @@
                </div>
              </div>
              <div
@@ -431,7 +414,7 @@
                >
                  {% trans "Load Additional Data Registry Cases" %}
                  <span
-@@ -585,8 +585,8 @@
+@@ -556,8 +556,8 @@
                      data-bind="visible: additional_registry_cases().length > 0"
                    >
                      <tr>
@@ -442,7 +425,7 @@
                      </tr>
                    </thead>
                    <tbody
-@@ -608,7 +608,7 @@
+@@ -579,7 +579,7 @@
                        </td>
                        <td>
                          <i
@@ -451,7 +434,7 @@
                            class="fa fa-remove"
                            data-bind="click: $parent.removeRegistryQuery"
                          ></i>
-@@ -618,7 +618,7 @@
+@@ -589,7 +589,7 @@
                  </table>
                  <button
                    type="button"
@@ -460,7 +443,7 @@
                    data-bind="click: addRegistryQuery"
                  >
                    <i class="fa fa-plus"></i>
-@@ -628,10 +628,10 @@
+@@ -599,10 +599,10 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
@@ -473,7 +456,7 @@
                >
                  {% trans "Case property with additional case id to add to results" %}
                  <span
-@@ -661,15 +661,15 @@
+@@ -632,15 +632,15 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_RELATED_LOOKUPS' %}
@@ -493,7 +476,7 @@
                        data-bind="checked: include_all_related_cases"
                      />
                    </label>
-@@ -678,18 +678,18 @@
+@@ -649,18 +649,18 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' and not app.split_screen_dynamic_search %}

--- a/corehq/apps/translations/app_translations/download.py
+++ b/corehq/apps/translations/app_translations/download.py
@@ -202,18 +202,12 @@ def get_module_search_command_rows(langs, module, domain):
     if not module_offers_search(module) or not toggles.SYNC_SEARCH_CASE_CLAIM.enabled(domain):
         return []
 
-    rows = [
+    return [
         ('title_label', 'list')
         + tuple(module.search_config.title_label.get(lang, '') for lang in langs),
         ('description', 'list')
         + tuple(module.search_config.description.get(lang, '') for lang in langs),
     ]
-    if toggles.CASE_SEARCH_DEPRECATED.enabled(domain):
-        return [
-            ('search_label', 'list')
-            + tuple(module.search_config.search_label.label.get(lang, '') for lang in langs),
-        ] + rows
-    return rows
 
 
 def get_case_search_rows(langs, module, domain):

--- a/corehq/apps/translations/app_translations/download.py
+++ b/corehq/apps/translations/app_translations/download.py
@@ -202,12 +202,18 @@ def get_module_search_command_rows(langs, module, domain):
     if not module_offers_search(module) or not toggles.SYNC_SEARCH_CASE_CLAIM.enabled(domain):
         return []
 
-    return [
+    rows = [
         ('title_label', 'list')
         + tuple(module.search_config.title_label.get(lang, '') for lang in langs),
         ('description', 'list')
         + tuple(module.search_config.description.get(lang, '') for lang in langs),
     ]
+    if toggles.CASE_SEARCH_DEPRECATED.enabled(domain):
+        return [
+            ('search_label', 'list')
+            + tuple(module.search_config.search_button_label.get(lang, '') for lang in langs),
+        ] + rows
+    return rows
 
 
 def get_case_search_rows(langs, module, domain):

--- a/corehq/apps/translations/app_translations/upload_module.py
+++ b/corehq/apps/translations/app_translations/upload_module.py
@@ -27,7 +27,6 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
         self.condensed_rows = None
         self.case_list_form_label = None
         self.case_list_menu_item_label = None
-        self.search_label = None
         self.title_label = None
         self.description = None
         self.select_text = None
@@ -87,9 +86,6 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
 
         if self.case_list_menu_item_label:
             self._update_translation(self.case_list_menu_item_label, self.module.case_list.label)
-
-        if self.search_label:
-            self._update_translation(self.search_label, self.module.search_config.search_label.label)
 
         if self.title_label:
             self._update_translation(self.title_label, self.module.search_config.title_label)
@@ -226,7 +222,6 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
         self.condensed_rows = []
         self.case_list_form_label = None
         self.case_list_menu_item_label = None
-        self.search_label = None
         self.title_label = None
         self.description = None
         self.select_text = None
@@ -281,9 +276,6 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
             elif row['case_property'] == 'case_list_menu_item_label':
                 self.case_list_menu_item_label = row
 
-            # It's a case search label. Don't add it to condensed rows
-            elif row['case_property'] == 'search_label':
-                self.search_label = row
             elif row['case_property'] == 'title_label':
                 self.title_label = row
             elif row['case_property'] == 'description':

--- a/corehq/apps/translations/app_translations/upload_module.py
+++ b/corehq/apps/translations/app_translations/upload_module.py
@@ -27,6 +27,7 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
         self.condensed_rows = None
         self.case_list_form_label = None
         self.case_list_menu_item_label = None
+        self.search_label = None
         self.title_label = None
         self.description = None
         self.select_text = None
@@ -86,6 +87,9 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
 
         if self.case_list_menu_item_label:
             self._update_translation(self.case_list_menu_item_label, self.module.case_list.label)
+
+        if self.search_label:
+            self._update_translation(self.search_label, self.module.search_config.search_button_label)
 
         if self.title_label:
             self._update_translation(self.title_label, self.module.search_config.title_label)
@@ -222,6 +226,7 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
         self.condensed_rows = []
         self.case_list_form_label = None
         self.case_list_menu_item_label = None
+        self.search_label = None
         self.title_label = None
         self.description = None
         self.select_text = None
@@ -276,6 +281,8 @@ class BulkAppTranslationModuleUpdater(BulkAppTranslationUpdater):
             elif row['case_property'] == 'case_list_menu_item_label':
                 self.case_list_menu_item_label = row
 
+            elif row['case_property'] == 'search_label':
+                self.search_label = row
             elif row['case_property'] == 'title_label':
                 self.title_label = row
             elif row['case_property'] == 'description':

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -368,7 +368,6 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBaseWithApp):
         ("menu1", (
             ("case_list_form_label", "list", "Register Mother", "Inscrivez-Mère"),
             ("case_list_menu_item_label", "list", "List Stethoscopes", "French List of Stethoscopes"),
-            ("search_label", "list", "Find a Mother", "Mère!"),
             ("title_label", "list", "Find a Mom", "Maman!"),
             ("description", "list", "More information", "Plus d'information"),
             ("select_text", "list", "Continue with case", "Continuer avec le cas"),
@@ -425,7 +424,6 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBaseWithApp):
             ("menu1", "case_list_form_label", "list", "", "Register Mother", "", "", "", ""),
             ("menu1", "case_list_menu_item_label", "list", "",
              "List Stethoscopes", "French List of Stethoscopes", "", "", ""),
-            ("menu1", "search_label", "list", "", "Find a Mother", "", "", "", ""),
             ("menu1", "title_label", "list", "Find a Mom", "Maman!", "", "", "", ""),
             ("menu1", "description", "list", "More information", "Plus d'information", "", "", "", ""),
             ("menu1", "select_text", "list", "Continue with case", "Continuer avec le cas", "", "", "", ""),
@@ -824,13 +822,11 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBaseWithApp):
         module = self.app.get_module(0)
 
         # default values
-        self.assertEqual(module.search_config.search_label.label, {'en': 'Search All Cases'})
         self.assertEqual(module.search_config.title_label, {})
         self.assertEqual(module.search_config.description, {})
 
         self.upload_raw_excel_translations(self.multi_sheet_upload_headers, self.multi_sheet_upload_data)
 
-        self.assertEqual(module.search_config.search_label.label, {'en': 'Find a Mother', 'fra': 'Mère!'})
         self.assertEqual(module.search_config.title_label, {'en': 'Find a Mom', 'fra': 'Maman!'})
         self.assertEqual(module.search_config.description,
                          {'en': 'More information', 'fra': "Plus d'information"})


### PR DESCRIPTION
## Product Description

Removes the ability to configure a custom label for the "Search All Cases" button. The button will always use the default label "Search All Cases" (still translatable via the app's locale system).

Checking production, this label has only been used by internal or paused projects.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6493

## Feature Flag

`CASE_SEARCH_DEPRECATED` (gated the label UI), `SYNC_SEARCH_CASE_CLAIM` (gated media)

## Safety Assurance

### Safety story

Feature was confirmed to only be used on internal/test projects via a production data analysis script before removal. Existing CouchDB documents with `search_label`/`command_label` data are unaffected at runtime — the fields are simply ignored by the schema and will be dropped on next save.

### Automated test coverage

Existing suite XML, app strings, translation, and view tests updated to reflect removal. All tests pass.

### QA Plan

- Verify the case search button still appears with the default label "Search All Cases" in the app builder preview and on device
- Verify the "Label for Searching" field no longer appears in the case search configuration UI

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change