### PR TITLE
Add metric and tag for tracking rate-limiting better.

### DIFF
--- a/corehq/apps/api/resources/meta.py
+++ b/corehq/apps/api/resources/meta.py
@@ -10,6 +10,7 @@ from corehq.project_limits.rate_limiter import (
 )
 from corehq.project_limits.shortcuts import get_standard_ratio_rate_definition
 from corehq.toggles import API_THROTTLE_WHITELIST
+from corehq.util.metrics import metrics_counter
 
 
 api_rate_limiter = RateLimiter(
@@ -54,6 +55,7 @@ class HQThrottle(BaseThrottle):
         from tastypie.models import ApiAccess
 
         api_rate_limiter.report_usage(identifier.domain)
+        metrics_counter('commcare.api.request', tags={'domain': identifier.domain})
         # Write out the access to the DB for logging purposes.
         url = kwargs.get('url', '')
         if len(url) > 255:

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -50,11 +50,22 @@ class RateLimiter(object):
         allowed = False
         # allow usage if any scope has capacity
         for _limit_scope, rates in self.iter_rates(scope):
-            allow = all(current_rate < limit
-                        for _rate_counter, current_rate, limit in rates)
+            exceeded_windows = [
+                rate_counter.key
+                for rate_counter, current_rate, limit in rates
+                if current_rate >= limit
+            ]
             # for each scope all counters must be below threshold
-            if allow:
+            if not exceeded_windows:
                 allowed = True
+            else:
+                for window in exceeded_windows:
+                    metrics_counter('commcare.rate_limit_exceeded', tags={
+                        'key': self.feature_key,
+                        'scope': scope,
+                        'limit_scope': _limit_scope,
+                        'window': window,
+                    })
         if not allowed:
             metrics_counter('commcare.rate_limit_rejected', tags={
                 'key': self.feature_key,

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -55,8 +55,11 @@ class RateLimiter(object):
             # for each scope all counters must be below threshold
             if allow:
                 allowed = True
-            else:
-                metrics_counter('commcare.rate_limit_exceeded', tags={'key': self.feature_key, 'scope': scope})
+        if not allowed:
+            metrics_counter('commcare.rate_limit_rejected', tags={
+                'key': self.feature_key,
+                'scope': scope,
+            })
         return allowed
 
     def get_retry_after(self, scope):

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -50,13 +50,22 @@ class RateLimiter(object):
         allowed = False
         # allow usage if any scope has capacity
         for _limit_scope, rates in self.iter_rates(scope):
-            allow = all(current_rate < limit
-                        for _rate_counter, current_rate, limit in rates)
+            exceeded_windows = [
+                rate_counter.key
+                for rate_counter, current_rate, limit in rates
+                if current_rate >= limit
+            ]
             # for each scope all counters must be below threshold
-            if allow:
+            if not exceeded_windows:
                 allowed = True
             else:
-                metrics_counter('commcare.rate_limit_exceeded', tags={'key': self.feature_key, 'scope': scope})
+                metrics_counter('commcare.rate_limit_exceeded', tags={
+                    'key': self.feature_key,
+                    'scope': scope,
+                    # exceeded_windows are ordered highest-priority
+                    # first (week, day, hour, minute, second)
+                    'window': exceeded_windows[0],
+                })
         return allowed
 
     def get_retry_after(self, scope):

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -50,22 +50,13 @@ class RateLimiter(object):
         allowed = False
         # allow usage if any scope has capacity
         for _limit_scope, rates in self.iter_rates(scope):
-            exceeded_windows = [
-                rate_counter.key
-                for rate_counter, current_rate, limit in rates
-                if current_rate >= limit
-            ]
+            allow = all(current_rate < limit
+                        for _rate_counter, current_rate, limit in rates)
             # for each scope all counters must be below threshold
-            if not exceeded_windows:
+            if allow:
                 allowed = True
             else:
-                metrics_counter('commcare.rate_limit_exceeded', tags={
-                    'key': self.feature_key,
-                    'scope': scope,
-                    # exceeded_windows are ordered highest-priority
-                    # first (week, day, hour, minute, second)
-                    'window': exceeded_windows[0],
-                })
+                metrics_counter('commcare.rate_limit_exceeded', tags={'key': self.feature_key, 'scope': scope})
         return allowed
 
     def get_retry_after(self, scope):

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -66,11 +66,6 @@ class RateLimiter(object):
                         'limit_scope': _limit_scope,
                         'window': window,
                     })
-        if not allowed:
-            metrics_counter('commcare.rate_limit_rejected', tags={
-                'key': self.feature_key,
-                'scope': scope,
-            })
         return allowed
 
     def get_retry_after(self, scope):


### PR DESCRIPTION
## Technical Summary

* Adds a new metric for a count of the requests processed by the API rate limiter
* Adds a "window" tag so that we can see which window ("week", "day, "hour", "minute" or "second") was tripped on a throttled request. If multiple windows were tripped, the highest priority one is reported.

More context: [SUPPORT-27051](https://dimagi.atlassian.net/browse/SUPPORT-27051)

## Safety Assurance

### Safety story

Only changes metrics, not behavior.

### Automated test coverage

Not applicable

### QA Plan

None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SUPPORT-27051]: https://dimagi.atlassian.net/browse/SUPPORT-27051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ