### PR TITLE
Remove weekly window from API rate limiter

### DIFF
--- a/corehq/apps/api/resources/meta.py
+++ b/corehq/apps/api/resources/meta.py
@@ -1,3 +1,4 @@
+import attr
 from tastypie.authorization import ReadOnlyAuthorization
 from tastypie.throttle import BaseThrottle
 
@@ -12,12 +13,17 @@ from corehq.project_limits.shortcuts import get_standard_ratio_rate_definition
 from corehq.toggles import API_THROTTLE_WHITELIST
 
 
+# Weekly windows are intentionally omitted: sustained weekly quotas are
+# not useful for API traffic and result in hard-to-diagnose throttling
+# when a client's 7-day rolling volume hits the cap.
 api_rate_limiter = RateLimiter(
     feature_key='api',
     get_rate_limits=PerUserRateDefinition(
-        per_user_rate_definition=get_standard_ratio_rate_definition(events_per_day=1000),
+        per_user_rate_definition=attr.evolve(
+            get_standard_ratio_rate_definition(events_per_day=1000),
+            per_week=None,
+        ),
         constant_rate_definition=RateDefinition(
-            per_week=100,
             per_day=50,
             per_hour=30,
             per_minute=10,

--- a/corehq/project_limits/tests/test_rate_limiter.py
+++ b/corehq/project_limits/tests/test_rate_limiter.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 from testil import eq
 
+from corehq.apps.api.resources.meta import api_rate_limiter
 from corehq.project_limits.rate_counter.presets import (
     second_rate_counter,
     week_rate_counter,
@@ -69,3 +70,18 @@ def test_get_window_of_first_exceeded_limit_priority():
     expected_window = 'week'
     actual_window = rate_limiter.get_window_of_first_exceeded_limit('my_domain')
     eq(actual_window, expected_window)
+
+
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_domain', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription', lambda domain: 10)
+@patch('corehq.project_limits.rate_limiter._get_account_name', lambda domain: 'my_account')
+def test_api_rate_limiter_windows():
+    rate_limits = api_rate_limiter.get_rate_limits('my_domain')
+    windows_by_scope = {
+        scope: [rate_counter.key for rate_counter, __ in limits]
+        for scope, limits in rate_limits
+    }
+    assert windows_by_scope == {
+        'my_domain': ['day', 'hour', 'minute', 'second'],
+        'my_account': ['day', 'hour', 'minute', 'second'],
+    }


### PR DESCRIPTION
## Product Description

Drops per-week rate limiting for API requests.

All other features continue to use the standard ratio unchanged.

## Safety Assurance

### Safety story

Small change. Narrow scope.

### Automated test coverage

Yes

### QA Plan

None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
