### PR TITLE
Require 'related' feature flag for related lookups in Case Search

### DIFF
--- a/corehq/apps/case_search/filter_dsl.py
+++ b/corehq/apps/case_search/filter_dsl.py
@@ -2,13 +2,10 @@ import re
 from dataclasses import dataclass
 from typing import Union
 
-from django.conf import settings
 from django.utils.translation import gettext as _
 
 from eulxml.xpath import parse as parse_xpath
 from eulxml.xpath.ast import BinaryExpression, FunctionCall, serialize
-
-from dimagi.utils.logging import notify_exception
 
 import corehq
 from corehq import toggles
@@ -29,7 +26,6 @@ from corehq.apps.case_search.xpath_functions.ancestor_functions import (
 from corehq.apps.case_search.xpath_functions.comparison import (
     property_comparison_query,
 )
-from corehq.util.quickcache import quickcache
 
 
 @dataclass
@@ -71,14 +67,9 @@ def print_ast(node):
     visit(node, 0)
 
 
-# log once per domain per day for case search and non case search
-# The intent is to later raise XPathFunctionException
-@quickcache(['context.domain', 'context.helper.is_case_search'],
-            timeout=24 * 60 * 60, skip_arg=lambda _: settings.UNIT_TESTING)
-def _require_related_lookups_flag(context):
-    if not toggles.CASE_SEARCH_RELATED_LOOKUPS.enabled(context.domain):
-        location = 'case search' if context.helper.is_case_search else 'reporting'
-        notify_exception(None, f"CSQL related case expression without FF enabled: {location}")
+def _require_related_lookups_flag(context, node):
+    if context.helper.is_case_search and not toggles.CASE_SEARCH_RELATED_LOOKUPS.enabled(context.domain):
+        raise XPathFunctionException(_("You cannot query related cases here"), node)
 
 
 def build_filter_from_ast(node, context):
@@ -103,7 +94,7 @@ def build_filter_from_ast(node, context):
         if isinstance(node, FunctionCall):
             if node.name in XPATH_QUERY_FUNCTIONS:
                 if node.name in ['subcase-exists', 'subcase-count', 'ancestor-exists']:
-                    _require_related_lookups_flag(context)
+                    _require_related_lookups_flag(context, node)
                 return XPATH_QUERY_FUNCTIONS[node.name](node, context)
             else:
                 raise XPathFunctionException(
@@ -122,11 +113,11 @@ def build_filter_from_ast(node, context):
         if is_ancestor_comparison(node):
             # this node represents a filter on a property for a related case
             if serialize(node.left.right) != '@case_id':
-                _require_related_lookups_flag(context)
+                _require_related_lookups_flag(context, node)
             return ancestor_comparison_query(context, node)
 
         if _is_subcase_count(node):
-            _require_related_lookups_flag(context)
+            _require_related_lookups_flag(context, node)
             return XPATH_QUERY_FUNCTIONS['subcase-count'](node, context)
 
         if node.op in COMPARISON_OPERATORS:

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -35,6 +35,7 @@ from corehq.apps.registry.tests.utils import (
 )
 from corehq.apps.users.models import HqPermissions
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
+from corehq.util.test_utils import flag_enabled
 
 
 def case(name, type_, properties):
@@ -89,6 +90,7 @@ patch_get_app_cached = mock.patch('corehq.apps.case_search.utils.get_app_cached'
 
 @es_test(requires=[case_search_adapter], setup_class=True)
 @mock.patch.object(DataRegistryHelper, '_check_user_has_access', new=mock.Mock())
+@flag_enabled('CASE_SEARCH_RELATED_LOOKUPS')
 class TestCaseSearchRegistry(TestCase):
 
     @classmethod

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -1,7 +1,9 @@
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase, TestCase
 
+import pytest
 import pytz
 from eulxml.xpath import parse as parse_xpath
 from time_machine import travel
@@ -9,7 +11,7 @@ from time_machine import travel
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from couchforms.geopoint import GeoPoint
 
-from corehq.apps.case_search.exceptions import CaseFilterError
+from corehq.apps.case_search.exceptions import CaseFilterError, XPathFunctionException
 from corehq.apps.case_search.filter_dsl import (
     SearchFilterContext,
     build_filter_from_ast,
@@ -508,21 +510,42 @@ class TestFilterDslLookups(ElasticTestMixin, TestCase):
         self.checkQuery(built_filter, expected_filter, is_raw_query=True)
 
 
-@patch('corehq.apps.case_search.xpath_functions.subcase_functions'
-       '._get_parent_case_ids_matching_subcase_query',
-       new=MagicMock(return_value=[]))
-def test_subcase_query_logging():
+def _search_context(is_case_search):
+    helper = QueryHelper("mydomain")
+    helper.is_case_search = is_case_search
+    return SearchFilterContext("mydomain", helper=helper)
+
+
+@contextmanager
+def assert_calls_subcase_fn():
+    mock = MagicMock()
+    path = 'corehq.apps.case_search.xpath_functions.XPATH_QUERY_FUNCTIONS'
+    with patch.dict(path, {'subcase-count': mock}):
+        yield mock
+    mock.assert_called()
+
+
+def test_subcase_query_skipped_in_reporting_context():
     parsed = parse_xpath("subcase-count('grandmother', house='Tyrell') >= 1")
-    with patch('corehq.apps.case_search.filter_dsl.notify_exception') as notify:
-        build_filter_from_ast(parsed, SearchFilterContext("mydomain"))
-        notify.assert_called()
+    with assert_calls_subcase_fn():
+        build_filter_from_ast(parsed, _search_context(is_case_search=False))
 
-    with patch('corehq.apps.case_search.filter_dsl.notify_exception') as notify:
-        with flag_enabled('CASE_SEARCH_RELATED_LOOKUPS'):
-            build_filter_from_ast(parsed, SearchFilterContext("mydomain"))
-        notify.assert_not_called()
 
+def test_subcase_query_raises_without_flag():
+    parsed = parse_xpath("subcase-count('grandmother', house='Tyrell') >= 1")
+    with pytest.raises(XPathFunctionException):
+        build_filter_from_ast(parsed, _search_context(is_case_search=True))
+
+
+@flag_enabled('CASE_SEARCH_RELATED_LOOKUPS')
+def test_subcase_query_allowed_with_flag():
+    parsed = parse_xpath("subcase-count('grandmother', house='Tyrell') >= 1")
+    with assert_calls_subcase_fn():
+        build_filter_from_ast(parsed, _search_context(is_case_search=True))
+
+
+def test_parent_case_id_bypasses_flag_check():
     parsed = parse_xpath("parent/@case_id = '123abc'")
-    with patch('corehq.apps.case_search.filter_dsl.notify_exception') as notify:
-        build_filter_from_ast(parsed, SearchFilterContext("mydomain"))
-        notify.assert_not_called()
+    with patch('corehq.apps.case_search.filter_dsl.ancestor_comparison_query') as mock:
+        build_filter_from_ast(parsed, _search_context(is_case_search=True))
+    mock.assert_called()


### PR DESCRIPTION
## Product Description
No user-facing change for domains with the `CASE_SEARCH_RELATED_LOOKUPS` feature flag enabled. Domains without the flag that attempt related-case expressions (`subcase-exists`, `subcase-count`, `ancestor-exists`, or ancestor-property comparisons) from case search will now receive an `XPathFunctionException` instead of silently executing the query while a warning is logged.

Gonna let the logging run a while longer yet before merging this PR.

## Technical Summary
https://dimagi.atlassian.net/browse/USH-6470

The existing gate in `_require_related_lookups_flag` logged via `notify_exception` (once per domain per day) with a TODO to eventually raise. This PR promotes the gate to an exception. The exception is only raised in case-search context (`context.helper.is_case_search`); reporting queries are unaffected, since reports already passed the gate implicitly.

## Feature Flag
`CASE_SEARCH_RELATED_LOOKUPS`

## Safety Assurance

### Safety story
Raising instead of logging is a behavior change only for case-search callers that were previously producing the `notify_exception` warnings. Reporting callers are explicitly excluded. The set of affected domains should be identifiable from existing `notify_exception` logs for \"CSQL related case expression without FF enabled: case search\".

### Automated test coverage
Included

### QA Plan
Spot-check on staging that a case-search query using `subcase-count` on a domain without the flag returns a user-visible error rather than succeeding.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change