### PR TITLE
Delay dependency upgrades by 7 days (uv + Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
   open-pull-requests-limit: 7
   labels:
   - product/invisible
+  # Wait 7 days after a release before opening an upgrade PR.
+  cooldown:
+    default-days: 7
+    include:
+      - "*"
   # Focus on major versions only
   # Todo: remove once we're in steady-state on major versions
   ignore:
@@ -25,6 +30,10 @@ updates:
   labels:
   - product/invisible
   - dependencies/javascript
+  cooldown:
+    default-days: 7
+    include:
+      - "*"
   # Focus on major versions only
   # Todo: remove once we're in steady-state on major versions
   ignore:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,9 @@ Repository = "https://github.com/dimagi/commcare-hq"
 [tool.uv]
 required-version = ">=0.7.0"
 default-groups = ["dev", "sso"]
+# Skip package versions released in the last 7 days during resolution.
+# Evaluated relative to "now" on each `uv lock` / `uv lock --upgrade`.
+exclude-newer = "7 days"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Technical Summary
Adds a 7-day cooldown window for dependency upgrades, applied in two complementary places:

- **`pyproject.toml`** — `exclude-newer = \"7 days\"` under `[tool.uv]`. uv's resolver will skip versions released in the last 7 days (including transitives) on `uv lock`, `uv lock --upgrade`, `uv add`, etc. A plain `uv sync` against the existing lock file is unaffected.
- **`.github/dependabot.yml`** — `cooldown: { default-days: 7, include: [\"*\"] }` added to the `uv` and `npm` ecosystems. Delays Dependabot version-update PRs until a release is at least 7 days old.

### Why both?
- `exclude-newer` shapes uv's resolution — helpful for our own `uv lock --upgrade` runs and transitive pins.
- Dependabot doesn't use uv's resolver, so it needs its own cooldown to delay the PRs it opens.

### Security updates are unaffected
Per GitHub's [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-): *\"The cooldown option is only available for version updates, not security updates.\"* Dependabot security PRs (from Dependabot alerts / GHSAs) will still be opened promptly.

One caveat for manual workflows: if you run `uv lock --upgrade-package <pkg>` to pull in a fresh security fix yourself, `exclude-newer` will hide versions younger than 7 days. Override on the CLI when needed:

```bash
uv lock --upgrade-package <pkg> --exclude-newer \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
```

or add an `exclude-newer-package` entry for that specific package.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Configuration-only change. No runtime code touched. Effects are scoped to dependency resolution and PR scheduling, both reversible by reverting this PR.

### Automated test coverage
N/A — config-only.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change