### PR TITLE
Turn soft logging into hard failure

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -146,8 +146,7 @@ def app_aware_search(request, domain, app_id):
     Returns results as a fixture with the same structure as a casedb instance.
     """
     if not case_search_enabled_for_domain(domain):
-        # TODO return HttpResponse(CASE_SEARCH_DISABLED_MSG, status=404)
-        _notify_bad_case_search_request(domain)
+        return HttpResponse(CASE_SEARCH_DISABLED_MSG, status=404)
 
     start_time = datetime.now()
     request_dict = dict((request.GET if request.method == 'GET' else request.POST).lists())
@@ -159,12 +158,6 @@ def app_aware_search(request, domain, app_id):
     profiler.timing_context.add_to_sentry_breadcrumbs()
     _log_search_timing(start_time, request_dict, domain, app_id)
     return HttpResponse(fixtures, content_type="text/xml; charset=utf-8")
-
-
-# log once per domain per day
-@quickcache(['domain'], timeout=ONE_DAY)
-def _notify_bad_case_search_request(domain):
-    notify_exception(None, "Attempted a case search without the project setting enabled")
 
 
 def _log_search_timing(start_time, request_dict, domain, app_id):


### PR DESCRIPTION
## Product Description

Make the case search checkbox actually gate access to the case search feature

<img width="1247" height="566" alt="image" src="https://github.com/user-attachments/assets/cf5c304b-06c3-4ded-bcb2-5b9d8d0eea3d" />

-----------------

<img width="2725" height="600" alt="image" src="https://github.com/user-attachments/assets/dfe8d649-abe9-48c5-9fd5-0f50a024ac09" />


## Technical Summary
https://dimagi.atlassian.net/browse/USH-6513
No projects have hit the logging condition yet (except me testing this), which means we can make it a hard requirement now.

## Feature Flag


## Safety Assurance
This has the potential to break workflows, but the logging mitigates that.  Also, there's a very easy fix if someone does slip through (check the checkbox).

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
