### PR TITLE
Disable datadog trace in dev environments

### DIFF
--- a/dev_settings.py
+++ b/dev_settings.py
@@ -169,3 +169,6 @@ if settingshelper.is_testing():
 # LOG FILES
 DJANGO_LOG_FILE = "/tmp/commcare-hq.django.log"
 LOG_FILE = "/tmp/commcare-hq.log"
+
+# Disable datadog trace
+os.environ.setdefault('DD_TRACE_ENABLED', 'false')


### PR DESCRIPTION

## Product Description


## Technical Summary
I get spammed about the dd agent not running _all the time_
This just turns it off, in the same way as `testsettings` does.  
https://github.com/dimagi/commcare-hq/blob/4a60d675e2332a1c2f4769240f8a69dee5f35047/testsettings.py#L65

also relevant:

https://github.com/dimagi/commcare-hq/blob/4a60d675e2332a1c2f4769240f8a69dee5f35047/manage.py#L161-L165

## Feature Flag


## Safety Assurance
Only affects dev environments.

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
