### PR TITLE
Clean up form action diff code and tests

### DIFF
--- a/corehq/apps/app_manager/form_action_diff.py
+++ b/corehq/apps/app_manager/form_action_diff.py
@@ -185,6 +185,7 @@ def _merge(diff, action):
 
 
 def _drop(prop, path, update, conflicts):
+    """Remove prop->path mapping if it exists"""
     if prop in update and update[prop].question_path == path:
         dropped = update[prop]
         if conflicts.get(prop):

--- a/corehq/apps/app_manager/form_action_diff.py
+++ b/corehq/apps/app_manager/form_action_diff.py
@@ -24,7 +24,7 @@ def get_case_mappings(actions):
             prop: [to_json(u) for u in [update] + conflicts.get(prop, [])]
             for prop, update in actions.update_case.update.items()
         })
-        # concurrent delete + change -> conflict with no update
+        # concurrent delete + change -> conflict with no item in update_case.update
         for prop in conflicts.keys() - actions.update_case.update.keys():
             data[prop] = [to_json(q, conflicting_delete=True) for q in conflicts[prop]]
     return data
@@ -179,7 +179,7 @@ def _merge(diff, action):
         conflicted_paths = {q.question_path for q in conflicts.get(prop, [])}
         for ccu in question_map.values():
             if ccu.question_path not in conflicted_paths:
-                # concurrent change + delete -> conflict with no update
+                # concurrent change + delete -> conflict with no item in update_case.update
                 # note order: changed in session A then deleted in session B
                 _add_item(prop, ccu, conflicts)
 
@@ -209,7 +209,7 @@ def _drop(prop, path, update, conflicts):
 def _add_question(prop, question, update, conflicts, is_missing):
     ccu = ConditionalCaseUpdate(question)
     if is_missing:
-        # concurrent delete + change -> conflict with no update
+        # concurrent delete + change -> conflict with no item in update_case.update
         # note order: deleted in session A then changed in session B
         _add_item(prop, ccu, conflicts)
     elif prop not in update or not update[prop].question_path:

--- a/corehq/apps/app_manager/form_action_diff.py
+++ b/corehq/apps/app_manager/form_action_diff.py
@@ -233,6 +233,11 @@ def _convert_update_to_delete_plus_add(diff):
     is no longer supported by the merge algorithm. This can be removed
     when all clients (Vellum and case_config_ui.js) have been updated to
     not use the 'update' key.
+
+    Note: the only things that change in an 'update' operation are
+    question attributes other than 'question_path' (e.g., 'update_mode').
+    Therefore, the mapping key (case property) and/or 'question_path'
+    will not change when an 'update' operation is merged.
     """
     if diff.get('update'):
         diff = diff.copy()

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap3/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap3/case_config_ko_templates.html
@@ -290,7 +290,7 @@
             <button class="close" aria-label="close" data-bind="click: $parent.dismissConflictingDelete">&times;</button>
             <p class="alert-heading">
               <i class="fa fa-triangle-exclamation"></i>
-              {% trans "Property mapping concurrently changed and deleted" %}
+              {% trans "This mapping was changed and deleted in separate sessions" %}
             </p>
             <p>{% trans "Dismiss this alert to keep the mapping." %}</p>
           </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap5/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap5/case_config_ko_templates.html
@@ -289,7 +289,7 @@
           <div class="alert alert-warning mt-2" data-bind="visible: $data.conflictingDelete?.()">
             <p class="alert-heading">
               <i class="fa fa-triangle-exclamation"></i>
-              {% trans "Property mapping concurrently changed and deleted" %}
+              {% trans "This mapping was changed and deleted in separate sessions" %}
             </p>
             <p>{% trans "Dismiss this alert to keep the mapping." %}</p>
             <button type="button" class="btn-close" aria-label="{% trans_html_attr "Close" %}"

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -202,7 +202,7 @@ class UpdateCaseActionApplyDiffTests(SimpleTestCase):
         paths = [update.question_path for update in self._conflicting(actions)['one']]
         assert set(paths) == {'/data/question1', '/data/question2', '/data/question3'}
 
-    def test_adding_duplicate_property_does_nothing(self):
+    def test_adding_duplicate_mapping_does_nothing(self):
         actions = UpdateCaseAction({'update': {
             'one': {'question_path': '/data/question1'}
         }})
@@ -215,7 +215,7 @@ class UpdateCaseActionApplyDiffTests(SimpleTestCase):
         assert set(actions.update.keys()) == {'one'}
         assert actions.update['one'].question_path == '/data/question1'
 
-    def test_adding_existing_modified_property_overwrites_the_property(self):
+    def test_adding_existing_mapping_overwrites_the_mapping(self):
         actions = UpdateCaseAction({'update': {
             'one': {'question_path': '/data/one', 'update_mode': 'always'},
         }})
@@ -240,7 +240,7 @@ class UpdateCaseActionApplyDiffTests(SimpleTestCase):
 
         assert set(actions.update.keys()) == {'two'}
 
-    def test_deleting_a_missing_property_does_nothing(self):
+    def test_deleting_a_missing_mapping_does_nothing(self):
         actions = UpdateCaseAction({'update': {
             'one': {'question_path': '/data/one'},
         }})
@@ -267,7 +267,7 @@ class UpdateCaseActionApplyDiffTests(SimpleTestCase):
 
         assert actions.update['one'].update_mode == 'edit'
 
-    def test_updating_a_missing_property_adds_a_conflict(self):
+    def test_updating_a_missing_mapping_adds_a_conflict(self):
         actions = UpdateCaseAction({'update': {
             'one': {'question_path': '/data/one'},
         }})

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -359,12 +359,12 @@ class FormActionsTests(SimpleTestCase):
         assert actions.all_property_names() == {'one'}
 
     def test_get_case_mappings_serializes_all_updates(self):
-        actions = FormActions({
-            'open_case': {
+        actions = FormActions(
+            open_case=OpenCaseAction({
                 'name_update': {'question_path': 'name1'},
                 'conflicts': [{'question_path': 'name2'}],
-            },
-            'update_case': {
+            }),
+            update_case=UpdateCaseAction({
                 'update': {
                     'one': {'question_path': '/A/'},
                     'two': {'question_path': '/C/'},
@@ -373,8 +373,8 @@ class FormActionsTests(SimpleTestCase):
                     'one': [{'question_path': '/B/'}, {'question_path': '/D/'}],
                     'three': [{'question_path': '/E/'}],
                 }
-            },
-        })
+            }),
+        )
 
         json = get_case_mappings(actions)
 
@@ -395,15 +395,15 @@ class FormActionsTests(SimpleTestCase):
         }
 
     def test_get_case_mappings_with_conflicts_and_concurrent_delete(self):
-        actions = FormActions({
-            'open_case': {'name_update': {'question_path': 'name'}},
-            'update_case': {
+        actions = FormActions(
+            open_case=OpenCaseAction({'name_update': {'question_path': 'name'}}),
+            update_case=UpdateCaseAction({
                 'update': {},
                 'conflicts': {
                     'one': [{'question_path': '/A/'}, {'question_path': '/B/'}],
                 }
-            },
-        })
+            }),
+        )
 
         json = get_case_mappings(actions)
 
@@ -423,17 +423,17 @@ class FormActionsTests(SimpleTestCase):
             merge_case_mappings(diff, actions)
 
     def test_merge_empty_diff(self):
-        actions = FormActions({
-            'open_case': {
+        actions = FormActions(
+            open_case=OpenCaseAction({
                 'name_update': {'question_path': 'name'},
-            },
-            'update_case': {
+            }),
+            update_case=UpdateCaseAction({
                 'update': {
                     'one': {'question_path': 'one'},
                     'two': {'question_path': 'two'},
                 }
-            }
-        })
+            }),
+        )
         snapshot = actions.to_json()
 
         merge_case_mappings({}, actions)
@@ -443,17 +443,17 @@ class FormActionsTests(SimpleTestCase):
         assert actions.to_json() == snapshot
 
     def test_merge_case_mappings_with_all_actions_at_once(self):
-        actions = FormActions({
-            'open_case': {
+        actions = FormActions(
+            open_case=OpenCaseAction({
                 'name_update': {'question_path': 'old_name'},
-            },
-            'update_case': {
+            }),
+            update_case=UpdateCaseAction({
                 'update': {
                     'one': {'question_path': 'one'},
                     'two': {'question_path': 'two'},
                 }
-            }
-        })
+            }),
+        )
 
         merge_case_mappings({
             'open_case': {
@@ -476,17 +476,17 @@ class FormActionsTests(SimpleTestCase):
     def test_merge_case_mappings_with_double_addition(self):
         # a scenario that would have previously caused DiffConflictException
         # update + add => delete + add + add (last add wins)
-        actions = FormActions({
-            'open_case': {
+        actions = FormActions(
+            open_case=OpenCaseAction({
                 'name_update': {'question_path': 'form_name'},
-            },
-            'update_case': {
+            }),
+            update_case=UpdateCaseAction({
                 'update': {
                     'one': {'question_path': 'one'},
                     'two': {'question_path': 'two'},
                 }
-            }
-        })
+            }),
+        )
 
         merge_case_mappings({
             'open_case': {
@@ -515,14 +515,10 @@ class FormActionsTests(SimpleTestCase):
     def test_merge_case_mappings_with_double_deletion(self):
         # a scenario that would have previously caused DiffConflictException
         # delete + update => delete + delete + add (conflicting delete)
-        actions = FormActions({
-            'update_case': {
-                'update': {
-                    'one': {'question_path': 'one'},
-                    'two': {'question_path': 'two'},
-                }
-            }
-        })
+        actions = FormActions(update_case=UpdateCaseAction({'update': {
+            'one': {'question_path': 'one'},
+            'two': {'question_path': 'two'},
+        }}))
 
         merge_case_mappings({
             'update_case': {
@@ -542,14 +538,12 @@ class FormActionsTests(SimpleTestCase):
         assert conflict.update_mode == 'edit'
 
     def test_merge_case_mappings_with_conflicting_delete(self):
-        actions = FormActions({
-            'update_case': {
-                'update': {
-                    'one': {'question_path': 'one', 'update_mode': 'always'},
-                    'two': {'question_path': 'two'},
-                }
+        actions = FormActions(update_case=UpdateCaseAction({
+            'update': {
+                'one': {'question_path': 'one', 'update_mode': 'always'},
+                'two': {'question_path': 'two'},
             }
-        })
+        }))
 
         merge_case_mappings({
             'update_case': {
@@ -565,13 +559,11 @@ class FormActionsTests(SimpleTestCase):
         assert conflict.update_mode == 'always'
 
     def test_merge_case_mappings_already_deleted(self):
-        actions = FormActions({
-            'update_case': {
-                'update': {
-                    'two': {'question_path': 'two'},
-                }
+        actions = FormActions(update_case=UpdateCaseAction({
+            'update': {
+                'two': {'question_path': 'two'},
             }
-        })
+        }))
 
         merge_case_mappings({
             'update_case': {
@@ -800,12 +792,12 @@ class CombinedDiffTests(SimpleTestCase):
 class TestMultiTools(SimpleTestCase):
 
     def test_make_multi(self):
-        actions_json = FormActions({
-            'open_case': {
+        actions_json = FormActions(
+            open_case=OpenCaseAction({
                 'name_update': {'question_path': 'form_name'},
                 'conflicts': [{'question_path': 'other_name'}],
-            },
-            'update_case': {
+            }),
+            update_case=UpdateCaseAction({
                 'update': {
                     'one': {'question_path': 'one'},
                     'two': {'question_path': 'two'},
@@ -815,13 +807,13 @@ class TestMultiTools(SimpleTestCase):
                     'two': [{'question_path': 'other_two'}],
                     'three': [{'question_path': 'three'}],
                 },
-            },
-            'usercase_update': {
+            }),
+            usercase_update=UpdateCaseAction({
                 'update': {
                     'one': {'question_path': 'test_path'},
                 },
-            },
-        }).to_json()
+            }),
+        ).to_json()
         snapshot = deepcopy(actions_json)
 
         multi = make_multi(actions_json)
@@ -852,8 +844,8 @@ class TestMultiTools(SimpleTestCase):
         assert actions_json == snapshot, 'actions_json should not be mutated'
 
     def test_make_multi_with_conflicts_and_concurrent_delete(self):
-        actions_json = FormActions({
-            'update_case': {
+        actions_json = FormActions(
+            update_case=UpdateCaseAction({
                 'update': {},
                 'conflicts': {
                     'one': [
@@ -861,8 +853,8 @@ class TestMultiTools(SimpleTestCase):
                         {'question_path': 'other_two'},
                     ],
                 },
-            },
-        }).to_json()
+            }),
+        ).to_json()
         snapshot = deepcopy(actions_json)
 
         multi = make_multi(actions_json)

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -84,7 +84,7 @@ class OpenCaseActionApplyDiffTests(SimpleTestCase):
 
         assert action.name_update.update_mode == 'edit'
 
-    def test_merge_case_mappings_updating_missing_name_raises_error(self):
+    def test_merge_case_mappings_updating_missing_mapping_creates_conflict(self):
         actions = FormActions(open_case=OpenCaseAction({'name_update': {'question_path': '/data/name'}}))
 
         diff = {'open_case': {'update': [{'question_path': '/data/missing_name', 'update_mode': 'edit'}]}}

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -28,27 +28,32 @@ class OpenCaseActionApplyDiffTests(SimpleTestCase):
 
         assert action.name_update.question_path == 'name'
 
-    def test_name_update(self):
-        actions = FormActions(open_case=OpenCaseAction({'name_update': {'question_path': 'name'}}))
+    def test_add_mapping_with_different_question_path_creates_conflict(self):
+        # added "/data/new_name" mapping should conflict with existing "/data/name" mapping
+        actions = FormActions(open_case=OpenCaseAction({
+            'name_update': {'question_path': '/data/name'},
+        }))
 
-        diff = {'open_case': {'add': [{'question_path': 'new_name'}]}}
+        diff = {'open_case': {'add': [{'question_path': '/data/new_name'}]}}
         merge_case_mappings(diff, actions)
         action = actions.open_case
 
         multi_paths = [update.question_path for update in [action.name_update] + action.conflicts]
-        assert multi_paths == ['name', 'new_name']
+        assert multi_paths == ['/data/name', '/data/new_name']
 
     def test_conflicting_name_addition_is_overwritten(self):
+        # added "/name" mapping should overwrite existing "/name" mapping
         actions = FormActions(open_case=OpenCaseAction({
-            'name_update': {'question_path': 'name', 'update_mode': 'always'},
+            'name_update': {'question_path': '/data/name', 'update_mode': 'always'},
         }))
 
-        diff = {'open_case': {'add': [{'question_path': 'name', 'update_mode': 'edit'}]}}
+        diff = {'open_case': {'add': [{'question_path': '/data/name', 'update_mode': 'edit'}]}}
         merge_case_mappings(diff, actions)
         action = actions.open_case
 
-        assert action.name_update.question_path == 'name'
+        assert action.name_update.question_path == '/data/name'
         assert action.name_update.update_mode == 'edit'
+        assert not action.conflicts
 
     def test_merge_case_mappings_remove_name(self):
         actions = FormActions(open_case=OpenCaseAction.wrap({

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -21,12 +21,12 @@ from ..views.forms import _case_mapping_diff_has_changes
 class OpenCaseActionApplyDiffTests(SimpleTestCase):
 
     def test_no_changes(self):
-        actions = FormActions(open_case=OpenCaseAction({'name_update': {'question_path': 'name'}}))
+        actions = FormActions(open_case=OpenCaseAction({'name_update': {'question_path': '/data/name'}}))
 
         merge_case_mappings({}, actions)
         action = actions.open_case
 
-        assert action.name_update.question_path == 'name'
+        assert action.name_update.question_path == '/data/name'
 
     def test_add_mapping_with_different_question_path_creates_conflict(self):
         # added "/data/new_name" mapping should conflict with existing "/data/name" mapping
@@ -57,80 +57,80 @@ class OpenCaseActionApplyDiffTests(SimpleTestCase):
 
     def test_merge_case_mappings_remove_name(self):
         actions = FormActions(open_case=OpenCaseAction.wrap({
-            'name_update_multi': [{'question_path': 'name1'}, {'question_path': 'name2'}]
+            'name_update_multi': [{'question_path': '/data/name1'}, {'question_path': '/data/name2'}]
         }))
 
-        diff = {'open_case': {'delete': [{'question_path': 'name1'}]}}
+        diff = {'open_case': {'delete': [{'question_path': '/data/name1'}]}}
         merge_case_mappings(diff, actions)
         action = actions.open_case
 
-        assert action.name_update.question_path == 'name2'
+        assert action.name_update.question_path == '/data/name2'
 
     def test_merge_case_mappings_remove_name_does_nothing_when_name_is_absent(self):
-        actions = FormActions(open_case=OpenCaseAction({'name_update': {'question_path': 'name2'}}))
+        actions = FormActions(open_case=OpenCaseAction({'name_update': {'question_path': '/data/name2'}}))
 
-        diff = {'open_case': {'delete': [{'question_path': 'name1'}]}}
+        diff = {'open_case': {'delete': [{'question_path': '/data/name1'}]}}
         merge_case_mappings(diff, actions)
         action = actions.open_case
 
-        assert action.name_update.question_path == 'name2'
+        assert action.name_update.question_path == '/data/name2'
 
     def test_merge_case_mappings_update_mode(self):
-        actions = FormActions(open_case=OpenCaseAction({'name_update': {'question_path': 'name'}}))
+        actions = FormActions(open_case=OpenCaseAction({'name_update': {'question_path': '/data/name'}}))
 
-        diff = {'open_case': {'update': [{'question_path': 'name', 'update_mode': 'edit'}]}}
+        diff = {'open_case': {'update': [{'question_path': '/data/name', 'update_mode': 'edit'}]}}
         merge_case_mappings(diff, actions)
         action = actions.open_case
 
         assert action.name_update.update_mode == 'edit'
 
     def test_merge_case_mappings_updating_missing_name_raises_error(self):
-        actions = FormActions(open_case=OpenCaseAction({'name_update': {'question_path': 'name'}}))
+        actions = FormActions(open_case=OpenCaseAction({'name_update': {'question_path': '/data/name'}}))
 
-        diff = {'open_case': {'update': [{'question_path': 'missing_name', 'update_mode': 'edit'}]}}
+        diff = {'open_case': {'update': [{'question_path': '/data/missing_name', 'update_mode': 'edit'}]}}
         merge_case_mappings(diff, actions)
 
-        assert [c.question_path for c in actions.open_case.conflicts] == ['missing_name']
+        assert [c.question_path for c in actions.open_case.conflicts] == ['/data/missing_name']
 
     def test_merge_case_mappings_remove_conflicted_name(self):
         actions = FormActions(open_case=OpenCaseAction({
-            'name_update': {'question_path': 'name1'},
-            'conflicts': [{'question_path': 'name2'}, {'question_path': 'name3'}],
+            'name_update': {'question_path': '/data/name1'},
+            'conflicts': [{'question_path': '/data/name2'}, {'question_path': '/data/name3'}],
         }))
 
-        diff = {'open_case': {'delete': [{'question_path': 'name1'}]}}
+        diff = {'open_case': {'delete': [{'question_path': '/data/name1'}]}}
         merge_case_mappings(diff, actions)
         action = actions.open_case
 
-        assert action.name_update.question_path == 'name2'
-        assert action.conflicts[0].question_path == 'name3'
+        assert action.name_update.question_path == '/data/name2'
+        assert action.conflicts[0].question_path == '/data/name3'
         assert len(action.conflicts) == 1
 
     def test_delete_conflict(self):
         action = OpenCaseAction({
-            'name_update': {'question_path': 'name1'},
-            'conflicts': [{'question_path': 'name2'}],
+            'name_update': {'question_path': '/data/name1'},
+            'conflicts': [{'question_path': '/data/name2'}],
         })
         form_actions = FormActions(open_case=action)
 
-        diff = {'open_case': {'delete': [{'question_path': 'name2'}]}}
+        diff = {'open_case': {'delete': [{'question_path': '/data/name2'}]}}
         merge_case_mappings(diff, form_actions)
 
-        assert action.name_update.question_path == 'name1'
+        assert action.name_update.question_path == '/data/name1'
         assert not action.conflicts
 
     def test_delete_one_of_multiple_conflicts(self):
         action = OpenCaseAction({
-            'name_update': {'question_path': 'name1'},
-            'conflicts': [{'question_path': 'name2'}, {'question_path': 'name3'}],
+            'name_update': {'question_path': '/data/name1'},
+            'conflicts': [{'question_path': '/data/name2'}, {'question_path': '/data/name3'}],
         })
         form_actions = FormActions(open_case=action)
 
-        diff = {'open_case': {'delete': [{'question_path': 'name2'}]}}
+        diff = {'open_case': {'delete': [{'question_path': '/data/name2'}]}}
         merge_case_mappings(diff, form_actions)
 
         assert action.name_update
-        assert action.conflicts[0].question_path == 'name3'
+        assert action.conflicts[0].question_path == '/data/name3'
         assert len(action.conflicts) == 1
 
 
@@ -138,130 +138,130 @@ class UpdateCaseActionApplyDiffTests(SimpleTestCase):
 
     def test_no_changes(self):
         actions = UpdateCaseAction({'update': {
-            'one': {'question_path': 'one'}
+            'one': {'question_path': '/data/one'}
         }})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({}, form_actions)
 
-        assert actions.update['one'].question_path == 'one'
+        assert actions.update['one'].question_path == '/data/one'
 
     def test_add_value_no_conflict(self):
         actions = UpdateCaseAction({'update': {
-            'one': {'question_path': 'one'},
-            'two': {'question_path': 'two'},
+            'one': {'question_path': '/data/one'},
+            'two': {'question_path': '/data/two'},
         }})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
-            'add': {'three': [{'question_path': 'some_path'}]},
+            'add': {'three': [{'question_path': '/data/some_path'}]},
         }}, form_actions)
 
         assert set(actions.update.keys()) == {'one', 'two', 'three'}
 
     def test_add_value_creates_conflict(self):
         actions = UpdateCaseAction({'update': {
-            'one': {'question_path': 'question1'}
+            'one': {'question_path': '/data/question1'}
         }})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
-            'add': {'one': [{'question_path': 'question2'}]}
+            'add': {'one': [{'question_path': '/data/question2'}]}
         }}, form_actions)
 
         assert set(self._conflicting(actions)) == {'one'}
         paths = {c.question_path for c in self._conflicting(actions)['one']}
-        assert paths == {'question1', 'question2'}
+        assert paths == {'/data/question1', '/data/question2'}
 
     def test_add_value_with_legacy_update_multi_conflict(self):
         form_actions = FormActions({'update_case': {'update_multi': {
-            'one': [{'question_path': 'question1'}, {'question_path': 'question2'}]
+            'one': [{'question_path': '/data/question1'}, {'question_path': '/data/question2'}]
         }}})
 
         merge_case_mappings({'update_case': {
-            'add': {'one': [{'question_path': 'question3'}]}
+            'add': {'one': [{'question_path': '/data/question3'}]}
         }}, form_actions)
         actions = form_actions.update_case
 
         assert set(actions.conflicts) == {'one'}
         paths = [update.question_path for update in self._conflicting(actions)['one']]
-        assert set(paths) == {'question1', 'question2', 'question3'}
+        assert set(paths) == {'/data/question1', '/data/question2', '/data/question3'}
 
     def test_add_value_with_existing_conflict(self):
         actions = UpdateCaseAction({
-            'update': {'one': {'question_path': 'question1'}},
-            'conflicts': {'one': [{'question_path': 'question2'}]}
+            'update': {'one': {'question_path': '/data/question1'}},
+            'conflicts': {'one': [{'question_path': '/data/question2'}]}
         })
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
-            'add': {'one': [{'question_path': 'question3'}]}
+            'add': {'one': [{'question_path': '/data/question3'}]}
         }}, form_actions)
 
         assert set(actions.conflicts) == {'one'}
         paths = [update.question_path for update in self._conflicting(actions)['one']]
-        assert set(paths) == {'question1', 'question2', 'question3'}
+        assert set(paths) == {'/data/question1', '/data/question2', '/data/question3'}
 
     def test_adding_duplicate_property_does_nothing(self):
         actions = UpdateCaseAction({'update': {
-            'one': {'question_path': 'question1'}
+            'one': {'question_path': '/data/question1'}
         }})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
-            'add': {'one': [{'question_path': 'question1'}]}
+            'add': {'one': [{'question_path': '/data/question1'}]}
         }}, form_actions)
 
         assert set(actions.update.keys()) == {'one'}
-        assert actions.update['one'].question_path == 'question1'
+        assert actions.update['one'].question_path == '/data/question1'
 
     def test_adding_existing_modified_property_overwrites_the_property(self):
         actions = UpdateCaseAction({'update': {
-            'one': {'question_path': 'one', 'update_mode': 'always'},
+            'one': {'question_path': '/data/one', 'update_mode': 'always'},
         }})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
-            'add': {'one': [{'question_path': 'one', 'update_mode': 'edit'}]},
+            'add': {'one': [{'question_path': '/data/one', 'update_mode': 'edit'}]},
         }}, form_actions)
 
         assert actions.update['one'].update_mode == 'edit'
 
     def test_remove_value(self):
         actions = UpdateCaseAction({'update': {
-            'one': {'question_path': 'one'},
-            'two': {'question_path': 'two'},
+            'one': {'question_path': '/data/one'},
+            'two': {'question_path': '/data/two'},
         }})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
-            'delete': {'one': [{'question_path': 'one'}]},
+            'delete': {'one': [{'question_path': '/data/one'}]},
         }}, form_actions)
 
         assert set(actions.update.keys()) == {'two'}
 
     def test_deleting_a_missing_property_does_nothing(self):
         actions = UpdateCaseAction({'update': {
-            'one': {'question_path': 'one'},
+            'one': {'question_path': '/data/one'},
         }})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
-            'delete': {'one': [{'question_path': 'two'}]}
+            'delete': {'one': [{'question_path': '/data/two'}]}
         }}, form_actions)
 
         assert actions.update.keys() == {'one'}
-        assert actions.update['one'].question_path == 'one'
+        assert actions.update['one'].question_path == '/data/one'
 
     def test_update_value(self):
         actions = UpdateCaseAction({'update': {
-            'one': {'question_path': 'question_one', 'update_mode': 'always'},
+            'one': {'question_path': '/data/one', 'update_mode': 'always'},
         }})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
             'update': {
-                'one': [{'question_path': 'question_one', 'update_mode': 'edit'}],
+                'one': [{'question_path': '/data/one', 'update_mode': 'edit'}],
             }
         }}, form_actions)
 
@@ -269,39 +269,39 @@ class UpdateCaseActionApplyDiffTests(SimpleTestCase):
 
     def test_updating_a_missing_property_adds_a_conflict(self):
         actions = UpdateCaseAction({'update': {
-            'one': {'question_path': 'question_one'},
+            'one': {'question_path': '/data/one'},
         }})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
-            'update': {'two': [{'question_path': 'question_two', 'update_mode': 'edit'}]}
+            'update': {'two': [{'question_path': '/data/two', 'update_mode': 'edit'}]}
         }}, form_actions)
 
         assert 'two' not in actions.update
-        assert [c.question_path for c in actions.conflicts['two']] == ['question_two']
+        assert [c.question_path for c in actions.conflicts['two']] == ['/data/two']
 
     def test_updating_a_missing_question_adds_a_conflict(self):
         # If the specific mapping was deleted by a different session, updating it shouldn't restore it
         actions = UpdateCaseAction({'update': {
-            'one': {'question_path': 'question_one'}
+            'one': {'question_path': '/data/one'}
         }})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
             'update': {
-                'one': [{'question_path': 'question_two', 'update_mode': 'edit'}]
+                'one': [{'question_path': '/data/two', 'update_mode': 'edit'}]
             }
         }}, form_actions)
 
-        assert actions.update['one'].question_path == 'question_one'
-        assert [c.question_path for c in actions.conflicts['one']] == ['question_two']
+        assert actions.update['one'].question_path == '/data/one'
+        assert [c.question_path for c in actions.conflicts['one']] == ['/data/two']
 
     def test_delete_conflict(self):
-        actions = UpdateCaseAction({'conflicts': {'one': [{'question_path': 'question_one'}]}})
+        actions = UpdateCaseAction({'conflicts': {'one': [{'question_path': '/data/one'}]}})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
-            'delete': {'one': [{'question_path': 'question_one', 'conflicting_delete': True}]},
+            'delete': {'one': [{'question_path': '/data/one', 'conflicting_delete': True}]},
         }}, form_actions)
 
         assert not actions.update
@@ -309,33 +309,33 @@ class UpdateCaseActionApplyDiffTests(SimpleTestCase):
 
     def test_delete_removes_conflict(self):
         actions = UpdateCaseAction({
-            'update': {'one': {'question_path': 'question_one'}},
-            'conflicts': {'one': [{'question_path': 'question_two'}]},
+            'update': {'one': {'question_path': '/data/one'}},
+            'conflicts': {'one': [{'question_path': '/data/two'}]},
         })
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
-            'delete': {'one': [{'question_path': 'question_one'}]},
+            'delete': {'one': [{'question_path': '/data/one'}]},
         }}, form_actions)
 
-        assert actions.update['one'].question_path == 'question_two'
+        assert actions.update['one'].question_path == '/data/two'
         assert not actions.conflicts
 
     def test_multiple_actions_attempting_to_affect_the_same_key_updates_action(self):
         actions = UpdateCaseAction({'update': {
-            'one': {'question_path': 'one'},
-            'two': {'question_path': 'two'},
+            'one': {'question_path': '/data/one'},
+            'two': {'question_path': '/data/two'},
         }})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
-            'delete': {'two': [{'question_path': 'two'}]},
-            'add': {'two': [{'question_path': 'two', 'update_mode': 'edit'}]},
+            'delete': {'two': [{'question_path': '/data/two'}]},
+            'add': {'two': [{'question_path': '/data/two', 'update_mode': 'edit'}]},
         }}, form_actions)
 
-        assert actions.update['one'].question_path == 'one'
+        assert actions.update['one'].question_path == '/data/one'
         assert actions.update['one'].update_mode == 'always'
-        assert actions.update['two'].question_path == 'two'
+        assert actions.update['two'].question_path == '/data/two'
         assert actions.update['two'].update_mode == 'edit'
         assert not actions.conflicts
 
@@ -359,15 +359,15 @@ class FormActionsTests(SimpleTestCase):
         assert actions.all_property_names() == set()
 
     def test_all_property_names_adds_update_case_names(self):
-        update_case = UpdateCaseAction({'update': {'one': {'question_path': 'two'}}})
+        update_case = UpdateCaseAction({'update': {'one': {'question_path': '/data/two'}}})
         actions = FormActions(update_case=update_case)
         assert actions.all_property_names() == {'one'}
 
     def test_get_case_mappings_serializes_all_updates(self):
         actions = FormActions(
             open_case=OpenCaseAction({
-                'name_update': {'question_path': 'name1'},
-                'conflicts': [{'question_path': 'name2'}],
+                'name_update': {'question_path': '/data/name1'},
+                'conflicts': [{'question_path': '/data/name2'}],
             }),
             update_case=UpdateCaseAction({
                 'update': {
@@ -385,8 +385,8 @@ class FormActionsTests(SimpleTestCase):
 
         assert json == {
             'name': [
-                {'question_path': 'name1', 'update_mode': 'always'},
-                {'question_path': 'name2', 'update_mode': 'always'},
+                {'question_path': '/data/name1', 'update_mode': 'always'},
+                {'question_path': '/data/name2', 'update_mode': 'always'},
             ],
             'one': [
                 {'question_path': '/A/', 'update_mode': 'always'},
@@ -401,7 +401,7 @@ class FormActionsTests(SimpleTestCase):
 
     def test_get_case_mappings_with_conflicts_and_concurrent_delete(self):
         actions = FormActions(
-            open_case=OpenCaseAction({'name_update': {'question_path': 'name'}}),
+            open_case=OpenCaseAction({'name_update': {'question_path': '/data/name'}}),
             update_case=UpdateCaseAction({
                 'update': {},
                 'conflicts': {
@@ -413,7 +413,7 @@ class FormActionsTests(SimpleTestCase):
         json = get_case_mappings(actions)
 
         assert json == {
-            'name': [{'question_path': 'name', 'update_mode': 'always'}],
+            'name': [{'question_path': '/data/name', 'update_mode': 'always'}],
             'one': [
                 {'question_path': '/A/', 'update_mode': 'always', 'conflicting_delete': True},
                 {'question_path': '/B/', 'update_mode': 'always', 'conflicting_delete': True},
@@ -430,12 +430,12 @@ class FormActionsTests(SimpleTestCase):
     def test_merge_empty_diff(self):
         actions = FormActions(
             open_case=OpenCaseAction({
-                'name_update': {'question_path': 'name'},
+                'name_update': {'question_path': '/data/name'},
             }),
             update_case=UpdateCaseAction({
                 'update': {
-                    'one': {'question_path': 'one'},
-                    'two': {'question_path': 'two'},
+                    'one': {'question_path': '/data/one'},
+                    'two': {'question_path': '/data/two'},
                 }
             }),
         )
@@ -443,38 +443,38 @@ class FormActionsTests(SimpleTestCase):
 
         merge_case_mappings({}, actions)
 
-        assert actions['open_case']['name_update']['question_path'] == 'name'
+        assert actions['open_case']['name_update']['question_path'] == '/data/name'
         assert list(actions['update_case']['update'].keys()) == ['one', 'two']
         assert actions.to_json() == snapshot
 
     def test_merge_case_mappings_with_all_actions_at_once(self):
         actions = FormActions(
             open_case=OpenCaseAction({
-                'name_update': {'question_path': 'old_name'},
+                'name_update': {'question_path': '/data/old_name'},
             }),
             update_case=UpdateCaseAction({
                 'update': {
-                    'one': {'question_path': 'one'},
-                    'two': {'question_path': 'two'},
+                    'one': {'question_path': '/data/one'},
+                    'two': {'question_path': '/data/two'},
                 }
             }),
         )
 
         merge_case_mappings({
             'open_case': {
-                'add': [{'question_path': 'new_name'}],
-                'delete': [{'question_path': 'old_name'}],
+                'add': [{'question_path': '/data/new_name'}],
+                'delete': [{'question_path': '/data/old_name'}],
             },
             'update_case': {
-                'add': {'three': [{'question_path': 'three'}]},
-                'delete': {'one': [{'question_path': 'one'}]},
+                'add': {'three': [{'question_path': '/data/three'}]},
+                'delete': {'one': [{'question_path': '/data/one'}]},
                 'update': {
-                    'two': [{'question_path': 'two', 'update_mode': 'edit'}]
+                    'two': [{'question_path': '/data/two', 'update_mode': 'edit'}]
                 }
             }
         }, actions)
 
-        assert actions.open_case.name_update.question_path == 'new_name'
+        assert actions.open_case.name_update.question_path == '/data/new_name'
         assert set(actions.update_case.update.keys()) == {'two', 'three'}
         assert actions.update_case.update['two'].update_mode == 'edit'
 
@@ -483,37 +483,37 @@ class FormActionsTests(SimpleTestCase):
         # update + add => delete + add + add (last add wins)
         actions = FormActions(
             open_case=OpenCaseAction({
-                'name_update': {'question_path': 'form_name'},
+                'name_update': {'question_path': '/data/form_name'},
             }),
             update_case=UpdateCaseAction({
                 'update': {
-                    'one': {'question_path': 'one'},
-                    'two': {'question_path': 'two'},
+                    'one': {'question_path': '/data/one'},
+                    'two': {'question_path': '/data/two'},
                 }
             }),
         )
 
         merge_case_mappings({
             'open_case': {
-                'delete': [{'question_path': 'form_name'}],
+                'delete': [{'question_path': '/data/form_name'}],
                 'add': [
-                    {'question_path': 'form_name', 'update_mode': 'always'},
-                    {'question_path': 'form_name', 'update_mode': 'edit'}
+                    {'question_path': '/data/form_name', 'update_mode': 'always'},
+                    {'question_path': '/data/form_name', 'update_mode': 'edit'}
                 ],
             },
             'update_case': {
-                'delete': {'one': [{'question_path': 'one'}]},
+                'delete': {'one': [{'question_path': '/data/one'}]},
                 'add': {'one': [
-                    {'question_path': 'one', 'update_mode': 'always'},
-                    {'question_path': 'one', 'update_mode': 'edit'},
+                    {'question_path': '/data/one', 'update_mode': 'always'},
+                    {'question_path': '/data/one', 'update_mode': 'edit'},
                 ]},
             },
         }, actions)
 
-        assert actions.open_case.name_update.question_path == 'form_name'
+        assert actions.open_case.name_update.question_path == '/data/form_name'
         assert actions.open_case.name_update.update_mode == 'edit'
         assert not actions.open_case.conflicts
-        assert actions.update_case.update['one'].question_path == 'one'
+        assert actions.update_case.update['one'].question_path == '/data/one'
         assert actions.update_case.update['one'].update_mode == 'edit'
         assert not actions.update_case.conflicts
 
@@ -521,59 +521,59 @@ class FormActionsTests(SimpleTestCase):
         # a scenario that would have previously caused DiffConflictException
         # delete + update => delete + delete + add (conflicting delete)
         actions = FormActions(update_case=UpdateCaseAction({'update': {
-            'one': {'question_path': 'one'},
-            'two': {'question_path': 'two'},
+            'one': {'question_path': '/data/one'},
+            'two': {'question_path': '/data/two'},
         }}))
 
         merge_case_mappings({
             'update_case': {
                 'delete': {'one': [
-                    {'question_path': 'one'},
-                    {'question_path': 'one', 'update_mode': 'edit'},
+                    {'question_path': '/data/one'},
+                    {'question_path': '/data/one', 'update_mode': 'edit'},
                 ]},
                 'add': {'one': [
-                    {'question_path': 'one', 'update_mode': 'edit'}
+                    {'question_path': '/data/one', 'update_mode': 'edit'}
                 ]},
             },
         }, actions)
 
         assert 'one' not in actions.update_case.update
         conflict, = actions.update_case.conflicts['one']
-        assert conflict.question_path == 'one'
+        assert conflict.question_path == '/data/one'
         assert conflict.update_mode == 'edit'
 
     def test_merge_case_mappings_with_conflicting_delete(self):
         actions = FormActions(update_case=UpdateCaseAction({
             'update': {
-                'one': {'question_path': 'one', 'update_mode': 'always'},
-                'two': {'question_path': 'two'},
+                'one': {'question_path': '/data/one', 'update_mode': 'always'},
+                'two': {'question_path': '/data/two'},
             }
         }))
 
         merge_case_mappings({
             'update_case': {
                 'delete': {'one': [
-                    {'question_path': 'one', 'update_mode': 'edit'},
+                    {'question_path': '/data/one', 'update_mode': 'edit'},
                 ]},
             },
         }, actions)
 
         assert 'one' not in actions.update_case.update
         conflict, = actions.update_case.conflicts['one']
-        assert conflict.question_path == 'one'
+        assert conflict.question_path == '/data/one'
         assert conflict.update_mode == 'always'
 
     def test_merge_case_mappings_already_deleted(self):
         actions = FormActions(update_case=UpdateCaseAction({
             'update': {
-                'two': {'question_path': 'two'},
+                'two': {'question_path': '/data/two'},
             }
         }))
 
         merge_case_mappings({
             'update_case': {
                 'delete': {'one': [
-                    {'question_path': 'one', 'update_mode': 'edit'},
+                    {'question_path': '/data/one', 'update_mode': 'edit'},
                 ]},
             },
         }, actions)
@@ -582,7 +582,7 @@ class FormActionsTests(SimpleTestCase):
         assert 'one' not in actions.update_case.conflicts
 
     def test_update_form_actions_with_conditional_update(self):
-        action = OpenCaseAction({'name_update': {'question_path': 'name'}})
+        action = OpenCaseAction({'name_update': {'question_path': '/data/name'}})
         form_actions = FormActions(open_case=action)
         actions_json = {
             'open_case': {'condition': {'type': 'if', 'question': 'name', 'answer': 'bob', 'operator': '='}}
@@ -596,27 +596,27 @@ class FormActionsTests(SimpleTestCase):
         assert action.condition.operator == '='
 
     def test_update_form_actions_ignores_direct_name_update(self):
-        action = OpenCaseAction({'name_update': {'question_path': 'name'}})
+        action = OpenCaseAction({'name_update': {'question_path': '/data/name'}})
         form_actions = FormActions(open_case=action)
-        actions_json = {'open_case': {'name_update': {'question_path': 'name2'}}}
+        actions_json = {'open_case': {'name_update': {'question_path': '/data/name2'}}}
 
         update_form_actions(form_actions, actions_json, {})
 
-        assert action.name_update.question_path == 'name'
+        assert action.name_update.question_path == '/data/name'
         assert not action.conflicts
 
     def test_update_form_actions_ignores_direct_name_update_multi(self):
-        action = OpenCaseAction({'name_update': {'question_path': 'name'}})
+        action = OpenCaseAction({'name_update': {'question_path': '/data/name'}})
         form_actions = FormActions(open_case=action)
-        actions_json = {'open_case': {'name_update_multi': [{'question_path': 'name2'}]}}
+        actions_json = {'open_case': {'name_update_multi': [{'question_path': '/data/name2'}]}}
 
         update_form_actions(form_actions, actions_json, {})
 
-        assert action.name_update.question_path == 'name'
+        assert action.name_update.question_path == '/data/name'
         assert not action.conflicts
 
     def test_update_form_actions_with_invalid_key_raises_exception(self):
-        action = OpenCaseAction({'name_update': {'question_path': 'name'}})
+        action = OpenCaseAction({'name_update': {'question_path': '/data/name'}})
         form_actions = FormActions(open_case=action)
         actions_json = {"open_case": {'invalid_property': {}}}
 
@@ -624,23 +624,23 @@ class FormActionsTests(SimpleTestCase):
             update_form_actions(form_actions, actions_json, {})
 
     def test_update_form_actions_ignores_direct_updates(self):
-        actions = UpdateCaseAction({'update': {'one': {'question_path': 'one'}}})
+        actions = UpdateCaseAction({'update': {'one': {'question_path': '/data/one'}}})
         form_actions = FormActions(update_case=actions)
-        actions_json = {'update_case': {'update': {'one': {'question_path': 'two'}}}}
+        actions_json = {'update_case': {'update': {'one': {'question_path': '/data/two'}}}}
 
         update_form_actions(form_actions, actions_json, {})
 
-        assert actions.update['one'].question_path == 'one'
+        assert actions.update['one'].question_path == '/data/one'
         assert not actions.conflicts
 
     def test_update_form_actions_ignores_direct_update_multi(self):
-        actions = UpdateCaseAction({'update': {'one': {'question_path': 'one'}}})
+        actions = UpdateCaseAction({'update': {'one': {'question_path': '/data/one'}}})
         form_actions = FormActions(update_case=actions)
-        actions_json = {'update_case': {'update_multi': {'one': {'question_path': 'two'}}}}
+        actions_json = {'update_case': {'update_multi': {'one': {'question_path': '/data/two'}}}}
 
         update_form_actions(form_actions, actions_json, {})
 
-        assert actions.update['one'].question_path == 'one'
+        assert actions.update['one'].question_path == '/data/one'
         assert not actions.conflicts
 
     def test_update_form_actions_updates_condition(self):
@@ -688,12 +688,12 @@ class CaseMappingDiffHasChangesTests(SimpleTestCase):
     def test_has_changes(self):
         diff = {
             'open_case': {
-                'delete': [{'question_path': 'old_name'}],
-                'add': [{'question_path': 'new_name'}],
+                'delete': [{'question_path': '/data/old_name'}],
+                'add': [{'question_path': '/data/new_name'}],
             },
             'update_case': {
-                'delete': {'one': [{'question_path': 'one'}]},
-                'add': {'two': [{'question_path': 'two'}]},
+                'delete': {'one': [{'question_path': '/data/one'}]},
+                'add': {'two': [{'question_path': '/data/two'}]},
             }
         }
 
@@ -742,16 +742,16 @@ class CombinedDiffTests(SimpleTestCase):
     def test_from_combined_diff_non_registration_name_stays_in_update(self):
         combined_diff = {
             'add': {
-                'name': [{'question_path': 'one'}],
-                'other': [{'question_path': 'two'}],
+                'name': [{'question_path': '/data/one'}],
+                'other': [{'question_path': '/data/two'}],
             },
             'update': {
-                'name': [{'question_path': 'three'}],
-                'other': [{'question_path': 'four'}],
+                'name': [{'question_path': '/data/three'}],
+                'other': [{'question_path': '/data/four'}],
             },
             'delete': {
-                'name': [{'question_path': 'five'}],
-                'other': [{'question_path': 'six'}],
+                'name': [{'question_path': '/data/five'}],
+                'other': [{'question_path': '/data/six'}],
             },
         }
         snapshot = deepcopy(combined_diff)
@@ -765,16 +765,16 @@ class CombinedDiffTests(SimpleTestCase):
     def test_from_combined_diff_registration_name_is_in_open_case(self):
         combined_diff = {
             'add': {
-                'name': [{'question_path': 'one'}],
-                'other': [{'question_path': 'two'}],
+                'name': [{'question_path': '/data/one'}],
+                'other': [{'question_path': '/data/two'}],
             },
             'update': {
-                'name': [{'question_path': 'three'}],
-                'other': [{'question_path': 'four'}],
+                'name': [{'question_path': '/data/three'}],
+                'other': [{'question_path': '/data/four'}],
             },
             'delete': {
-                'name': [{'question_path': 'five'}],
-                'other': [{'question_path': 'six'}],
+                'name': [{'question_path': '/data/five'}],
+                'other': [{'question_path': '/data/six'}],
             },
         }
         snapshot = deepcopy(combined_diff)
@@ -782,14 +782,14 @@ class CombinedDiffTests(SimpleTestCase):
         diff = from_combined_diff(combined_diff, is_registration=True)
 
         assert diff['open_case'] == {
-            'add': [{'question_path': 'one'}],
-            'update': [{'question_path': 'three'}],
-            'delete': [{'question_path': 'five'}],
+            'add': [{'question_path': '/data/one'}],
+            'update': [{'question_path': '/data/three'}],
+            'delete': [{'question_path': '/data/five'}],
         }
         assert diff['update_case'] == {
-            'add': {'other': [{'question_path': 'two'}]},
-            'update': {'other': [{'question_path': 'four'}]},
-            'delete': {'other': [{'question_path': 'six'}]},
+            'add': {'other': [{'question_path': '/data/two'}]},
+            'update': {'other': [{'question_path': '/data/four'}]},
+            'delete': {'other': [{'question_path': '/data/six'}]},
         }
         assert combined_diff == snapshot, 'combined_diff should not be mutated'
 
@@ -799,23 +799,23 @@ class TestMultiTools(SimpleTestCase):
     def test_make_multi(self):
         actions_json = FormActions(
             open_case=OpenCaseAction({
-                'name_update': {'question_path': 'form_name'},
-                'conflicts': [{'question_path': 'other_name'}],
+                'name_update': {'question_path': '/data/form_name'},
+                'conflicts': [{'question_path': '/data/other_name'}],
             }),
             update_case=UpdateCaseAction({
                 'update': {
-                    'one': {'question_path': 'one'},
-                    'two': {'question_path': 'two'},
+                    'one': {'question_path': '/data/one'},
+                    'two': {'question_path': '/data/two'},
                 },
                 'conflicts': {
-                    'one': [{'question_path': 'other_one'}],
-                    'two': [{'question_path': 'other_two'}],
-                    'three': [{'question_path': 'three'}],
+                    'one': [{'question_path': '/data/other_one'}],
+                    'two': [{'question_path': '/data/other_two'}],
+                    'three': [{'question_path': '/data/three'}],
                 },
             }),
             usercase_update=UpdateCaseAction({
                 'update': {
-                    'one': {'question_path': 'test_path'},
+                    'one': {'question_path': '/data/test_path'},
                 },
             }),
         ).to_json()
@@ -825,22 +825,22 @@ class TestMultiTools(SimpleTestCase):
 
         assert multi['open_case'] == _Subdict({
             'name_update_multi': [
-                _Subdict({'question_path': 'form_name'}),
-                _Subdict({'question_path': 'other_name'}),
+                _Subdict({'question_path': '/data/form_name'}),
+                _Subdict({'question_path': '/data/other_name'}),
             ],
         })
         assert multi['update_case'] == _Subdict({
             'update_multi': {
                 'one': [
-                    _Subdict({'question_path': 'one'}),
-                    _Subdict({'question_path': 'other_one'}),
+                    _Subdict({'question_path': '/data/one'}),
+                    _Subdict({'question_path': '/data/other_one'}),
                 ],
                 'two': [
-                    _Subdict({'question_path': 'two'}),
-                    _Subdict({'question_path': 'other_two'}),
+                    _Subdict({'question_path': '/data/two'}),
+                    _Subdict({'question_path': '/data/other_two'}),
                 ],
                 'three': [
-                    _Subdict({'question_path': 'three', 'conflicting_delete': True}),
+                    _Subdict({'question_path': '/data/three', 'conflicting_delete': True}),
                 ]
             },
         })
@@ -854,8 +854,8 @@ class TestMultiTools(SimpleTestCase):
                 'update': {},
                 'conflicts': {
                     'one': [
-                        {'question_path': 'two'},
-                        {'question_path': 'other_two'},
+                        {'question_path': '/data/two'},
+                        {'question_path': '/data/other_two'},
                     ],
                 },
             }),
@@ -867,8 +867,8 @@ class TestMultiTools(SimpleTestCase):
         assert multi['update_case'] == _Subdict({
             'update_multi': {
                 'one': [
-                    _Subdict({'question_path': 'two', 'conflicting_delete': True}),
-                    _Subdict({'question_path': 'other_two', 'conflicting_delete': True}),
+                    _Subdict({'question_path': '/data/two', 'conflicting_delete': True}),
+                    _Subdict({'question_path': '/data/other_two', 'conflicting_delete': True}),
                 ]
             },
         })
@@ -879,8 +879,8 @@ class TestMultiTools(SimpleTestCase):
             'open_case': {
                 'external_id': '0000',
                 'name_update_multi': [
-                    {'question_path': 'form_name'},
-                    {'question_path': 'other_name'},
+                    {'question_path': '/data/form_name'},
+                    {'question_path': '/data/other_name'},
                 ],
                 'name_update': {},
                 'conflicts': [],
@@ -888,15 +888,15 @@ class TestMultiTools(SimpleTestCase):
             'update_case': {
                 'condition': {'type': 'never'},
                 'update_multi': {
-                    'one': [{'question_path': 'one'}, {'question_path': 'other_one'}],
-                    'two': [{'question_path': 'two'}, {'question_path': 'other_two'}],
+                    'one': [{'question_path': '/data/one'}, {'question_path': '/data/other_one'}],
+                    'two': [{'question_path': '/data/two'}, {'question_path': '/data/other_two'}],
                 },
                 'update': {},
                 'conflicts': {},
             },
             'usercase_update': {
                 'update': {
-                    'one': {'question_path': 'test_path'},
+                    'one': {'question_path': '/data/test_path'},
                 },
             },
         }
@@ -909,7 +909,7 @@ class TestMultiTools(SimpleTestCase):
             'update_case': {'condition': {'type': 'never'}},
             'usercase_update': {
                 'update': {
-                    'one': {'question_path': 'test_path'},
+                    'one': {'question_path': '/data/test_path'},
                 },
             },
         }

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -703,8 +703,9 @@ class CaseMappingDiffHasChangesTests(SimpleTestCase):
 
 
 class ConvertUpdateToAddPlusDeleteTests(SimpleTestCase):
+    # 'update' key in diff is for backward compatibility
 
-    def test_simple(self):
+    def test_simple_update(self):
         diff = {'update': {'one': [{'question_path': '/data/one'}]}}
         snapshot = deepcopy(diff)
 
@@ -716,7 +717,7 @@ class ConvertUpdateToAddPlusDeleteTests(SimpleTestCase):
         }
         assert diff == snapshot, 'original diff should not be mutated'
 
-    def test_extended(self):
+    def test_update_with_add_and_delete(self):
         diff = {
             'add': {'one': [{'question_path': '/data/add'}]},
             'delete': {'one': [{'question_path': '/data/del'}]},

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -267,7 +267,9 @@ class UpdateCaseActionApplyDiffTests(SimpleTestCase):
 
         assert actions.update['one'].update_mode == 'edit'
 
-    def test_updating_a_missing_mapping_adds_a_conflict(self):
+    def test_updating_a_deleted_mapping_adds_a_conflict(self):
+        # If the mapping was deleted by a different session, updating it should
+        # create a conflict rather than restoring the original mapping
         actions = UpdateCaseAction({'update': {
             'one': {'question_path': '/data/one'},
         }})
@@ -280,17 +282,16 @@ class UpdateCaseActionApplyDiffTests(SimpleTestCase):
         assert 'two' not in actions.update
         assert [c.question_path for c in actions.conflicts['two']] == ['/data/two']
 
-    def test_updating_a_missing_question_adds_a_conflict(self):
-        # If the specific mapping was deleted by a different session, updating it shouldn't restore it
+    def test_updating_a_changed_mapping_adds_a_conflict(self):
+        # If the mapping was changed by a different session, updating it should
+        # create a conflict rather than updating the original mapping
         actions = UpdateCaseAction({'update': {
             'one': {'question_path': '/data/one'}
         }})
         form_actions = FormActions(update_case=actions)
 
         merge_case_mappings({'update_case': {
-            'update': {
-                'one': [{'question_path': '/data/two', 'update_mode': 'edit'}]
-            }
+            'update': {'one': [{'question_path': '/data/two', 'update_mode': 'edit'}]}
         }}, form_actions)
 
         assert actions.update['one'].question_path == '/data/one'

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -66,7 +66,7 @@ class OpenCaseActionApplyDiffTests(SimpleTestCase):
 
         assert action.name_update.question_path == '/data/name2'
 
-    def test_merge_case_mappings_remove_name_does_nothing_when_name_is_absent(self):
+    def test_merge_case_mappings_delete_mapping_does_nothing_when_the_mapping_is_absent(self):
         actions = FormActions(open_case=OpenCaseAction({'name_update': {'question_path': '/data/name2'}}))
 
         diff = {'open_case': {'delete': [{'question_path': '/data/name1'}]}}

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -445,7 +445,7 @@ class FormActionsTests(SimpleTestCase):
     def test_merge_case_mappings_with_all_actions_at_once(self):
         actions = FormActions({
             'open_case': {
-                'name_update': {'question_path': 'form_name'},
+                'name_update': {'question_path': 'old_name'},
             },
             'update_case': {
                 'update': {
@@ -458,7 +458,7 @@ class FormActionsTests(SimpleTestCase):
         merge_case_mappings({
             'open_case': {
                 'add': [{'question_path': 'new_name'}],
-                'delete': [{'question_path': 'form_name'}],
+                'delete': [{'question_path': 'old_name'}],
             },
             'update_case': {
                 'add': {'three': [{'question_path': 'three'}]},

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -479,8 +479,10 @@ class FormActionsTests(SimpleTestCase):
         assert actions.update_case.update['two'].update_mode == 'edit'
 
     def test_merge_case_mappings_with_double_addition(self):
-        # a scenario that would have previously caused DiffConflictException
+        # A scenario that would have previously caused DiffConflictException:
         # update + add => delete + add + add (last add wins)
+        # Edge case is probably not possible to create in real life,
+        # although a bug allowed it in the past.
         actions = FormActions(
             open_case=OpenCaseAction({
                 'name_update': {'question_path': '/data/form_name'},

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/forms/case_config_ko_templates.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/forms/case_config_ko_templates.html.diff.txt
@@ -227,7 +227,7 @@
 -            <button class="close" aria-label="close" data-bind="click: $parent.dismissConflictingDelete">&times;</button>
              <p class="alert-heading">
                <i class="fa fa-triangle-exclamation"></i>
-               {% trans "Property mapping concurrently changed and deleted" %}
+               {% trans "This mapping was changed and deleted in separate sessions" %}
              </p>
              <p>{% trans "Dismiss this alert to keep the mapping." %}</p>
 +            <button type="button" class="btn-close" aria-label="{% trans_html_attr "Close" %}"


### PR DESCRIPTION
Follow-up to [review comments](https://github.com/dimagi/commcare-hq/pull/37543#pullrequestreview-4079186077)

## Product Description

Improves the user-facing alert shown when a case property mapping is concurrently changed and deleted in separate sessions — the wording is now clearer about what happened.

No other user-facing behavior changes.

## Technical Summary

This branch is a readability/maintenance pass on `form_action_diff.py` and its test module. No logic changes outside of the alert text above.

## Safety Assurance

### Safety story

The Python changes are limited to comments, docstrings, and test names/structure — no production code paths change. The only runtime change is the translated alert string in the case config Knockout templates, which is cosmetic. Existing automated tests continue to cover the merge/diff logic.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
