### PR TITLE
Add permissions to control Locked Admin Questions feature

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -165,6 +165,7 @@ advanced_v0 = pro_v1 + [
     privileges.GEOJSON_EXPORT,
     privileges.CUSTOM_ICON_BADGES,
     privileges.LOCATION_COLUMNS_IN_USER_LAST_ACTIVITY_REPORT,
+    privileges.LOCKED_ADMIN_QUESTIONS,
 ]
 
 enterprise_v0 = advanced_v0 + [

--- a/corehq/apps/accounting/migrations/0117_locked_admin_questions_priv.py
+++ b/corehq/apps/accounting/migrations/0117_locked_admin_questions_priv.py
@@ -1,0 +1,39 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.privileges import LOCKED_ADMIN_QUESTIONS
+
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _grandfather_privilege(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+
+    skip_editions = ','.join((
+        SoftwarePlanEdition.PAUSED,
+        SoftwarePlanEdition.FREE,
+        SoftwarePlanEdition.STANDARD,
+        SoftwarePlanEdition.PRO,
+    ))
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        LOCKED_ADMIN_QUESTIONS,
+        skip_edition=skip_editions,
+        noinput=True,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0116_creditadjustment_payment_type'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _grandfather_privilege,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -327,8 +327,10 @@ def _get_vellum_plugins(domain, form, module, options):
         vellum_plugins.append("saveToCase")
     if toggles.COMMCARE_CONNECT.enabled(domain):
         vellum_plugins.append("commcareConnect")
-    if toggles.LOCKED_ADMIN_QUESTIONS.enabled(domain, namespace=toggles.NAMESPACE_DOMAIN):
-        # replace with privilege check once added to appropriate software plan(s)
+    if (
+        toggles.LOCKED_ADMIN_QUESTIONS.enabled(domain, namespace=toggles.NAMESPACE_DOMAIN)
+        and domain_has_privilege(domain, privileges.LOCKED_ADMIN_QUESTIONS)
+    ):
         vellum_plugins.append("lock")
 
     form_uses_case = (
@@ -363,6 +365,7 @@ def _get_vellum_features(request, domain, app):
         'markdown_tables': app.enable_markdown_tables,
         'use_custom_repeat_button_text': app.build_version >= LooseVersion('2.55'),
         'support_document_upload': app.support_document_upload,
+        'edit_locked_questions': request.couch_user.can_edit_locked_questions_in_apps(),
     })
     return vellum_features
 

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -255,6 +255,9 @@ class Command(BaseCommand):
         Role(slug=privileges.LOCATION_COLUMNS_IN_USER_LAST_ACTIVITY_REPORT,
              name='Location columns in user last activity report',
              description="Add primary location's hierarchy to excel export in User Last Activity Report"),
+        Role(slug=privileges.LOCKED_ADMIN_QUESTIONS,
+             name='Locked Admin Questions',
+             description="Allow questions to be locked in the form builder to limit editing"),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -200,8 +200,11 @@ class HqPermissions(DocumentSchema):
 
     edit_motech = BooleanProperty(default=False)
     edit_data = BooleanProperty(default=False)
+
     edit_apps = BooleanProperty(default=False)
     view_apps = BooleanProperty(default=False)
+    edit_locked_questions_in_apps = BooleanProperty(default=False)
+
     edit_shared_exports = BooleanProperty(default=False)
     access_all_locations = BooleanProperty(default=True)
     access_api = BooleanProperty(default=False)

--- a/corehq/apps/users/static/users/js/edit_role.js
+++ b/corehq/apps/users/static/users/js/edit_role.js
@@ -468,10 +468,15 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-apps-checkbox",
                     screenReaderEditAndViewText: gettext("Edit & View Apps"),
                     screenReaderViewOnlyText: gettext("View-Only Applications"),
-                    showAllowCheckbox: false,
-                    allowCheckboxText: null,
-                    allowCheckboxId: null,
-                    allowCheckboxPermission: null,
+                    showAllowCheckbox: toggles.toggleEnabled("LOCKED_ADMIN_QUESTIONS") && privileges.hasPrivilege("locked_admin_questions"),
+                    allowCheckboxText: gettext("Allow locking and unlocking questions in forms."),
+                    allowCheckboxId: "edit-locked-questions-checkbox",
+                    get allowCheckboxPermission() {
+                        return self.role.permissions.edit_locked_questions_in_apps;
+                    },
+                    set allowCheckboxPermission(value) {
+                        self.role.permissions.edit_locked_questions_in_apps = value;
+                    },
                 },
                 {
                     get showOption() {

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -135,6 +135,8 @@ CUSTOM_ICON_BADGES = 'custom_icon_badges'
 
 LOCATION_COLUMNS_IN_USER_LAST_ACTIVITY_REPORT = 'location_columns_in_user_last_activity_report'
 
+LOCKED_ADMIN_QUESTIONS = 'locked_admin_questions'
+
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,
     API_ACCESS,
@@ -205,6 +207,7 @@ MAX_PRIVILEGES = [
     GEOJSON_EXPORT,
     CUSTOM_ICON_BADGES,
     LOCATION_COLUMNS_IN_USER_LAST_ACTIVITY_REPORT,
+    LOCKED_ADMIN_QUESTIONS,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -292,4 +295,5 @@ class Titles(object):
             LOCATION_COLUMNS_IN_USER_LAST_ACTIVITY_REPORT: _(
                 "Add primary location's hierarchy to excel export in User Last Activity Report"
             ),
+            LOCKED_ADMIN_QUESTIONS: _("Locked Admin Questions"),
         }.get(privilege, privilege)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1234,15 +1234,6 @@ LOCKED_ADMIN_QUESTIONS = FeatureRelease(
     description="Enables Locked Admin Questions workflows in HQ and the form builder.",
 )
 
-EDIT_LOCKED_QUESTIONS = FeatureRelease(
-    'edit_locked_questions',
-    "Edit Locked Admin Questions",
-    TAG_RELEASE,
-    [NAMESPACE_USER],
-    owner="Evan Joseph-Pinero",
-    description="Allows locking and unlocking questions in forms."
-)
-
 CACHE_AND_INDEX = StaticToggle(
     'cache_and_index',
     'REC: Enable the "Cache and Index" format option when choosing sort properties '

--- a/migrations.lock
+++ b/migrations.lock
@@ -136,6 +136,7 @@ accounting
  0114_custom_icon_badges_priv
  0115_loc_cols_in_user_last_activity_priv
  0116_creditadjustment_payment_type
+ 0117_locked_admin_questions_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Product Description
For projects on Advanced or above with the LOCKED_ADMIN_QUESTIONS feature flag enabled, adds the ability to set the user permission edit_locked_questions_in_apps / "Allow locking and unlocking questions in forms" when "Edit Applications" is checked :
<img width="832" height="101" alt="image" src="https://github.com/user-attachments/assets/cfbf6f3a-d15a-43e4-a778-bc143cad6ba3" />

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19547 and https://dimagi.atlassian.net/browse/SAAS-19548
Adds a software plan-level privilege for Locked Admin Questions, which will gate this in-development feature to Advanced plans and above. Adds a user role privilege, that will allow individual users to edit locked questions, which replaces the EDIT_LOCKED_ADMIN_QUESTIONS feature flag.

## Feature Flag
These changes are under the LOCKED_ADMIN_QUESTIONS until development and QA are complete.

## Safety Assurance

### Safety story
Followed existing pattern for adding a new software plan privilege and tested all functionality locally.

### Automated test coverage
Migrations run in tests, but there are not tests added for these changes specifically.

### QA Plan
Locked Admin Questions will get QA as a whole when development nears completion.


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code. Pay particular attention to _backward incompatible_ operations like `RemoveField`, `RenameField`, `RemoveConstraint`, and [others described here](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md) that can cause errors when migrations are applied to a live database.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
