### PR TITLE
Add separate FF for normal case list setting

### DIFF
--- a/corehq/apps/domain/management/commands/update_case_search_toggles.py
+++ b/corehq/apps/domain/management/commands/update_case_search_toggles.py
@@ -2,7 +2,6 @@ from django.core.management.base import BaseCommand
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_app_doc, get_app_ids_in_domain
-from corehq.apps.case_search.models import CaseSearchConfig
 from corehq.toggles import NAMESPACE_DOMAIN
 
 
@@ -38,88 +37,7 @@ class Command(BaseCommand):
         return [m for m in app_doc.get('modules', []) if m['module_type'] == 'basic' and m['case_type']]
 
     @staticmethod
-    def _domain_uses_advanced_feature(domain_name):
-        reasons = []
-        csc = CaseSearchConfig.objects.get_or_none(pk=domain_name)
-        # USH Specific toggle to making case search user input available to other parts of the app.
-        if csc and csc.enabled and toggles.USH_INLINE_SEARCH.enabled(domain_name):
-            reasons.append("toggle USH_INLINE_SEARCH")
-        if csc and csc.synchronous_web_apps:  # Synchronous Web Apps Submissions
-            reasons.append("synchronous_web_apps")
-        if csc and csc.ignore_patterns.exists():  # Remove Special Characters
-            reasons.append("ignore_patterns (Remove Special Characters)")
-        if csc and csc.sync_cases_on_form_entry:  # Sync before entering form
-            reasons.append("sync_cases_on_form_entry")
-        return reasons
-
-    @staticmethod
-    def _app_uses_advanced_feature(app):
-        reasons = []
-
-        for m in Command._get_case_list_modules(app):
-            search_config = m.get('search_config', {})
-            properties = search_config.get('properties', [])
-            default_properties = search_config.get('default_properties', [])
-            mod = _module_name(m)
-
-            # _xpath_query
-            if any(p.get('property') == '_xpath_query' for p in default_properties):
-                reasons.append(f"module '{mod}': xpath_query default property")
-            # Mobile Report Dropdown
-            if any(
-                p.get('input_', '') in ['select', 'select1']
-                and p.get('itemset', {}).get('instance_id', '').startswith('commcare-reports:')
-                for p in properties
-            ):
-                reasons.append(f"module '{mod}': mobile report search field")
-            # Checkbox selections
-            if any(
-                p.get('input_', '') == 'checkbox'
-                and p.get('itemset', {}).get('instance_id', '').startswith('item-list:')
-                for p in properties
-            ):
-                reasons.append(f"module '{mod}': checkbox search field")
-            # Geocoder Widget
-            if any(
-                p.get('input_') is None and p.get('appearance') == 'address'
-                for p in properties
-            ):
-                reasons.append(f"module '{mod}': geocoder search field")
-            # Default Value Expressions
-            if any(
-                bool(p.get('default_value'))
-                for p in properties
-            ):
-                reasons.append(f"module '{mod}': default expression")
-            # Clearing search terms resets search results
-            if search_config.get('search_on_clear', False):
-                reasons.append(f"module '{mod}': search_on_clear")
-            # Hide Property on Search Screen / Exclude from Search Filters
-            if any(p.get('hidden', False) or p.get('exclude', False) for p in properties):
-                reasons.append(f"module '{mod}': hidden/excluded property")
-            # Case property with additional case id to add to results
-            if search_config.get('custom_related_case_property'):
-                reasons.append(f"module '{mod}': custom_related_case_property")
-            # Custom search input instance name
-            if search_config.get('instance_name'):
-                reasons.append(f"module '{mod}': instance_name")
-            # Additional Case List and Case Search Types
-            if search_config.get('additional_case_types'):
-                reasons.append(f"module '{mod}': additional_case_types")
-            # Custom Search Sort Properties
-            if search_config.get('custom_sort_properties'):
-                reasons.append(f"module '{mod}': custom_sort_properties")
-            # Multiple Select Case List / Auto-select case search results
-            if m.get('case_details', {}).get('short', {}).get('multi_select', False):
-                reasons.append(f"module '{mod}': multi_select")
-
-            if reasons:
-                break
-
-        return reasons
-
-    @staticmethod
-    def _app_uses_deprecated_feature(app):
+    def _app_uses_normal_case_list_option(app):
         reasons = []
 
         for m in Command._get_case_list_modules(app):
@@ -130,56 +48,6 @@ class Command(BaseCommand):
             # Normal Navigation / See More - only if case search is actually configured
             if bool(search_config.get('properties')) and not auto_launch:
                 reasons.append(f"module '{mod}': not auto_launch (See More / Normal Case List)")
-            if search_config.get('additional_relevant'):  # Claim condition
-                reasons.append(f"module '{mod}': additional_relevant (claim condition)")
-            # USH Specific toggle to use Search Filter in case search options.
-            if search_config.get('search_filter'):
-                reasons.append(f"module '{mod}': search_filter")
-
-            if reasons:
-                break
-
-        return reasons
-
-    @staticmethod
-    def _app_uses_related_lookup_feature(app):
-        reasons = []
-        csql_fns = [
-            "ancestor-exists",  # CSQL Expression: ancestor-exists
-            "subcase-exists",   # CSQL Expression: subcase-exists
-            "subcase-count",    # CSQL Expression: subcase-count
-            "parent/"           # Related properties
-        ]
-
-        def is_parent_reference(prop):
-            return prop.startswith('parent/') and prop.removeprefix('parent/') != '@case_id'
-
-        for m in Command._get_case_list_modules(app):
-            search_config = m.get('search_config', {})
-            properties = search_config.get('properties', [])
-            default_properties = search_config.get('default_properties', [])
-            mod = _module_name(m)
-
-            # CSQL Expression: ancestor-exists / subcase-exists / subcase-count
-            # Related properties (via xpath_query)
-            for p in default_properties:
-                if (
-                    p.get('property') == '_xpath_query'
-                    and p.get('defaultValue')
-                    and any(fn in p['defaultValue'] for fn in csql_fns)
-                ):
-                    matched = [fn for fn in csql_fns if fn in p['defaultValue']]
-                    reasons.append(f"module '{mod}': xpath_query default with {matched}")
-
-            # Related properties
-            if any(is_parent_reference(p['name']) for p in properties):
-                reasons.append(f"module '{mod}': parent/ search property")
-            # Related properties
-            if any(is_parent_reference(p.get('property', '')) for p in default_properties):
-                reasons.append(f"module '{mod}': parent/ default property")
-            # Include related cases in search results
-            if search_config.get('include_all_related_cases', False):
-                reasons.append(f"module '{mod}': include_all_related_cases")
 
             if reasons:
                 break
@@ -192,57 +60,28 @@ class Command(BaseCommand):
         if dry_run:
             self.stdout.write("DRY RUN - No toggles will be set\n")
 
-        domains = options['domains'] or toggles.SYNC_SEARCH_CASE_CLAIM.get_enabled_domains()
+        domains = options['domains'] or toggles.CASE_SEARCH_DEPRECATED.get_enabled_domains()
         for domain_name in domains:
-            advanced_reasons = Command._domain_uses_advanced_feature(domain_name)
-            if advanced_reasons:
-                advanced_reasons = [f"domain: {r}" for r in advanced_reasons]
-
-            deprecated_reasons = []
-            related_lookup_reasons = []
+            normal_case_list_reasons = []
             for app_id in get_app_ids_in_domain(domain_name):
-                if advanced_reasons and deprecated_reasons and related_lookup_reasons:
+                if normal_case_list_reasons:
                     break
 
                 app = get_app_doc(domain_name, app_id)
                 app_label = f"{app['_id']} ({app.get('name', 'unknown')})"
 
-                if not advanced_reasons:
-                    app_reasons = Command._app_uses_advanced_feature(app)
+                if not normal_case_list_reasons:
+                    app_reasons = Command._app_uses_normal_case_list_option(app)
                     if app_reasons:
-                        advanced_reasons = [f"app {app_label}: {r}" for r in app_reasons]
+                        normal_case_list_reasons = [f"app {app_label}: {r}" for r in app_reasons]
 
-                if not deprecated_reasons:
-                    app_reasons = Command._app_uses_deprecated_feature(app)
-                    if app_reasons:
-                        deprecated_reasons = [f"app {app_label}: {r}" for r in app_reasons]
-
-                if not related_lookup_reasons:
-                    app_reasons = Command._app_uses_related_lookup_feature(app)
-                    if app_reasons:
-                        related_lookup_reasons = [f"app {app_label}: {r}" for r in app_reasons]
-
-            self.stdout.write(f"for domain '{domain_name}' enable:")
-            if advanced_reasons:
-                self.stdout.write("  CASE_SEARCH_ADVANCED")
+            self.stdout.write(f"for domain '{domain_name}':")
+            if normal_case_list_reasons:
+                self.stdout.write("  enable CASE_SEARCH_DEPRECATED_NORMAL_CASE_LIST")
                 if verbose:
-                    for reason in advanced_reasons:
+                    for reason in normal_case_list_reasons:
                         self.stdout.write(f"    - {reason}")
                 if not dry_run:
-                    toggles.CASE_SEARCH_ADVANCED.set(domain_name, True, NAMESPACE_DOMAIN)
-            if deprecated_reasons:
-                self.stdout.write("  CASE_SEARCH_DEPRECATED")
-                if verbose:
-                    for reason in deprecated_reasons:
-                        self.stdout.write(f"    - {reason}")
-                if not dry_run:
-                    toggles.CASE_SEARCH_DEPRECATED.set(domain_name, True, NAMESPACE_DOMAIN)
-            if related_lookup_reasons:
-                self.stdout.write("  CASE_SEARCH_RELATED_LOOKUPS")
-                if verbose:
-                    for reason in related_lookup_reasons:
-                        self.stdout.write(f"    - {reason}")
-                if not dry_run:
-                    toggles.CASE_SEARCH_RELATED_LOOKUPS.set(domain_name, True, NAMESPACE_DOMAIN)
+                    toggles.CASE_SEARCH_DEPRECATED_NORMAL_CASE_LIST.set(domain_name, True, NAMESPACE_DOMAIN)
 
             self.stdout.write("\n")

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -966,6 +966,15 @@ CASE_SEARCH_DEPRECATED = StaticToggle(
     parent_toggles=[SYNC_SEARCH_CASE_CLAIM],
 )
 
+CASE_SEARCH_DEPRECATED_NORMAL_CASE_LIST = StaticToggle(
+    'case_search_deprecated_normal_case_list',
+    'Case Search: Normal case list option Deprecated',
+    TAG_DEPRECATED,
+    help_link='https://dimagi.atlassian.net/wiki/spaces/GS/pages/2146606528/Case+Search+and+Claim',
+    namespaces=[NAMESPACE_DOMAIN],
+    parent_toggles=[SYNC_SEARCH_CASE_CLAIM],
+)
+
 CASE_SEARCH_ADVANCED = StaticToggle(
     'case_search_advanced',
     'Advanced Case Search',


### PR DESCRIPTION
## Product Description

Adds a new `CASE_SEARCH_DEPRECATED_NORMAL_CASE_LIST` toggle and updates the `update_case_search_toggles` management command to identify which `CASE_SEARCH_DEPRECATED` domains actually use the normal case list option and enable the new flag for them.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6492

## Feature Flag

`CASE_SEARCH_DEPRECATED_NORMAL_CASE_LIST` (new), `CASE_SEARCH_DEPRECATED` (unchanged)

## Safety Assurance

### Safety story

The new FF is not yet wired to any template gate in this PR — the template change comes in the next PR after the command has run. No user-visible behavior changes in this PR.

### Automated test coverage

Management command is a script; no new logic that requires unit tests.

### QA Plan

- Run command in staging and verify output identifies correct domains
- Verify `CASE_SEARCH_DEPRECATED_NORMAL_CASE_LIST` is set on expected domains
- Check on staging with `--dry-run`
  - `mriese` should get new FF ✅
  - `mriese-user-config` should not get new FF ✅

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)