### PR TITLE
Include search_button_label in bulk translations for all case search modules

### DIFF
--- a/corehq/apps/translations/app_translations/download.py
+++ b/corehq/apps/translations/app_translations/download.py
@@ -203,16 +203,13 @@ def get_module_search_command_rows(langs, module, domain):
         return []
 
     rows = [
+        ('search_label', 'list')
+        + tuple(module.search_config.search_button_label.get(lang, '') for lang in langs),
         ('title_label', 'list')
         + tuple(module.search_config.title_label.get(lang, '') for lang in langs),
         ('description', 'list')
         + tuple(module.search_config.description.get(lang, '') for lang in langs),
     ]
-    if toggles.CASE_SEARCH_DEPRECATED.enabled(domain):
-        return [
-            ('search_label', 'list')
-            + tuple(module.search_config.search_button_label.get(lang, '') for lang in langs),
-        ] + rows
     return rows
 
 

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -1134,7 +1134,8 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
     def test_module_search_labels_rows(self):
         app = AppFactory.case_claim_app_factory().app
         self.assertEqual(get_module_search_command_rows(app.langs, app.modules[0], app.domain),
-                         [('title_label', 'list', 'Find a Mom'),
+                         [('search_label', 'list', 'Search All Cases'),
+                          ('title_label', 'list', 'Find a Mom'),
                           ('description', 'list', 'More information')])
 
     @flag_enabled('SYNC_SEARCH_CASE_CLAIM')


### PR DESCRIPTION
## Product Description
Fixes the bulk app translations download to include the `search_label` row (Search All Cases button label) for all case search modules, not just those with `CASE_SEARCH_DEPRECATED` enabled.

## Technical Summary
Related to USH-6493 / PR #37612 (remove search label configuration).

https://dimagi.atlassian.net/browse/USH-6493

## Feature Flag
`SYNC_SEARCH_CASE_CLAIM`

## Safety Assurance

### Safety story

### Automated test coverage
Existing bulk translation tests cover the download/upload round-trip. No new test cases needed for this fix.

### QA Plan
- Download bulk translations for a case search module on a domain with `SYNC_SEARCH_CASE_CLAIM` enabled — confirm `search_label` row appears regardless of `CASE_SEARCH_DEPRECATED`
- Upload a modified translation for that row and confirm it saves to `search_button_label`
- Checked locally

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change