### PR TITLE
Minor refactors to existing form deletion logic not yet in use

### DIFF
--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 # @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
-def permanently_delete_eligible_data(dry_run=False):
+def permanently_delete_eligible_data(dry_run=True):
     """
     Permanently delete database objects that are eligible for hard deletion.
     To be eligible an object must have a ``deleted_on`` value
@@ -37,7 +37,8 @@ def permanently_delete_eligible_data(dry_run=False):
     in a future PR coming soon (Q1 2024).
     """
     dry_run_tag = '[DRY RUN] ' if dry_run else ''
-    form_counts = XFormInstance.objects.hard_delete_expired_forms(dry_run=dry_run)
+    commit = not dry_run
+    form_counts = XFormInstance.objects.hard_delete_expired_forms(commit=commit)
 
     logger.info(f"{dry_run_tag}'permanently_delete_eligible_data' ran with the following results:\n")
     for table, count in form_counts.items():

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -38,10 +38,11 @@ def permanently_delete_eligible_data(dry_run=True):
     """
     dry_run_tag = '[DRY RUN] ' if dry_run else ''
     commit = not dry_run
-    form_count = XFormInstance.objects.hard_delete_expired_forms(commit=commit)
+    form_counts = XFormInstance.objects.hard_delete_expired_forms(commit=commit)
 
     logger.info(f"{dry_run_tag}'permanently_delete_eligible_data' ran with the following results:\n")
-    logger.info(f"{dry_run_tag}{form_count} forms were deleted.")
+    for table, count in form_counts.items():
+        logger.info(f"{dry_run_tag}{count} {table} objects were deleted.")
 
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -13,7 +13,6 @@ from corehq.apps.cleanup.dbaccessors import (
     find_ucr_tables_for_deleted_domains,
 )
 from corehq.apps.cleanup.tests.util import is_monday
-from corehq.apps.cleanup.utils import get_cutoff_date_for_data_deletion
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.tasks import mail_admins_async
 from corehq.form_processor.models import XFormInstance
@@ -27,8 +26,8 @@ logger = logging.getLogger(__name__)
 def permanently_delete_eligible_data(dry_run=False):
     """
     Permanently delete database objects that are eligible for hard deletion.
-    To be eligible means to have a ``deleted_on`` field with a value less than
-    the cutoff date returned from ``get_cutoff_date_for_data_deletion``.
+    To be eligible an object must have a ``deleted_on`` value
+    older than the settings.DATA_RETENTION_WINDOW
     :param dry_run: if True, no changes will be committed to the database
     """
     """
@@ -38,8 +37,7 @@ def permanently_delete_eligible_data(dry_run=False):
     in a future PR coming soon (Q1 2024).
     """
     dry_run_tag = '[DRY RUN] ' if dry_run else ''
-    cutoff_date = get_cutoff_date_for_data_deletion()
-    form_counts = XFormInstance.objects.hard_delete_forms_before_cutoff(cutoff_date, dry_run=dry_run)
+    form_counts = XFormInstance.objects.hard_delete_expired_forms(dry_run=dry_run)
 
     logger.info(f"{dry_run_tag}'permanently_delete_eligible_data' ran with the following results:\n")
     for table, count in form_counts.items():

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -38,11 +38,10 @@ def permanently_delete_eligible_data(dry_run=True):
     """
     dry_run_tag = '[DRY RUN] ' if dry_run else ''
     commit = not dry_run
-    form_counts = XFormInstance.objects.hard_delete_expired_forms(commit=commit)
+    form_count = XFormInstance.objects.hard_delete_expired_forms(commit=commit)
 
     logger.info(f"{dry_run_tag}'permanently_delete_eligible_data' ran with the following results:\n")
-    for table, count in form_counts.items():
-        logger.info(f"{dry_run_tag}{count} {table} objects were deleted.")
+    logger.info(f"{dry_run_tag}{form_count} forms were deleted.")
 
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))

--- a/corehq/apps/cleanup/tests/test_tasks.py
+++ b/corehq/apps/cleanup/tests/test_tasks.py
@@ -21,7 +21,7 @@ class TestPermanentlyDeleteEligibleData(TestCase):
         self.domain = 'test_permanently_delete_eligible_data'
 
     @travel('2020-01-10')
-    def test_deletes_data(self):
+    def test_deletes_data_outside_of_retention_window(self):
         form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 2))
 
         with override_settings(DATA_RETENTION_WINDOW=7):
@@ -31,7 +31,7 @@ class TestPermanentlyDeleteEligibleData(TestCase):
             XFormInstance.objects.get_form(form.form_id)
 
     @travel('2020-01-10')
-    def test_does_not_delete_data(self):
+    def test_does_not_delete_data_within_retention_window(self):
         form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 4))
 
         with override_settings(DATA_RETENTION_WINDOW=7):
@@ -40,7 +40,7 @@ class TestPermanentlyDeleteEligibleData(TestCase):
         assert XFormInstance.objects.get_form(form.form_id) is not None
 
     @travel('2020-01-10')
-    def test_does_not_delete_data_if_in_dry_run_mode(self):
+    def test_does_not_delete_data_in_dry_run(self):
         form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 2))
 
         with override_settings(DATA_RETENTION_WINDOW=7):

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -198,18 +198,18 @@ class XFormInstanceManager(RequireDBManager):
         the DATA_RETENTION_WINDOW, meaning the ``deleted_on`` field is
         older than the current time - the DATA_RETENTION_WINDOW.
         :param commit: defaults to False. If True, will delete expired forms
-        :return: dictionary of count of deleted forms
+        :return: count of forms deleted
         """
         expiration_date = get_cutoff_date_for_data_deletion()
-        counts = {}
+        total_count = 0
         for db_name in get_db_aliases_for_partitioned_query():
             queryset = self.using(db_name).filter(deleted_on__lt=expiration_date)
             if commit:
-                deleted_counts = queryset.delete()[1]
+                deleted_count = queryset.delete()[0]
             else:
-                deleted_counts = {'form_processor.XFormInstance': queryset.count()}
-            counts.update(deleted_counts)
-        return counts
+                deleted_count = queryset.count()
+            total_count += deleted_count
+        return total_count
 
     def iter_form_ids_by_xmlns(self, domain, xmlns=None):
         q_expr = Q(domain=domain) & Q(state=self.model.NORMAL)

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -19,6 +19,7 @@ from dimagi.utils.couch import RedisLockableMixIn
 from dimagi.utils.couch.safe_index import safe_index
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 
+from corehq.apps.cleanup.utils import get_cutoff_date_for_data_deletion
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.models import BlobMeta
@@ -191,18 +192,19 @@ class XFormInstanceManager(RequireDBManager):
             )
         return result
 
-    def hard_delete_forms_before_cutoff(self, cutoff, dry_run=True):
+    def hard_delete_expired_forms(self, dry_run=True):
         """
-        Permanently deletes forms with deleted_on set to a datetime earlier than
-        the specified cutoff datetime
-        :param cutoff: datetime used to obtain the forms to be hard deleted
+        Permanently deletes forms that were soft deleted outside of
+        the DATA_RETENTION_WINDOW, meaning the ``deleted_on`` field is
+        older than the current time - the DATA_RETENTION_WINDOW.
         :param dry_run: if True, no changes will be committed to the database
         and this method is effectively read-only
-        :return: dictionary of count of deleted objects per table
+        :return: dictionary of count of deleted forms
         """
+        expiration_date = get_cutoff_date_for_data_deletion()
         counts = {}
         for db_name in get_db_aliases_for_partitioned_query():
-            queryset = self.using(db_name).filter(deleted_on__lt=cutoff)
+            queryset = self.using(db_name).filter(deleted_on__lt=expiration_date)
             if dry_run:
                 deleted_counts = {'form_processor.XFormInstance': queryset.count()}
             else:

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -1,4 +1,5 @@
 import logging
+from collections import Counter
 from contextlib import contextmanager
 from datetime import datetime
 from io import BytesIO
@@ -201,15 +202,15 @@ class XFormInstanceManager(RequireDBManager):
         :return: dictionary of count of deleted forms
         """
         expiration_date = get_cutoff_date_for_data_deletion()
-        counts = {}
+        total_count = {}
         for db_name in get_db_aliases_for_partitioned_query():
             queryset = self.using(db_name).filter(deleted_on__lt=expiration_date)
             if commit:
                 deleted_counts = queryset.delete()[1]
             else:
                 deleted_counts = {'form_processor.XFormInstance': queryset.count()}
-            counts.update(deleted_counts)
-        return counts
+            total_count = Counter(total_count) + Counter(deleted_counts)
+        return total_count
 
     def iter_form_ids_by_xmlns(self, domain, xmlns=None):
         q_expr = Q(domain=domain) & Q(state=self.model.NORMAL)

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -198,18 +198,18 @@ class XFormInstanceManager(RequireDBManager):
         the DATA_RETENTION_WINDOW, meaning the ``deleted_on`` field is
         older than the current time - the DATA_RETENTION_WINDOW.
         :param commit: defaults to False. If True, will delete expired forms
-        :return: count of forms deleted
+        :return: dictionary of count of deleted forms
         """
         expiration_date = get_cutoff_date_for_data_deletion()
-        total_count = 0
+        counts = {}
         for db_name in get_db_aliases_for_partitioned_query():
             queryset = self.using(db_name).filter(deleted_on__lt=expiration_date)
             if commit:
-                deleted_count = queryset.delete()[0]
+                deleted_counts = queryset.delete()[1]
             else:
-                deleted_count = queryset.count()
-            total_count += deleted_count
-        return total_count
+                deleted_counts = {'form_processor.XFormInstance': queryset.count()}
+            counts.update(deleted_counts)
+        return counts
 
     def iter_form_ids_by_xmlns(self, domain, xmlns=None):
         q_expr = Q(domain=domain) & Q(state=self.model.NORMAL)

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -192,23 +192,22 @@ class XFormInstanceManager(RequireDBManager):
             )
         return result
 
-    def hard_delete_expired_forms(self, dry_run=True):
+    def hard_delete_expired_forms(self, commit=False):
         """
         Permanently deletes forms that were soft deleted outside of
         the DATA_RETENTION_WINDOW, meaning the ``deleted_on`` field is
         older than the current time - the DATA_RETENTION_WINDOW.
-        :param dry_run: if True, no changes will be committed to the database
-        and this method is effectively read-only
+        :param commit: defaults to False. If True, will delete expired forms
         :return: dictionary of count of deleted forms
         """
         expiration_date = get_cutoff_date_for_data_deletion()
         counts = {}
         for db_name in get_db_aliases_for_partitioned_query():
             queryset = self.using(db_name).filter(deleted_on__lt=expiration_date)
-            if dry_run:
-                deleted_counts = {'form_processor.XFormInstance': queryset.count()}
-            else:
+            if commit:
                 deleted_counts = queryset.delete()[1]
+            else:
+                deleted_counts = {'form_processor.XFormInstance': queryset.count()}
             counts.update(deleted_counts)
         return counts
 

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -417,7 +417,7 @@ class TestHardDeleteExpiredForms(TestCase):
         with override_settings(DATA_RETENTION_WINDOW=7):
             count = XFormInstance.objects.hard_delete_expired_forms(commit=True)
 
-        assert count == 1
+        assert count == {'form_processor.XFormInstance': 1}
         assert XFormInstance.objects.partitioned_get(valid_form.form_id)
         assert XFormInstance.objects.partitioned_get(soft_deleted_form.form_id)
         with pytest.raises(XFormInstance.DoesNotExist):
@@ -432,7 +432,7 @@ class TestHardDeleteExpiredForms(TestCase):
         with override_settings(DATA_RETENTION_WINDOW=7):
             count = XFormInstance.objects.hard_delete_expired_forms()
 
-        assert count == 1
+        assert count == {'form_processor.XFormInstance': 1}
         assert XFormInstance.objects.partitioned_get(valid_form.form_id)
         assert XFormInstance.objects.partitioned_get(soft_deleted_form.form_id)
         assert XFormInstance.objects.partitioned_get(expired_form.form_id)
@@ -450,8 +450,8 @@ class TestHardDeleteExpiredForms(TestCase):
             dry_run_counts = XFormInstance.objects.hard_delete_expired_forms()
             actual_counts = XFormInstance.objects.hard_delete_expired_forms(commit=True)
 
-        self.assertEqual(dry_run_counts, 5)
-        self.assertEqual(actual_counts, 5)
+        self.assertEqual(dry_run_counts, {'form_processor.XFormInstance': 5})
+        self.assertEqual(actual_counts, {'form_processor.XFormInstance': 5})
 
 
 class DeleteAttachmentsFSDBTests(TestCase):

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -450,8 +450,8 @@ class TestHardDeleteExpiredForms(TestCase):
             dry_run_counts = XFormInstance.objects.hard_delete_expired_forms()
             actual_counts = XFormInstance.objects.hard_delete_expired_forms(commit=True)
 
-        self.assertEqual(dry_run_counts, {'form_processor.XFormInstance': 5})
-        self.assertEqual(actual_counts, {'form_processor.XFormInstance': 5})
+        assert dry_run_counts == {'form_processor.XFormInstance': 5}
+        assert actual_counts == {'form_processor.XFormInstance': 5}
 
 
 class DeleteAttachmentsFSDBTests(TestCase):

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -408,7 +408,7 @@ class TestHardDeleteExpiredForms(TestCase):
         valid_form = create_form_for_test(self.domain)
 
         with override_settings(DATA_RETENTION_WINDOW=7):
-            count = XFormInstance.objects.hard_delete_expired_forms(dry_run=False)
+            count = XFormInstance.objects.hard_delete_expired_forms(commit=True)
 
         assert count == {'form_processor.XFormInstance': 1}
         assert XFormInstance.objects.partitioned_get(valid_form.form_id)
@@ -417,7 +417,7 @@ class TestHardDeleteExpiredForms(TestCase):
             assert XFormInstance.objects.partitioned_get(expired_form.form_id)
 
     @travel('2020-01-10')
-    def test_dry_run_prevents_deletion(self):
+    def test_commit_set_to_false_prevents_deletion(self):
         expired_form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 1))
         soft_deleted_form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 9))
         valid_form = create_form_for_test(self.domain)
@@ -440,8 +440,8 @@ class TestHardDeleteExpiredForms(TestCase):
             create_form_for_test(self.domain)
 
         with override_settings(DATA_RETENTION_WINDOW=7):
-            dry_run_counts = XFormInstance.objects.hard_delete_expired_forms(dry_run=True)
-            actual_counts = XFormInstance.objects.hard_delete_expired_forms(dry_run=False)
+            dry_run_counts = XFormInstance.objects.hard_delete_expired_forms()
+            actual_counts = XFormInstance.objects.hard_delete_expired_forms(commit=True)
 
         self.assertEqual(dry_run_counts, {'form_processor.XFormInstance': 5})
         self.assertEqual(actual_counts, {'form_processor.XFormInstance': 5})

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -1,10 +1,12 @@
+import pytest
 import uuid
 from datetime import datetime
+from time_machine import travel
 
 from django.conf import settings
 from django.core.files.uploadedfile import UploadedFile
 from django.db import transaction
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from corehq.blobs import NotFound as BlobNotFound, get_blob_db
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB, TemporaryS3BlobDB
@@ -15,7 +17,11 @@ from ..backends.sql.processor import FormProcessorSQL
 from ..exceptions import AttachmentNotFound, XFormNotFound
 from ..interfaces.processor import ProcessedForms
 from ..models import CaseTransaction, XFormInstance, XFormOperation
-from ..tests.utils import FormProcessorTestUtils, create_form_for_test, sharded
+from ..tests.utils import (
+    FormProcessorTestUtils,
+    create_form_for_test,
+    sharded,
+)
 from ..parsers.form import apply_deprecation
 from ..utils import get_simple_form_xml, get_simple_wrapped_form
 from ..utils.xform import TestFormMetadata
@@ -390,63 +396,55 @@ class XFormInstanceManagerTest(TestCase):
         return form
 
 
-class TestHardDeleteFormsBeforeCutoff(TestCase):
-
-    def test_form_is_hard_deleted_if_deleted_on_is_before_cutoff(self):
-        form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 1, 12, 29))
-
-        XFormInstance.objects.hard_delete_forms_before_cutoff(self.cutoff, dry_run=False)
-
-        with self.assertRaises(XFormNotFound):
-            XFormInstance.objects.get_form(form.form_id)
-
-    def test_form_is_not_hard_deleted_if_deleted_on_is_cutoff(self):
-        form = create_form_for_test(self.domain, deleted_on=self.cutoff)
-
-        XFormInstance.objects.hard_delete_forms_before_cutoff(self.cutoff, dry_run=False)
-
-        fetched_form = XFormInstance.objects.get_form(form.form_id)
-        self.assertIsNotNone(fetched_form)
-
-    def test_form_is_not_hard_deleted_if_deleted_on_is_after_cutoff(self):
-        form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 1, 12, 31))
-
-        XFormInstance.objects.hard_delete_forms_before_cutoff(self.cutoff, dry_run=False)
-
-        fetched_form = XFormInstance.objects.get_form(form.form_id)
-        self.assertIsNotNone(fetched_form)
-
-    def test_form_is_not_hard_deleted_if_deleted_on_is_null(self):
-        form = create_form_for_test(self.domain, deleted_on=None)
-
-        XFormInstance.objects.hard_delete_forms_before_cutoff(self.cutoff, dry_run=False)
-
-        fetched_form = XFormInstance.objects.get_form(form.form_id)
-        self.assertIsNotNone(fetched_form)
-
-    def test_returns_deleted_counts(self):
-        expected_count = 5
-        for _ in range(expected_count):
-            create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 1, 12, 29))
-
-        counts = XFormInstance.objects.hard_delete_forms_before_cutoff(self.cutoff, dry_run=False)
-
-        self.assertEqual(counts, {'form_processor.XFormInstance': 5})
-
-    def test_nothing_is_deleted_if_dry_run_is_true(self):
-        form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 1, 12, 29))
-
-        # dry_run defaults to True
-        counts = XFormInstance.objects.hard_delete_forms_before_cutoff(self.cutoff)
-
-        # should not raise XFormNotFound
-        XFormInstance.objects.get_form(form.form_id)
-        # still returns accurate count
-        self.assertEqual(counts, {'form_processor.XFormInstance': 1})
+class TestHardDeleteExpiredForms(TestCase):
 
     def setUp(self):
-        self.domain = 'test_hard_delete_forms_before_cutoff'
-        self.cutoff = datetime(2020, 1, 1, 12, 30)
+        self.domain = 'test_hard_delete_expired_forms'
+
+    @travel('2020-01-10')
+    def test_only_deletes_expired_form(self):
+        expired_form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 1))
+        soft_deleted_form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 9))
+        valid_form = create_form_for_test(self.domain)
+
+        with override_settings(DATA_RETENTION_WINDOW=7):
+            count = XFormInstance.objects.hard_delete_expired_forms(dry_run=False)
+
+        assert count == {'form_processor.XFormInstance': 1}
+        assert XFormInstance.objects.partitioned_get(valid_form.form_id)
+        assert XFormInstance.objects.partitioned_get(soft_deleted_form.form_id)
+        with pytest.raises(XFormInstance.DoesNotExist):
+            assert XFormInstance.objects.partitioned_get(expired_form.form_id)
+
+    @travel('2020-01-10')
+    def test_dry_run_prevents_deletion(self):
+        expired_form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 1))
+        soft_deleted_form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 9))
+        valid_form = create_form_for_test(self.domain)
+
+        with override_settings(DATA_RETENTION_WINDOW=7):
+            count = XFormInstance.objects.hard_delete_expired_forms()
+
+        assert count == {'form_processor.XFormInstance': 1}
+        assert XFormInstance.objects.partitioned_get(valid_form.form_id)
+        assert XFormInstance.objects.partitioned_get(soft_deleted_form.form_id)
+        assert XFormInstance.objects.partitioned_get(expired_form.form_id)
+
+    @travel('2020-01-10')
+    def test_returned_counts(self):
+        for _ in range(5):
+            create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 1))
+        for _ in range(3):
+            create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 5))
+        for _ in range(2):
+            create_form_for_test(self.domain)
+
+        with override_settings(DATA_RETENTION_WINDOW=7):
+            dry_run_counts = XFormInstance.objects.hard_delete_expired_forms(dry_run=True)
+            actual_counts = XFormInstance.objects.hard_delete_expired_forms(dry_run=False)
+
+        self.assertEqual(dry_run_counts, {'form_processor.XFormInstance': 5})
+        self.assertEqual(actual_counts, {'form_processor.XFormInstance': 5})
 
 
 class DeleteAttachmentsFSDBTests(TestCase):

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -396,10 +396,17 @@ class XFormInstanceManagerTest(TestCase):
         return form
 
 
+@sharded
 class TestHardDeleteExpiredForms(TestCase):
 
     def setUp(self):
         self.domain = 'test_hard_delete_expired_forms'
+
+    def tearDown(self):
+        if settings.USE_PARTITIONED_DATABASE:
+            FormProcessorTestUtils.delete_all_sql_forms(self.domain)
+            FormProcessorTestUtils.delete_all_sql_cases(self.domain)
+        super().tearDown()
 
     @travel('2020-01-10')
     def test_only_deletes_expired_form(self):
@@ -410,7 +417,7 @@ class TestHardDeleteExpiredForms(TestCase):
         with override_settings(DATA_RETENTION_WINDOW=7):
             count = XFormInstance.objects.hard_delete_expired_forms(commit=True)
 
-        assert count == {'form_processor.XFormInstance': 1}
+        assert count == 1
         assert XFormInstance.objects.partitioned_get(valid_form.form_id)
         assert XFormInstance.objects.partitioned_get(soft_deleted_form.form_id)
         with pytest.raises(XFormInstance.DoesNotExist):
@@ -425,7 +432,7 @@ class TestHardDeleteExpiredForms(TestCase):
         with override_settings(DATA_RETENTION_WINDOW=7):
             count = XFormInstance.objects.hard_delete_expired_forms()
 
-        assert count == {'form_processor.XFormInstance': 1}
+        assert count == 1
         assert XFormInstance.objects.partitioned_get(valid_form.form_id)
         assert XFormInstance.objects.partitioned_get(soft_deleted_form.form_id)
         assert XFormInstance.objects.partitioned_get(expired_form.form_id)
@@ -443,8 +450,8 @@ class TestHardDeleteExpiredForms(TestCase):
             dry_run_counts = XFormInstance.objects.hard_delete_expired_forms()
             actual_counts = XFormInstance.objects.hard_delete_expired_forms(commit=True)
 
-        self.assertEqual(dry_run_counts, {'form_processor.XFormInstance': 5})
-        self.assertEqual(actual_counts, {'form_processor.XFormInstance': 5})
+        self.assertEqual(dry_run_counts, 5)
+        self.assertEqual(actual_counts, 5)
 
 
 class DeleteAttachmentsFSDBTests(TestCase):


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15221

Picking back up the tombstones work, and this is still  just a prefactor for that. This method is still not in use in our codebase, so these changes don't mean much, but I just want to have a solid starting point before attempting to integrate tombstones logic as well.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
It does feel strange to make changes to delete methods that are not yet in use, so on one hand it feels incredibly safe, but on the other these methods will obviously be used to do critical work at some point in the future. Prior to these being production ready, there will be in depth testing involved, likely including QA, but that is not a part of this PR.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I added additional tests, and consolidated others that I felt could be expressed in one test for TestHardDeleteExpiredForms.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
