### PR TITLE
Remove vestigial case search feature flags

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2236,7 +2236,6 @@ class CaseSearch(DocumentSchema):
     - again_label: Removed with SSCS migration (Feb 2026)
     - search_again_label: Removed with SSCS migration (Feb 2026)
     - dynamic_search: Removed deprecated functionality (Apr 2026)
-      These fields may still exist in CouchDB documents but are no longer used.
     - command_label: Superseded by search_label (2021 migration)
     - search_label: Removed; search button always uses default label (Apr 2026)
       These fields may still exist in CouchDB documents but are no longer used.

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/spec/split_screen_case_search_spec.js
@@ -2,7 +2,6 @@ import _ from "underscore";
 import Backbone from "backbone";
 import Marionette from "backbone.marionette";
 import sinon from "sinon";
-import Toggles from "hqwebapp/js/toggles";
 import FormplayerFrontend from "cloudcare/js/formplayer/app";
 import API from "cloudcare/js/formplayer/menus/api";
 import Controller from "cloudcare/js/formplayer/menus/controller";
@@ -42,7 +41,6 @@ describe('Split Screen Case Search', function () {
             },
             addRegions: function () { return; },
         };
-        stubs.splitScreenToggleEnabled = sinon.stub(Toggles, 'toggleEnabled').withArgs('SPLIT_SCREEN_CASE_SEARCH');
     });
 
     beforeEach(function () {
@@ -50,7 +48,6 @@ describe('Split Screen Case Search', function () {
         user.displayOptions = {
             singleAppMode: false,
         };
-        stubs.splitScreenToggleEnabled.returns(true);
     });
 
     afterEach(function () {

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1006,17 +1006,6 @@ CASE_SEARCH_CACHE_KEY = StaticToggle(
     parent_toggles=[SYNC_SEARCH_CASE_CLAIM],
 )
 
-USH_CASE_LIST_MULTI_SELECT = StaticToggle(
-    'ush_case_list_multi_select',
-    'USH: Allow selecting multiple cases from the case list',
-    TAG_FROZEN,
-    namespaces=[NAMESPACE_DOMAIN],
-    help_link='https://confluence.dimagi.com/display/saas/USH%3A+Allow+selecting+multiple+cases+from+the+case+list',  # noqa: E501
-    description="""
-    Allows user to select multiple cases and load them all into the form.
-    """
-)
-
 GEOCODER_MY_LOCATION_BUTTON = StaticToggle(
     "geocoder_my_location_button",
     "USH: Add button to geocoder to populate search with the user's current location",

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1046,16 +1046,6 @@ USH_EMPTY_CASE_LIST_TEXT = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN]
 )
 
-SPLIT_SCREEN_CASE_SEARCH = StaticToggle(
-    'split_screen_case_search',
-    "Split screen case search: In case search, show the search filters in a sidebar on the left and the results"
-    " on the right.",
-    TAG_FROZEN,
-    help_link='https://confluence.dimagi.com/display/USH/Split+Screen+Case+Search',
-    namespaces=[NAMESPACE_DOMAIN],
-    parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
-)
-
 HIDE_SYNC_BUTTON = StaticToggle(
     "hide_sync_button",
     "USH: Hide Sync Button in Web Apps",

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1050,17 +1050,6 @@ USH_SEARCH_FILTER = StaticToggle(
     parent_toggles=[SYNC_SEARCH_CASE_CLAIM],
 )
 
-USH_INLINE_SEARCH = StaticToggle(
-    'inline_case_search',
-    "USH Specific toggle to making case search user input available to other parts of the app.",
-    TAG_FROZEN,
-    help_link='https://docs.google.com/document/d/1Mmx1FrYZrcEmWidqSkNjC_gWSJ6xzRFKoP3Rn_xSaj4/edit#',
-    namespaces=[NAMESPACE_DOMAIN],
-    description="""
-    Temporary toggle to manage the release of the 'inline search' / 'case search input' feature.
-    """,
-)
-
 USH_EMPTY_CASE_LIST_TEXT = StaticToggle(
     'empty_case_list_text',
     "USH: Allow customizing the text displayed when case list contains no cases in web apps",

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1017,20 +1017,6 @@ USH_CASE_LIST_MULTI_SELECT = StaticToggle(
     """
 )
 
-USH_CASE_CLAIM_UPDATES = StaticToggle(
-    'case_claim_autolaunch',
-    "USH Specific toggle to support several different case search/claim workflows in web apps",
-    TAG_FROZEN,
-    help_link='https://confluence.dimagi.com/display/USH/Case+Search+Configuration',
-    namespaces=[NAMESPACE_DOMAIN],
-    description="""
-    USH Specific toggle to support several different case search/claim workflows in web apps:
-    "search first", "see more", and "skip to default case search results", Geocoder
-    and other options in Webapps Case Search.
-    """,
-    parent_toggles=[SYNC_SEARCH_CASE_CLAIM]
-)
-
 GEOCODER_MY_LOCATION_BUTTON = StaticToggle(
     "geocoder_my_location_button",
     "USH: Add button to geocoder to populate search with the user's current location",

--- a/docs/apps/advanced_app_features.rst
+++ b/docs/apps/advanced_app_features.rst
@@ -26,8 +26,7 @@ Several of these features are simple from an app builder's perspective, but they
 concepts into suite concepts.  Other features force the app builder to understand suite concepts, so they may
 be challenging for app builders to learn but are less prone to interacting poorly with other features:
 
-#. Case search, which maps fairly cleanly to the ``<remote-request>`` element (except when using the
-   ``USH_INLINE_SEARCH`` flag).
+#. Case search, which maps fairly cleanly to the ``<remote-request>`` element
 #. Advanced modules
 
 Display Only Forms

--- a/docs/formplayer.rst
+++ b/docs/formplayer.rst
@@ -271,8 +271,7 @@ For projects using CommCare mobile, case search and claim is typically an unusua
 use web apps, and therefore have guaranteed connectivity, may use it much more heavily, even to the point that the user
 is unaware of their casedb and always uses case search to find cases.
 
-To support this approach, HQ allows apps to be configured with several alternate navigation flows. These workflows
-are gated by the ``USH_CASE_CLAIM_UPDATES`` feature flag.
+To support this approach, HQ allows apps to be configured with several alternate navigation flows.
 
 The default case search and claim workflow shows the user the following screens:
 


### PR DESCRIPTION
## Product Description
These feature flags no longer gate any functionality and can be removed.

## Technical Summary
https://dimagi.atlassian.net/browse/USH-6475
These are flags for functionality that has already been shuffled off to other places.  Now that that's been live for a bit, we can remove the flags themselves without much fuss.

PR'd into https://github.com/dimagi/commcare-hq/pull/37634, which removes a flag that depends on one of these.

## Feature Flag
Case Search stuff, see commit messages

## Safety Assurance


### Safety story
The functionality that was previously gated by these feature flags no longer is, so this PR really only affects the list of toggles, and doesn't touch anything else besides documentation.

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
