### PR TITLE
Remove USH_SEARCH_FILTER toggle and search_filter feature

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2238,6 +2238,7 @@ class CaseSearch(DocumentSchema):
     - dynamic_search: Removed deprecated functionality (Apr 2026)
     - command_label: Superseded by search_label (2021 migration)
     - search_label: Removed; search button always uses default label (Apr 2026)
+    - search_filter: Removed with USH_SEARCH_FILTER toggle (Apr 2026)
       These fields may still exist in CouchDB documents but are no longer used.
     """
     search_button_label = LabelProperty(default={'en': 'Search All Cases'})
@@ -2245,7 +2246,6 @@ class CaseSearch(DocumentSchema):
     auto_launch = BooleanProperty(default=False)        # if true, skip the casedb case list
     default_search = BooleanProperty(default=False)     # if true, skip the search fields screen
     additional_relevant = StringProperty(exclude_if_none=True)  # in "addition" to the default relevancy condition
-    search_filter = StringProperty(exclude_if_none=True)
     search_button_display_condition = StringProperty(exclude_if_none=True)
     default_properties = SchemaListProperty(DefaultCaseSearchProperty)
     custom_sort_properties = SchemaListProperty(CaseSearchCustomSortProperty)

--- a/corehq/apps/app_manager/static/app_manager/js/details/bootstrap3/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/bootstrap3/screen_config.js
@@ -196,7 +196,6 @@ const module = function (spec) {
             _.pick(spec, caseClaimModels.searchConfigKeys),
             spec.lang,
             self.shortScreen.saveButton,
-            self.filter.filterText,
         );
     }
     if (spec.state.long !== undefined) {

--- a/corehq/apps/app_manager/static/app_manager/js/details/bootstrap5/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/bootstrap5/screen_config.js
@@ -196,7 +196,6 @@ const module = function (spec) {
             _.pick(spec, caseClaimModels.searchConfigKeys),
             spec.lang,
             self.shortScreen.saveButton,
-            self.filter.filterText,
         );
     }
     if (spec.state.long !== undefined) {

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -204,12 +204,12 @@ var additionalRegistryCaseModel = function (xpath, saveButton) {
 
 var searchConfigKeys = [
     'auto_launch', 'blacklisted_owner_ids_expression', 'default_search',
-    'title_label', 'description', 'search_button_display_condition', 'search_filter',
+    'title_label', 'description', 'search_button_display_condition',
     'additional_relevant', 'data_registry', 'data_registry_workflow', 'additional_registry_cases',
     'custom_related_case_property', 'inline_search', 'instance_name', 'include_all_related_cases',
     'search_on_clear',
 ];
-var searchConfigModel = function (options, lang, searchFilterObservable, saveButton) {
+var searchConfigModel = function (options, lang, saveButton) {
     assertProperties.assertRequired(options, searchConfigKeys);
 
     options.title_label = options.title_label[lang] || "";
@@ -266,17 +266,6 @@ var searchConfigModel = function (options, lang, searchFilterObservable, saveBut
     });
 
 
-    // Allow search filter to be copied from another part of the page
-    self.setSearchFilterVisible = ko.computed(function () {
-        return searchFilterObservable && searchFilterObservable();
-    });
-    self.setSearchFilterEnabled = ko.computed(function () {
-        return self.setSearchFilterVisible() && searchFilterObservable() !== self.search_filter();
-    });
-    self.setSearchFilter = function () {
-        self.search_filter(searchFilterObservable());
-    };
-
     subscribeToSave(self, searchConfigKeys, saveButton);
     // media image/audio buttons
     $(".case-search-multimedia-input button").on("click", function () {
@@ -324,10 +313,10 @@ var _getAppearance = function (searchProperty) {
     return appearance;
 };
 
-var searchViewModel = function (searchProperties, defaultProperties, customSortProperties, searchConfigOptions, lang, saveButton, searchFilterObservable) {
+var searchViewModel = function (searchProperties, defaultProperties, customSortProperties, searchConfigOptions, lang, saveButton) {
     var self = {};
 
-    self.searchConfig = searchConfigModel(searchConfigOptions, lang, searchFilterObservable, saveButton);
+    self.searchConfig = searchConfigModel(searchConfigOptions, lang, saveButton);
     self.default_properties = ko.observableArray();
     self.custom_sort_properties = ko.observableArray();
 

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -240,8 +240,6 @@ class RemoteRequestFactory(object):
             if additional_types:
                 nodeset = CaseTypeXpath(self.module.case_type).cases(
                     additional_types, instance_name=self.storage_instance)
-            if self.module.search_config.search_filter and toggles.USH_SEARCH_FILTER.enabled(self.app.domain):
-                nodeset = f"{nodeset}[{interpolate_xpath(self.module.search_config.search_filter)}]"
         nodeset += EXCLUDE_RELATED_CASES_FILTER
 
         datum_cls = InstanceDatum if self.module.is_multi_select() else SessionDatum

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -61,7 +61,6 @@ from corehq.apps.case_search.models import (
     CASE_SEARCH_REGISTRY_ID_KEY,
     case_search_sync_cases_on_form_entry_enabled_for_domain,
 )
-from corehq.toggles import USH_SEARCH_FILTER
 from corehq.util.timer import time_method
 from corehq.util.view_utils import absolute_reverse
 
@@ -639,8 +638,6 @@ class EntriesHelper(object):
                     root_element = "results"
                 elif loads_registry_case:
                     instance_name, root_element = "results", "results"
-                if detail_module.search_config.search_filter and USH_SEARCH_FILTER.enabled(self.app.domain):
-                    filter_xpath += f"[{interpolate_xpath(detail_module.search_config.search_filter)}]"
                 filter_xpath += EXCLUDE_RELATED_CASES_FILTER
 
             nodeset = EntriesHelper._get_nodeset_xpath(

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_search_properties.html
@@ -376,46 +376,6 @@
               ></textarea>
             </div>
           </div>
-          {% if request|toggle_enabled:'USH_SEARCH_FILTER' %}
-            <div class="form-group">
-              <label
-                for="search-filter"
-                class="control-label {% css_label_class %}"
-              >
-                {% trans "Search Filter" %}
-                <span
-                  class="hq-help-template"
-                  data-title="{% trans "Search Filter" %}"
-                  data-content="{% trans_html_attr "An XPath expression to filter the search results." %}"
-                >
-                </span>
-              </label>
-              <div class="{% css_field_class %}">
-                <textarea
-                  data-bind="
-                          value: search_filter,
-                          xpathValidator: {
-                            text: search_filter,
-                            allowCaseHashtags: true,
-                            errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
-                          }"
-                  class="form-control vertical-resize"
-                  id="search-filter"
-                  spellcheck="false"
-                ></textarea>
-                <p class="help-block">
-                  <button
-                    class="pull-right btn-xs btn btn-default"
-                    data-bind="visible: setSearchFilterVisible, enable: setSearchFilterEnabled, click: setSearchFilter"
-                  >
-                    <i class="fa-solid fa-reply"></i>
-                    {% trans "Copy case list filter" %}
-                  </button>
-                  {% trans "Example: age > 5" %}
-                </p>
-              </div>
-            </div>
-          {% endif %}
           {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
           <div class="form-group">
             <label

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_search_properties.html
@@ -376,46 +376,6 @@
               ></textarea>
             </div>
           </div>
-          {% if request|toggle_enabled:'USH_SEARCH_FILTER' %}
-            <div class="form-group">  {# todo B5: css-form-group #}
-              <label
-                for="search-filter"
-                class="form-label {% css_label_class %}"
-              >
-                {% trans "Search Filter" %}
-                <span
-                  class="hq-help-template"
-                  data-title="{% trans "Search Filter" %}"
-                  data-content="{% trans_html_attr "An XPath expression to filter the search results." %}"
-                >
-                </span>
-              </label>
-              <div class="{% css_field_class %}">
-                <textarea
-                  data-bind="
-                          value: search_filter,
-                          xpathValidator: {
-                            text: search_filter,
-                            allowCaseHashtags: true,
-                            errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
-                          }"
-                  class="form-control vertical-resize"
-                  id="search-filter"
-                  spellcheck="false"
-                ></textarea>
-                <p class="help-block">
-                  <button
-                    class="float-end btn-sm btn btn-outline-primary"
-                    data-bind="visible: setSearchFilterVisible, enable: setSearchFilterEnabled, click: setSearchFilter"
-                  >
-                    <i class="fa-solid fa-reply"></i>
-                    {% trans "Copy case list filter" %}
-                  </button>
-                  {% trans "Example: age > 5" %}
-                </p>
-              </div>
-            </div>
-          {% endif %}
           {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
           <div class="form-group">  {# todo B5: css-form-group #}
             <label

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -314,7 +314,6 @@ class OverwriteCaseSearchConfigTests(SimpleTestCase):
             auto_launch=True,
             default_search=True,
             additional_relevant="instance('groups')/groups/group",
-            search_filter="name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name",
             search_button_display_condition="false()",
             blacklisted_owner_ids_expression="instance('commcaresession')/session/context/userid",
             default_properties=[

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -58,7 +58,6 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
             ],
-            search_filter="active = 'yes'",
             auto_launch=True,
             inline_search=True,
         )
@@ -81,7 +80,6 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
         self.module = self.app.modules[0]
         self.form = self.module.forms[0]
 
-    @flag_enabled('USH_SEARCH_FILTER')
     def test_inline_search(self):
         suite = self.app.create_suite()
 
@@ -118,7 +116,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                     </display>
                   </prompt>
                 </query>
-                <datum id="case_id" nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
+                <datum id="case_id" nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                     value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
             </session>
           </entry>
@@ -130,7 +128,6 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
         self.assertXmlDoesNotHaveXpath(suite, "./detail[@id='m0_search_short']")
         self.assertXmlDoesNotHaveXpath(suite, "./detail[@id='m0_search_long']")
 
-    @flag_enabled('USH_SEARCH_FILTER')
     def test_inline_search_case_list_item(self):
         self.module.case_list.show = True
         suite = self.app.create_suite()
@@ -161,14 +158,13 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                     </display>
                   </prompt>
                 </query>
-                <datum id="case_id" nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
+                <datum id="case_id" nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                     value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
             </session>
           </entry>
         </partial>"""  # noqa: E501
         self.assertXmlPartialEqual(expected_entry_query, suite, "./entry[2]")
 
-    @flag_enabled('USH_SEARCH_FILTER')
     def test_inline_search_multi_select(self):
         self.module.case_details.short.multi_select = True
         self.module.case_details.short.columns.append(
@@ -216,7 +212,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                     </display>
                   </prompt>
                 </query>
-                <instance-datum id="selected_cases" nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
+                <instance-datum id="selected_cases" nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                     value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long" max-select-value="100"/>
             </session>
           </entry>
@@ -355,7 +351,6 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
             f"./entry[1]/instance[@id='{instance_id}']",
         )
 
-    @flag_enabled('USH_SEARCH_FILTER')
     def test_inline_search_with_other_relationship_parent_select_(self):
         """Inline search module with 'parent select' relationship is 'other' (None)"""
         module = self.app.add_module(Module.new_module("Followup2", None))
@@ -406,7 +401,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                 </prompt>
               </query>
               <datum id="case_id"
-                nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())]"
+                nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]"
                 value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
             </session>
           </entry>
@@ -414,7 +409,6 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
 
         self.assertXmlPartialEqual(expected_entry, suite, "./entry[1]")
 
-    @flag_enabled('USH_SEARCH_FILTER')
     def test_inline_search_with_parent_relationship_parent_select(self):
         """Inline search module with 'parent select' relationship is 'parent'"""
         module = self.app.add_module(Module.new_module("Followup2", None))
@@ -468,7 +462,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                 </prompt>
               </query>
               <datum id="case_id"
-                nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][active = 'yes'][not(commcare_is_related_case=true())][index/parent=instance('commcaresession')/session/data/parent_id]"
+                nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())][index/parent=instance('commcaresession')/session/data/parent_id]"
                 value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
             </session>
           </entry>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -167,7 +167,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
                 CaseSearchProperty(name='consent', label={'en': 'Consent to search'}, input_="checkbox"),
             ],
             additional_relevant="instance('groups')/groups/group",
-            search_filter="name = instance('item-list:trees')/trees_list/trees[favorite='yes']/name",
             default_properties=[
                 DefaultCaseSearchProperty(
                     property='ɨŧsȺŧɍȺᵽ',
@@ -279,25 +278,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
         suite = self.app.create_suite()
         self.assertXmlPartialEqual(self.get_xml('search_command_detail'), suite, "./detail")
-
-    @flag_enabled('CASE_SEARCH_ADVANCED')
-    @flag_enabled('USH_SEARCH_FILTER')
-    def test_case_search_filter(self):
-        search_filter = "rating > 3"
-        self.module.search_config.search_filter = search_filter
-        suite = self.app.create_suite()
-        suite = parse_normalize(suite, to_string=False)
-        ref_path = './remote-request[1]/session/datum/@nodeset'
-        self.assertEqual(
-            "instance('{}')/{}/case[@case_type='{}'][{}]{}".format(
-                RESULTS_INSTANCE,
-                RESULTS_INSTANCE,
-                self.module.case_type,
-                search_filter,
-                EXCLUDE_RELATED_CASES_FILTER
-            ),
-            suite.xpath(ref_path)[0]
-        )
 
     @flag_enabled('CASE_SEARCH_ADVANCED')
     def test_additional_types(self):

--- a/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
+++ b/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
@@ -606,7 +606,8 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
             """
             <partial>
                 <remote-request>
-                    <post relevant="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0"
+                    <post relevant="count(instance('casedb')/casedb/case"""
+            """[@case_id=instance('commcaresession')/session/data/case_id]) = 0"
                         url="http://localhost:8000/a/test-domain/phone/claim-case/">
                         <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
                     </post>

--- a/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
+++ b/corehq/apps/app_manager/tests/test_suite_session_endpoints.py
@@ -505,7 +505,6 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
             ],
-            search_filter="active = 'yes'",
             auto_launch=True,
             inline_search=True,
         )
@@ -543,7 +542,6 @@ class SessionEndpointTests(SimpleTestCase, TestXmlMixin):
             properties=[
                 CaseSearchProperty(name='name', label={'en': 'Name'}),
             ],
-            search_filter="active = 'yes'",
             auto_launch=True,
             inline_search=True,
         )

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -257,7 +257,6 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
                     module.search_config.custom_sort_properties if module_offers_search(module) else [],
                 'auto_launch': module.search_config.auto_launch if module_offers_search(module) else False,
                 'default_search': module.search_config.default_search if module_offers_search(module) else False,
-                'search_filter': module.search_config.search_filter if module_offers_search(module) else "",
                 'search_button_display_condition':
                     module.search_config.search_button_display_condition if module_offers_search(module) else "",
                 'additional_relevant':
@@ -1298,7 +1297,7 @@ def _gather_and_update_search_properties(params, app, module, lang):
         except CaseSearchConfigError as e:
             return HttpResponseBadRequest(e)
         xpath_props = [
-            "search_filter", "blacklisted_owner_ids_expression",
+            "blacklisted_owner_ids_expression",
             "search_button_display_condition", "additional_relevant"
         ]
 
@@ -1349,7 +1348,6 @@ def _gather_and_update_search_properties(params, app, module, lang):
             additional_relevant=search_properties.get('additional_relevant', ''),
             auto_launch=force_auto_launch or bool(search_properties.get('auto_launch')),
             default_search=bool(search_properties.get('default_search')),
-            search_filter=search_properties.get('search_filter', ""),
             search_button_display_condition=search_properties.get('search_button_display_condition', ""),
             blacklisted_owner_ids_expression=search_properties.get('blacklisted_owner_ids_expression', ""),
             default_properties=[

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_search_properties.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_search_properties.html.diff.txt
@@ -313,28 +313,6 @@
 @@ -377,10 +377,10 @@
              </div>
            </div>
-           {% if request|toggle_enabled:'USH_SEARCH_FILTER' %}
--            <div class="form-group">
-+            <div class="form-group">  {# todo B5: css-form-group #}
-               <label
-                 for="search-filter"
--                class="control-label {% css_label_class %}"
-+                class="form-label {% css_label_class %}"
-               >
-                 {% trans "Search Filter" %}
-                 <span
-@@ -405,7 +405,7 @@
-                 ></textarea>
-                 <p class="help-block">
-                   <button
--                    class="pull-right btn-xs btn btn-default"
-+                    class="float-end btn-sm btn btn-outline-primary"
-                     data-bind="visible: setSearchFilterVisible, enable: setSearchFilterEnabled, click: setSearchFilter"
-                   >
-                     <i class="fa-solid fa-reply"></i>
-@@ -417,10 +417,10 @@
-             </div>
-           {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
 -          <div class="form-group">
 +          <div class="form-group">  {# todo B5: css-form-group #}
@@ -345,7 +323,7 @@
              >
                {% trans "Claim Condition" %}
                <span
-@@ -446,10 +446,10 @@
+@@ -406,10 +406,10 @@
              </div>
            </div>
            {% endif %}
@@ -358,7 +336,7 @@
              >
                {% trans "Don't search cases owned by the following ids" %}
                <span
-@@ -482,10 +482,10 @@
+@@ -442,10 +442,10 @@
              </div>
            </div>
            {% if data_registry_enabled %}
@@ -371,7 +349,7 @@
                >
                  {% trans "Data Registry" %}
                  <span
-@@ -496,7 +496,7 @@
+@@ -456,7 +456,7 @@
                  </span>
                </label>
                <div class="{% css_field_class %}">
@@ -380,7 +358,7 @@
                    class="form-control"
                    id="data-registry"
                    data-bind="value: data_registry"
-@@ -510,15 +510,15 @@
+@@ -470,15 +470,15 @@
                  </select>
                </div>
              </div>
@@ -399,7 +377,7 @@
                    class="form-control"
                    data-bind="value: data_registry_workflow"
                  >
-@@ -529,12 +529,12 @@
+@@ -489,12 +489,12 @@
                </div>
              </div>
              <div
@@ -414,7 +392,7 @@
                >
                  {% trans "Load Additional Data Registry Cases" %}
                  <span
-@@ -556,8 +556,8 @@
+@@ -516,8 +516,8 @@
                      data-bind="visible: additional_registry_cases().length > 0"
                    >
                      <tr>
@@ -425,7 +403,7 @@
                      </tr>
                    </thead>
                    <tbody
-@@ -579,7 +579,7 @@
+@@ -539,7 +539,7 @@
                        </td>
                        <td>
                          <i
@@ -434,7 +412,7 @@
                            class="fa fa-remove"
                            data-bind="click: $parent.removeRegistryQuery"
                          ></i>
-@@ -589,7 +589,7 @@
+@@ -549,7 +549,7 @@
                  </table>
                  <button
                    type="button"
@@ -443,7 +421,7 @@
                    data-bind="click: addRegistryQuery"
                  >
                    <i class="fa fa-plus"></i>
-@@ -599,10 +599,10 @@
+@@ -559,10 +559,10 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
@@ -456,7 +434,7 @@
                >
                  {% trans "Case property with additional case id to add to results" %}
                  <span
-@@ -632,15 +632,15 @@
+@@ -592,15 +592,15 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_RELATED_LOOKUPS' %}
@@ -476,7 +454,7 @@
                        data-bind="checked: include_all_related_cases"
                      />
                    </label>
-@@ -649,18 +649,18 @@
+@@ -609,18 +609,18 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1031,14 +1031,6 @@ GEOCODER_USER_PROXIMITY = StaticToggle(
     """,
 )
 
-USH_SEARCH_FILTER = StaticToggle(
-    'case_search_filter',
-    "USH Specific toggle to use Search Filter in case search options.",
-    TAG_DEPRECATED,
-    namespaces=[NAMESPACE_DOMAIN],
-    parent_toggles=[SYNC_SEARCH_CASE_CLAIM],
-)
-
 USH_EMPTY_CASE_LIST_TEXT = StaticToggle(
     'empty_case_list_text',
     "USH: Allow customizing the text displayed when case list contains no cases in web apps",


### PR DESCRIPTION
## Product Description

No user-facing changes. `USH_SEARCH_FILTER` has been disabled in production already after checking that the feature is not used by any production domain.

The search filter UI and functionality are being removed as cleanup.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6516

Removes the `USH_SEARCH_FILTER` `StaticToggle` and all associated `search_filter` functionality:

- `corehq/toggles/__init__.py` — removes the `StaticToggle` definition
- `CaseSearch` model (`app_manager/models.py`) — removes the `search_filter` field (CouchDB; existing documents may still contain the field but it is no longer read)
- `case_search_properties.html` (Bootstrap 3 and Bootstrap 5) — removes the search filter UI block
- `remote_requests.py` and `entries.py` — removes application of `search_filter` to suite XML nodesets
- `update_case_search_toggles.py` management command — removes check for `search_filter` when deciding whether to enable the toggle
- Updates tests that referenced the toggle or field

## Feature Flag

`USH_SEARCH_FILTER` (removed)

## Safety Assurance

### Safety story

This removes dead code behind a deprecated toggle. No domains should have the toggle enabled in production. The CouchDB `CaseSearch` model change is backward-compatible — old documents may retain the field, but it is never read or applied.

### Automated test coverage

Existing suite and module tests exercise the affected code paths:

- `test_suite_inline_search.py`
- `test_suite_remote_request.py`
- `test_modules.py`
- `test_suite_session_endpoints.py`

### QA Plan

No QA needed — removing a deprecated, unused feature flag. Automated tests are sufficient.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change