### PR TITLE
Remove unnecessary test cleanup

### DIFF
--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -1129,8 +1129,6 @@ class TestDeleteElasticFormsAndCases(TestCase):
         forms = [create_form_for_test(self.domain.name) for i in range(3)]
         form_ids = [f.form_id for f in forms]
         other_form = create_form_for_test(self.other_domain.name)
-        self.addCleanup(XFormInstance.objects.hard_delete_forms, self.domain.name, form_ids)
-        self.addCleanup(XFormInstance.objects.hard_delete_forms, self.other_domain.name, [other_form.form_id])
         form_adapter.bulk_index(forms + [other_form], refresh=True)
 
         mod.delete_all_forms(self.domain.name)
@@ -1145,8 +1143,6 @@ class TestDeleteElasticFormsAndCases(TestCase):
     def test_delete_all_cases_deletes_es_documents(self):
         case1 = create_case(self.domain.name, save=True)
         case2 = create_case(self.other_domain.name, save=True)
-        self.addCleanup(CommCareCase.objects.hard_delete_cases, self.domain.name, [case1.case_id])
-        self.addCleanup(CommCareCase.objects.hard_delete_cases, self.other_domain.name, [case2.case_id])
         case_adapter.bulk_index([case1, case2], refresh=True)
         case_search_adapter.bulk_index([case1, case2], refresh=True)
 

--- a/corehq/apps/geospatial/tests/test_utils.py
+++ b/corehq/apps/geospatial/tests/test_utils.py
@@ -67,6 +67,7 @@ class TestSetGPSProperty(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.domain_obj = create_domain(cls.DOMAIN)
+        cls.addClassCleanup(cls.domain_obj.delete)
 
         case_type = 'foobar'
 
@@ -82,15 +83,7 @@ class TestSetGPSProperty(TestCase):
         cls.user = CommCareUser.create(
             cls.DOMAIN, 'UserA', '1234', None, None
         )
-
-    @classmethod
-    def tearDownClass(cls):
-        CommCareCase.objects.hard_delete_cases(cls.DOMAIN, [
-            cls.case_obj.case_id,
-        ])
-        cls.user.delete(cls.DOMAIN, None)
-        cls.domain_obj.delete()
-        super().tearDownClass()
+        cls.addClassCleanup(cls.user.delete, cls.DOMAIN, None)
 
     def test_set_case_gps_property(self):
         submit_data = {
@@ -136,9 +129,11 @@ class TestUpdateCasesOwner(TestCase):
     def setUp(self):
         super().setUp()
         self.user_a = CommCareUser.create(self.domain, 'User_A', '1234', None, None)
+        self.addCleanup(self.user_a.delete, self.domain, None)
         self.case_1 = create_case(self.domain, case_id=uuid4().hex, save=True, owner_id=self.user_a.user_id)
 
         self.user_b = CommCareUser.create(self.domain, 'User_B', '1234', None, None)
+        self.addCleanup(self.user_b.delete, self.domain, None)
         self.case_2 = create_case(self.domain, case_id=uuid4().hex, save=True, owner_id=self.user_b.user_id)
         self.related_case_2 = create_case(
             self.domain,
@@ -149,15 +144,6 @@ class TestUpdateCasesOwner(TestCase):
         self._create_parent_index(self.related_case_2, self.case_2.case_id)
 
         self.cases = [self.case_1, self.case_2, self.related_case_2]
-
-    def tearDown(self):
-        self.user_a.delete(self.domain, None)
-        self.user_b.delete(self.domain, None)
-        CommCareCase.objects.hard_delete_cases(
-            self.domain,
-            [case.case_id for case in self.cases]
-        )
-        super().tearDown()
 
     def _create_parent_index(self, case, parent_case_id):
         index = CommCareCaseIndex(

--- a/corehq/apps/geospatial/tests/test_views.py
+++ b/corehq/apps/geospatial/tests/test_views.py
@@ -20,7 +20,7 @@ from corehq.apps.geospatial.views import (
 )
 from corehq.apps.locations.models import LocationType, SQLLocation
 from corehq.apps.users.models import CommCareUser, WebUser
-from corehq.form_processor.models import CommCareCase, CommCareCaseIndex
+from corehq.form_processor.models import CommCareCaseIndex
 from corehq.form_processor.tests.utils import create_case
 from corehq.util.test_utils import flag_enabled
 
@@ -260,6 +260,7 @@ class TestGetPaginatedCasesOrUsers(BaseGeospatialViewClass):
             created_via=None,
             user_data={GPS_POINT_CASE_PROPERTY: '12.34 45.67'}
         )
+        cls.addClassCleanup(cls.user_a.delete, cls.domain, None)
         cls.user_b = CommCareUser.create(
             cls.domain,
             username='UserB',
@@ -267,17 +268,8 @@ class TestGetPaginatedCasesOrUsers(BaseGeospatialViewClass):
             created_by=None,
             created_via=None
         )
+        cls.addClassCleanup(cls.user_b.delete, cls.domain, None)
         user_adapter.bulk_index([cls.user_a, cls.user_b], refresh=True)
-
-    @classmethod
-    def tearDownClass(cls):
-        CommCareCase.objects.hard_delete_cases(cls.domain, [
-            cls.case_a.case_id,
-            cls.case_b.case_id,
-        ])
-        cls.user_a.delete(cls.domain, None)
-        cls.user_b.delete(cls.domain, None)
-        super().tearDownClass()
 
     def test_get_paginated_cases(self):
         expected_output = {
@@ -572,7 +564,9 @@ class TestCasesReassignmentView(BaseGeospatialViewClass):
     def setUp(self):
         super().setUp()
         self.user_a = CommCareUser.create(self.domain, 'User_A', '1234', None, None)
+        self.addCleanup(self.user_a.delete, self.domain, None)
         self.user_b = CommCareUser.create(self.domain, 'User_B', '1234', None, None)
+        self.addCleanup(self.user_b.delete, self.domain, None)
         user_adapter.bulk_index([self.user_a, self.user_b], refresh=True)
 
         self.case_1 = create_case(self.domain, case_id=uuid4().hex, save=True, owner_id=self.user_a.user_id)
@@ -602,12 +596,6 @@ class TestCasesReassignmentView(BaseGeospatialViewClass):
         case_search_adapter.bulk_index(self.cases, refresh=True)
 
         self.client.login(username=self.username, password=self.password)
-
-    def tearDown(self):
-        self.user_a.delete(self.domain, None, None)
-        self.user_b.delete(self.domain, None, None)
-        CommCareCase.objects.hard_delete_cases(self.domain, [case.case_id for case in self.cases])
-        super().tearDown()
 
     def _create_parent_index(self, case, parent_case_id):
         index = CommCareCaseIndex(

--- a/corehq/apps/geospatial/tests/test_views.py
+++ b/corehq/apps/geospatial/tests/test_views.py
@@ -32,6 +32,7 @@ class BaseGeospatialViewClass(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
         cls.username = 'test-user'
         cls.password = '1234'
         cls.webuser = WebUser.create(
@@ -43,12 +44,7 @@ class BaseGeospatialViewClass(TestCase):
             is_admin=True,
         )
         cls.webuser.save()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.webuser.delete(None, None)
-        cls.domain_obj.delete()
-        super().tearDownClass()
+        cls.addClassCleanup(cls.webuser.delete, None, None)
 
     @property
     def endpoint(self):
@@ -561,12 +557,16 @@ def _sample_geojson_data(name='test-2'):
 class TestCasesReassignmentView(BaseGeospatialViewClass):
     urlname = CasesReassignmentView.urlname
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_a = CommCareUser.create(cls.domain, 'User_A', '1234', None, None)
+        cls.addClassCleanup(cls.user_a.delete, cls.domain, None)
+        cls.user_b = CommCareUser.create(cls.domain, 'User_B', '1234', None, None)
+        cls.addClassCleanup(cls.user_b.delete, cls.domain, None)
+
     def setUp(self):
         super().setUp()
-        self.user_a = CommCareUser.create(self.domain, 'User_A', '1234', None, None)
-        self.addCleanup(self.user_a.delete, self.domain, None)
-        self.user_b = CommCareUser.create(self.domain, 'User_B', '1234', None, None)
-        self.addCleanup(self.user_b.delete, self.domain, None)
         user_adapter.bulk_index([self.user_a, self.user_b], refresh=True)
 
         self.case_1 = create_case(self.domain, case_id=uuid4().hex, save=True, owner_id=self.user_a.user_id)

--- a/corehq/apps/integration/kyc/tests/test_models.py
+++ b/corehq/apps/integration/kyc/tests/test_models.py
@@ -15,7 +15,6 @@ from corehq.apps.integration.kyc.models import (
     UserDataStore,
 )
 from corehq.apps.users.models import CommCareUser, WebUser
-from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import create_case
 
 DOMAIN = 'test-domain'
@@ -28,6 +27,7 @@ class BaseKycUsersSetup(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.domain_obj = create_domain(DOMAIN)
+        cls.addClassCleanup(cls.domain_obj.delete)
         cls.web_user = WebUser.create(
             DOMAIN, 'web.user@{DOMAIN}.commcarehq.org', 'Passw0rd!', None, None, is_admin=True,
 
@@ -61,11 +61,6 @@ class BaseKycUsersSetup(TestCase):
             case_json={'other_case_property': 'other_case_value'},
         )
         case_search_adapter.bulk_index([self.user_case, self.other_case], refresh=True)
-        self.addCleanup(
-            CommCareCase.objects.hard_delete_cases,
-            DOMAIN,
-            [self.user_case.case_id, self.other_case.case_id]
-        )
 
 
 class TestGetUserObjectsUsers(BaseKycUsersSetup):
@@ -157,11 +152,6 @@ class TestGetUserObjectsCases(TestCase):
             case_json={'other_case_property': 'other_case_value'},
         )
         case_search_adapter.bulk_index([self.other_case], refresh=True)
-        self.addCleanup(
-            CommCareCase.objects.hard_delete_cases,
-            DOMAIN,
-            [self.other_case.case_id]
-        )
 
     def test_other_case_type(self):
         config = KycConfig(

--- a/corehq/apps/ota/tests/test_case_fixture_view.py
+++ b/corehq/apps/ota/tests/test_case_fixture_view.py
@@ -9,13 +9,11 @@ from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.case_search.const import COMMCARE_PROJECT
 from corehq.apps.case_search.models import CASE_SEARCH_REGISTRY_ID_KEY
-from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.registry.helper import DataRegistryHelper
 from corehq.apps.registry.models import RegistryAuditLog
 from corehq.apps.registry.tests.utils import create_registry_for_test
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.models import CommCareCase, XFormInstance
 from corehq.util.test_utils import generate_cases, flag_enabled
 
 
@@ -26,7 +24,9 @@ class CaseFixtureViewTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.domain_object = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_object.delete)
         cls.user = CommCareUser.create(cls.domain, "user", "123", None, None)
+        cls.addClassCleanup(cls.user.delete, deleted_by_domain=None, deleted_by=None)
 
         cls.grand_parent_case_id = 'mona'
         cls.parent_case_id = 'homer'
@@ -65,16 +65,7 @@ class CaseFixtureViewTests(TestCase):
 
         cls.app = AppFactory(cls.domain).app
         cls.app.save()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete(deleted_by_domain=None, deleted_by=None)
-        xform_ids = CommCareCase.objects.get_case_xform_ids(cls.parent_case_id)
-        CommCareCase.objects.hard_delete_cases(cls.domain, [case.case_id for case in cls.cases])
-        XFormInstance.objects.hard_delete_forms(cls.domain, xform_ids)
-        cls.app.delete()
-        Domain.get_db().delete_doc(cls.domain_object)  # no need to run the full domain delete
-        super().tearDownClass()
+        cls.addClassCleanup(cls.app.delete)
 
     def setUp(self):
         self.client = Client(enforce_csrf_checks=True)

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -512,13 +512,11 @@ class IndicatorPillowTest(BaseRepeaterTest):
         since = self.pillow.get_change_feed().get_latest_offsets()
 
         # save case to DB - should also publish to kafka
-        case = _save_sql_case(sample_doc)
+        _save_sql_case(sample_doc)
 
         # run pillow and check changes
         self.pillow.process_changes(since=since, forever=False)
         self._check_sample_doc_state(expected_indicators)
-
-        CommCareCase.objects.hard_delete_cases(case.domain, [case.case_id])
 
     @flag_enabled('SUPERSET_ANALYTICS')
     @mock.patch('corehq.apps.userreports.specs.datetime')
@@ -573,7 +571,6 @@ class IndicatorPillowTest(BaseRepeaterTest):
         self.pillow.process_changes(since=since, forever=False)
         self.assertEqual(0, self.adapter.get_query_object().count())
 
-        CommCareCase.objects.hard_delete_cases(case.domain, [case.case_id])
         return sample_doc
 
     @mock.patch('corehq.apps.userreports.specs.datetime')

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -344,7 +344,6 @@ class XFormInstanceManagerTest(TestCase):
         forms = [create_form_for_test(DOMAIN) for i in range(3)]
         form_ids = [form.form_id for form in forms]
         other_form = create_form_for_test('other_domain')
-        self.addCleanup(lambda: XFormInstance.objects.hard_delete_forms('other_domain', [other_form.form_id]))
         forms = XFormInstance.objects.get_forms(form_ids)
         self.assertEqual(3, len(forms))
 
@@ -465,7 +464,6 @@ class DeleteAttachmentsFSDBTests(TestCase):
         self.assertEqual(3, len(forms))
 
         other_form = create_form_for_test('other_domain')
-        self.addCleanup(lambda: XFormInstance.objects.hard_delete_forms('other_domain', [other_form.form_id]))
 
         attachments = sorted(
             get_blob_db().metadb.get_for_parents(form_ids),

--- a/corehq/motech/repeaters/tests/test_payload_generators.py
+++ b/corehq/motech/repeaters/tests/test_payload_generators.py
@@ -43,13 +43,8 @@ class TestSqlDataTypes(TestCase):
         super().setUpClass()
         cls.domain = SQL_DOMAIN
         cls.domain_obj = create_sql_domain(SQL_DOMAIN)
+        cls.addClassCleanup(cls.domain_obj.delete)
         cls.set_up_form()
-
-    @classmethod
-    def tearDownClass(cls):
-        XFormInstance.objects.hard_delete_forms(SQL_DOMAIN, [cls.form_id])
-        cls.domain_obj.delete()
-        super().tearDownClass()
 
     @classmethod
     def set_up_form(cls):


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Was looking for places where we explicitly delete forms/cases, which is only necessary in tests marked with `@sharded`, otherwise they will just be rolled back automatically. While doing that, I also modified some setup/teardown to speed up some tests (moved to setUpClass where appropriate) and to have more robust teardown in the event setup fails.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just making changes to tests, so tests passing is sufficient.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
