### PR TITLE
Clarify both class- and function-based tests are fine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,13 @@
 - **pytest conventions**: Use pytest features like Pythonic `assert`
   statements and parametrized tests for repetitive test cases.
 
+- **Class-based vs function-based tests**: Both styles are fine. Pick
+  whichever is more readable and maintainable for the situation —
+  there's no project-wide preference. Class-based tests (e.g.
+  `TestCase`, `SimpleTestCase`) suit shared expensive setup and
+  related test groupings; function-based tests suit standalone cases
+  and pair well with parametrization and explicit fixtures.
+
 - **Explicit fixtures**: Use [pytest-unmagic](https://github.com/dimagi/pytest-unmagic/)
   for explicit test fixtures.
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -26,6 +26,17 @@ most tests it is disabled by default, but it can be temporarily enabled using
 Testing best practices
 ======================
 
+Class-based vs function-based tests
+===================================
+
+Both styles are fine — pick whichever is more readable and maintainable for
+the situation. There is no project-wide preference. Class-based tests
+(``TestCase``, ``SimpleTestCase``) work well when several tests share
+expensive setup or naturally group together. Function-based tests work well
+for standalone cases and pair nicely with ``pytest.mark.parametrize`` and
+explicit `pytest-unmagic <https://github.com/dimagi/pytest-unmagic>`_
+fixtures.
+
 Test set up
 ===========
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
N/A — docs-only change to agent guidance.

## Technical Summary
The agent-facing testing guidance was ambiguous: `AGENTS.md` mentioned pytest-only features (Pythonic asserts, parametrize, unmagic fixtures) while `docs/testing.rst` showed `TestCase`-based examples for shared setup. Neither stated whether class-based or function-based tests were preferred, and recent test additions use both styles.

This adds an explicit note in both places that **both styles are fine — pick whichever is more readable and maintainable for the situation**, with a one-liner about when each tends to fit so AI agents (and humans skimming the docs) don't have to guess.

The motivation for this change was that I noticed (without this change) when I asked Claude to update some tests to conform to our testing conventions, it unnecessarily rewrote everything as function-based tests, I think implicitly inferring incorrectly from some examples in CLAUDE.md/AGENTS.md that we preferred function-based tests.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Documentation-only change. No code paths affected.

### Automated test coverage
N/A — no behavior change.

### QA Plan
N/A

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change