### PR TITLE
Fix checkbox alignment on edit role page

### DIFF
--- a/corehq/apps/users/templates/users/edit_role.html
+++ b/corehq/apps/users/templates/users/edit_role.html
@@ -129,7 +129,7 @@
                       class="col-md-1 controls"
                       x-show="area.showEditCheckbox"
                     >
-                      <div class="form-check">
+                      <div>
                         <input
                           class="form-check-input"
                           type="checkbox"
@@ -159,7 +159,7 @@
                       x-show="area.showViewCheckbox"
                     >
                       {# PLACEHOLDER checkbox when editPermission() is true #}
-                      <div class="form-check" x-show="area.editPermission">
+                      <div x-show="area.editPermission">
                         <input
                           class="form-check-input"
                           type="checkbox"
@@ -180,7 +180,7 @@
                       </div>
                       {# end PLACEHOLDER #}
                       {# REAL checkbox that controls viewPermission when editPermission() is false #}
-                      <div class="form-check" x-show="!area.editPermission">
+                      <div x-show="!area.editPermission">
                         <input
                           class="form-check-input"
                           type="checkbox"


### PR DESCRIPTION
## Product Description
Before:
<img width="746" height="203" alt="image" src="https://github.com/user-attachments/assets/80b6ec29-25a5-44fe-a2c3-1c316e58c431" />


After:
<img width="745" height="197" alt="image" src="https://github.com/user-attachments/assets/fca85b70-d470-41f1-9691-0d759e35062a" />



## Technical Summary
Fixes alignment of checkboxes where their labels are not contained in the same element, by removing the `form-check` class. Inline checkbox / label groups on this same page are unchanged as their alignment was already correct.


## Safety Assurance

### Safety story
This is a minor UI tweak, there's nothing risky here.

### Automated test coverage
n/a

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
