### PR TITLE
Add script to kickoff and return url for github action test run

### DIFF
--- a/scripts/run-tests-in-github-actions.sh
+++ b/scripts/run-tests-in-github-actions.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Trigger the tests.yml workflow for the current branch and print the run URL.
+# Usage: scripts/run-tests-in-github-actions.sh
+
+set -euo pipefail
+
+if ! command -v gh &>/dev/null; then
+    echo "Error: 'gh' (GitHub CLI) is not installed." >&2
+    echo "Install it from https://cli.github.com/" >&2
+    exit 1
+fi
+
+branch=$(git branch --show-current)
+if [[ -z $branch ]]; then
+    echo "Error: not on a branch (detached HEAD?)." >&2
+    exit 1
+fi
+
+echo "Triggering tests.yml on $branch..."
+gh workflow run tests.yml --ref "$branch" >/dev/null
+
+max_attempts=8
+for ((i = 0; i < max_attempts; i++)); do
+    sleep 2
+    url=$(gh run list --workflow=tests.yml --limit 5 --json url,headBranch \
+        -q "[.[] | select(.headBranch==\"$branch\")][0].url" || true)
+    if [[ -n ${url:-} ]]; then
+        echo "View the run at: $url"
+        exit 0
+    fi
+done
+
+echo "Workflow run not found yet — check 'gh run list --branch $branch'." >&2
+exit 1


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
I'm very guilty of opening a PR that I'm proud of, only to realize tests are failing, and 3 commits later my PR feels like a mess. I know others on the team manually run the test suite on their branch prior to creating a PR, and I just wanted to make that as easy as possible here.

Disclaimer: claude was used to generate this code. Iterated a bit on it but once it was working I was all set.

If we don't feel like this will add value for anyone, I can just keep this locally and no need to merge the PR!

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Internal tool

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
