### PR TITLE
Lock case property mappings when they reference a locked question

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1262,11 +1262,27 @@ class FormBase(DocumentSchema):
         return self.get_questions([], include_triggers=True, include_groups=True)
 
     @time_method()
-    @quickcache(['self.source', 'langs', 'include_triggers', 'include_groups', 'include_translations',
-                 'include_fixtures'],
-                timeout=24 * 60 * 60)
-    def get_questions(self, langs, include_triggers=False,
-                      include_groups=False, include_translations=False, include_fixtures=False):
+    @quickcache(
+        [
+            'self.source',
+            'langs',
+            'include_triggers',
+            'include_groups',
+            'include_translations',
+            'include_fixtures',
+            'include_locked_status',
+        ],
+        timeout=24 * 60 * 60,
+    )
+    def get_questions(
+        self,
+        langs,
+        include_triggers=False,
+        include_groups=False,
+        include_translations=False,
+        include_fixtures=False,
+        include_locked_status=False
+    ):
         try:
             return XForm(self.source, domain=self.get_app().domain).get_questions(
                 langs=langs,
@@ -1274,6 +1290,7 @@ class FormBase(DocumentSchema):
                 include_groups=include_groups,
                 include_translations=include_translations,
                 include_fixtures=include_fixtures,
+                include_locked_status=include_locked_status,
             )
         except XFormException as e:
             raise XFormException(_('Error in form "{}": {}').format(trans(self.name), e))

--- a/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
@@ -4,14 +4,18 @@ import toggles from "hqwebapp/js/toggles";
 import initialPageData from "hqwebapp/js/initial_page_data";
 
 export default {
-    getQuestions: function (questions, filter, excludeHidden, includeRepeat, excludeTrigger) {
+    getQuestions: function (
+        questions,
+        filter,
+        excludeHidden = false,
+        includeRepeat = false,
+        excludeTrigger = false,
+        disableLocked = false,
+    ) {
         // filter can be "all", or any of "select1", "select", or "input" separated by spaces
         var i,
             options = [],
             q;
-        excludeHidden = excludeHidden || false;
-        excludeTrigger = excludeTrigger || false;
-        includeRepeat = includeRepeat || false;
         filter = filter.split(" ");
         if (!excludeHidden) {
             filter.push('hidden');
@@ -26,6 +30,9 @@ export default {
                 if (includeRepeat || !q.repeat) {
                     if (!excludeTrigger || q.tag !== "trigger") {
                         if (allowAttachments || q.tag !== "upload") {
+                            if (disableLocked) {
+                                q.disabled = q.locked;
+                            }
                             options.push(q);
                         }
                     }

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap3/actions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap3/actions.js
@@ -462,6 +462,13 @@ var loadUpdateAction = {
             return false;
         });
 
+        self.hasLockedMappings = ko.observable(function () {
+            if (self.hasCaseProperties() && _.some(self.case_properties(), property => property.isLocked())) {
+                return true;
+            }
+            return self.hasPreload() && _.some(self.preload(), property => property.isLocked());
+        });
+
         return self;
     },
     unwrap: function (self) {
@@ -680,6 +687,13 @@ var openCaseAction = {
                 }
             }
             return false;
+        });
+
+        self.hasLockedMappings = ko.observable(function () {
+            return (
+                self.hasCaseProperties()
+                && _.some(self.case_properties(), property => property.isLocked())
+            );
         });
 
         return self;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap3/actions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap3/actions.js
@@ -603,7 +603,7 @@ var openCaseAction = {
                 return _(self.case_properties()).find(function (p) {
                     return p.key() === 'name' && p.required();
                 }).path();
-            } catch (e) {
+            } catch {
                 return null;
             }
         });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap3/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap3/case_config_ui.js
@@ -40,7 +40,12 @@ $(function () {
         };
 
         self.home = params.home;
-        self.questions = ko.observable(params.questions);
+        self.questions = ko.observable(
+            _.map(params.questions, question => {
+                question.disabled = question.locked;
+                return question;
+            }),
+        );
         self.save_url = params.save_url;
         self.caseType = params.caseType;
         self.module_id = params.module_id;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap3/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap3/case_config_ui.js
@@ -40,12 +40,7 @@ $(function () {
         };
 
         self.home = params.home;
-        self.questions = ko.observable(
-            _.map(params.questions, question => {
-                question.disabled = question.locked;
-                return question;
-            }),
-        );
+        self.questions = ko.observable(params.questions);
         self.save_url = params.save_url;
         self.caseType = params.caseType;
         self.module_id = params.module_id;
@@ -173,7 +168,13 @@ $(function () {
         };
 
         self.getQuestions = function (filter, excludeHidden, includeRepeat) {
-            return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat);
+            return caseConfigUtils.getQuestions(
+                self.questions(),
+                filter,
+                excludeHidden,
+                includeRepeat,
+                true,  //disableLocked
+            );
         };
 
         self.getAnswers = function (condition) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap5/actions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap5/actions.js
@@ -462,6 +462,13 @@ var loadUpdateAction = {
             return false;
         });
 
+        self.hasLockedMappings = ko.observable(function () {
+            if (self.hasCaseProperties() && _.some(self.case_properties(), property => property.isLocked())) {
+                return true;
+            }
+            return self.hasPreload() && _.some(self.preload(), property => property.isLocked());
+        });
+
         return self;
     },
     unwrap: function (self) {
@@ -680,6 +687,13 @@ var openCaseAction = {
                 }
             }
             return false;
+        });
+
+        self.hasLockedMappings = ko.observable(function () {
+            return (
+                self.hasCaseProperties()
+                && _.some(self.case_properties(), property => property.isLocked())
+            );
         });
 
         return self;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap5/actions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap5/actions.js
@@ -603,7 +603,7 @@ var openCaseAction = {
                 return _(self.case_properties()).find(function (p) {
                     return p.key() === 'name' && p.required();
                 }).path();
-            } catch (e) {
+            } catch {
                 return null;
             }
         });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap5/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap5/case_config_ui.js
@@ -40,7 +40,12 @@ $(function () {
         };
 
         self.home = params.home;
-        self.questions = ko.observable(params.questions);
+        self.questions = ko.observable(
+            _.map(params.questions, question => {
+                question.disabled = question.locked;
+                return question;
+            }),
+        );
         self.save_url = params.save_url;
         self.caseType = params.caseType;
         self.module_id = params.module_id;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap5/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap5/case_config_ui.js
@@ -40,12 +40,7 @@ $(function () {
         };
 
         self.home = params.home;
-        self.questions = ko.observable(
-            _.map(params.questions, question => {
-                question.disabled = question.locked;
-                return question;
-            }),
-        );
+        self.questions = ko.observable(params.questions);
         self.save_url = params.save_url;
         self.caseType = params.caseType;
         self.module_id = params.module_id;
@@ -173,7 +168,13 @@ $(function () {
         };
 
         self.getQuestions = function (filter, excludeHidden, includeRepeat) {
-            return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat);
+            return caseConfigUtils.getQuestions(
+                self.questions(),
+                filter,
+                excludeHidden,
+                includeRepeat,
+                true,  //disableLocked
+            );
         };
 
         self.getAnswers = function (condition) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_properties.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_properties.js
@@ -39,6 +39,10 @@ var casePropertyBase = {
             }
             return false;
         });
+        self.isLocked = ko.pureComputed(function () {
+            const question = self.action.caseConfig.questionMap[self.path()];
+            return !!(question && question.locked);
+        });
         return self;
     },
 };

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_properties.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_properties.js
@@ -41,7 +41,7 @@ var casePropertyBase = {
         });
         self.isLocked = ko.pureComputed(function () {
             const question = self.action.caseConfig.questionMap[self.path()];
-            return !!(question && question.locked);
+            return question && question.locked;
         });
         return self;
     },

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/case_config_ui.js
@@ -606,6 +606,10 @@ $(function () {
                     self.updatedDescription(value);
                 },
             });
+            self.isLocked = ko.pureComputed(function () {
+                const question = self.case_transaction.caseConfig.questionMap[self.path()];
+                return !!(question && question.locked);
+            });
             return self;
         },
     };

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/case_config_ui.js
@@ -42,7 +42,12 @@ $(function () {
 
         self.home = params.home;
         self.actions = filterActions(params.actions);
-        self.questions = ko.observable(params.questions);
+        self.questions = ko.observable(
+            _.map(params.questions, question => {
+                question.disabled = question.locked;
+                return question;
+            }),
+        );
         self.save_url = params.save_url;
         // `requires` is a ko observable so it can be read by another UI
         self.requires = params.requires;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/case_config_ui.js
@@ -42,12 +42,7 @@ $(function () {
 
         self.home = params.home;
         self.actions = filterActions(params.actions);
-        self.questions = ko.observable(
-            _.map(params.questions, question => {
-                question.disabled = question.locked;
-                return question;
-            }),
-        );
+        self.questions = ko.observable(params.questions);
         self.save_url = params.save_url;
         // `requires` is a ko observable so it can be read by another UI
         self.requires = params.requires;
@@ -170,7 +165,14 @@ $(function () {
         self.caseConfigViewModel = ko.observable(caseConfigViewModel(self));
 
         self.getQuestions = function (filter, excludeHidden, includeRepeat, excludeTrigger) {
-            return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat, excludeTrigger);
+            return caseConfigUtils.getQuestions(
+                self.questions(),
+                filter,
+                excludeHidden,
+                includeRepeat,
+                excludeTrigger,
+                true,  //disableLocked
+            );
         };
 
         self.getAnswers = function (condition) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/case_config_ui.js
@@ -613,7 +613,7 @@ $(function () {
             });
             self.isLocked = ko.pureComputed(function () {
                 const question = self.case_transaction.caseConfig.questionMap[self.path()];
-                return !!(question && question.locked);
+                return question && question.locked;
             });
             return self;
         },

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/case_config_ui.js
@@ -606,6 +606,10 @@ $(function () {
                     self.updatedDescription(value);
                 },
             });
+            self.isLocked = ko.pureComputed(function () {
+                const question = self.case_transaction.caseConfig.questionMap[self.path()];
+                return !!(question && question.locked);
+            });
             return self;
         },
     };

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/case_config_ui.js
@@ -42,7 +42,12 @@ $(function () {
 
         self.home = params.home;
         self.actions = filterActions(params.actions);
-        self.questions = ko.observable(params.questions);
+        self.questions = ko.observable(
+            _.map(params.questions, question => {
+                question.disabled = question.locked;
+                return question;
+            }),
+        );
         self.save_url = params.save_url;
         // `requires` is a ko observable so it can be read by another UI
         self.requires = params.requires;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/case_config_ui.js
@@ -42,12 +42,7 @@ $(function () {
 
         self.home = params.home;
         self.actions = filterActions(params.actions);
-        self.questions = ko.observable(
-            _.map(params.questions, question => {
-                question.disabled = question.locked;
-                return question;
-            }),
-        );
+        self.questions = ko.observable(params.questions);
         self.save_url = params.save_url;
         // `requires` is a ko observable so it can be read by another UI
         self.requires = params.requires;
@@ -170,7 +165,14 @@ $(function () {
         self.caseConfigViewModel = ko.observable(caseConfigViewModel(self));
 
         self.getQuestions = function (filter, excludeHidden, includeRepeat, excludeTrigger) {
-            return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat, excludeTrigger);
+            return caseConfigUtils.getQuestions(
+                self.questions(),
+                filter,
+                excludeHidden,
+                includeRepeat,
+                excludeTrigger,
+                true,  //disableLocked
+            );
         };
 
         self.getAnswers = function (condition) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/case_config_ui.js
@@ -613,7 +613,7 @@ $(function () {
             });
             self.isLocked = ko.pureComputed(function () {
                 const question = self.case_transaction.caseConfig.questionMap[self.path()];
-                return !!(question && question.locked);
+                return question && question.locked;
             });
             return self;
         },

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
@@ -22,8 +22,15 @@ const utils = {
                 + " (" + utils._truncateValue(question.hashtagValue || question.value, MAXLEN) + ")";
     },
     _getLabel: function (question, MAXLEN) {
-        return utils._truncateLabel((question.repeat ? '- ' : '')
-                + question.label, question.tag === 'hidden' ? ' (Hidden)' : '', MAXLEN);
+        const suffixes = [
+            question.tag === 'hidden' ? gettext(" (Hidden)") : "",
+            question.locked && question.disabled ? gettext(" (Locked)") : "",
+        ];
+        return utils._truncateLabel(
+            (question.repeat ? '- ' : '') + question.label,
+            suffixes.join(''),
+            MAXLEN,
+        );
     },
     _truncateLabel: function (label, suffix, MAXLEN) {
         suffix = suffix || "";

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap3/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap3/case_config_advanced.html
@@ -197,8 +197,17 @@
     <a href="#" role="button" class="case-action-move btn btn-purple grip" data-bind="visible: moveable()">
       <i class="fa-solid fa-up-down"></i>
     </a>
-    <button class="case-action-remove btn btn-purple"
-            data-bind="openModal: 'remove-action-modal-template'">
+    <button
+      class="case-action-remove btn btn-purple"
+      data-bind="
+        openModal: 'remove-action-modal-template',
+        disable: hasLockedMappings(),
+        attr: {
+            title: hasLockedMappings() ?
+              '{% trans_html_attr "This action cannot be removed because it references a locked question." %}'
+              : ''
+        }"
+    >
       <i class="fa-regular fa-trash-can"></i>
     </button>
   </div>
@@ -320,8 +329,17 @@
     <a href="#" role="button" class="case-action-move btn btn-purple grip">
       <i class="fa-solid fa-up-down"></i>
     </a>
-    <button class="case-action-remove btn btn-purple"
-            data-bind="openModal: 'remove-action-modal-template'">
+    <button
+      class="case-action-remove btn btn-purple"
+      data-bind="
+        openModal: 'remove-action-modal-template',
+        disable: hasLockedMappings(),
+        attr: {
+            title: hasLockedMappings() ?
+              '{% trans_html_attr "This action cannot be removed because it references a locked question." %}'
+              : ''
+        }"
+    >
       <i class="fa-regular fa-trash-can"></i>
     </button>
   </div>
@@ -381,8 +399,17 @@
     <a href="#" role="button" class="case-action-move btn btn-purple grip" data-bind="visible: moveable()">
       <i class="fa-solid fa-up-down"></i>
     </a>
-    <button class="case-action-remove btn btn-purple"
-            data-bind="openModal: 'remove-action-modal-template'">
+    <button
+      class="case-action-remove btn btn-purple"
+      data-bind="
+        openModal: 'remove-action-modal-template',
+        disable: hasLockedMappings(),
+        attr: {
+            title: hasLockedMappings() ?
+              '{% trans_html_attr "This action cannot be removed because it references a locked question." %}'
+              : ''
+        }"
+    >
       <i class="fa-regular fa-trash-can"></i>
     </button>
   </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap3/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap3/case_config_ko_templates.html
@@ -76,7 +76,7 @@
   <select class="form-control"
           data-bind="questionsSelect: $root.getQuestions('all', false, case_transaction.allow.repeats(), true),
                      value: path,
-                     disable: !$parent.hasPrivilege,
+                     disable: !$parent.hasPrivilege || isLocked(),
                      event: {
                        change: function(view, e) {
                          if (e.target.closest('#case-config-ko')) {
@@ -140,7 +140,10 @@
                        'has-error': validateProperty || validateQuestion,
                      }">
         <td class="col-sm-1 text-center">
-          <button class="btn btn-danger" data-bind="click: $parent.removePreload">
+          <button
+            class="btn btn-danger"
+            data-bind="click: $parent.removePreload, visible: !isLocked()"
+          >
             <i class="fa fa-remove"></i>
           </button>
         </td>
@@ -151,7 +154,7 @@
                             data: {
                               'property': $data,
                               'suggestedProperties': case_transaction.suggestedPreloadProperties,
-                              'isDisabled': false,
+                              'isDisabled': isLocked(),
                             }
                           }"></div>
           <p class="help-block"
@@ -279,9 +282,18 @@
                     }">
         <td class="col-sm-1 text-center"
             data-bind="if: $parent.hasPrivilege">
-          <button class="btn btn-danger" data-bind="click: $parent.removeProperty, visible: !required()">
-            <i class="fa fa-remove"></i>
-          </button>
+          <!-- ko ifnot: isLocked() -->
+            <button class="btn btn-danger" data-bind="click: $parent.removeProperty, visible: !required()">
+              <i class="fa fa-remove"></i>
+            </button>
+          <!-- /ko -->
+          <!-- ko if: isLocked() -->
+            <i
+              class="fa fa-lock"
+              title="{% trans_html_attr 'This mapping cannot be edited because it references a locked question.' %}"
+            >
+            </i>
+          <!-- /ko -->
         </td>
         <td data-bind="class: $parent.saveOnlyEditedFormFieldsEnabled ? 'col-sm-5' : 'col-sm-6'">
           <div class="full-width-select2"
@@ -305,14 +317,14 @@
                             data: {
                               property: $data,
                               suggestedProperties: case_transaction.suggestedSaveProperties,
-                              'isDisabled': !$parent.hasPrivilege,
+                              'isDisabled': !$parent.hasPrivilege || isLocked(),
                             },
                             afterRender: $root.makePopover
                           }"></div>
           <p class="help-block"
              data-bind="html: validate,
                         visible: validate"></p>
-          <!-- ko if: $parent.hasPrivilege -->
+          <!-- ko if: $parent.hasPrivilege && !isLocked() -->
           {% if request|request_has_privilege:"DATA_DICTIONARY" %}
             <p class="help-block"  data-bind="visible: !validate() && isDeprecated()">
               {% blocktrans %}
@@ -337,7 +349,7 @@
                                 afterRenderFunc: $root.makePopover"></inline-edit>
           {% endif %}
           <!-- /ko -->
-          <!-- ko if: $data.description() && !$parent.hasPrivilege -->
+          <!-- ko if: $data.description() && (!$parent.hasPrivilege || isLocked()) -->
             <p data-bind="text: $data.description"></p>
           <!-- /ko -->
         </td>
@@ -345,7 +357,7 @@
           <input type="checkbox"
                  data-bind="click: $parent.switchSaveOnlyIfEdited,
                             checked: $data.save_only_if_edited,
-                            disabled: $parent.hasPrivilege"
+                            disable: !$parent.hasPrivilege || isLocked()"
                   />
         </td>
       </tr>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap5/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap5/case_config_advanced.html
@@ -197,8 +197,17 @@
     <a href="#" role="button" class="case-action-move btn btn-purple grip" data-bind="visible: moveable()">
       <i class="fa-solid fa-up-down"></i>
     </a>
-    <button class="case-action-remove btn btn-purple"
-            data-bind="openModal: 'remove-action-modal-template'">
+    <button
+      class="case-action-remove btn btn-purple"
+      data-bind="
+        openModal: 'remove-action-modal-template',
+        disable: hasLockedMappings(),
+        attr: {
+            title: hasLockedMappings() ?
+              '{% trans_html_attr "This action cannot be removed because it references a locked question." %}'
+              : ''
+        }"
+    >
       <i class="fa-regular fa-trash-can"></i>
     </button>
   </div>
@@ -320,8 +329,17 @@
     <a href="#" role="button" class="case-action-move btn btn-purple grip">
       <i class="fa-solid fa-up-down"></i>
     </a>
-    <button class="case-action-remove btn btn-purple"
-            data-bind="openModal: 'remove-action-modal-template'">
+    <button
+      class="case-action-remove btn btn-purple"
+      data-bind="
+        openModal: 'remove-action-modal-template',
+        disable: hasLockedMappings(),
+        attr: {
+            title: hasLockedMappings() ?
+              '{% trans_html_attr "This action cannot be removed because it references a locked question." %}'
+              : ''
+        }"
+    >
       <i class="fa-regular fa-trash-can"></i>
     </button>
   </div>
@@ -381,8 +399,17 @@
     <a href="#" role="button" class="case-action-move btn btn-purple grip" data-bind="visible: moveable()">
       <i class="fa-solid fa-up-down"></i>
     </a>
-    <button class="case-action-remove btn btn-purple"
-            data-bind="openModal: 'remove-action-modal-template'">
+    <button
+      class="case-action-remove btn btn-purple"
+      data-bind="
+        openModal: 'remove-action-modal-template',
+        disable: hasLockedMappings(),
+        attr: {
+            title: hasLockedMappings() ?
+              '{% trans_html_attr "This action cannot be removed because it references a locked question." %}'
+              : ''
+        }"
+    >
       <i class="fa-regular fa-trash-can"></i>
     </button>
   </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap5/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/bootstrap5/case_config_ko_templates.html
@@ -76,7 +76,7 @@
   <select class="form-select"
           data-bind="questionsSelect: $root.getQuestions('all', false, case_transaction.allow.repeats(), true),
                      value: path,
-                     disable: !$parent.hasPrivilege,
+                     disable: !$parent.hasPrivilege || isLocked(),
                      event: {
                        change: function(view, e) {
                          if (e.target.closest('#case-config-ko')) {
@@ -140,7 +140,10 @@
                        'has-error': validateProperty || validateQuestion,  {# todo B5: css-has-error #}
                      }">
         <td class="col-md-1 text-center">
-          <button class="btn btn-outline-danger" data-bind="click: $parent.removePreload">
+          <button
+            class="btn btn-outline-danger"
+            data-bind="click: $parent.removePreload, visible: !isLocked()"
+          >
             <i class="fa fa-remove"></i>
           </button>
         </td>
@@ -151,7 +154,7 @@
                             data: {
                               'property': $data,
                               'suggestedProperties': case_transaction.suggestedPreloadProperties,
-                              'isDisabled': false,
+                              'isDisabled': isLocked(),
                             }
                           }"></div>
           <p class="help-block"
@@ -279,9 +282,18 @@
                     }">
         <td class="col-md-1 text-center"
             data-bind="if: $parent.hasPrivilege">
-          <button class="btn btn-outline-danger" data-bind="click: $parent.removeProperty, visible: !required()">
-            <i class="fa fa-remove"></i>
-          </button>
+          <!-- ko ifnot: isLocked() -->
+            <button class="btn btn-outline-danger" data-bind="click: $parent.removeProperty, visible: !required()">
+              <i class="fa fa-remove"></i>
+            </button>
+          <!-- /ko -->
+          <!-- ko if: isLocked() -->
+            <i
+              class="fa fa-lock"
+              title="{% trans_html_attr 'This mapping cannot be edited because it references a locked question.' %}"
+            >
+            </i>
+          <!-- /ko -->
         </td>
         <td data-bind="class: $parent.saveOnlyEditedFormFieldsEnabled ? 'col-md-5' : 'col-md-6'">
           <div class="full-width-select2"
@@ -306,14 +318,14 @@
                             data: {
                               property: $data,
                               suggestedProperties: case_transaction.suggestedSaveProperties,
-                              'isDisabled': !$parent.hasPrivilege,
+                              'isDisabled': !$parent.hasPrivilege || isLocked(),
                             },
                             afterRender: $root.makePopover
                           }"></div>
           <p class="help-block"
              data-bind="html: validate,
                         visible: validate"></p>
-          <!-- ko if: $parent.hasPrivilege -->
+          <!-- ko if: $parent.hasPrivilege && !isLocked() -->
           {% if request|request_has_privilege:"DATA_DICTIONARY" %}
             <p class="help-block"  data-bind="visible: !validate() && isDeprecated()">
               {% blocktrans %}
@@ -338,7 +350,7 @@
                                 afterRenderFunc: $root.makePopover"></inline-edit>
           {% endif %}
           <!-- /ko -->
-          <!-- ko if: $data.description() && !$parent.hasPrivilege -->
+          <!-- ko if: $data.description() && (!$parent.hasPrivilege || isLocked()) -->
             <p data-bind="text: $data.description"></p>
           <!-- /ko -->
         </td>
@@ -346,7 +358,7 @@
           <input type="checkbox"  {# todo B5: css-checkbox #}
                  data-bind="click: $parent.switchSaveOnlyIfEdited,
                             checked: $data.save_only_if_edited,
-                            disabled: $parent.hasPrivilege"
+                            disable: !$parent.hasPrivilege || isLocked()"
                   />
         </td>
       </tr>

--- a/corehq/apps/app_manager/tests/data/case_in_form.xml
+++ b/corehq/apps/app_manager/tests/data/case_in_form.xml
@@ -28,7 +28,7 @@
                 constraint="1 + instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/child_property_1"
                 jr:constraintMsg="jr:itext('question1-constraintMsg')"
                 relevant="instance('casedb')/casedb/case[@case_id=instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/index/parent]/parent_property_1 + 1 + instance('casedb')/casedb/case[@case_id=instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/index/parent]/parent_property_1" />
-            <bind nodeset="/data/question2" type="xsd:string" />
+            <bind nodeset="/data/question2" type="xsd:string" vellum:lock="all" />
             <bind nodeset="/data/question3" type="xsd:string" />
 
             <!-- repeat context test -->

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -226,6 +226,15 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
 
         self.assertEqual(questions, QUESTIONS)
 
+    def test_get_questions_with_locked_status(self):
+        form = self.app.get_form(self.form_unique_id)
+        questions = form.wrapped_xform().get_questions(['en'], include_locked_status=True)
+
+        locked_question = [q for q in questions if q['value'] == '/data/question2'][0]
+        unlocked_question = [q for q in questions if q['value'] == '/data/question1'][0]
+        self.assertTrue(locked_question['locked'])
+        self.assertFalse(unlocked_question['locked'])
+
     def test_get_questions_with_repeats(self):
         """
         This test ensures that questions that start with the repeat group id

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -29,7 +29,10 @@ QUESTIONS = [
                      "instance('casedb')/casedb/case[@case_id=instance('casedb')/casedb/case["
                      "@case_id=instance('commcaresession')/session/data/case_id]/index/parent"
                      "]/parent_property_1"),
-        'constraint': "1 + instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/child_property_1",
+        'constraint': (
+            "1 + instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]"
+            "/child_property_1"
+        ),
         'comment': None,
         'setvalue': None,
         'is_group': False,

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -675,7 +675,11 @@ def get_form_questions(request, domain, app_id):
         lang, langs = get_langs(request, app)
     except FormNotFoundException:
         raise Http404()
-    xform_questions = form.get_questions(langs, include_triggers=True)
+    include_locked_status = (
+        domain_has_privilege(domain, "locked_admin_questions")
+        and toggles.LOCKED_ADMIN_QUESTIONS.enabled_for_request(request)
+    )
+    xform_questions = form.get_questions(langs, include_triggers=True, include_locked_status=include_locked_status)
     return json_response(xform_questions)
 
 
@@ -752,7 +756,13 @@ def get_form_view_context(
             )
 
         try:
-            xform_questions = xform.get_questions(langs, include_triggers=True)
+            include_locked_status = (
+                domain_has_privilege(domain, "locked_admin_questions")
+                and toggles.LOCKED_ADMIN_QUESTIONS.enabled_for_request(request)
+            )
+            xform_questions = xform.get_questions(
+                langs, include_triggers=True, include_locked_status=include_locked_status
+            )
             form.validate_form()
         except etree.XMLSyntaxError as e:
             form_errors.append("Syntax Error: %s" % e)

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1048,9 +1048,16 @@ class XForm(WrappedNode):
                 instance_dict[instance_id] = src
         return instance_dict
 
-    def get_questions(self, langs, include_triggers=False,
-                      include_groups=False, include_translations=False,
-                      exclude_select_with_itemsets=False, include_fixtures=False):
+    def get_questions(
+            self,
+            langs,
+            include_triggers=False,
+            include_groups=False,
+            include_translations=False,
+            exclude_select_with_itemsets=False,
+            include_fixtures=False,
+            include_locked_status=False,
+        ):
         """
         parses out the questions from the xform, into the format:
         [{"label": label, "tag": tag, "value": value}, ...]
@@ -1140,6 +1147,10 @@ class XForm(WrappedNode):
                 "setvalue": self._get_setvalue(path),
                 "is_group": is_group,
             }
+
+            if include_locked_status:
+                question["locked"] = bool(cnode.bind_node) and cnode.bind_node.attrib.get('{v}lock') == 'all'
+
             if include_translations:
                 question["translations"] = self._get_label_translations(node, langs)
 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/forms/case_config_advanced.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/forms/case_config_advanced.html.diff.txt
@@ -225,7 +225,7 @@
    </div>
    <div class="panel-case-actions-actions">
      <a href="#" role="button" class="case-action-move btn btn-purple grip" data-bind="visible: moveable()">
-@@ -203,25 +203,25 @@
+@@ -212,25 +212,25 @@
      </button>
    </div>
    <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
@@ -261,7 +261,7 @@
                                options: caseConfig.caseTypes,
                                value: case_type,
                                optionsCaption: 'Choose a Case Type...'
-@@ -229,10 +229,10 @@
+@@ -238,10 +238,10 @@
              </div>
              <!-- ko if: actionType == 'load'-->
              &nbsp;{% trans "from" %}
@@ -274,7 +274,7 @@
                                optstrValue: 'id',
                                optstrText: 'module_name',
                                value: details_module">
-@@ -268,7 +268,7 @@
+@@ -277,7 +277,7 @@
  </script>
  
  <script type="text/html" id="auto-select:raw">
@@ -283,7 +283,7 @@
      <strong>{% trans "Raw Config" %}:</strong>&nbsp;&nbsp;
      {% trans "XPath function" %}
      <input type="text" class="form-control" data-bind="value: value_key" />&nbsp;&nbsp;
-@@ -277,7 +277,7 @@
+@@ -286,7 +286,7 @@
  </script>
  
  <script type="text/html" id="auto-select:user">
@@ -292,7 +292,7 @@
      <strong>{% trans "User Data Config" %}:</strong>&nbsp;&nbsp;
      {% trans "User data key" %}
      <input type="text" class="form-control" data-bind="value: value_key" />&nbsp;&nbsp;
-@@ -286,10 +286,10 @@
+@@ -295,10 +295,10 @@
  </script>
  
  <script type="text/html" id="auto-select:case">
@@ -305,7 +305,7 @@
              value: value_source">
      </select>&nbsp;&nbsp;
      {% trans "Index name" %}
-@@ -299,7 +299,7 @@
+@@ -308,7 +308,7 @@
  </script>
  
  <script type="text/html" id="auto-select:fixture">
@@ -314,7 +314,7 @@
      <strong>{% trans "Lookup Table Config" %}:</strong>&nbsp;&nbsp;
      {% trans "Lookup Table Tag" %}
      <input type="text" class="form-control" data-bind="value: value_source" />&nbsp;&nbsp;
-@@ -312,9 +312,9 @@
+@@ -321,9 +321,9 @@
  <script type="text/html" id="auto-select:usercase">
  </script>
  <script type="text/html" id="case-config:case-action-auto-select">
@@ -326,7 +326,7 @@
    </div>
    <div class="panel-case-actions-actions">
      <a href="#" role="button" class="case-action-move btn btn-purple grip">
-@@ -326,25 +326,25 @@
+@@ -344,25 +344,25 @@
      </button>
    </div>
    <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
@@ -361,7 +361,7 @@
                                  optstr: $parent.auto_select_modes,
                                  value: mode,
                                  optionsCaption: 'Choose a mode...'
-@@ -352,7 +352,7 @@
+@@ -370,7 +370,7 @@
              </div>
              <strong>)</strong>
              <br />
@@ -370,7 +370,7 @@
                <!-- ko template: {name: 'auto-select:' + mode()} --><!-- /ko -->
              </div>
              <!-- /ko -->
-@@ -373,9 +373,9 @@
+@@ -391,9 +391,9 @@
  </script>
  
  <script type="text/html" id="case-config:case-action-load-case-from-fixture">
@@ -382,7 +382,7 @@
    </div>
    <div class="panel-case-actions-actions">
      <a href="#" role="button" class="case-action-move btn btn-purple grip" data-bind="visible: moveable()">
-@@ -387,24 +387,24 @@
+@@ -414,24 +414,24 @@
      </button>
    </div>
    <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
@@ -416,7 +416,7 @@
                                  options: caseConfig.caseTypes,
                                  value: case_type,
                                  optionsCaption: 'Choose a Case Type...'
-@@ -413,10 +413,10 @@
+@@ -440,10 +440,10 @@
  
              <!-- ko if: actionType == 'load'-->
              &nbsp;{% trans "from" %}
@@ -429,7 +429,7 @@
                                  optstrValue: 'id',
                                  optstrText: 'module_name',
                                  value: details_module">
-@@ -429,54 +429,54 @@
+@@ -456,54 +456,54 @@
            <div class="help-block" data-bind="visible: !case_type">
              {% trans "Please select a case type." %}
            </div>
@@ -500,7 +500,7 @@
                  <label>{% trans "Arbitrary Datum id" %}&nbsp;</label>
                  <input type="text" class="form-control" data-bind="value: load_case_from_fixture.arbitrary_datum_id" />
                </div>
-@@ -495,7 +495,7 @@
+@@ -522,7 +522,7 @@
    <div data-bind="saveButton: saveButton"></div>
    <div data-bind="with: caseConfigViewModel">
      <div class="btn-group" data-bind="visible: actionOptions().length">
@@ -509,7 +509,7 @@
          <i class="fa fa-plus"></i>
          <span>{% trans "Add Action" %}</span> <span class="caret"></span>
        </button>
-@@ -510,76 +510,76 @@
+@@ -537,76 +537,76 @@
      </div>
      <div data-bind="visible: !actionOptions().length">
        <i class="fa fa-plus icon-muted"></i>
@@ -614,7 +614,7 @@
                    <input type="text" class="form-control textbox" data-bind="textInput: datum_function" />
                  </td>
                </tr>
-@@ -587,7 +587,7 @@
+@@ -614,7 +614,7 @@
            </table>
            <br><br>
          </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/forms/case_config_ko_templates.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/forms/case_config_ko_templates.html.diff.txt
@@ -68,7 +68,7 @@
 +  <select class="form-select"
            data-bind="questionsSelect: $root.getQuestions('all', false, case_transaction.allow.repeats(), true),
                       value: path,
-                      disable: !$parent.hasPrivilege,
+                      disable: !$parent.hasPrivilege || isLocked(),
 @@ -112,13 +112,13 @@
  
  <script type="text/html"
@@ -86,7 +86,7 @@
      <table class="table table-savecaseprops"
             data-bind="visible: case_preload().length">
        <thead>
-@@ -135,16 +135,16 @@
+@@ -135,19 +135,19 @@
        </thead>
  
        <tbody data-bind="foreach: case_preload">
@@ -97,9 +97,12 @@
 +                       'has-error': validateProperty || validateQuestion,  {# todo B5: css-has-error #}
                       }">
 -        <td class="col-sm-1 text-center">
--          <button class="btn btn-danger" data-bind="click: $parent.removePreload">
 +        <td class="col-md-1 text-center">
-+          <button class="btn btn-outline-danger" data-bind="click: $parent.removePreload">
+           <button
+-            class="btn btn-danger"
++            class="btn btn-outline-danger"
+             data-bind="click: $parent.removePreload, visible: !isLocked()"
+           >
              <i class="fa fa-remove"></i>
            </button>
          </td>
@@ -108,7 +111,7 @@
            <div class="full-width-select2"
                 data-bind="template: {
                              name: 'case-config:case-properties:property',
-@@ -158,10 +158,10 @@
+@@ -161,10 +161,10 @@
               data-bind="html: validateProperty,
                          visible: validateProperty"></p>
          </td>
@@ -121,7 +124,7 @@
            <div class="full-width-select2"
                 data-bind="template: 'case-config:case-properties:question'"></div>
            <p class="help-block"
-@@ -176,7 +176,7 @@
+@@ -179,7 +179,7 @@
        {% trans "No properties will be loaded" %}
      </div>
      <div class="add-property">
@@ -130,7 +133,7 @@
          <i class="fa fa-plus"></i>
          {% trans "Add Property" %}
        </button>
-@@ -186,11 +186,11 @@
+@@ -189,11 +189,11 @@
  
  <script type="text/html"
          id="case-config:case-transaction:case-properties">
@@ -146,7 +149,7 @@
               data-bind="visible: case_properties().length">
            <search-box data-apply-bindings="false"
                        params="value: case_property_query,
-@@ -208,7 +208,7 @@
+@@ -211,7 +211,7 @@
        <!-- /ko -->
      </h4>
    </div>
@@ -155,7 +158,7 @@
      <div class="alert alert-warning" data-bind="visible: hasDeprecatedProperties" >
        <p>
          <i class="fa fa-warning"></i>
-@@ -225,16 +225,16 @@
+@@ -228,16 +228,16 @@
             data-bind="visible: case_properties().length">
        <thead>
        <tr>
@@ -177,7 +180,7 @@
                    data-bind="makeHqHelp: {
                      description: '{% blocktrans trimmed %}
                          User Case Properties allow you to store data about a web or mobile user. Saving a user
-@@ -246,7 +246,7 @@
+@@ -249,7 +249,7 @@
            <!-- ko if: !$data.type || $data.type() == "case-property" -->
              {% trans "Case Property" %}
              <span
@@ -186,7 +189,7 @@
                    data-bind="makeHqHelp: {
                      description: '{% blocktrans trimmed %}
                          Saving a question as a case property makes it accessible and
-@@ -259,9 +259,9 @@
+@@ -262,9 +262,9 @@
          {% comment %} The odd style additions in this block were necessary to put the question mark
          in line with the text when the text is both wrapped and unwrapped. {% endcomment %}
          <!-- ko if: saveOnlyEditedFormFieldsEnabled -->
@@ -199,7 +202,7 @@
                description: '{% trans "Only save the answer if form submission will change the property from its previous value." %}',
                placement: 'left'
              }"></span>
-@@ -271,34 +271,35 @@
+@@ -274,16 +274,16 @@
        </thead>
  
        <tbody data-bind="foreach: visible_case_properties">
@@ -214,10 +217,15 @@
 -        <td class="col-sm-1 text-center"
 +        <td class="col-md-1 text-center"
              data-bind="if: $parent.hasPrivilege">
--          <button class="btn btn-danger" data-bind="click: $parent.removeProperty, visible: !required()">
-+          <button class="btn btn-outline-danger" data-bind="click: $parent.removeProperty, visible: !required()">
-             <i class="fa fa-remove"></i>
-           </button>
+           <!-- ko ifnot: isLocked() -->
+-            <button class="btn btn-danger" data-bind="click: $parent.removeProperty, visible: !required()">
++            <button class="btn btn-outline-danger" data-bind="click: $parent.removeProperty, visible: !required()">
+               <i class="fa fa-remove"></i>
+             </button>
+           <!-- /ko -->
+@@ -295,22 +295,23 @@
+             </i>
+           <!-- /ko -->
          </td>
 -        <td data-bind="class: $parent.saveOnlyEditedFormFieldsEnabled ? 'col-sm-5' : 'col-sm-6'">
 +        <td data-bind="class: $parent.saveOnlyEditedFormFieldsEnabled ? 'col-md-5' : 'col-md-6'">
@@ -243,7 +251,7 @@
            <div class="full-width-select2"
                 data-bind="template: {
                              name: 'case-config:case-properties:property',
-@@ -341,8 +342,8 @@
+@@ -353,8 +354,8 @@
              <p data-bind="text: $data.description"></p>
            <!-- /ko -->
          </td>
@@ -253,8 +261,8 @@
 +          <input type="checkbox"  {# todo B5: css-checkbox #}
                   data-bind="click: $parent.switchSaveOnlyIfEdited,
                              checked: $data.save_only_if_edited,
-                             disabled: $parent.hasPrivilege"
-@@ -352,7 +353,7 @@
+                             disable: !$parent.hasPrivilege || isLocked()"
+@@ -364,7 +365,7 @@
        </tbody>
      </table>
      <div data-bind="if: searchAndFilter">


### PR DESCRIPTION
## Product Description
On a subscription with access to locked questions, when a case / user property mapping references a locked question, it will not be editable or deletable, nor will new case property mappings be able to be added that reference the question.


https://github.com/user-attachments/assets/172edcad-b895-4c40-b4c9-fc101cc0ffc6


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19549
Updates `XForm.get_questions` to accept an optional kwarg `include_locked_status`, which will add the `locked` property to the returned question dict. This is used by javascript on the case management page to block property mappings referencing `locked` questions from being edited or deleted, and prevents these questions from being selected for new mappings.

Backend validation will come in a later PR.

## Feature Flag
LOCKED_ADMIN_QUESTIONS

## Safety Assurance

### Safety story
Tested locally on case management, user properties, and advanced case management pages. This is mostly UI toggling (disabled/enabled/visible) and the core python code change is tested. Also confirmed that on question list reload (when the app version has changed after saving), locked/disabled state are maintained or updated correctly on questions. 

### Automated test coverage
Added a test for the `include_locked_status` kwarg including the `locked` property on questions as expected.

### QA Plan
Locked Admin Questions will get QA as a whole before the feature flag is removed.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
