### PR TITLE
Remove CASE_SEARCH_DEPRECATED feature flag

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2255,6 +2255,7 @@ class CaseSearch(DocumentSchema):
     - dynamic_search: Removed deprecated functionality (Apr 2026)
     - command_label: Superseded by search_label (2021 migration)
     - search_label: Removed; search button always uses default label (Apr 2026)
+    - additional_relevant: Removing that feature (Apr 2026)
     - search_filter: Removed with USH_SEARCH_FILTER toggle (Apr 2026)
       These fields may still exist in CouchDB documents but are no longer used.
     """
@@ -2262,7 +2263,6 @@ class CaseSearch(DocumentSchema):
     properties = SchemaListProperty(CaseSearchProperty)
     auto_launch = BooleanProperty(default=False)        # if true, skip the casedb case list
     default_search = BooleanProperty(default=False)     # if true, skip the search fields screen
-    additional_relevant = StringProperty(exclude_if_none=True)  # in "addition" to the default relevancy condition
     search_button_display_condition = StringProperty(exclude_if_none=True)
     default_properties = SchemaListProperty(DefaultCaseSearchProperty)
     custom_sort_properties = SchemaListProperty(CaseSearchCustomSortProperty)
@@ -2295,8 +2295,6 @@ class CaseSearch(DocumentSchema):
     def get_relevant(self, case_session_var, multi_select=False):
         xpath = CaseClaimXpath(case_session_var)
         default_condition = xpath.multi_case_relevant() if multi_select else xpath.default_relevant()
-        if self.additional_relevant:
-            return f"({default_condition}) and ({self.additional_relevant})"
         return default_condition
 
     def get_search_title_label(self, app, lang, for_default=False):

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -205,7 +205,7 @@ var additionalRegistryCaseModel = function (xpath, saveButton) {
 var searchConfigKeys = [
     'auto_launch', 'blacklisted_owner_ids_expression', 'default_search',
     'title_label', 'description', 'search_button_display_condition',
-    'additional_relevant', 'data_registry', 'data_registry_workflow', 'additional_registry_cases',
+    'data_registry', 'data_registry_workflow', 'additional_registry_cases',
     'custom_related_case_property', 'inline_search', 'instance_name', 'include_all_related_cases',
     'search_on_clear',
 ];

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -242,14 +242,12 @@ var searchConfigModel = function (options, lang, saveButton) {
                     return "es_only";
                 }
                 return "auto_launch";
-            } else if (self.default_search()) {
-                return "see_more";
             }
             return "classic";
         },
         write: function (value) {
             self.auto_launch(_.contains(["es_only", "auto_launch"], value));
-            self.default_search(_.contains(["es_only", "see_more"], value));
+            self.default_search(value === "es_only");
         },
     });
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_search_properties.html
@@ -239,14 +239,6 @@
                     <option value="auto_launch">
                       {% trans "Search First" %}
                     </option>
-                    {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
-                      <option
-                        value="see_more"
-                        data-bind="hidden: restrictWorkflowForDataRegistry"
-                      >
-                        {% trans "See More" %}
-                      </option>
-                    {% endif %}
                     <option value="es_only">
                       {% trans "Skip to Default Case Search Results" %}
                     </option>
@@ -376,36 +368,6 @@
               ></textarea>
             </div>
           </div>
-          {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
-          <div class="form-group">
-            <label
-              for="claim-relevant-condition"
-              class="control-label {% css_label_class %}"
-            >
-              {% trans "Claim Condition" %}
-              <span
-                class="hq-help-template"
-                data-title="{% trans "Claim Condition" %}"
-                data-content="{% trans_html_attr "If this expression evaluates to false, no case will be claimed." %}"
-              >
-              </span>
-            </label>
-            <div class="{% css_field_class %}">
-              <textarea
-                data-bind="
-                          value: additional_relevant,
-                          xpathValidator: {
-                            text: additional_relevant,
-                            allowCaseHashtags: true,
-                            errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
-                          }"
-                class="form-control vertical-resize"
-                id="claim-relevant-condition"
-                spellcheck="false"
-              ></textarea>
-            </div>
-          </div>
-          {% endif %}
           <div class="form-group">
             <label
               for="blacklisted-user-ids"

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_search_properties.html
@@ -239,14 +239,6 @@
                     <option value="auto_launch">
                       {% trans "Search First" %}
                     </option>
-                    {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
-                      <option
-                        value="see_more"
-                        data-bind="hidden: restrictWorkflowForDataRegistry"
-                      >
-                        {% trans "See More" %}
-                      </option>
-                    {% endif %}
                     <option value="es_only">
                       {% trans "Skip to Default Case Search Results" %}
                     </option>
@@ -376,36 +368,6 @@
               ></textarea>
             </div>
           </div>
-          {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
-          <div class="form-group">  {# todo B5: css-form-group #}
-            <label
-              for="claim-relevant-condition"
-              class="form-label {% css_label_class %}"
-            >
-              {% trans "Claim Condition" %}
-              <span
-                class="hq-help-template"
-                data-title="{% trans "Claim Condition" %}"
-                data-content="{% trans_html_attr "If this expression evaluates to false, no case will be claimed." %}"
-              >
-              </span>
-            </label>
-            <div class="{% css_field_class %}">
-              <textarea
-                data-bind="
-                          value: additional_relevant,
-                          xpathValidator: {
-                            text: additional_relevant,
-                            allowCaseHashtags: true,
-                            errorHtml: document.getElementById('searchFilterXpathErrorHtml').innerHTML,
-                          }"
-                class="form-control vertical-resize"
-                id="claim-relevant-condition"
-                spellcheck="false"
-              ></textarea>
-            </div>
-          </div>
-          {% endif %}
           <div class="form-group">  {# todo B5: css-form-group #}
             <label
               for="blacklisted-user-ids"

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -1,7 +1,7 @@
 <partial>
   <remote-request>
     <post url="https://www.example.com/a/test_domain/phone/claim-case/"
-          relevant="(count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/search_case_id]) = 0) and (instance('groups')/groups/group)">
+          relevant="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/search_case_id]) = 0">
       <data key="case_id" ref="instance('commcaresession')/session/data/search_case_id"/>
     </post>
     <command id="search_command.{module_id}">
@@ -13,7 +13,6 @@
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
-    <instance id="groups" src="jr://fixture/user-groups"/>
     <instance id="item-list:moons" src="jr://fixture/item-list:moons"/>
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
     <instance id="locations" src="jr://fixture/locations"/>

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -313,7 +313,6 @@ class OverwriteCaseSearchConfigTests(SimpleTestCase):
             ],
             auto_launch=True,
             default_search=True,
-            additional_relevant="instance('groups')/groups/group",
             search_button_display_condition="false()",
             blacklisted_owner_ids_expression="instance('commcaresession')/session/context/userid",
             default_properties=[

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -166,7 +166,6 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
                 CaseSearchProperty(name='dob', label={'en': 'Date of birth'}, input_="date"),
                 CaseSearchProperty(name='consent', label={'en': 'Consent to search'}, input_="checkbox"),
             ],
-            additional_relevant="instance('groups')/groups/group",
             default_properties=[
                 DefaultCaseSearchProperty(
                     property='ɨŧsȺŧɍȺᵽ',
@@ -194,19 +193,10 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             config.get_relevant(config.case_session_var),
             "count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/search_case_id]) = 0")  # noqa: E501
 
-        config.additional_relevant = "double(now()) mod 2 = 0"
-        self.assertEqual(
-            config.get_relevant(config.case_session_var),
-            "(count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/search_case_id]) = 0) and (double(now()) mod 2 = 0)")  # noqa: E501
-
     def test_search_config_relevant_multi_select(self):
         config = CaseSearch()
 
         self.assertEqual(config.get_relevant(config.case_session_var, multi_select=True), "$case_id != ''")
-
-        config.additional_relevant = "double(now()) mod 2 = 0"
-        self.assertEqual(config.get_relevant(config.case_session_var, multi_select=True),
-                         "($case_id != '') and (double(now()) mod 2 = 0)")
 
     def test_remote_request(self):
         """

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -259,8 +259,6 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
                 'default_search': module.search_config.default_search if module_offers_search(module) else False,
                 'search_button_display_condition':
                     module.search_config.search_button_display_condition if module_offers_search(module) else "",
-                'additional_relevant':
-                    module.search_config.additional_relevant if module_offers_search(module) else "",
                 'blacklisted_owner_ids_expression': (
                     module.search_config.blacklisted_owner_ids_expression if module_offers_search(module) else ""),
                 # populate labels even if module_offers_search is false - search_config might just not exist yet
@@ -1298,7 +1296,7 @@ def _gather_and_update_search_properties(params, app, module, lang):
             return HttpResponseBadRequest(e)
         xpath_props = [
             "blacklisted_owner_ids_expression",
-            "search_button_display_condition", "additional_relevant"
+            "search_button_display_condition"
         ]
 
         def _check_xpath(xpath, location):
@@ -1345,7 +1343,6 @@ def _gather_and_update_search_properties(params, app, module, lang):
             description=description,
             properties=properties,
             additional_case_types=module.search_config.additional_case_types,
-            additional_relevant=search_properties.get('additional_relevant', ''),
             auto_launch=force_auto_launch or bool(search_properties.get('auto_launch')),
             default_search=bool(search_properties.get('default_search')),
             search_button_display_condition=search_properties.get('search_button_display_condition', ""),

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_search_properties.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_search_properties.html.diff.txt
@@ -228,7 +228,7 @@
                      class="form-control"
                      data-bind="value: workflow"
                      id="search-workflow"
-@@ -265,10 +265,10 @@
+@@ -257,10 +257,10 @@
            </div>
            {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
              <div
@@ -241,7 +241,7 @@
                  {% trans "Make search input available after search" %}
                  <span
                    class="hq-help-template"
-@@ -277,9 +277,9 @@
+@@ -269,9 +269,9 @@
                  >
                  </span>
                </label>
@@ -253,7 +253,7 @@
                    <input
                      type="hidden"
                      name="search-input"
-@@ -291,8 +291,8 @@
+@@ -283,8 +283,8 @@
                  </p>
                </div>
              </div>
@@ -264,7 +264,7 @@
                  {% trans "Search Input Instance Name" %}
                  <span
                    class="hq-help-template"
-@@ -312,16 +312,16 @@
+@@ -304,16 +304,16 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'SYNC_SEARCH_CASE_CLAIM' %}
@@ -284,7 +284,7 @@
                  >
                  </span>
                </label>
-@@ -329,10 +329,10 @@
+@@ -321,10 +321,10 @@
                  {% input_trans module.search_config.title_label langs input_name='title_label' input_id='title_label' data_bind="value: title_label" %}
                </div>
              </div>
@@ -297,7 +297,7 @@
                >
                  {% trans "Search Screen Subtitle" %}
                  <span
-@@ -347,10 +347,10 @@
+@@ -339,10 +339,10 @@
                </div>
              </div>
            {% endif %}
@@ -310,23 +310,10 @@
              >
                {% trans "Display Condition" %}
                <span
-@@ -377,10 +377,10 @@
+@@ -368,10 +368,10 @@
+               ></textarea>
              </div>
            </div>
-           {% if request|toggle_enabled:'CASE_SEARCH_DEPRECATED' %}
--          <div class="form-group">
-+          <div class="form-group">  {# todo B5: css-form-group #}
-             <label
-               for="claim-relevant-condition"
--              class="control-label {% css_label_class %}"
-+              class="form-label {% css_label_class %}"
-             >
-               {% trans "Claim Condition" %}
-               <span
-@@ -406,10 +406,10 @@
-             </div>
-           </div>
-           {% endif %}
 -          <div class="form-group">
 +          <div class="form-group">  {# todo B5: css-form-group #}
              <label
@@ -336,7 +323,7 @@
              >
                {% trans "Don't search cases owned by the following ids" %}
                <span
-@@ -442,10 +442,10 @@
+@@ -404,10 +404,10 @@
              </div>
            </div>
            {% if data_registry_enabled %}
@@ -349,7 +336,7 @@
                >
                  {% trans "Data Registry" %}
                  <span
-@@ -456,7 +456,7 @@
+@@ -418,7 +418,7 @@
                  </span>
                </label>
                <div class="{% css_field_class %}">
@@ -358,7 +345,7 @@
                    class="form-control"
                    id="data-registry"
                    data-bind="value: data_registry"
-@@ -470,15 +470,15 @@
+@@ -432,15 +432,15 @@
                  </select>
                </div>
              </div>
@@ -377,7 +364,7 @@
                    class="form-control"
                    data-bind="value: data_registry_workflow"
                  >
-@@ -489,12 +489,12 @@
+@@ -451,12 +451,12 @@
                </div>
              </div>
              <div
@@ -392,7 +379,7 @@
                >
                  {% trans "Load Additional Data Registry Cases" %}
                  <span
-@@ -516,8 +516,8 @@
+@@ -478,8 +478,8 @@
                      data-bind="visible: additional_registry_cases().length > 0"
                    >
                      <tr>
@@ -403,7 +390,7 @@
                      </tr>
                    </thead>
                    <tbody
-@@ -539,7 +539,7 @@
+@@ -501,7 +501,7 @@
                        </td>
                        <td>
                          <i
@@ -412,7 +399,7 @@
                            class="fa fa-remove"
                            data-bind="click: $parent.removeRegistryQuery"
                          ></i>
-@@ -549,7 +549,7 @@
+@@ -511,7 +511,7 @@
                  </table>
                  <button
                    type="button"
@@ -421,7 +408,7 @@
                    data-bind="click: addRegistryQuery"
                  >
                    <i class="fa fa-plus"></i>
-@@ -559,10 +559,10 @@
+@@ -521,10 +521,10 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
@@ -434,7 +421,7 @@
                >
                  {% trans "Case property with additional case id to add to results" %}
                  <span
-@@ -592,15 +592,15 @@
+@@ -554,15 +554,15 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_RELATED_LOOKUPS' %}
@@ -454,7 +441,7 @@
                        data-bind="checked: include_all_related_cases"
                      />
                    </label>
-@@ -609,18 +609,18 @@
+@@ -571,18 +571,18 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -957,15 +957,6 @@ SYNC_SEARCH_CASE_CLAIM = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-CASE_SEARCH_DEPRECATED = StaticToggle(
-    'case_search_deprecated',
-    'Case Search: Deprecated',
-    TAG_DEPRECATED,
-    help_link='https://dimagi.atlassian.net/wiki/spaces/GS/pages/2146606528/Case+Search+and+Claim',
-    namespaces=[NAMESPACE_DOMAIN],
-    parent_toggles=[SYNC_SEARCH_CASE_CLAIM],
-)
-
 CASE_SEARCH_DEPRECATED_NORMAL_CASE_LIST = StaticToggle(
     'case_search_deprecated_normal_case_list',
     'Case Search: Normal case list option Deprecated',


### PR DESCRIPTION
## Product Description
Removes the `CASE_SEARCH_DEPRECATED` feature flag and the two deprecated case search behaviors it gated: the **See More** workflow option and the **Claim Condition** field. Checked production for any usage. None outside of internal domains. See sheet referenced in Jira story.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6516

## Feature Flag
`CASE_SEARCH_DEPRECATED` — being removed

## Safety Assurance

### Safety story
- Model fields (`additional_relevant`, `default_search`, `search_button_label`) are preserved so existing apps continue generating valid suite XML
- The See More and Claim Condition UI options were only accessible to domains with the deprecated flag enabled; removing the flag gate is the expected final step after migration

### Automated test coverage
Existing suite generation tests (`test_suite_remote_request.py`, `test_modules.py`) cover `additional_relevant` and `default_search` and continue to pass since the model/suite code is unchanged.

### QA Plan
- Verify Claim Condition field no longer appears in case search config UI

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change