### PR TITLE
Fix typo in generated test filename in evaluate_couch_model_for_sql

### DIFF
--- a/corehq/apps/cleanup/management/commands/evaluate_couch_model_for_sql.py
+++ b/corehq/apps/cleanup/management/commands/evaluate_couch_model_for_sql.py
@@ -98,7 +98,7 @@ class Command(BaseCommand):
         print(f"\n################# add {command_file} #################")
         print(command_content)
 
-        test_file_name = f'test_{self.class_name.lower()}_attr_comparision.py'
+        test_file_name = f'test_{self.class_name.lower()}_attr_comparison.py'
         test_file = os.path.join("corehq", "apps", self.django_app, "tests", test_file_name)
         test_content = self.generate_test_file()
         print(f"\n################# add {test_file} #################\n")


### PR DESCRIPTION
## Product Description
N/A — developer tooling.

## Technical Summary
Fixes a typo in the test filename generated by the `evaluate_couch_model_for_sql` management command: `comparision` → `comparison`.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Single-character typo fix in a string used to name a generated file. The command prints the file content for a developer to add manually, so the only effect is that future generated test files will have the correctly spelled name.

### Automated test coverage
N/A — change is to a string literal in a developer-facing management command.

### QA Plan
N/A

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change