### PR TITLE
Pass reason=merge when triggering staging-branches removal

### DIFF
--- a/.github/workflows/rebuild-staging.yml
+++ b/.github/workflows/rebuild-staging.yml
@@ -86,7 +86,8 @@ jobs:
         gh workflow run remove-branch.yml \
           --repo dimagi/staging-branches \
           -f file=commcare-hq-staging.yml \
-          -f branch="$BRANCH"
+          -f branch="$BRANCH" \
+          -f reason=merge
 
   rebuild-staging:
     needs: check-branch


### PR DESCRIPTION
## Product Description
N/A — CI plumbing only.

## Technical Summary
Companion to https://github.com/dimagi/staging-branches/pull/8, which adds a `reason` choice input (`unspecified` / `merge` / `conflict`) to that repo's `remove-branch.yml` workflow so the auto-generated commit message reflects why a branch was removed. **The two PRs are intended to be merged together.**

This call site fires after a staging branch is merged to master, so it should pass `reason=merge`. Other ad-hoc invocations (e.g. removing a conflicting branch) will continue to be triggered by hand from the staging-branches repo with the appropriate reason.

## Feature Flag
N/A

## Safety Assurance

### Safety story
The change is a single extra `-f reason=merge` flag on a `gh workflow run` invocation. The receiving workflow defaults `reason` to `unspecified` and only varies the commit message text — no behavior change beyond wording. The companion PR keeps `unspecified` as the default input, so even if these merge out of order, the worst case is a single cleanup commit that reads `Remove branch …` instead of `Remove merged branch …` until both are deployed.

### Automated test coverage
N/A — this is a workflow_dispatch parameter, exercised end-to-end the next time a staging branch is merged.

### QA Plan
After both PRs land, merge any staging branch and confirm the resulting commit on `dimagi/staging-branches@main` reads `Remove merged branch \`<name>\` from commcare-hq-staging.yml`.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations