### PR TITLE
Disallow bulk editing translations for locked questions

### DIFF
--- a/corehq/apps/translations/app_translations/upload_form.py
+++ b/corehq/apps/translations/app_translations/upload_form.py
@@ -87,6 +87,7 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
         label_ids_to_skip = self._get_label_ids_to_skip(rows)
 
         locked_label_ids = set()
+        warned_locked_labels = set()
         if (
             domain_has_privilege(self.app.domain, 'locked_admin_questions')
             and LOCKED_ADMIN_QUESTIONS.enabled(self.app.domain, namespace=NAMESPACE_DOMAIN)
@@ -103,6 +104,17 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
                 if label_id in label_ids_to_skip:
                     continue
                 if label_id in locked_label_ids:
+                    if (
+                        label_id not in warned_locked_labels
+                        and self._translation_would_change(row, label_id, translation_element, lang)
+                    ):
+                        self.msgs.append((
+                            messages.warning,
+                            _("Translation for '{}' was not updated because the question is locked.").format(
+                                label_id
+                            ),
+                        ))
+                        warned_locked_labels.add(label_id)
                     continue
                 if label_id == 'submit_label':
                     try:
@@ -230,6 +242,23 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
         # rather than bog down question iteration, just discard None if it was added
         locked_label_refs.discard(None)
         return locked_label_refs & {row['label'] for row in rows}
+
+    def _translation_would_change(self, row, label_id, translation_element, lang):
+        text_node = translation_element.find("./{f}text[@id='%s']" % label_id)
+        if not text_node.exists():
+            return False
+
+        for trans_type, uploaded_value in self._get_translations_for_row(row, lang).items():
+            if trans_type == 'default':
+                current_node = self._get_value_node(text_node)
+            else:
+                current_node = text_node.find("./{f}value[@form='%s']" % trans_type)
+
+            current_value = (current_node.xml.text or '') if current_node.exists() else ''
+            if uploaded_value != current_value:
+                return True
+
+        return False
 
     def _get_text_node(self, translation_node, label_id):
         text_node = translation_node.find("./{f}text[@id='%s']" % label_id)

--- a/corehq/apps/translations/app_translations/upload_form.py
+++ b/corehq/apps/translations/app_translations/upload_form.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext as _
 from lxml import etree
 from lxml.etree import Element, XMLSyntaxError
 
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.exceptions import XFormException
 from corehq.apps.app_manager.models import ShadowForm
 from corehq.apps.app_manager.util import save_xform
@@ -18,6 +19,7 @@ from corehq.apps.translations.app_translations.utils import (
     get_unicode_dicts,
 )
 from corehq.apps.translations.exceptions import BulkAppTranslationsException
+from corehq.toggles import LOCKED_ADMIN_QUESTIONS, NAMESPACE_DOMAIN
 
 
 class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
@@ -84,21 +86,31 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
         # Skip labels that have no translation provided
         label_ids_to_skip = self._get_label_ids_to_skip(rows)
 
+        locked_label_ids = set()
+        if (
+            domain_has_privilege(self.app.domain, 'locked_admin_questions')
+            and LOCKED_ADMIN_QUESTIONS.enabled(self.app.domain, namespace=NAMESPACE_DOMAIN)
+        ):
+            locked_label_ids = self._get_locked_label_ids(rows)
+
         # Update the translations
         for lang in self.langs:
             translation_element = self.itext.find("./{f}translation[@lang='%s']" % lang)
             assert translation_element.exists()
 
             for row in rows:
-                if row['label'] in label_ids_to_skip:
+                label_id = row['label']
+                if label_id in label_ids_to_skip:
                     continue
-                if row['label'] == 'submit_label':
+                if label_id in locked_label_ids:
+                    continue
+                if label_id == 'submit_label':
                     try:
                         self.form.submit_label[lang] = row[self._get_col_key('default', lang)]
                     except KeyError:
                         pass
                     continue
-                if row['label'] == 'submit_notification_label':
+                if label_id == 'submit_notification_label':
                     notification_value = ''
                     try:
                         notification_value = row[self._get_col_key('default', lang)]
@@ -193,6 +205,31 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
                     messages.error,
                     _("You must provide at least one translation for the label '{}'.").format(label)))
         return label_ids_to_skip
+
+    def _get_locked_label_ids(self, rows):
+        locked_label_refs = set()
+        for question in self.form.get_questions(
+            self.langs,
+            include_triggers=True,
+            include_groups=True,
+            include_fixtures=True,
+            include_locked_status=True,
+        ):
+            if not question.get('locked'):
+                continue
+
+            locked_label_refs.add(question.get('label_ref'))
+            locked_label_refs.add(question.get('constraintMsg_ref'))
+
+            for option in question.get('options', []):
+                locked_label_refs.add(option.get('label_ref'))
+
+            data_source = question.get('data_source', {})
+            locked_label_refs.add(data_source.get('label_ref'))
+
+        # rather than bog down question iteration, just discard None if it was added
+        locked_label_refs.discard(None)
+        return locked_label_refs & {row['label'] for row in rows}
 
     def _get_text_node(self, translation_node, label_id):
         text_node = translation_node.find("./{f}text[@id='%s']" % label_id)

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -10,9 +10,12 @@ from unittest.mock import patch
 from couchexport.export import export_raw
 from couchexport.models import Format
 
+from lxml import etree
+
 from corehq.apps.app_manager.models import Application, Module, ReportAppConfig
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import TestXmlMixin
+from corehq.apps.app_manager.xform import WrappedNode
 from corehq.apps.translations.app_translations.download import (
     get_bulk_app_sheets_by_name,
     get_bulk_app_single_sheet_by_name,
@@ -1581,3 +1584,30 @@ class GetLockedLabelIdsTest(SimpleTestCase):
             mock_form.get_questions.return_value = questions
             locked = self.updater._get_locked_label_ids(rows)
         assert locked == {'locked_q-label'}
+
+
+class TranslationWouldChangeTest(SimpleTestCase):
+    def setUp(self):
+        self.updater = _make_minimal_updater()
+        self.translation_element = WrappedNode(etree.fromstring(
+            '<translation xmlns="http://www.w3.org/2002/xforms" lang="en">'
+            '<text id="q-label"><value>Current</value></text>'
+            '</translation>'
+        ))
+
+    def _row(self, default_en=''):
+        return {'label': 'q-label', 'default_en': default_en}
+
+    def _would_change(self, default_en):
+        return self.updater._translation_would_change(
+            self._row(default_en), 'q-label', self.translation_element, 'en'
+        )
+
+    def test_when_value_differs(self):
+        assert self._would_change('New value')
+
+    def test_when_value_matches(self):
+        assert not self._would_change('Current')
+
+    def test_when_empty_cell_clears_existing_value(self):
+        assert self._would_change('')

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -159,6 +159,15 @@ EXCEL_DATA = (
 class BulkAppTranslationTestBase(SimpleTestCase, TestXmlMixin):
     root = os.path.dirname(__file__)
 
+    def setUp(self):
+        super().setUp()
+        patcher = patch(
+            'corehq.apps.translations.app_translations.upload_form.domain_has_privilege',
+            return_value=False,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def upload_raw_excel_translations(self, app, excel_headers, excel_data, expected_messages=None, lang=None):
         """
         Prepares bulk app translation excel file and uploads it
@@ -281,6 +290,7 @@ class BulkAppTranslationTestBaseWithApp(BulkAppTranslationTestBase):
         """
         super(BulkAppTranslationTestBaseWithApp, self).setUp()
         self.app = Application.wrap(self.get_json("app"))
+        self.app.domain = 'test-domain'
 
     def upload_raw_excel_translations(self, excel_headers, excel_data, lang=None, expected_messages=None):
         super(BulkAppTranslationTestBaseWithApp, self).upload_raw_excel_translations(self.app,
@@ -1379,7 +1389,14 @@ class AggregateMarkdownNodeTests(SimpleTestCase, TestXmlMixin):
         return workbook.worksheets_by_title[title]
 
     def setUp(self):
-        self.app = Application.new_app('domain', "Untitled Application")
+        super().setUp()
+        patcher = patch(
+            'corehq.apps.translations.app_translations.upload_form.domain_has_privilege',
+            return_value=False,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.app = Application.new_app('test-domain', "Untitled Application")
         self.app.langs = ['en', 'afr', 'fra']
         module1 = self.app.add_module(Module.new_module('module', None))
         form1 = self.app.new_form(module1.id, "Untitled Form", None)
@@ -1491,3 +1508,76 @@ class ReportModuleTest(BulkAppTranslationTestBase):
         self.upload_raw_excel_translations(self.app, self.headers, data, expected_messages=messages)
         module = self.app.get_module(0)
         self.assertEqual(module.report_configs[0].header, {"en": "My Report"})
+
+
+def _make_minimal_updater():
+    app = Application.new_app('test-domain', 'Test App')
+    app.langs = ['en']
+    module = app.add_module(Module.new_module('module', None))
+    form = app.new_form(module.id, 'Form', None)
+    return BulkAppTranslationFormUpdater(app, 'menu1_form1', unique_id=form.unique_id)
+
+
+class GetLockedLabelIdsTest(SimpleTestCase):
+    def setUp(self):
+        self.updater = _make_minimal_updater()
+
+    def _rows(self, *labels):
+        return [{'label': label} for label in labels]
+
+    def test_locks_label_constraint_and_option_refs(self):
+        questions = [
+            {'value': '/data/free_q', 'label_ref': 'free_q-label', 'locked': False},
+            {
+                'value': '/data/locked_q',
+                'label_ref': 'locked_q-label',
+                'constraintMsg_ref': 'locked_q-constraintMsg',
+                'locked': True,
+            },
+            {
+                'value': '/data/locked_choice',
+                'label_ref': 'locked_choice-label',
+                'locked': True,
+                'options': [
+                    {'label_ref': 'locked_choice-yes-label'},
+                    {'label_ref': 'locked_choice-no-label'},
+                ],
+            },
+            {
+                'value': '/data/free_choice',
+                'label_ref': 'free_choice-label',
+                'locked': False,
+                'options': [{'label_ref': 'free_choice-maybe-label'}],
+            },
+        ]
+        rows = self._rows(
+            'free_q-label',
+            'locked_q-label',
+            'locked_q-constraintMsg',
+            'locked_choice-label',
+            'locked_choice-yes-label',
+            'locked_choice-no-label',
+            'free_choice-label',
+            'free_choice-maybe-label',
+        )
+        with patch.object(self.updater, 'form') as mock_form:
+            mock_form.get_questions.return_value = questions
+            locked = self.updater._get_locked_label_ids(rows)
+        assert locked == {
+            'locked_q-label',
+            'locked_q-constraintMsg',
+            'locked_choice-label',
+            'locked_choice-yes-label',
+            'locked_choice-no-label',
+        }
+
+    def test_returns_only_refs_present_in_rows(self):
+        questions = [
+            {'value': '/data/free_q', 'label_ref': 'free_q-label', 'locked': False},
+            {'value': '/data/locked_q', 'label_ref': 'locked_q-label', 'locked': True},
+        ]
+        rows = self._rows('locked_q-label', 'free_q-label')
+        with patch.object(self.updater, 'form') as mock_form:
+            mock_form.get_questions.return_value = questions
+            locked = self.updater._get_locked_label_ids(rows)
+        assert locked == {'locked_q-label'}

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -1578,6 +1578,7 @@ class GetLockedLabelIdsTest(SimpleTestCase):
         questions = [
             {'value': '/data/free_q', 'label_ref': 'free_q-label', 'locked': False},
             {'value': '/data/locked_q', 'label_ref': 'locked_q-label', 'locked': True},
+            {'value': '/data/missing_locked_q', 'label_ref': 'missing_locked_q-label', 'locked': True},
         ]
         rows = self._rows('locked_q-label', 'free_q-label')
         with patch.object(self.updater, 'form') as mock_form:


### PR DESCRIPTION
## Product Description
When the project has access to locked admin questions, adds a validation step when uploading form translations to see that no locked questions have their translations changed. Shows one warning message per locked question that would have been updated after uploading the translations file:
<img width="552" height="59" alt="image" src="https://github.com/user-attachments/assets/3cfd7731-b843-46a9-a9de-b2da67413383" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19550
Gets a form's questions with their `locked` status to build a list of label refs that should be locked when processing uploaded form translations. For each translation, checks if the translation would change, and if so, adds a warning message to the user that the translation was not updated. Only shows one message per label ref, even the question was updated in multiple languages.


## Feature Flag
LOCKED_ADMIN_QUESTIONS

## Safety Assurance

### Safety story
Tested locally to see that bulk uploaded translations are still processed correctly for unlocked questions, that translations are _not_ updated for locked questions, and that warning messages are shown correctly to the user when attempting to update translations for locked questions.

### Automated test coverage
Added automated tests for both helper functions used here. Also updates existing bulk form translations tests so they do not fail on DB access from `domain_has_privilege` or the lack of a `domain` on their applications.

### QA Plan
I don't think this particular change needs QA, but it could potentially be rolled into holistic QA for Locked Admin Questions.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
