### PR TITLE
Upgrade serialize-javascript from 7.0.4 to 7.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,10 +91,10 @@
         "zxcvbn": "4.4.2"
     },
     "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "chai": "4.3.6",
         "colors": "1.4.0",
         "eslint": "10.0.2",
-        "@eslint/js": "^10.0.1",
         "grunt": "1.5.3",
         "grunt-cli": "1.4.3",
         "grunt-contrib-watch": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7318,9 +7318,9 @@ semver@^7.7.2, semver@^7.7.3:
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
 
 serialize-javascript@^6.0.2, serialize-javascript@^7.0.3:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.4.tgz#c517735bd5b7631dd1fc191ee19cbb713ff8e05c"
-  integrity sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
+  integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
 
 set-blocking@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Product Description

No user-facing behavior changes.

## Technical Summary

Transitive dependency bump for `serialize-javascript`, picking up upstream fixes that improve robustness of array-like object serialization.

- Bumps `serialize-javascript` in `yarn.lock` from 7.0.4 → 7.0.5 (resolves both `^6.0.2` and `^7.0.3` ranges from existing transitive consumers, e.g. terser-webpack-plugin).
- Reorders `devDependencies` in `package.json` so `@eslint/js` is alphabetized correctly — no functional change.

## Safety Assurance

### Safety story

Patch-level upgrade of a transitive dev/build-time dependency used during webpack/terser bundling. The release notes describe internal robustness fixes only, with no API changes. Risk is limited to the build pipeline; if anything regressed, it would surface immediately at bundle time.

### Automated test coverage

Existing CI (lint, build, JS tests) exercises the bundling pipeline that consumes this library.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
