### PR TITLE
Upgrade setuptools to 82.0.1 and remove pkg_resources usage

### DIFF
--- a/corehq/apps/hqadmin/management/commands/clean_2fa_sessions.py
+++ b/corehq/apps/hqadmin/management/commands/clean_2fa_sessions.py
@@ -1,7 +1,7 @@
 from looseversion import LooseVersion
 from getpass import getpass
 from importlib import import_module
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, distribution
 
 from django.conf import settings
 from django.core.cache import caches
@@ -111,7 +111,7 @@ VALIDATED_STEP_DATA_PATH = ["validated_step_data", "auth", "password"]
 
 def get_two_factor_version():
     try:
-        dist = get_distribution("django-two-factor-auth")
-    except DistributionNotFound:
+        dist = distribution("django-two-factor-auth")
+    except PackageNotFoundError:
         return None
     return dist.version

--- a/manage.py
+++ b/manage.py
@@ -139,7 +139,8 @@ def run_patches():
 def patch_pkg_resources():
     """Patch pkg_resources for unmaintained eulxml
 
-    The most recent commit to eulxml was 5 years ago as of May 2026.
+    The most recent commit to eulxml was 5 years ago as of May 2026,
+    and pkg_resources was removed from setuptools in early 2026.
     """
     from importlib.abc import Loader, MetaPathFinder
     from importlib.resources import files

--- a/manage.py
+++ b/manage.py
@@ -131,8 +131,52 @@ def _set_source_root(source_root):
 
 
 def run_patches():
+    patch_pkg_resources()
     patch_jsonfield()
     unpatch_sys_modules()
+
+
+def patch_pkg_resources():
+    """Patch pkg_resources for unmaintained eulxml
+
+    The most recent commit to eulxml was 5 years ago as of May 2026.
+    """
+    from importlib.abc import Loader, MetaPathFinder
+    from importlib.resources import files
+    from importlib.util import spec_from_loader
+
+    class LegacyResources:
+        @staticmethod
+        def resource_filename(package, resource):
+            sys.modules.pop('pkg_resources', None)  # force re-import
+            path = files(package).joinpath(resource)
+            assert path.is_dir() or path.is_file(), f"unknown path: {path}"
+            return str(path)
+
+        @staticmethod
+        def resource_isdir(package, resource):
+            sys.modules.pop('pkg_resources', None)  # force re-import
+            return files(package).joinpath(resource).is_dir()
+
+    class LegacyResourcesLoader(Loader):
+        def create_module(self, spec):
+            return LegacyResources
+
+        def exec_module(self, module):
+            pass
+
+    class LegacyResourcesFinder(MetaPathFinder):
+        def find_spec(self, fullname, path, target=None):
+            if fullname == 'pkg_resources':
+                frame = sys._getframe(1)
+                while frame.f_globals.get("__name__", "").startswith('importlib'):
+                    frame = frame.f_back
+                caller = frame.f_globals.get("__name__", "")
+                if caller == 'eulxml':
+                    return spec_from_loader(fullname, LegacyResourcesLoader())
+            return None
+
+    sys.meta_path.append(LegacyResourcesFinder())
 
 
 def patch_jsonfield():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ default-groups = ["dev", "sso"]
 dev = [
     'dependency-metrics',
     'django-extensions',
-    'fixture',
     'git-build-branch',
     'gnureadline',
     'ipython', # for nicer django shell experience

--- a/uv.lock
+++ b/uv.lock
@@ -2929,11 +2929,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/a1/7f/a1d4f4c7b66f0fc02
 
 [[package]]
 name = "setuptools"
-version = "80.8.0"
+version = "82.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/d2/ec1acaaff45caed5c2dedb33b67055ba9d4e96b091094df90762e60135fe/setuptools-80.8.0.tar.gz", hash = "sha256:49f7af965996f26d43c8ae34539c8d99c5042fbff34302ea151eaa9c207cd257", size = 1319720, upload-time = "2025-05-20T14:02:53.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/29/93c53c098d301132196c3238c312825324740851d77a8500a2462c0fd888/setuptools-80.8.0-py3-none-any.whl", hash = "sha256:95a60484590d24103af13b686121328cc2736bee85de8936383111e421b9edc0", size = 1201470, upload-time = "2025-05-20T14:02:51.348Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,6 @@ dev = [
     { name = "django-extensions" },
     { name = "fakecouch" },
     { name = "faker" },
-    { name = "fixture" },
     { name = "flaky" },
     { name = "git-build-branch" },
     { name = "gnureadline" },
@@ -755,7 +754,6 @@ dev = [
     { name = "django-extensions" },
     { name = "fakecouch" },
     { name = "faker" },
-    { name = "fixture" },
     { name = "flaky", specifier = ">=3.8" },
     { name = "git-build-branch" },
     { name = "gnureadline" },
@@ -1424,15 +1422,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/5e/77/1c3ff07b6739b9a1d
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/ec/91a434c8a53d40c3598966621dea9c50512bec6ce8e76fa1751015e74cef/faker-40.1.2-py3-none-any.whl", hash = "sha256:93503165c165d330260e4379fd6dc07c94da90c611ed3191a0174d2ab9966a42", size = 1985633, upload-time = "2026-01-13T20:51:47.982Z" },
 ]
-
-[[package]]
-name = "fixture"
-version = "1.5.11"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/2d/3aac77e169452439bde543f0d2a61a1569f89dd0a562c76463f6168c912d/fixture-1.5.11.tar.gz", hash = "sha256:caf3896fbdb1a83fa0b12defef2f3bafcbdad1d10f8dd1aae26303f749e64612", size = 67136, upload-time = "2017-10-02T10:32:08.6Z" }
 
 [[package]]
 name = "flaky"

--- a/uv.lock
+++ b/uv.lock
@@ -1336,16 +1336,16 @@ wheels = [
 
 [[package]]
 name = "dropbox"
-version = "11.36.2"
+version = "12.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "six" },
     { name = "stone" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/0f/2059c5ef8669e625a533661a2054a82241696954df6662aeee51a34b1022/dropbox-11.36.2.tar.gz", hash = "sha256:d48d3d16d486c78b11c14a1c4a28a2611fbf5a0d0a358b861bfd9482e603c500", size = 585092, upload-time = "2023-06-12T23:39:46.394Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/56/ac085f58e8e0d0bcafdf98c2605e454ac946e3d0c72679669ae112dc30be/dropbox-12.0.2.tar.gz", hash = "sha256:50057fd5ad5fcf047f542dfc6747a896e7ef982f1b5f8500daf51f3abd609962", size = 560236, upload-time = "2024-06-03T16:45:30.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/96/1cd39be567d8e361fc06a4135e40ddbf1410f99524771a7f3e5807a26a35/dropbox-11.36.2-py3-none-any.whl", hash = "sha256:a21e4d2bcbeb1d8067ff87969aea48792c9a8266182491153feff2be9c1b9c8f", size = 594038, upload-time = "2023-06-12T23:39:44.245Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/de/95d8204d9a20fbdb353c5f8e4229b0fcb90f22b96f8246ff1f47c8a45fd5/dropbox-12.0.2-py3-none-any.whl", hash = "sha256:c5b7e9c2668adb6b12dcecd84342565dc50f7d35ab6a748d155cb79040979d1c", size = 572076, upload-time = "2024-06-03T16:45:28.153Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Product Description

No user-facing changes. This is a developer-facing dependency upgrade.

## Technical Summary

Setuptools 81+ deprecates the `pkg_resources` API, so this PR also removes our remaining usages of it:

- **Upgrade `setuptools`** from 80.8.0 to 82.0.1.
- **Replace `pkg_resources` with `importlib.metadata`** in `clean_2fa_sessions.py`.
- **Upgrade `dropbox`** from 11.36.2 to 12.0.2 to pick up a version that no longer depends on `pkg_resources`. No breaking changes relevant to our usage. See the [dropbox upgrade notes](https://github.com/dropbox/dropbox-sdk-python/blob/main/UPGRADING.md).
- **Shim `pkg_resources` for `eulxml`** in `manage.py`. `eulxml` is unmaintained (last commit ~5 years ago) and still imports `pkg_resources` for `resource_filename` / `resource_isdir`. Rather than fork/replace it now, a narrow `MetaPathFinder` intercepts only `eulxml`'s import of `pkg_resources` and serves a tiny shim backed by `importlib.resources`. Any other caller still raises, so we don't silently mask new pkg_resources usage elsewhere.
- **Remove `fixture`** from dev dependencies. Added 13 years ago, last released on PyPI in 2017, no current usage.


## Safety Assurance

### Safety story

Low risk: dependency-only changes plus a single management-command refactor.

- The `clean_2fa_sessions` change is a like-for-like swap of stdlib equivalents. `importlib.metadata` is the documented replacement for `pkg_resources` distribution lookups.
- The `eulxml` shim is scoped by caller name — only `eulxml` resolves to the shim; everything else raises `ModuleNotFoundError`, so any unexpected `pkg_resources` consumer surfaces loudly rather than silently breaking.
- The `dropbox` upgrade was reviewed against the project's UPGRADING.md; the breaking changes do not affect our integration.
- Removing `fixture` is safe: it has no importers in the repo and is super old, most likely unused.

### Automated test coverage

Existing test suite exercises the affected import paths at startup and through normal CI.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
