### PR TITLE
Bump actions to resolve Node.js 20 deprecation

### DIFF
--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -59,7 +59,7 @@ jobs:
           ./manage.py copy_required_static_files
 
       - name: Upload Static Files On Push
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: staticfiles-${{ github.sha }}
           path: REQUIRED_STATIC_FILES.zip

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -14,7 +14,7 @@ jobs:
       checks: write
     steps:
       - name: Report product label check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const labels = context.payload.pull_request.labels.map(l => l.name);

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -22,7 +22,7 @@ jobs:
           ./scripts/test-make-docs.sh
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: make-docs-artifacts
           path: artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       env:
         TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       if: env.TOKEN != ''
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: dimagi
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
       env:
         TOKEN: ${{ secrets.CODECOV_TOKEN }}
       if: env.TOKEN != ''
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml
@@ -73,7 +73,7 @@ jobs:
       run: scripts/docker down
     - name: Upload test artifacts
       if: always()
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: test-artifacts
         path: artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
       env:
         TOKEN: ${{ secrets.CODECOV_TOKEN }}
       if: env.TOKEN != ''
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml


### PR DESCRIPTION
## Product Description
No user-facing change. Internal CI maintenance.

## Technical Summary
GitHub flagged that several actions in our workflows still run on Node.js 20, which will be forced to Node.js 24 on June 2nd 2026 and removed entirely on September 16th 2026. See the deprecation notice: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This bumps each flagged action to its first major version that ships with Node.js 24:

- `docker/login-action` v3 → v4 (`tests.yml`)
- ~~`codecov/codecov-action` v4 → v5 (`tests.yml`)~~ [reverted](https://github.com/dimagi/commcare-hq/pull/37670/commits/8bcab61a6735218fe3d27ef912bdaa54774a55f9)
- `actions/upload-artifact` v5 → v7 (`tests.yml`, `build-static.yml`, `test-docs.yml`)
- `actions/github-script` v7 → v9 (`required-labels.yml`)

~~`codecov-action@v5` switched to a new wrapper CLI internally, but the inputs we pass (`token`, `files`, `fail_ci_if_error`) still work as before.~~

Example workflow run with warnings: https://github.com/dimagi/commcare-hq/actions/runs/25325842609

## Feature Flag
N/A

## Safety Assurance

### Safety story
CI-only change. The deprecation warning will resolve once these workflows run, and any regression would surface immediately as a failed CI step on this PR.

### Automated test coverage
N/A — this PR exercises itself by running the updated workflows.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations
