### PR TITLE
GA Save to Case to Advanced+ plans

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -166,6 +166,7 @@ advanced_v0 = pro_v1 + [
     privileges.CUSTOM_ICON_BADGES,
     privileges.LOCATION_COLUMNS_IN_USER_LAST_ACTIVITY_REPORT,
     privileges.LOCKED_ADMIN_QUESTIONS,
+    privileges.VELLUM_SAVE_TO_CASE,
 ]
 
 enterprise_v0 = advanced_v0 + [

--- a/corehq/apps/accounting/migrations/0118_vellum_save_to_case_priv.py
+++ b/corehq/apps/accounting/migrations/0118_vellum_save_to_case_priv.py
@@ -1,0 +1,39 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.privileges import VELLUM_SAVE_TO_CASE
+
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _grandfather_privilege(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+
+    skip_editions = ','.join((
+        SoftwarePlanEdition.PAUSED,
+        SoftwarePlanEdition.FREE,
+        SoftwarePlanEdition.STANDARD,
+        SoftwarePlanEdition.PRO,
+    ))
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        VELLUM_SAVE_TO_CASE,
+        skip_edition=skip_editions,
+        noinput=True,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0117_locked_admin_questions_priv'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _grandfather_privilege,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -16,7 +16,7 @@ from corehq.apps.es import AppES
 from corehq.apps.es.aggregations import NestedAggregation, TermsAggregation
 from corehq.util.quickcache import quickcache
 from quickcache.django_quickcache import tiered_django_cache
-from corehq.toggles import VELLUM_SAVE_TO_CASE
+from corehq import privileges
 from corehq.apps.es import apps as app_es
 
 
@@ -530,8 +530,9 @@ def get_case_types_from_apps(domain, include_save_to_case_updates=True):
     Also returns case types for SaveToCase properties in the domain, if the toggle is enabled.
     :returns: A set of case_types
     """
+    from corehq.apps.accounting.utils import domain_has_privilege
     save_to_case_updates = set()
-    if include_save_to_case_updates and VELLUM_SAVE_TO_CASE.enabled(domain):
+    if include_save_to_case_updates and domain_has_privilege(domain, privileges.VELLUM_SAVE_TO_CASE):
         save_to_case_updates = _get_save_to_case_updates(domain)
     q = _get_case_types_from_apps_query(domain)
     case_types = set(q.run().aggregations.modules.case_types.keys)

--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -16,9 +16,10 @@ from corehq.apps.app_manager.exceptions import (
     AppValidationError,
     SavedAppBuildException,
 )
+from corehq import privileges
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.users.dbaccessors import get_all_users_by_domain
 from corehq.apps.app_manager.const import USERCASE_TYPE
-from corehq.toggles import VELLUM_SAVE_TO_CASE
 from corehq.util.metrics import metrics_counter
 
 logger = get_task_logger(__name__)
@@ -104,7 +105,7 @@ def _refresh_data_dictionary_from_app(domain, app_id):
     from corehq.apps.data_dictionary.util import create_properties_for_case_types
 
     case_type_to_prop = defaultdict(set)
-    if VELLUM_SAVE_TO_CASE.enabled(domain):
+    if domain_has_privilege(domain, privileges.VELLUM_SAVE_TO_CASE):
         for form in app.get_forms():
             case_type_to_prop.update(form.get_save_to_case_updates())
     for module in app.get_modules():

--- a/corehq/apps/app_manager/tests/test_tasks.py
+++ b/corehq/apps/app_manager/tests/test_tasks.py
@@ -4,6 +4,7 @@ import os
 from django.test import TestCase
 from unittest.mock import patch
 
+from corehq import privileges
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.apps.app_manager.dbaccessors import get_app, get_build_ids
 from corehq.apps.app_manager.models import CaseReferences, ConditionalCaseUpdate, import_app
@@ -16,7 +17,7 @@ from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import get_simple_form, patch_validate_xform
 from corehq.apps.app_manager.views.releases import make_app_build
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.util.test_utils import flag_enabled
+from corehq.util.test_utils import privilege_enabled
 
 
 @patch_validate_xform()
@@ -113,7 +114,7 @@ class AppManagerTasksTest(TestCase):
             make_app_build(factory.app, "comment", user_id="user_id")
             metric_counter_mock.assert_not_called()
 
-    @flag_enabled('VELLUM_SAVE_TO_CASE')
+    @privilege_enabled(privileges.VELLUM_SAVE_TO_CASE)
     def test_refresh_data_dictionary_from_app(self):
         factory = AppFactory(build_version='2.56.0')
         m0, f0 = factory.new_basic_module('update', 'case')

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -259,7 +259,7 @@ def _get_base_vellum_options(request, domain, form, displayLang):
             'is_registration_form': form.is_registration_form(),
         }
 
-    if toggles.VELLUM_SAVE_TO_CASE.enabled(domain):
+    if domain_has_privilege(domain, privileges.VELLUM_SAVE_TO_CASE):
         options['saveToCase'] = {
             'existingCaseTypes': sorted(get_data_dict_case_types(domain, is_deprecated=False)),
         }
@@ -319,7 +319,7 @@ def _get_vellum_plugins(domain, form, module, options):
         vellum_plugins.append("commtrack")
     if "caseManagement" in options:
         vellum_plugins.append("caseManagement")
-    if toggles.VELLUM_SAVE_TO_CASE.enabled(domain):
+    if domain_has_privilege(domain, privileges.VELLUM_SAVE_TO_CASE):
         vellum_plugins.append("saveToCase")
     if toggles.COMMCARE_CONNECT.enabled(domain):
         vellum_plugins.append("commcareConnect")

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -258,6 +258,10 @@ class Command(BaseCommand):
         Role(slug=privileges.LOCKED_ADMIN_QUESTIONS,
              name='Locked Admin Questions',
              description="Allow questions to be locked in the form builder to limit editing"),
+        Role(slug=privileges.VELLUM_SAVE_TO_CASE,
+             name='Advanced Case Actions (old Save To Case questions)',
+             description="Allow adding Advanced Case Actions (old Save To Case questions) "
+                         "in the form builder."),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -137,6 +137,8 @@ LOCATION_COLUMNS_IN_USER_LAST_ACTIVITY_REPORT = 'location_columns_in_user_last_a
 
 LOCKED_ADMIN_QUESTIONS = 'locked_admin_questions'
 
+VELLUM_SAVE_TO_CASE = 'save_to_case'
+
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,
     API_ACCESS,
@@ -208,6 +210,7 @@ MAX_PRIVILEGES = [
     CUSTOM_ICON_BADGES,
     LOCATION_COLUMNS_IN_USER_LAST_ACTIVITY_REPORT,
     LOCKED_ADMIN_QUESTIONS,
+    VELLUM_SAVE_TO_CASE,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -296,4 +299,5 @@ class Titles(object):
                 "Add primary location's hierarchy to excel export in User Last Activity Report"
             ),
             LOCKED_ADMIN_QUESTIONS: _("Locked Admin Questions"),
+            VELLUM_SAVE_TO_CASE: _("Save to Case"),
         }.get(privilege, privilege)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1125,7 +1125,8 @@ SECURE_SESSION_TIMEOUT = StaticToggle(
 # not referenced in code directly but passed through to vellum
 # see toggles_dict
 
-VELLUM_SAVE_TO_CASE = StaticToggle(
+VELLUM_SAVE_TO_CASE = FrozenPrivilegeToggle(
+    privileges.VELLUM_SAVE_TO_CASE,
     'save_to_case',
     "Adds save to case as a question to the form builder",
     TAG_GA_PATH,

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1128,7 +1128,7 @@ SECURE_SESSION_TIMEOUT = StaticToggle(
 VELLUM_SAVE_TO_CASE = FrozenPrivilegeToggle(
     privileges.VELLUM_SAVE_TO_CASE,
     'save_to_case',
-    "Adds save to case as a question to the form builder",
+    "Adds Advanced Case Actions as a question to the form builder",
     TAG_GA_PATH,
     [NAMESPACE_DOMAIN],
     description='This flag allows case management inside repeat groups',

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -224,7 +224,9 @@ class privilege_enabled:
     """
     imports = (  # (Alphabetical to reduce conflicts)
         'corehq.apps.app_manager.app_strings.domain_has_privilege',
+        'corehq.apps.app_manager.tasks.domain_has_privilege',
         'corehq.apps.app_manager.util.domain_has_privilege',
+        'corehq.apps.app_manager.views.formdesigner.domain_has_privilege',
         'corehq.apps.callcenter.sync_usercase.domain_has_privilege',
         'corehq.apps.callcenter.tasks.domain_has_privilege',
         'corehq.apps.case_importer.do_import.domain_has_privilege',

--- a/migrations.lock
+++ b/migrations.lock
@@ -137,6 +137,7 @@ accounting
  0115_loc_cols_in_user_last_activity_priv
  0116_creditadjustment_payment_type
  0117_locked_admin_questions_priv
+ 0118_vellum_save_to_case_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Product Description
GA Save to Case to Advanced and Enterprise plans.

Domains currently using the feature via the legacy `save_to_case` feature flag keep access regardless of plan

## Technical Summary
🐟 Review by commit

Follows the toggle→paid-privilege promotion pattern documented on `FrozenPrivilegeToggle` 

The `dbaccessors` call site uses a lazy import for `domain_has_privilege` to avoid a circular import via `domain.models -> app_manager.dbaccessors -> accounting.utils -> domain.models`.


## Feature Flag
`VELLUM_SAVE_TO_CASE` (slug `save_to_case`) — being promoted to a paid privilege.

## Safety Assurance

### Safety story
- Tested on staging

### Automated test coverage


### QA Plan

### Migrations
- [x] The migrations in this code can be safely applied first independently of the code. 

The migration only adds a new role and grants it to existing Advanced+ subscriptions; it doesn't read from or modify any column the old code uses. 
I'll run the migration in a private release before deploy.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change