### PR TITLE
Add Django admin entry for LookupTable

### DIFF
--- a/corehq/apps/fixtures/admin.py
+++ b/corehq/apps/fixtures/admin.py
@@ -1,0 +1,11 @@
+from django.contrib import admin
+
+from .models import LookupTable
+
+
+@admin.register(LookupTable)
+class LookupTableAdmin(admin.ModelAdmin):
+    list_display = ['domain', 'tag', 'is_global', 'last_modified']
+    list_filter = ['is_global']
+    search_fields = ['domain', 'tag']
+    ordering = ['domain', 'tag']


### PR DESCRIPTION
## Product Description
Adds the `LookupTable` model to the Django admin, enabling staff to browse lookup tables (filter by global/non-global, search by domain or tag) via `/admin/fixtures/lookuptable/`.

## Technical Summary
Registers a `ModelAdmin` for `corehq.apps.fixtures.models.LookupTable`. List view shows domain, tag, is_global, and last_modified, with a sidebar filter on is_global and a search box over domain and tag.

<img width="3067" height="706" alt="image" src="https://github.com/user-attachments/assets/f9ec98c7-61cf-460d-986a-0f2c74a37971" />


## Feature Flag
N/A

## Safety Assurance

### Safety story
Read-only addition of a new `admin.py`; no model, migration, or runtime path changes. Access to the Django admin is already gated by superuser / staff permissions, so visibility is limited to admins.  I did manual testing.

### Automated test coverage
None added — admin registration is exercised by Django's `system check` (passes) and by admin autodiscovery.

### QA Plan
Manual: log into `/admin/`, confirm "Fixtures → Lookup tables" appears, confirm list view renders and search/filter work.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change