### PR TITLE
Upgrade codecov/codecov-action to v5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
       env:
         TOKEN: ${{ secrets.CODECOV_TOKEN }}
       if: env.TOKEN != ''
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml


### PR DESCRIPTION
## Product Description
No user-facing change. Internal CI maintenance.

## Technical Summary
Re-applies the `codecov/codecov-action` v4 to v5 bump that was originally part of #37670 but [reverted](https://github.com/dimagi/commcare-hq/commit/8bcab61a6735218fe3d27ef912bdaa54774a55f9) there after v5 failed GPG signature verification when downloading the Codecov uploader (`codecov.SHA256SUM.sig` was missing from the CDN). That looked like a transient upstream issue, so this PR retries the upgrade on its own — keeping it isolated from the other Node.js 20 deprecation bumps so it can be reverted independently if the failure recurs.

The motivation is the same as #37670: GitHub is forcing Node.js 20 actions to Node.js 24 on June 2nd 2026 and removing them on September 16th 2026 (see the [deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). `codecov-action@v5` is the first major version that ships with Node.js 24. The inputs we pass (`token`, `files`, `fail_ci_if_error`) are unchanged across the v4 to v5 boundary despite v5 switching to a new wrapper CLI internally.

## Safety Assurance

### Safety story
CI-only change. If the GPG verification failure resurfaces, the codecov upload step fails on this PR's own CI run and the change can be reverted with no production impact. Coverage reporting is the only thing affected — it has no bearing on test pass/fail or deploys.

### Automated test coverage
N/A — this PR exercises itself by running the updated workflow.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations