### PR TITLE
Notify Sentry on Postgres service check failures

### DIFF
--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -12,7 +12,6 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import cache
 from django.db import connections
-from django.db.utils import OperationalError
 
 import requests
 import urllib3
@@ -203,7 +202,8 @@ def check_postgres():
         try:
             db_conn.cursor()
             c_status = 'OK'
-        except OperationalError:
+        except Exception:
+            notify_exception(None, message=f"check_postgres failed for {settings.DATABASES[db]['NAME']}")
             c_status = 'FAIL'
             connected = False
         status_str += "%s:%s:%s " % (db, settings.DATABASES[db]['NAME'], c_status)


### PR DESCRIPTION
## Product Description
No user-facing change. Improves observability of Postgres connectivity issues surfaced by the `check_postgres` service check.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19700

`check_postgres` previously caught only `OperationalError`, so other failure modes (timeouts, auth, network) were swallowed into a generic `FAIL` with no detail in Sentry. This widens the catch to `Exception` and calls `notify_exception` with the offending DB name so we can see the actual error in Sentry when the check fails.

This is intentionally a band-aid — there's likely room for a deeper improvement to `service_checks` (e.g. consistent structured reporting across all checks), but the goal here is just to get better signal on Postgres failures now.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Tiny, additive change in an admin/diagnostic code path. The check still returns the same `FAIL` status; the only new behavior is an extra `notify_exception` call on the failure branch. Broadening to `Exception` means any unexpected error during `db_conn.cursor()` is now reported instead of propagating.

### Automated test coverage
None added. The change is a logging/notification tweak in a diagnostic endpoint.

### QA Plan
No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change