### PR TITLE
Pass in all args from advanced modules getQuestions

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap3/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap3/case_config_ui.js
@@ -173,6 +173,7 @@ $(function () {
                 filter,
                 excludeHidden,
                 includeRepeat,
+                false, //excludeTrigger
                 true,  //disableLocked
             );
         };

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap5/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/bootstrap5/case_config_ui.js
@@ -173,6 +173,7 @@ $(function () {
                 filter,
                 excludeHidden,
                 includeRepeat,
+                false, //excludeTrigger
                 true,  //disableLocked
             );
         };


### PR DESCRIPTION
## Product Description
Fixes a bug introduced in 2be9cf23a551e1351fd992d5b42b76697b9afd93 where locked questions would have been selectable in the "question" dropdown for advanced mappings, and trigger (label) questions would not have appeared at all.
Fixed:

<img width="308" height="166" alt="image" src="https://github.com/user-attachments/assets/868ab1f0-45b6-4906-b3f6-045cdd808995" />


## Technical Summary
Bugfix brought about by local testing. I had previously added the new argument without checking which arguments were / were not already being passed in.

## Feature Flag
In terms of locked questions not being correctly disabled in dropdowns, that effect is limited to the LOCKED_ADMIN_QUESTIONS feature flag. All changes here are behind the advanced modules feature flag.

## Safety Assurance

### Safety story
Fixes a UI bug. Tested locally.

### Automated test coverage
Not here.

### QA Plan
Not for this change specifically, but should be covered in QA.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
