### PR TITLE
Export audit log: identify columns by id, not label

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -447,7 +447,7 @@ def _log_export_generated(export_instance, row_count, logging_context):
         "export_format": export_instance.export_format,
         "row_count": row_count,
         "columns": [
-            col.label
+            col.item.readable_path
             for table in export_instance.tables if table.selected
             for col in table.columns if col.selected
         ],

--- a/corehq/apps/export/tests/test_export_logging.py
+++ b/corehq/apps/export/tests/test_export_logging.py
@@ -169,7 +169,11 @@ class TestLogExportGenerated(SimpleTestCase):
             case_type="patient",
             tables=[
                 TableConfiguration(label="Main", path=MAIN_TABLE, selected=True, columns=[
-                    ExportColumn(label="Patient Name", item=ExportItem(path=[PathNode(name="name")]), selected=True),
+                    ExportColumn(
+                        label="Patient Name",
+                        item=ExportItem(path=[PathNode(name="name")]),
+                        selected=True,
+                    ),
                     ExportColumn(label="Hidden", item=ExportItem(path=[PathNode(name="x")]), selected=False),
                 ]),
                 TableConfiguration(label="Unselected", path=[PathNode(name="other")], selected=False, columns=[

--- a/corehq/apps/export/tests/test_export_logging.py
+++ b/corehq/apps/export/tests/test_export_logging.py
@@ -143,6 +143,26 @@ class TestLogExportGenerated(SimpleTestCase):
         assert "bulk" not in data
 
     @patch('corehq.apps.export.export.export_audit_logger')
+    def test_columns_logged_use_question_path_not_label(self, mock_logger):
+        export = _make_form_export(columns=[
+            ExportColumn(
+                label="What is your name?",
+                item=ExportItem(path=[PathNode(name="form"), PathNode(name="name")]),
+                selected=True,
+            ),
+            ExportColumn(
+                label="Child age",
+                item=ExportItem(
+                    path=[PathNode(name="form"), PathNode(name="children"), PathNode(name="age")],
+                ),
+                selected=True,
+            ),
+        ])
+        _log_export_generated(export, row_count=0, logging_context=None)
+
+        assert _logged_data(mock_logger)["columns"] == ["form.name", "form.children.age"]
+
+    @patch('corehq.apps.export.export.export_audit_logger')
     def test_only_selected_columns_from_selected_tables(self, mock_logger):
         export = CaseExportInstance(
             domain="test-domain",

--- a/corehq/apps/export/tests/test_export_logging.py
+++ b/corehq/apps/export/tests/test_export_logging.py
@@ -39,9 +39,9 @@ def _make_case_export(case_type="patient"):
             path=MAIN_TABLE,
             selected=True,
             columns=[
-                ExportColumn(label="name", item=ExportItem(path=[PathNode(name="name")]), selected=True),
-                ExportColumn(label="dob", item=ExportItem(path=[PathNode(name="dob")]), selected=True),
-                ExportColumn(label="hidden", item=ExportItem(path=[PathNode(name="hidden")]), selected=False),
+                ExportColumn(label="Patient Name", item=ExportItem(path=[PathNode(name="name")]), selected=True),
+                ExportColumn(label="Date of Birth", item=ExportItem(path=[PathNode(name="dob")]), selected=True),
+                ExportColumn(label="Hidden", item=ExportItem(path=[PathNode(name="hidden")]), selected=False),
             ],
         )],
     )
@@ -149,11 +149,11 @@ class TestLogExportGenerated(SimpleTestCase):
             case_type="patient",
             tables=[
                 TableConfiguration(label="Main", path=MAIN_TABLE, selected=True, columns=[
-                    ExportColumn(label="name", item=ExportItem(path=[PathNode(name="name")]), selected=True),
-                    ExportColumn(label="hidden", item=ExportItem(path=[PathNode(name="x")]), selected=False),
+                    ExportColumn(label="Patient Name", item=ExportItem(path=[PathNode(name="name")]), selected=True),
+                    ExportColumn(label="Hidden", item=ExportItem(path=[PathNode(name="x")]), selected=False),
                 ]),
                 TableConfiguration(label="Unselected", path=[PathNode(name="other")], selected=False, columns=[
-                    ExportColumn(label="ignored", item=ExportItem(path=[PathNode(name="y")]), selected=True),
+                    ExportColumn(label="Ignored", item=ExportItem(path=[PathNode(name="y")]), selected=True),
                 ]),
             ],
         )


### PR DESCRIPTION
## Product Description
No user-facing change. Affects only what gets written to the export audit log.

## Technical Summary
Follow-up to #37595, which introduced the export audit log. The `columns` field previously recorded each column's user-facing `label` (e.g. "Age", "Date of Birth"). This change switches it to the column's question path / case property name (e.g. `form.children.age`, `dob`) — a stable identifier that survives label edits and translations, which is what's actually useful in an audit log.

Read the commits in order; the first one intentionally leaves CI red.

## Feature Flag
None.

## Safety Assurance

### Safety story
Touches only the audit log payload — no production data, user-visible behavior, or migrations. The log has no downstream consumers to update.

### Automated test coverage
Strengthened existing tests in `test_export_logging.py` to distinguish labels from identifiers; added `test_columns_logged_use_question_path_not_label` for nested form paths.

### QA Plan
N/A — covered by automated tests; no UI surface.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
