### PR TITLE
Require domain membership before adding an enterprise admin

### DIFF
--- a/corehq/apps/enterprise/forms.py
+++ b/corehq/apps/enterprise/forms.py
@@ -12,6 +12,7 @@ from corehq.apps.export.models.export_settings import ExportFileType
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput
 from corehq.apps.sso.models import IdentityProvider
+from corehq.apps.users.models import WebUser
 from corehq.privileges import DEFAULT_EXPORT_SETTINGS
 
 
@@ -24,6 +25,17 @@ def _get_sso_email_domains(account):
     """
     idps = IdentityProvider.objects.filter(owner=account, is_active=True)
     return {d.lower() for idp in idps for d in idp.get_email_domains()}
+
+
+def _is_member_of_account(email, account):
+    """
+    Returns True if a WebUser exists for the given email and is a member
+    of at least one project space in the given BillingAccount.
+    """
+    web_user = WebUser.get_by_username(email)
+    if not isinstance(web_user, WebUser):
+        return False
+    return bool(set(account.get_domains()).intersection(web_user.get_domains()))
 
 
 class EnterpriseAdminForm(forms.Form):
@@ -61,6 +73,14 @@ class EnterpriseAdminForm(forms.Form):
                     "must use an email at one of: %(domains)s"
                 ),
                 params={"domains": ", ".join(sorted(sso_domains))},
+            )
+        if not _is_member_of_account(email, self.account):
+            raise ValidationError(
+                _(
+                    "This user must be a member of at least one project "
+                    "space in this enterprise account before being added "
+                    "as an enterprise administrator."
+                ),
             )
         return email
 

--- a/corehq/apps/enterprise/tests/test_enterprise_admins.py
+++ b/corehq/apps/enterprise/tests/test_enterprise_admins.py
@@ -25,10 +25,14 @@ def _noop(*args, **kwargs):
     pass
 
 
+# Stub publish_domain_saved so these tests don't require a running
+# Kafka broker; otherwise the underlying producer call raises
+# NoBrokersAvailable in dev environments without Kafka up.
+_no_kafka_publish = patch('corehq.apps.accounting.models.publish_domain_saved', _noop)
+
+
 def _delete_domain(domain):
-    # Kafka is not available in the test environment; stub the publish
-    # call so domain teardown doesn't depend on a broker.
-    with patch('corehq.apps.accounting.models.publish_domain_saved', _noop):
+    with _no_kafka_publish:
         domain.delete()
 
 
@@ -99,9 +103,7 @@ class _EnterpriseAdminViewTestBase(TestCase):
             edition=SoftwarePlanEdition.ENTERPRISE,
         )
         start = date.today()
-        # Kafka is not available in the test environment; stub the publish
-        # call so fixture setup/teardown doesn't depend on a broker.
-        with patch('corehq.apps.accounting.models.publish_domain_saved', _noop):
+        with _no_kafka_publish:
             generate_domain_subscription(
                 cls.account, cls.domain,
                 date_start=start,
@@ -125,9 +127,7 @@ class _EnterpriseAdminViewTestBase(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.admin_user.delete(cls.domain_name, deleted_by=None)
-        # Kafka is not available in the test environment; stub the publish
-        # call so fixture setup/teardown doesn't depend on a broker.
-        with patch('corehq.apps.accounting.models.publish_domain_saved', _noop):
+        with _no_kafka_publish:
             cls.domain.delete()
         super().tearDownClass()
 

--- a/corehq/apps/enterprise/tests/test_enterprise_admins.py
+++ b/corehq/apps/enterprise/tests/test_enterprise_admins.py
@@ -25,6 +25,13 @@ def _noop(*args, **kwargs):
     pass
 
 
+def _delete_domain(domain):
+    # Kafka is not available in the test environment; stub the publish
+    # call so domain teardown doesn't depend on a broker.
+    with patch('corehq.apps.accounting.models.publish_domain_saved', _noop):
+        domain.delete()
+
+
 def _make_idp(account, slug, is_active=True, domains=None):
     idp = IdentityProvider.objects.create(
         owner=account,
@@ -304,6 +311,46 @@ class AddEnterpriseAdminViewTests(_EnterpriseAdminViewTestBase):
         assert response.status_code == 404
         account = self._reload_account()
         assert 'blocked@example.com' not in account.enterprise_admin_emails
+
+    @flag_enabled('ENTERPRISE_ADMIN_SELF_SERVICE')
+    def test_add_rejects_unknown_email(self):
+        # An email with no backing WebUser cannot be added: the candidate
+        # admin would be unable to view the dashboard since membership of
+        # an account project space is required.
+        response = self.client.post(
+            self.add_url, {'email': 'no-such-user@example.com'},
+        )
+        self.assertRedirects(response, self.list_url)
+        account = self._reload_account()
+        assert 'no-such-user@example.com' not in account.enterprise_admin_emails
+        msgs = [str(m) for m in get_messages(response.wsgi_request)]
+        assert any('member of at least one project space' in m for m in msgs)
+
+    @flag_enabled('ENTERPRISE_ADMIN_SELF_SERVICE')
+    def test_add_rejects_user_not_in_account_domains(self):
+        # A WebUser exists, but is only a member of a domain unrelated to
+        # this enterprise account.
+        outside_domain = create_domain('ent-admin-outside')
+        self.addCleanup(_delete_domain, outside_domain)
+        self._create_member('out-of-account@example.com', domain_name='ent-admin-outside')
+        response = self.client.post(
+            self.add_url, {'email': 'out-of-account@example.com'},
+        )
+        self.assertRedirects(response, self.list_url)
+        account = self._reload_account()
+        assert 'out-of-account@example.com' not in account.enterprise_admin_emails
+        msgs = [str(m) for m in get_messages(response.wsgi_request)]
+        assert any('member of at least one project space' in m for m in msgs)
+
+    @flag_enabled('ENTERPRISE_ADMIN_SELF_SERVICE')
+    def test_add_accepts_user_who_is_member_of_account_domain(self):
+        self._create_member('member@example.com')
+        response = self.client.post(
+            self.add_url, {'email': 'member@example.com'},
+        )
+        self.assertRedirects(response, self.list_url)
+        account = self._reload_account()
+        assert 'member@example.com' in account.enterprise_admin_emails
 
 
 class RemoveEnterpriseAdminViewTests(_EnterpriseAdminViewTestBase):

--- a/corehq/apps/enterprise/tests/test_enterprise_admins.py
+++ b/corehq/apps/enterprise/tests/test_enterprise_admins.py
@@ -132,6 +132,14 @@ class _EnterpriseAdminViewTestBase(TestCase):
         self.account.refresh_from_db()
         return self.account
 
+    def _create_member(self, email, domain_name=None):
+        """Create a WebUser as a member of ``domain_name`` (defaults to the
+        shared account domain) and register cleanup."""
+        domain_name = domain_name or self.domain_name
+        user = WebUser.create(domain_name, email, 'pw', None, None)
+        self.addCleanup(user.delete, domain_name, deleted_by=None)
+        return user
+
 
 class EnterpriseAdminsGetViewTests(_EnterpriseAdminViewTestBase):
 
@@ -202,6 +210,7 @@ class AddEnterpriseAdminViewTests(_EnterpriseAdminViewTestBase):
 
     @flag_enabled('ENTERPRISE_ADMIN_SELF_SERVICE')
     def test_add_valid_email_appends_lowercased(self):
+        self._create_member('newadmin@example.com')
         response = self.client.post(
             self.add_url, {'email': 'NewAdmin@Example.com'},
         )
@@ -243,6 +252,7 @@ class AddEnterpriseAdminViewTests(_EnterpriseAdminViewTestBase):
     @flag_enabled('ENTERPRISE_ADMIN_SELF_SERVICE')
     def test_add_with_sso_allows_matching_domain(self):
         _make_idp(self.account, slug='idp-sso-ok', domains=['corp.com'])
+        self._create_member('newperson@corp.com')
         response = self.client.post(
             self.add_url, {'email': 'newperson@corp.com'},
         )
@@ -255,6 +265,7 @@ class AddEnterpriseAdminViewTests(_EnterpriseAdminViewTestBase):
         # An active IdP with no AuthenticatedEmailDomain rows imposes no
         # domain restriction.
         _make_idp(self.account, slug='idp-no-domains')
+        self._create_member('someone@unrestricted.com')
         response = self.client.post(
             self.add_url, {'email': 'someone@unrestricted.com'},
         )
@@ -276,6 +287,7 @@ class AddEnterpriseAdminViewTests(_EnterpriseAdminViewTestBase):
 
     @flag_enabled('ENTERPRISE_ADMIN_SELF_SERVICE')
     def test_add_logs_info(self):
+        self._create_member('logger@example.com')
         with self.assertLogs(
             'corehq.apps.enterprise.views', level='INFO'
         ) as cap:


### PR DESCRIPTION
## Product Description

On the Enterprise Admin Management page, **Add Administrator** now rejects an email unless that user already exists as a WebUser and is a member of at least one project space in the enterprise account. Banner error: *"This user must be a member of at least one project space in this enterprise account before being added as an enterprise administrator."*

<img width="1800" height="703" alt="Screenshot 2026-05-11 at 11 05 26 AM" src="https://github.com/user-attachments/assets/48b0cb7c-d292-41c2-a0f7-a275ebc45588" />

(in the above screenshot, I tried to add "not-a-member@example.com".)


## Technical Summary

Dimagi superusers are not special-cased. (They would typically not be added as an admin anyway.)

## Feature Flag

`ENTERPRISE_ADMIN_SELF_SERVICE` (gates the page).

## Safety Assurance

### Safety story

Strictly additive validation at add-time. Existing entries in `account.enterprise_admin_emails` are not re-validated, so already-listed admins are unaffected. No model or schema changes.

### Automated test coverage

30 tests in `corehq/apps/enterprise/tests/test_enterprise_admins.py` pass locally; three new tests cover unknown-email / non-member-WebUser / member happy-path branches.

### QA Plan

On a project with `ENTERPRISE_ADMIN_SELF_SERVICE` enabled:
- [x] Add an email for a user that doesn't exist on HQ → expect the new error.
- [x] Add a WebUser who is only a member of an unrelated project → expect the new error.
- [x] Add a WebUser who is a member of any project space in the enterprise account → succeeds.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
