### PR TITLE
Reject form-action saves that touch locked-question mappings

### DIFF
--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -38,6 +38,11 @@ class RearrangeError(AppEditingError):
     pass
 
 
+class FormActionsChangeError(AppEditingError):
+    """A proposed change to a form's actions cannot be applied."""
+    pass
+
+
 class XFormException(AppManagerException):
     pass
 

--- a/corehq/apps/app_manager/form_action_diff.py
+++ b/corehq/apps/app_manager/form_action_diff.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 
 from .models import ConditionalCaseUpdate
 
@@ -322,11 +322,52 @@ def collect_locked_mappings(form_actions, locked_paths):
     and after applying the incoming change; any difference means a locked
     mapping was touched.
     """
-    return set()
+    if not locked_paths:
+        return set()
+    return {m for m in _iter_form_action_mappings(form_actions)
+            if m.path in locked_paths}
 
 
 def collect_locked_advanced_mappings(advanced_form_actions, locked_paths):
     """Set of entries from an :class:`AdvancedFormActions` whose ``path`` is in
     ``locked_paths``. See :func:`collect_locked_mappings`.
     """
-    return set()
+
+CaseUpdateMapping = namedtuple(
+    'CaseUpdateMapping',
+    ['kind', 'prop', 'path', 'update_mode', 'case_tag'],
+    defaults=[''],
+)
+
+
+def _iter_form_action_mappings(form_actions):
+    open_case = form_actions.open_case
+    yield CaseUpdateMapping('open.name', 'name', open_case.name_update.question_path,
+                            open_case.name_update.update_mode)
+    for ccu in open_case.conflicts:
+        yield CaseUpdateMapping('open.name', 'name', ccu.question_path, ccu.update_mode)
+
+    yield from _iter_update_action_mappings('update', form_actions.update_case)
+    yield from _iter_update_action_mappings(
+        'usercase_update', form_actions.usercase_update,
+    )
+
+    for path, name in form_actions.case_preload.preload.items():
+        yield CaseUpdateMapping('case_preload', name, path, None)
+    for path, name in form_actions.usercase_preload.preload.items():
+        yield CaseUpdateMapping('usercase_preload', name, path, None)
+
+    for i, sub in enumerate(form_actions.subcases):
+        kind = f'subcase[{i}]:{sub.case_type or ""}'
+        yield CaseUpdateMapping(kind, 'name', sub.name_update.question_path,
+                                sub.name_update.update_mode)
+        for prop, ccu in sub.case_properties.items():
+            yield CaseUpdateMapping(kind, prop, ccu.question_path, ccu.update_mode)
+
+
+def _iter_update_action_mappings(kind, action):
+    for prop, ccu in action.update.items():
+        yield CaseUpdateMapping(kind, prop, ccu.question_path, ccu.update_mode)
+    for prop, ccus in action.conflicts.items():
+        for ccu in ccus:
+            yield CaseUpdateMapping(kind, prop, ccu.question_path, ccu.update_mode)

--- a/corehq/apps/app_manager/form_action_diff.py
+++ b/corehq/apps/app_manager/form_action_diff.py
@@ -311,3 +311,22 @@ class _NameConflictsAdapter:
 
 def _check_name(key):
     assert key == 'name', f'Invalid OpenCaseAction field: {key}'
+
+
+def collect_locked_mappings(form_actions, locked_paths):
+    """Set of mapping entries in ``form_actions`` whose ``path`` is in
+    ``locked_paths``.
+
+    Used to detect whether a locked-question mapping was added, removed,
+    repointed, or otherwise modified by a save: compare the result before
+    and after applying the incoming change; any difference means a locked
+    mapping was touched.
+    """
+    return set()
+
+
+def collect_locked_advanced_mappings(advanced_form_actions, locked_paths):
+    """Set of entries from an :class:`AdvancedFormActions` whose ``path`` is in
+    ``locked_paths``. See :func:`collect_locked_mappings`.
+    """
+    return set()

--- a/corehq/apps/app_manager/form_action_diff.py
+++ b/corehq/apps/app_manager/form_action_diff.py
@@ -332,6 +332,11 @@ def collect_locked_advanced_mappings(advanced_form_actions, locked_paths):
     """Set of entries from an :class:`AdvancedFormActions` whose ``path`` is in
     ``locked_paths``. See :func:`collect_locked_mappings`.
     """
+    if not locked_paths:
+        return set()
+    return {m for m in _iter_advanced_form_action_mappings(advanced_form_actions)
+            if m.path in locked_paths}
+
 
 CaseUpdateMapping = namedtuple(
     'CaseUpdateMapping',
@@ -363,6 +368,24 @@ def _iter_form_action_mappings(form_actions):
                                 sub.name_update.update_mode)
         for prop, ccu in sub.case_properties.items():
             yield CaseUpdateMapping(kind, prop, ccu.question_path, ccu.update_mode)
+
+
+def _iter_advanced_form_action_mappings(advanced_form_actions):
+    for action in advanced_form_actions.load_update_cases:
+        tag = action.case_tag or ''
+        for prop, ccu in action.case_properties.items():
+            yield CaseUpdateMapping('case_property', prop, ccu.question_path,
+                                    ccu.update_mode, tag)
+        for path, name in action.preload.items():
+            yield CaseUpdateMapping('preload', name, path, None, tag)
+
+    for action in advanced_form_actions.open_cases:
+        tag = action.case_tag or ''
+        yield CaseUpdateMapping('name', 'name', action.name_update.question_path,
+                                action.name_update.update_mode, tag)
+        for prop, ccu in action.case_properties.items():
+            yield CaseUpdateMapping('case_property', prop, ccu.question_path,
+                                    ccu.update_mode, tag)
 
 
 def _iter_update_action_mappings(kind, action):

--- a/corehq/apps/app_manager/form_action_diff.py
+++ b/corehq/apps/app_manager/form_action_diff.py
@@ -1,4 +1,5 @@
-from collections import defaultdict, namedtuple
+from collections import defaultdict
+from typing import NamedTuple
 
 from .models import ConditionalCaseUpdate
 
@@ -314,8 +315,8 @@ def _check_name(key):
 
 
 def collect_locked_mappings(form_actions, locked_paths):
-    """Set of mapping entries in ``form_actions`` whose ``path`` is in
-    ``locked_paths``.
+    """Set of mapping entries in ``form_actions`` whose ``question_path`` is
+    in ``locked_paths``.
 
     Used to detect whether a locked-question mapping was added, removed,
     repointed, or otherwise modified by a save: compare the result before
@@ -325,24 +326,37 @@ def collect_locked_mappings(form_actions, locked_paths):
     if not locked_paths:
         return set()
     return {m for m in _iter_form_action_mappings(form_actions)
-            if m.path in locked_paths}
+            if m.question_path in locked_paths}
 
 
 def collect_locked_advanced_mappings(advanced_form_actions, locked_paths):
-    """Set of entries from an :class:`AdvancedFormActions` whose ``path`` is in
-    ``locked_paths``. See :func:`collect_locked_mappings`.
+    """Set of entries from an :class:`AdvancedFormActions` whose
+    ``question_path`` is in ``locked_paths``.
+    See :func:`collect_locked_mappings`.
     """
     if not locked_paths:
         return set()
     return {m for m in _iter_advanced_form_action_mappings(advanced_form_actions)
-            if m.path in locked_paths}
+            if m.question_path in locked_paths}
 
 
-CaseUpdateMapping = namedtuple(
-    'CaseUpdateMapping',
-    ['kind', 'prop', 'path', 'update_mode', 'case_tag'],
-    defaults=[''],
-)
+class CaseUpdateMapping(NamedTuple):
+    """
+    Attributes:
+        action_path: Identifies which container in ``FormActions`` this mapping
+            was extracted from. e.g., ``'open.name'``, ``'update'``, etc.
+        prop: The case-property name being read or written.
+        question_path: The XForm question path the mapping reads or writes.
+        update_mode: ``'always'`` or ``'edit'`` for
+            :class:`ConditionalCaseUpdate`-backed mappings. ``None`` for
+            preload mappings.
+        case_tag: User-assigned tag for advanced form actions.
+    """
+    action_path: str
+    prop: str
+    question_path: str
+    update_mode: str | None
+    case_tag: str = ''
 
 
 def _iter_form_action_mappings(form_actions):
@@ -363,11 +377,11 @@ def _iter_form_action_mappings(form_actions):
         yield CaseUpdateMapping('usercase_preload', name, path, None)
 
     for i, sub in enumerate(form_actions.subcases):
-        kind = f'subcase[{i}]:{sub.case_type or ""}'
-        yield CaseUpdateMapping(kind, 'name', sub.name_update.question_path,
+        action_path = f'subcase[{i}]:{sub.case_type or ""}'
+        yield CaseUpdateMapping(action_path, 'name', sub.name_update.question_path,
                                 sub.name_update.update_mode)
         for prop, ccu in sub.case_properties.items():
-            yield CaseUpdateMapping(kind, prop, ccu.question_path, ccu.update_mode)
+            yield CaseUpdateMapping(action_path, prop, ccu.question_path, ccu.update_mode)
 
 
 def _iter_advanced_form_action_mappings(advanced_form_actions):
@@ -388,9 +402,9 @@ def _iter_advanced_form_action_mappings(advanced_form_actions):
                                     ccu.update_mode, tag)
 
 
-def _iter_update_action_mappings(kind, action):
+def _iter_update_action_mappings(action_path, action):
     for prop, ccu in action.update.items():
-        yield CaseUpdateMapping(kind, prop, ccu.question_path, ccu.update_mode)
+        yield CaseUpdateMapping(action_path, prop, ccu.question_path, ccu.update_mode)
     for prop, ccus in action.conflicts.items():
         for ccu in ccus:
-            yield CaseUpdateMapping(kind, prop, ccu.question_path, ccu.update_mode)
+            yield CaseUpdateMapping(action_path, prop, ccu.question_path, ccu.update_mode)

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -838,9 +838,9 @@ class CollectLockedMappingsTests(SimpleTestCase):
         result = collect_locked_mappings(actions, {'/data/question2'})
         assert result == {
             CaseUpdateMapping(
-                kind='update',
+                action_path='update',
                 prop='locked_prop',
-                path='/data/question2',
+                question_path='/data/question2',
                 update_mode='always',
             )
         }
@@ -859,9 +859,9 @@ class CollectLockedMappingsTests(SimpleTestCase):
         result = collect_locked_mappings(actions, {'/data/locked'})
         assert result == {
             CaseUpdateMapping(
-                kind='update',
+                action_path='update',
                 prop='p',
-                path='/data/locked',
+                question_path='/data/locked',
                 update_mode='always',
             )
         }
@@ -877,9 +877,9 @@ class CollectLockedMappingsTests(SimpleTestCase):
         result = collect_locked_mappings(actions, {'/data/locked'})
         assert result == {
             CaseUpdateMapping(
-                kind='open.name',
+                action_path='open.name',
                 prop='name',
-                path='/data/locked',
+                question_path='/data/locked',
                 update_mode='always',
             )
         }
@@ -895,9 +895,9 @@ class CollectLockedMappingsTests(SimpleTestCase):
         result = collect_locked_mappings(actions, {'/data/locked'})
         assert result == {
             CaseUpdateMapping(
-                kind='usercase_update',
+                action_path='usercase_update',
                 prop='p',
-                path='/data/locked',
+                question_path='/data/locked',
                 update_mode='always',
             )
         }
@@ -914,9 +914,9 @@ class CollectLockedMappingsTests(SimpleTestCase):
         result = collect_locked_mappings(actions, {'/data/locked'})
         assert result == {
             CaseUpdateMapping(
-                kind='case_preload',
+                action_path='case_preload',
                 prop='preloaded_prop',
-                path='/data/locked',
+                question_path='/data/locked',
                 update_mode=None,
             )
         }
@@ -932,9 +932,9 @@ class CollectLockedMappingsTests(SimpleTestCase):
         result = collect_locked_mappings(actions, {'/data/locked'})
         assert result == {
             CaseUpdateMapping(
-                kind='usercase_preload',
+                action_path='usercase_preload',
                 prop='preloaded_prop',
-                path='/data/locked',
+                question_path='/data/locked',
                 update_mode=None,
             )
         }
@@ -961,15 +961,15 @@ class CollectLockedMappingsTests(SimpleTestCase):
         )
         assert result == {
             CaseUpdateMapping(
-                kind='subcase[0]:child',
+                action_path='subcase[0]:child',
                 prop='name',
-                path='/data/locked_name',
+                question_path='/data/locked_name',
                 update_mode='always',
             ),
             CaseUpdateMapping(
-                kind='subcase[0]:child',
+                action_path='subcase[0]:child',
                 prop='p',
-                path='/data/locked_prop',
+                question_path='/data/locked_prop',
                 update_mode='always',
             ),
         }
@@ -1000,15 +1000,15 @@ class CollectLockedMappingsTests(SimpleTestCase):
         result = collect_locked_mappings(actions, {'/data/locked'})
         assert result == {
             CaseUpdateMapping(
-                kind='subcase[0]:child',
+                action_path='subcase[0]:child',
                 prop='p',
-                path='/data/locked',
+                question_path='/data/locked',
                 update_mode='always',
             ),
             CaseUpdateMapping(
-                kind='subcase[1]:child',
+                action_path='subcase[1]:child',
                 prop='p',
-                path='/data/locked',
+                question_path='/data/locked',
                 update_mode='always',
             ),
         }
@@ -1065,9 +1065,9 @@ class CollectLockedAdvancedMappingsTests(SimpleTestCase):
         result = collect_locked_advanced_mappings(actions, {'/data/question2'})
         assert result == {
             CaseUpdateMapping(
-                kind='case_property',
+                action_path='case_property',
                 prop='locked_prop',
-                path='/data/question2',
+                question_path='/data/question2',
                 update_mode='always',
                 case_tag='load_patient',
             )
@@ -1085,16 +1085,16 @@ class CollectLockedAdvancedMappingsTests(SimpleTestCase):
         result = collect_locked_advanced_mappings(actions, {'/data/question2'})
         assert result == {
             CaseUpdateMapping(
-                kind='case_property',
+                action_path='case_property',
                 prop='p',
-                path='/data/question2',
+                question_path='/data/question2',
                 update_mode='always',
                 case_tag='tag_a',
             ),
             CaseUpdateMapping(
-                kind='case_property',
+                action_path='case_property',
                 prop='p',
-                path='/data/question2',
+                question_path='/data/question2',
                 update_mode='always',
                 case_tag='tag_b',
             ),
@@ -1113,9 +1113,9 @@ class CollectLockedAdvancedMappingsTests(SimpleTestCase):
         result = collect_locked_advanced_mappings(actions, {'/data/locked'})
         assert result == {
             CaseUpdateMapping(
-                kind='preload',
+                action_path='preload',
                 prop='preloaded_prop',
-                path='/data/locked',
+                question_path='/data/locked',
                 update_mode=None,
                 case_tag='load_patient',
             )
@@ -1144,16 +1144,16 @@ class CollectLockedAdvancedMappingsTests(SimpleTestCase):
         )
         assert result == {
             CaseUpdateMapping(
-                kind='name',
+                action_path='name',
                 prop='name',
-                path='/data/locked_name',
+                question_path='/data/locked_name',
                 update_mode='always',
                 case_tag='open_patient',
             ),
             CaseUpdateMapping(
-                kind='case_property',
+                action_path='case_property',
                 prop='p',
-                path='/data/locked_prop',
+                question_path='/data/locked_prop',
                 update_mode='always',
                 case_tag='open_patient',
             ),

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -6,6 +6,7 @@ from django.test import SimpleTestCase
 from ..form_action_diff import (
     CaseUpdateMapping,
     _convert_update_to_delete_plus_add,
+    collect_locked_advanced_mappings,
     collect_locked_mappings,
     from_combined_diff,
     get_case_mappings,
@@ -15,8 +16,11 @@ from ..form_action_diff import (
     _drop_multi_updates,
 )
 from ..models import (
+    AdvancedFormActions,
+    AdvancedOpenCaseAction,
     ConditionalCaseUpdate,
     FormActions,
+    LoadUpdateAction,
     OpenCaseAction,
     OpenSubCaseAction,
     PreloadAction,
@@ -937,6 +941,96 @@ class CollectLockedMappingsTests(SimpleTestCase):
         }))
         result, = collect_locked_mappings(actions, {'/data/locked'})
         assert result.update_mode == 'edit'
+
+
+def _load_update_action(case_tag, properties, *, case_type='patient'):
+    return LoadUpdateAction(
+        case_type=case_type,
+        case_tag=case_tag,
+        case_properties={
+            prop: ConditionalCaseUpdate(question_path=path)
+            for prop, path in properties.items()
+        },
+    )
+
+
+class CollectLockedAdvancedMappingsTests(SimpleTestCase):
+
+    def test_no_locked_paths_returns_empty(self):
+        actions = AdvancedFormActions(load_update_cases=[
+            _load_update_action('load_patient', {'p': '/data/question1'}),
+        ])
+        assert collect_locked_advanced_mappings(actions, set()) == set()
+
+    def test_load_update_mapping_against_locked_path_is_collected(self):
+        actions = AdvancedFormActions(load_update_cases=[
+            _load_update_action('load_patient', {
+                'safe_prop': '/data/question1',
+                'locked_prop': '/data/question2',
+            }),
+        ])
+        result = collect_locked_advanced_mappings(actions, {'/data/question2'})
+        assert result == {CaseUpdateMapping(
+            kind='case_property',
+            prop='locked_prop',
+            path='/data/question2',
+            update_mode='always',
+            case_tag='load_patient',
+        )}
+
+    def test_indexes_by_case_tag(self):
+        # Two actions with the same case_type but different case_tags should
+        # be tracked independently.
+        actions = AdvancedFormActions(load_update_cases=[
+            _load_update_action('tag_a', {'p': '/data/question2'}),
+            _load_update_action('tag_b', {'p': '/data/question2'}),
+        ])
+        result = collect_locked_advanced_mappings(actions, {'/data/question2'})
+        assert result == {
+            CaseUpdateMapping(
+                kind='case_property', prop='p', path='/data/question2',
+                update_mode='always', case_tag='tag_a',
+            ),
+            CaseUpdateMapping(
+                kind='case_property', prop='p', path='/data/question2',
+                update_mode='always', case_tag='tag_b',
+            ),
+        }
+
+    def test_load_update_preload_against_locked_path_is_collected(self):
+        actions = AdvancedFormActions(load_update_cases=[LoadUpdateAction(
+            case_type='patient',
+            case_tag='load_patient',
+            preload={'/data/locked': 'preloaded_prop'},
+        )])
+        result = collect_locked_advanced_mappings(actions, {'/data/locked'})
+        assert result == {CaseUpdateMapping(
+            kind='preload', prop='preloaded_prop', path='/data/locked',
+            update_mode=None, case_tag='load_patient',
+        )}
+
+    def test_open_case_mappings_against_locked_path_are_collected(self):
+        actions = AdvancedFormActions(open_cases=[AdvancedOpenCaseAction(
+            case_type='patient',
+            case_tag='open_patient',
+            name_update=ConditionalCaseUpdate(question_path='/data/locked_name'),
+            case_properties={
+                'p': ConditionalCaseUpdate(question_path='/data/locked_prop'),
+            },
+        )])
+        result = collect_locked_advanced_mappings(
+            actions, {'/data/locked_name', '/data/locked_prop'},
+        )
+        assert result == {
+            CaseUpdateMapping(
+                kind='name', prop='name', path='/data/locked_name',
+                update_mode='always', case_tag='open_patient',
+            ),
+            CaseUpdateMapping(
+                kind='case_property', prop='p', path='/data/locked_prop',
+                update_mode='always', case_tag='open_patient',
+            ),
+        }
 
 
 class TestMultiTools(SimpleTestCase):

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -810,94 +810,166 @@ class CombinedDiffTests(SimpleTestCase):
 
 
 class CollectLockedMappingsTests(SimpleTestCase):
-
     def test_no_locked_paths_returns_empty(self):
-        actions = FormActions(update_case=UpdateCaseAction(update={
-            'name': ConditionalCaseUpdate(question_path='/data/question1'),
-        }))
+        actions = FormActions(
+            update_case=UpdateCaseAction(
+                update={
+                    'name': ConditionalCaseUpdate(
+                        question_path='/data/question1'
+                    ),
+                }
+            )
+        )
         assert collect_locked_mappings(actions, set()) == set()
 
     def test_update_case_mapping_against_locked_path_is_collected(self):
-        actions = FormActions(update_case=UpdateCaseAction(update={
-            'name': ConditionalCaseUpdate(question_path='/data/question1'),
-            'locked_prop': ConditionalCaseUpdate(question_path='/data/question2'),
-        }))
+        actions = FormActions(
+            update_case=UpdateCaseAction(
+                update={
+                    'name': ConditionalCaseUpdate(
+                        question_path='/data/question1'
+                    ),
+                    'locked_prop': ConditionalCaseUpdate(
+                        question_path='/data/question2'
+                    ),
+                }
+            )
+        )
         result = collect_locked_mappings(actions, {'/data/question2'})
-        assert result == {CaseUpdateMapping(
-            kind='update',
-            prop='locked_prop',
-            path='/data/question2',
-            update_mode='always',
-        )}
+        assert result == {
+            CaseUpdateMapping(
+                kind='update',
+                prop='locked_prop',
+                path='/data/question2',
+                update_mode='always',
+            )
+        }
 
     def test_update_case_conflict_against_locked_path_is_collected(self):
-        actions = FormActions(update_case=UpdateCaseAction(
-            update={'p': ConditionalCaseUpdate(question_path='/data/safe')},
-            conflicts={'p': [ConditionalCaseUpdate(question_path='/data/locked')]},
-        ))
+        actions = FormActions(
+            update_case=UpdateCaseAction(
+                update={
+                    'p': ConditionalCaseUpdate(question_path='/data/safe')
+                },
+                conflicts={
+                    'p': [ConditionalCaseUpdate(question_path='/data/locked')]
+                },
+            )
+        )
         result = collect_locked_mappings(actions, {'/data/locked'})
-        assert result == {CaseUpdateMapping(
-            kind='update', prop='p', path='/data/locked', update_mode='always',
-        )}
+        assert result == {
+            CaseUpdateMapping(
+                kind='update',
+                prop='p',
+                path='/data/locked',
+                update_mode='always',
+            )
+        }
 
     def test_open_case_name_update_against_locked_path_is_collected(self):
-        actions = FormActions(open_case=OpenCaseAction(
-            name_update=ConditionalCaseUpdate(question_path='/data/locked'),
-        ))
+        actions = FormActions(
+            open_case=OpenCaseAction(
+                name_update=ConditionalCaseUpdate(
+                    question_path='/data/locked'
+                ),
+            )
+        )
         result = collect_locked_mappings(actions, {'/data/locked'})
-        assert result == {CaseUpdateMapping(
-            kind='open.name', prop='name', path='/data/locked', update_mode='always',
-        )}
+        assert result == {
+            CaseUpdateMapping(
+                kind='open.name',
+                prop='name',
+                path='/data/locked',
+                update_mode='always',
+            )
+        }
 
     def test_usercase_update_against_locked_path_is_collected(self):
-        actions = FormActions(usercase_update=UpdateCaseAction(update={
-            'p': ConditionalCaseUpdate(question_path='/data/locked'),
-        }))
+        actions = FormActions(
+            usercase_update=UpdateCaseAction(
+                update={
+                    'p': ConditionalCaseUpdate(question_path='/data/locked'),
+                }
+            )
+        )
         result = collect_locked_mappings(actions, {'/data/locked'})
-        assert result == {CaseUpdateMapping(
-            kind='usercase_update', prop='p', path='/data/locked',
-            update_mode='always',
-        )}
+        assert result == {
+            CaseUpdateMapping(
+                kind='usercase_update',
+                prop='p',
+                path='/data/locked',
+                update_mode='always',
+            )
+        }
 
     def test_case_preload_against_locked_path_is_collected(self):
-        actions = FormActions(case_preload=PreloadAction(preload={
-            '/data/locked': 'preloaded_prop',
-            '/data/safe': 'other_prop',
-        }))
+        actions = FormActions(
+            case_preload=PreloadAction(
+                preload={
+                    '/data/locked': 'preloaded_prop',
+                    '/data/safe': 'other_prop',
+                }
+            )
+        )
         result = collect_locked_mappings(actions, {'/data/locked'})
-        assert result == {CaseUpdateMapping(
-            kind='case_preload', prop='preloaded_prop', path='/data/locked',
-            update_mode=None,
-        )}
+        assert result == {
+            CaseUpdateMapping(
+                kind='case_preload',
+                prop='preloaded_prop',
+                path='/data/locked',
+                update_mode=None,
+            )
+        }
 
     def test_usercase_preload_against_locked_path_is_collected(self):
-        actions = FormActions(usercase_preload=PreloadAction(preload={
-            '/data/locked': 'preloaded_prop',
-        }))
+        actions = FormActions(
+            usercase_preload=PreloadAction(
+                preload={
+                    '/data/locked': 'preloaded_prop',
+                }
+            )
+        )
         result = collect_locked_mappings(actions, {'/data/locked'})
-        assert result == {CaseUpdateMapping(
-            kind='usercase_preload', prop='preloaded_prop', path='/data/locked',
-            update_mode=None,
-        )}
+        assert result == {
+            CaseUpdateMapping(
+                kind='usercase_preload',
+                prop='preloaded_prop',
+                path='/data/locked',
+                update_mode=None,
+            )
+        }
 
     def test_subcase_mappings_against_locked_path_are_collected(self):
-        actions = FormActions(subcases=[OpenSubCaseAction(
-            case_type='child',
-            name_update=ConditionalCaseUpdate(question_path='/data/locked_name'),
-            case_properties={
-                'p': ConditionalCaseUpdate(question_path='/data/locked_prop'),
-            },
-        )])
+        actions = FormActions(
+            subcases=[
+                OpenSubCaseAction(
+                    case_type='child',
+                    name_update=ConditionalCaseUpdate(
+                        question_path='/data/locked_name'
+                    ),
+                    case_properties={
+                        'p': ConditionalCaseUpdate(
+                            question_path='/data/locked_prop'
+                        ),
+                    },
+                )
+            ]
+        )
         result = collect_locked_mappings(
-            actions, {'/data/locked_name', '/data/locked_prop'},
+            actions,
+            {'/data/locked_name', '/data/locked_prop'},
         )
         assert result == {
             CaseUpdateMapping(
-                kind='subcase[0]:child', prop='name', path='/data/locked_name',
+                kind='subcase[0]:child',
+                prop='name',
+                path='/data/locked_name',
                 update_mode='always',
             ),
             CaseUpdateMapping(
-                kind='subcase[0]:child', prop='p', path='/data/locked_prop',
+                kind='subcase[0]:child',
+                prop='p',
+                path='/data/locked_prop',
                 update_mode='always',
             ),
         }
@@ -905,28 +977,38 @@ class CollectLockedMappingsTests(SimpleTestCase):
     def test_subcases_with_same_case_type_are_tracked_independently(self):
         # OpenSubCaseAction permits multiple subcases of the same case_type.
         # Position is part of the kind so neither collapses into the other.
-        actions = FormActions(subcases=[
-            OpenSubCaseAction(
-                case_type='child',
-                case_properties={
-                    'p': ConditionalCaseUpdate(question_path='/data/locked'),
-                },
-            ),
-            OpenSubCaseAction(
-                case_type='child',
-                case_properties={
-                    'p': ConditionalCaseUpdate(question_path='/data/locked'),
-                },
-            ),
-        ])
+        actions = FormActions(
+            subcases=[
+                OpenSubCaseAction(
+                    case_type='child',
+                    case_properties={
+                        'p': ConditionalCaseUpdate(
+                            question_path='/data/locked'
+                        ),
+                    },
+                ),
+                OpenSubCaseAction(
+                    case_type='child',
+                    case_properties={
+                        'p': ConditionalCaseUpdate(
+                            question_path='/data/locked'
+                        ),
+                    },
+                ),
+            ]
+        )
         result = collect_locked_mappings(actions, {'/data/locked'})
         assert result == {
             CaseUpdateMapping(
-                kind='subcase[0]:child', prop='p', path='/data/locked',
+                kind='subcase[0]:child',
+                prop='p',
+                path='/data/locked',
                 update_mode='always',
             ),
             CaseUpdateMapping(
-                kind='subcase[1]:child', prop='p', path='/data/locked',
+                kind='subcase[1]:child',
+                prop='p',
+                path='/data/locked',
                 update_mode='always',
             ),
         }
@@ -934,12 +1016,17 @@ class CollectLockedMappingsTests(SimpleTestCase):
     def test_update_mode_is_part_of_mapping_identity(self):
         # update_mode is captured so that flipping "Save Only If Edited"
         # via a malicious POST shows up as a change.
-        actions = FormActions(update_case=UpdateCaseAction(update={
-            'p': ConditionalCaseUpdate(
-                question_path='/data/locked', update_mode='edit',
-            ),
-        }))
-        result, = collect_locked_mappings(actions, {'/data/locked'})
+        actions = FormActions(
+            update_case=UpdateCaseAction(
+                update={
+                    'p': ConditionalCaseUpdate(
+                        question_path='/data/locked',
+                        update_mode='edit',
+                    ),
+                }
+            )
+        )
+        (result,) = collect_locked_mappings(actions, {'/data/locked'})
         assert result.update_mode == 'edit'
 
 
@@ -955,80 +1042,120 @@ def _load_update_action(case_tag, properties, *, case_type='patient'):
 
 
 class CollectLockedAdvancedMappingsTests(SimpleTestCase):
-
     def test_no_locked_paths_returns_empty(self):
-        actions = AdvancedFormActions(load_update_cases=[
-            _load_update_action('load_patient', {'p': '/data/question1'}),
-        ])
+        actions = AdvancedFormActions(
+            load_update_cases=[
+                _load_update_action('load_patient', {'p': '/data/question1'}),
+            ]
+        )
         assert collect_locked_advanced_mappings(actions, set()) == set()
 
     def test_load_update_mapping_against_locked_path_is_collected(self):
-        actions = AdvancedFormActions(load_update_cases=[
-            _load_update_action('load_patient', {
-                'safe_prop': '/data/question1',
-                'locked_prop': '/data/question2',
-            }),
-        ])
+        actions = AdvancedFormActions(
+            load_update_cases=[
+                _load_update_action(
+                    'load_patient',
+                    {
+                        'safe_prop': '/data/question1',
+                        'locked_prop': '/data/question2',
+                    },
+                ),
+            ]
+        )
         result = collect_locked_advanced_mappings(actions, {'/data/question2'})
-        assert result == {CaseUpdateMapping(
-            kind='case_property',
-            prop='locked_prop',
-            path='/data/question2',
-            update_mode='always',
-            case_tag='load_patient',
-        )}
+        assert result == {
+            CaseUpdateMapping(
+                kind='case_property',
+                prop='locked_prop',
+                path='/data/question2',
+                update_mode='always',
+                case_tag='load_patient',
+            )
+        }
 
     def test_indexes_by_case_tag(self):
         # Two actions with the same case_type but different case_tags should
         # be tracked independently.
-        actions = AdvancedFormActions(load_update_cases=[
-            _load_update_action('tag_a', {'p': '/data/question2'}),
-            _load_update_action('tag_b', {'p': '/data/question2'}),
-        ])
+        actions = AdvancedFormActions(
+            load_update_cases=[
+                _load_update_action('tag_a', {'p': '/data/question2'}),
+                _load_update_action('tag_b', {'p': '/data/question2'}),
+            ]
+        )
         result = collect_locked_advanced_mappings(actions, {'/data/question2'})
         assert result == {
             CaseUpdateMapping(
-                kind='case_property', prop='p', path='/data/question2',
-                update_mode='always', case_tag='tag_a',
+                kind='case_property',
+                prop='p',
+                path='/data/question2',
+                update_mode='always',
+                case_tag='tag_a',
             ),
             CaseUpdateMapping(
-                kind='case_property', prop='p', path='/data/question2',
-                update_mode='always', case_tag='tag_b',
+                kind='case_property',
+                prop='p',
+                path='/data/question2',
+                update_mode='always',
+                case_tag='tag_b',
             ),
         }
 
     def test_load_update_preload_against_locked_path_is_collected(self):
-        actions = AdvancedFormActions(load_update_cases=[LoadUpdateAction(
-            case_type='patient',
-            case_tag='load_patient',
-            preload={'/data/locked': 'preloaded_prop'},
-        )])
+        actions = AdvancedFormActions(
+            load_update_cases=[
+                LoadUpdateAction(
+                    case_type='patient',
+                    case_tag='load_patient',
+                    preload={'/data/locked': 'preloaded_prop'},
+                )
+            ]
+        )
         result = collect_locked_advanced_mappings(actions, {'/data/locked'})
-        assert result == {CaseUpdateMapping(
-            kind='preload', prop='preloaded_prop', path='/data/locked',
-            update_mode=None, case_tag='load_patient',
-        )}
+        assert result == {
+            CaseUpdateMapping(
+                kind='preload',
+                prop='preloaded_prop',
+                path='/data/locked',
+                update_mode=None,
+                case_tag='load_patient',
+            )
+        }
 
     def test_open_case_mappings_against_locked_path_are_collected(self):
-        actions = AdvancedFormActions(open_cases=[AdvancedOpenCaseAction(
-            case_type='patient',
-            case_tag='open_patient',
-            name_update=ConditionalCaseUpdate(question_path='/data/locked_name'),
-            case_properties={
-                'p': ConditionalCaseUpdate(question_path='/data/locked_prop'),
-            },
-        )])
+        actions = AdvancedFormActions(
+            open_cases=[
+                AdvancedOpenCaseAction(
+                    case_type='patient',
+                    case_tag='open_patient',
+                    name_update=ConditionalCaseUpdate(
+                        question_path='/data/locked_name'
+                    ),
+                    case_properties={
+                        'p': ConditionalCaseUpdate(
+                            question_path='/data/locked_prop'
+                        ),
+                    },
+                )
+            ]
+        )
         result = collect_locked_advanced_mappings(
-            actions, {'/data/locked_name', '/data/locked_prop'},
+            actions,
+            {'/data/locked_name', '/data/locked_prop'},
         )
         assert result == {
             CaseUpdateMapping(
-                kind='name', prop='name', path='/data/locked_name',
-                update_mode='always', case_tag='open_patient',
+                kind='name',
+                prop='name',
+                path='/data/locked_name',
+                update_mode='always',
+                case_tag='open_patient',
             ),
             CaseUpdateMapping(
-                kind='case_property', prop='p', path='/data/locked_prop',
-                update_mode='always', case_tag='open_patient',
+                kind='case_property',
+                prop='p',
+                path='/data/locked_prop',
+                update_mode='always',
+                case_tag='open_patient',
             ),
         }
 

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -4,7 +4,9 @@ import pytest
 from django.test import SimpleTestCase
 
 from ..form_action_diff import (
+    CaseUpdateMapping,
     _convert_update_to_delete_plus_add,
+    collect_locked_mappings,
     from_combined_diff,
     get_case_mappings,
     merge_case_mappings,
@@ -13,7 +15,12 @@ from ..form_action_diff import (
     _drop_multi_updates,
 )
 from ..models import (
-    FormActions, UpdateCaseAction, OpenCaseAction
+    ConditionalCaseUpdate,
+    FormActions,
+    OpenCaseAction,
+    OpenSubCaseAction,
+    PreloadAction,
+    UpdateCaseAction,
 )
 from ..views.forms import _case_mapping_diff_has_changes
 
@@ -796,6 +803,140 @@ class CombinedDiffTests(SimpleTestCase):
             'delete': {'other': [{'question_path': '/data/six'}]},
         }
         assert combined_diff == snapshot, 'combined_diff should not be mutated'
+
+
+class CollectLockedMappingsTests(SimpleTestCase):
+
+    def test_no_locked_paths_returns_empty(self):
+        actions = FormActions(update_case=UpdateCaseAction(update={
+            'name': ConditionalCaseUpdate(question_path='/data/question1'),
+        }))
+        assert collect_locked_mappings(actions, set()) == set()
+
+    def test_update_case_mapping_against_locked_path_is_collected(self):
+        actions = FormActions(update_case=UpdateCaseAction(update={
+            'name': ConditionalCaseUpdate(question_path='/data/question1'),
+            'locked_prop': ConditionalCaseUpdate(question_path='/data/question2'),
+        }))
+        result = collect_locked_mappings(actions, {'/data/question2'})
+        assert result == {CaseUpdateMapping(
+            kind='update',
+            prop='locked_prop',
+            path='/data/question2',
+            update_mode='always',
+        )}
+
+    def test_update_case_conflict_against_locked_path_is_collected(self):
+        actions = FormActions(update_case=UpdateCaseAction(
+            update={'p': ConditionalCaseUpdate(question_path='/data/safe')},
+            conflicts={'p': [ConditionalCaseUpdate(question_path='/data/locked')]},
+        ))
+        result = collect_locked_mappings(actions, {'/data/locked'})
+        assert result == {CaseUpdateMapping(
+            kind='update', prop='p', path='/data/locked', update_mode='always',
+        )}
+
+    def test_open_case_name_update_against_locked_path_is_collected(self):
+        actions = FormActions(open_case=OpenCaseAction(
+            name_update=ConditionalCaseUpdate(question_path='/data/locked'),
+        ))
+        result = collect_locked_mappings(actions, {'/data/locked'})
+        assert result == {CaseUpdateMapping(
+            kind='open.name', prop='name', path='/data/locked', update_mode='always',
+        )}
+
+    def test_usercase_update_against_locked_path_is_collected(self):
+        actions = FormActions(usercase_update=UpdateCaseAction(update={
+            'p': ConditionalCaseUpdate(question_path='/data/locked'),
+        }))
+        result = collect_locked_mappings(actions, {'/data/locked'})
+        assert result == {CaseUpdateMapping(
+            kind='usercase_update', prop='p', path='/data/locked',
+            update_mode='always',
+        )}
+
+    def test_case_preload_against_locked_path_is_collected(self):
+        actions = FormActions(case_preload=PreloadAction(preload={
+            '/data/locked': 'preloaded_prop',
+            '/data/safe': 'other_prop',
+        }))
+        result = collect_locked_mappings(actions, {'/data/locked'})
+        assert result == {CaseUpdateMapping(
+            kind='case_preload', prop='preloaded_prop', path='/data/locked',
+            update_mode=None,
+        )}
+
+    def test_usercase_preload_against_locked_path_is_collected(self):
+        actions = FormActions(usercase_preload=PreloadAction(preload={
+            '/data/locked': 'preloaded_prop',
+        }))
+        result = collect_locked_mappings(actions, {'/data/locked'})
+        assert result == {CaseUpdateMapping(
+            kind='usercase_preload', prop='preloaded_prop', path='/data/locked',
+            update_mode=None,
+        )}
+
+    def test_subcase_mappings_against_locked_path_are_collected(self):
+        actions = FormActions(subcases=[OpenSubCaseAction(
+            case_type='child',
+            name_update=ConditionalCaseUpdate(question_path='/data/locked_name'),
+            case_properties={
+                'p': ConditionalCaseUpdate(question_path='/data/locked_prop'),
+            },
+        )])
+        result = collect_locked_mappings(
+            actions, {'/data/locked_name', '/data/locked_prop'},
+        )
+        assert result == {
+            CaseUpdateMapping(
+                kind='subcase[0]:child', prop='name', path='/data/locked_name',
+                update_mode='always',
+            ),
+            CaseUpdateMapping(
+                kind='subcase[0]:child', prop='p', path='/data/locked_prop',
+                update_mode='always',
+            ),
+        }
+
+    def test_subcases_with_same_case_type_are_tracked_independently(self):
+        # OpenSubCaseAction permits multiple subcases of the same case_type.
+        # Position is part of the kind so neither collapses into the other.
+        actions = FormActions(subcases=[
+            OpenSubCaseAction(
+                case_type='child',
+                case_properties={
+                    'p': ConditionalCaseUpdate(question_path='/data/locked'),
+                },
+            ),
+            OpenSubCaseAction(
+                case_type='child',
+                case_properties={
+                    'p': ConditionalCaseUpdate(question_path='/data/locked'),
+                },
+            ),
+        ])
+        result = collect_locked_mappings(actions, {'/data/locked'})
+        assert result == {
+            CaseUpdateMapping(
+                kind='subcase[0]:child', prop='p', path='/data/locked',
+                update_mode='always',
+            ),
+            CaseUpdateMapping(
+                kind='subcase[1]:child', prop='p', path='/data/locked',
+                update_mode='always',
+            ),
+        }
+
+    def test_update_mode_is_part_of_mapping_identity(self):
+        # update_mode is captured so that flipping "Save Only If Edited"
+        # via a malicious POST shows up as a change.
+        actions = FormActions(update_case=UpdateCaseAction(update={
+            'p': ConditionalCaseUpdate(
+                question_path='/data/locked', update_mode='edit',
+            ),
+        }))
+        result, = collect_locked_mappings(actions, {'/data/locked'})
+        assert result.update_mode == 'edit'
 
 
 class TestMultiTools(SimpleTestCase):

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -237,6 +237,14 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
         form = self.app.get_form(self.form_with_repeats_unique_id)
         assert not form.wrapped_xform().has_locked_questions
 
+    def test_locked_question_paths(self):
+        form = self.app.get_form(self.form_unique_id)
+        assert form.wrapped_xform().locked_question_paths == {'/data/question2'}
+
+    def test_locked_question_paths_empty_when_none_locked(self):
+        form = self.app.get_form(self.form_with_repeats_unique_id)
+        assert form.wrapped_xform().locked_question_paths == set()
+
     def test_get_questions_with_locked_status(self):
         form = self.app.get_form(self.form_unique_id)
         questions = form.wrapped_xform().get_questions(['en'], include_locked_status=True)

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -19,7 +19,7 @@ from django.http import (
     JsonResponse,
 )
 from django.urls import reverse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, gettext_lazy
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
@@ -52,11 +52,14 @@ from corehq.apps.app_manager.decorators import (
 from corehq.apps.app_manager.exceptions import (
     AppInDifferentDomainException,
     AppMisconfigurationError,
+    FormActionsChangeError,
     FormNotFoundException,
     ModuleNotFoundException,
     XFormValidationFailed,
 )
 from corehq.apps.app_manager.form_action_diff import (
+    collect_locked_advanced_mappings,
+    collect_locked_mappings,
     from_combined_diff,
     get_case_mappings,
     make_multi,
@@ -130,6 +133,12 @@ from corehq.project_limits.const import (
 )
 from corehq.project_limits.models import SystemLimit
 from corehq.util.view_utils import set_file_download
+
+
+_LOCKED_QUESTION_MAPPING_ERROR = gettext_lazy(
+    "Case property mappings that reference locked questions cannot be "
+    "modified. Unlock the question in the form builder first."
+)
 
 
 @no_conflict_require_POST
@@ -213,10 +222,11 @@ def edit_advanced_form_actions(request, domain, app_id, form_unique_id):
     form = app.get_form(form_unique_id)
     json_loads = json.loads(request.POST.get('actions'))
     actions = AdvancedFormActions.wrap(json_loads)
-    if form.form_type == "shadow_form":
-        form.extra_actions = actions
-    else:
-        form.actions = actions
+
+    try:
+        _apply_advanced_form_actions_change(request, domain, form, actions)
+    except FormActionsChangeError:
+        return HttpResponseForbidden(_LOCKED_QUESTION_MAPPING_ERROR)
 
     datums_json = json.loads(request.POST.get('arbitrary_datums'))
     datums = [ArbitraryDatum.wrap(item) for item in datums_json]
@@ -236,6 +246,7 @@ def edit_form_actions(request, domain, app_id, form_unique_id):
     old_load_from_form = form.actions.load_from_form
 
     actions_json = json.loads(request.POST['actions'])
+
     if 'case_mapping_diff' in request.POST:
         diff = json.loads(request.POST['case_mapping_diff'])
     elif 'update_diff' in request.POST:
@@ -244,7 +255,11 @@ def edit_form_actions(request, domain, app_id, form_unique_id):
         diff = json.loads(request.POST['update_diff'])
     else:
         diff = {}
-    update_form_actions(form.actions, actions_json, diff)
+
+    try:
+        _apply_form_actions_change(request, domain, form, actions_json, diff)
+    except FormActionsChangeError:
+        return HttpResponseForbidden(_LOCKED_QUESTION_MAPPING_ERROR)
 
     if old_load_from_form:
         form.actions.load_from_form = old_load_from_form
@@ -266,6 +281,52 @@ def edit_form_actions(request, domain, app_id, form_unique_id):
     response_json['propertiesMap'] = get_all_case_properties(app)
     response_json['usercasePropertiesMap'] = get_usercase_properties(app)
     return json_response(response_json)
+
+
+def _apply_advanced_form_actions_change(request, domain, form, new_actions):
+    """Assign ``new_actions`` to ``form.actions`` (or ``form.extra_actions``
+    for shadow forms).
+
+    :raises FormActionsChangeError: if the change would add, remove, or
+        repoint a case-property mapping bound to a locked question.
+    """
+    locked_paths = _locked_paths_to_protect(request, domain, form)
+    current = form.extra_actions if form.form_type == 'shadow_form' else form.actions
+    if (
+        collect_locked_advanced_mappings(current, locked_paths)
+        != collect_locked_advanced_mappings(new_actions, locked_paths)
+    ):
+        raise FormActionsChangeError
+
+    if form.form_type == "shadow_form":
+        form.extra_actions = new_actions
+    else:
+        form.actions = new_actions
+
+
+def _apply_form_actions_change(request, domain, form, actions_json, diff):
+    """Apply ``actions_json`` and ``diff`` to ``form.actions``.
+
+    :raises FormActionsChangeError: if the change would add, remove, or
+        repoint a case-property mapping bound to a locked question.
+    """
+    locked_paths = _locked_paths_to_protect(request, domain, form)
+    before = collect_locked_mappings(form.actions, locked_paths)
+    update_form_actions(form.actions, actions_json, diff)
+    if collect_locked_mappings(form.actions, locked_paths) != before:
+        raise FormActionsChangeError
+
+
+def _locked_paths_to_protect(request, domain, form):
+    """Set of locked question paths whose case-property mappings must be
+    preserved on this request, or empty set if the feature is off.
+    """
+    if not (
+        domain_has_privilege(domain, "locked_admin_questions")
+        and toggles.LOCKED_ADMIN_QUESTIONS.enabled_for_request(request)
+    ):
+        return set()
+    return form.wrapped_xform().locked_question_paths
 
 
 @waf_allow('XSS_BODY')

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -712,6 +712,21 @@ class XForm(WrappedNode):
         return any(bind.attrib.get('{v}lock') == 'all' for bind in binds)
 
     @property
+    def locked_question_paths(self):
+        """Set of ``nodeset`` paths for binds with ``vellum:lock="all"``."""
+        if not self.exists():
+            return set()
+        try:
+            binds = self.bind_nodes
+        except XFormException:
+            return set()
+        return {
+            bind.attrib['nodeset']
+            for bind in binds
+            if bind.attrib.get('{v}lock') == 'all' and bind.attrib.get('nodeset')
+        }
+
+    @property
     @raise_if_none("Can't find <itext>")
     def itext_node(self):
         # awful, awful hack. It will be many weeks before I can look people in the eye again.


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The form builder UI already prevents users from touching case-property mappings bound to a locked question, so no normal user flow exercises this code path — but the backend currently has nothing stopping a direct POST to the form-actions endpoints from rewiring those mappings. This PR closes that gap so that "locked" actually means locked, regardless of how the request is constructed.

No user-visible change for legit form-builder traffic.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
- Ticket: [SAAS-19686](https://dimagi.atlassian.net/browse/SAAS-19686)
- Builds on the locked-questions case-property mapping work in #37647

Before applying an incoming change, check: _"which case-property mappings currently point at a locked question?"_ and store that on a new `CaseUpdateMapping` `namedtuple`. Apply the change but don't save it yet. Create a `CaseUpdateMapping` with the updated actions pointing at locked questions. If the two are different, reject the save with HTTP 403.

**`CaseUpdateMapping`.** _"this case property is bound to this question, in this part of the form, with this update mode."_ No existing model holds all of that — different pieces live on different objects — so this PR adds a small namedtuple that bundles them together. The before/after comparison is then just a set diff.

**Things the namedtuple intentionally captures, and why:**
- `update_mode` — so flipping "Save Only If Edited" on a locked mapping counts as a change, even when the question path is unchanged.
- Position for subcases — multiple subcases can share a `case_type`, so we identify each by its index in the list. Otherwise they'd collide and we could miss a deletion. The form builder doesn't let users reorder subcases, so this won't false-flag legit saves either.
- `case_tag` for advanced actions — same idea: two advanced actions referencing the same locked question stay distinct.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`LOCKED_ADMIN_QUESTIONS` toggle, gated behind the `locked_admin_questions` privilege. Both must be enabled for the protection to fire; otherwise the new code returns an empty set and the save path is unchanged.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Strictly additive: the check can only reject a save, never silently mutate one. If the before/after locked-binding sets are equal, the existing save path runs unchanged.
- Feature-flagged twice over (privilege + toggle), so zero behavior change for any domain that doesn't have the locked-questions feature enabled.
- 15 unit tests cover every binding location plus the position/case_tag/update_mode identity invariants.
- Tested locally by enabling and changing `disabled` inputs for locked mappings, attempting to save, and seeing the save is rejected and the error message is shown on screen.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
- `CollectLockedMappingsTests` (10 tests) — one per binding location in `FormActions`, plus subcase-position keying, `update_mode` identity, and the no-locked-paths early return.
- `CollectLockedAdvancedMappingsTests` (5 tests) — one per binding location in `AdvancedFormActions`, plus `case_tag` indexing and the no-locked-paths early return.

These would catch: a missing surface in the collector walk, identity collisions on duplicate-case_type subcases, and `update_mode` tampering passing through unchecked.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Locked case-property mappings will be exercised as part of the holistic QA pass for Locked Admin Questions, alongside the UI surfaces.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[SAAS-19686]: https://dimagi.atlassian.net/browse/SAAS-19686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ