### PR TITLE
Backend validation against modifying locked questions in form builder

### DIFF
--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -38,8 +38,8 @@ class RearrangeError(AppEditingError):
     pass
 
 
-class FormActionsChangeError(AppEditingError):
-    """A proposed change to a form's actions cannot be applied."""
+class LockedQuestionError(AppEditingError):
+    """An attempt to modify a locked question in a disallowed way"""
     pass
 
 

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -5,6 +5,7 @@ from django.test.testcases import SimpleTestCase
 
 from corehq.apps.app_manager.models import Application, Module
 from corehq.apps.app_manager.util import generate_xmlns
+from corehq.apps.app_manager.xform import XForm
 from corehq.util.test_utils import TestFileMixin
 
 QUESTIONS = [
@@ -244,6 +245,90 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
     def test_locked_question_paths_empty_when_none_locked(self):
         form = self.app.get_form(self.form_with_repeats_unique_id)
         assert form.wrapped_xform().locked_question_paths == set()
+
+    def test_question_signature_stable_for_unchanged_form(self):
+        form_a = self.app.get_form(self.form_unique_id)
+        form_b = self.app.get_form(self.form_unique_id)
+        sig_a = form_a.wrapped_xform().get_question_signature('/data/question2')
+        sig_b = form_b.wrapped_xform().get_question_signature('/data/question2')
+        assert sig_a == sig_b
+        assert sig_a  # non-empty for an existing question
+
+    def test_question_signature_empty_for_unknown_path(self):
+        form = self.app.get_form(self.form_unique_id)
+        assert form.wrapped_xform().get_question_signature('/data/does_not_exist') == frozenset()
+
+    def test_question_signature_changes_when_bind_changes(self):
+        # Mutate the bind type for /data/question2 and confirm signature differs.
+        form = self.app.get_form(self.form_unique_id)
+        original = form.wrapped_xform().get_question_signature('/data/question2')
+        modified_source = form.source.replace(
+            '<bind nodeset="/data/question2" type="xsd:string" vellum:lock="all" />',
+            '<bind nodeset="/data/question2" type="xsd:int" vellum:lock="all" />',
+        )
+        assert modified_source != form.source  # sanity: replacement happened
+        modified = XForm(modified_source).get_question_signature('/data/question2')
+        assert original != modified
+
+    def test_question_signature_changes_when_label_changes(self):
+        # Modifying the itext entry for /data/question2 should change the signature.
+        form = self.app.get_form(self.form_unique_id)
+        original = form.wrapped_xform().get_question_signature('/data/question2')
+        modified_source = form.source.replace(
+            '<text id="question2-label">',
+            '<text id="question2-label" data-changed="true">',
+        )
+        assert modified_source != form.source
+        modified = XForm(modified_source).get_question_signature('/data/question2')
+        assert original != modified
+
+    def test_question_signature_changes_when_constraint_added(self):
+        # Adding a constraint attribute to the bind should change the signature.
+        form = self.app.get_form(self.form_unique_id)
+        original = form.wrapped_xform().get_question_signature('/data/question2')
+        modified_source = form.source.replace(
+            '<bind nodeset="/data/question2" type="xsd:string" vellum:lock="all" />',
+            '<bind nodeset="/data/question2" type="xsd:string" '
+            'constraint=". &gt; 0" vellum:lock="all" />',
+        )
+        assert modified_source != form.source
+        modified = XForm(modified_source).get_question_signature('/data/question2')
+        assert original != modified
+
+    def test_question_signature_changes_when_hint_text_changes(self):
+        # Hint label refs are pulled in via itext; changing the hint text
+        # should flow through the signature.
+        form = self.app.get_form(self.form_unique_id)
+        original = form.wrapped_xform().get_question_signature('/data/question1')
+        modified_source = form.source.replace(
+            '<text id="question1-hint">',
+            '<text id="question1-hint" data-changed="true">',
+        )
+        assert modified_source != form.source
+        modified = XForm(modified_source).get_question_signature('/data/question1')
+        assert original != modified
+
+    def test_question_signature_changes_when_select_option_value_changes(self):
+        # Item value changes inside a select1 are part of the control subtree.
+        form = self.app.get_form(self.form_unique_id)
+        original = form.wrapped_xform().get_question_signature('/data/question15/question21')
+        modified_source = form.source.replace('<value>item22</value>', '<value>item99</value>')
+        assert modified_source != form.source
+        modified = XForm(modified_source).get_question_signature('/data/question15/question21')
+        assert original != modified
+
+    def test_question_signature_changes_when_data_instance_attr_changes(self):
+        # The data-instance node is part of the signature; the vellum:comment
+        # on /data/question2 lives there.
+        form = self.app.get_form(self.form_unique_id)
+        original = form.wrapped_xform().get_question_signature('/data/question2')
+        modified_source = form.source.replace(
+            '<question2 vellum:comment="This is a comment" />',
+            '<question2 vellum:comment="Edited comment" />',
+        )
+        assert modified_source != form.source
+        modified = XForm(modified_source).get_question_signature('/data/question2')
+        assert original != modified
 
     def test_get_questions_with_locked_status(self):
         form = self.app.get_form(self.form_unique_id)

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -111,6 +111,7 @@ from corehq.apps.app_manager.views.utils import (
 )
 from corehq.apps.app_manager.xform import (
     CaseError,
+    XForm,
     XFormException,
     XFormValidationError,
 )
@@ -140,6 +141,11 @@ from corehq.util.view_utils import set_file_download
 _LOCKED_QUESTION_MAPPING_ERROR = gettext_lazy(
     "Case property mappings that reference locked questions cannot be "
     "modified. Unlock the question in the form builder first."
+)
+
+_LOCKED_QUESTION_CONTENT_ERROR = gettext_lazy(
+    "Locked questions cannot be modified. Unlock the question in the form "
+    "builder first."
 )
 
 
@@ -358,6 +364,30 @@ def _check_case_mapping_diff_does_not_touch_locked(request, domain, form, case_m
         raise LockedQuestionError
 
 
+def _check_locked_questions_unmodified(request, domain, form, new_xml):
+    """Reject a save that changes anything about a locked question.
+
+    For every path that was locked in the old form, the question's signature
+    in the new XForm must be identical.
+
+    Users with ``edit_locked_questions_in_apps`` permission bypass this
+    check entirely; the UI lock is a safeguard against accidents for them,
+    not an authorization boundary.
+
+    :raises LockedQuestionError: if a locked question changed.
+    """
+    if request.couch_user.can_edit_locked_questions_in_apps(domain):
+        return
+    old_locked = _locked_paths_to_protect(request, domain, form)
+    if not old_locked:
+        return
+    old_xform = form.wrapped_xform()
+    new_xform = XForm(new_xml, domain=domain)
+    for path in old_locked:
+        if old_xform.get_question_signature(path) != new_xform.get_question_signature(path):
+            raise LockedQuestionError
+
+
 @waf_allow('XSS_BODY')
 @csrf_exempt
 @api_domain_view
@@ -450,6 +480,10 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
                 if isinstance(xform, str):
                     xform = xform.encode('utf-8')
                 case_mapping_diff = _get_case_mapping_diff(request, form)
+                try:
+                    _check_locked_questions_unmodified(request, domain, form, xform)
+                except LockedQuestionError:
+                    raise Exception(_LOCKED_QUESTION_CONTENT_ERROR)
                 try:
                     _check_case_mapping_diff_does_not_touch_locked(
                         request, domain, form, case_mapping_diff,
@@ -661,6 +695,7 @@ def patch_xform(request, domain, app_id, form_unique_id):
     case_mapping_diff = _get_case_mapping_diff(request, form)
 
     try:
+        _check_locked_questions_unmodified(request, domain, form, new_xml)
         _check_case_mapping_diff_does_not_touch_locked(
             request, domain, form, case_mapping_diff,
         )

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -52,8 +52,8 @@ from corehq.apps.app_manager.decorators import (
 from corehq.apps.app_manager.exceptions import (
     AppInDifferentDomainException,
     AppMisconfigurationError,
-    FormActionsChangeError,
     FormNotFoundException,
+    LockedQuestionError,
     ModuleNotFoundException,
     XFormValidationFailed,
 )
@@ -225,7 +225,7 @@ def edit_advanced_form_actions(request, domain, app_id, form_unique_id):
 
     try:
         _apply_advanced_form_actions_change(request, domain, form, actions)
-    except FormActionsChangeError:
+    except LockedQuestionError:
         return HttpResponseForbidden(_LOCKED_QUESTION_MAPPING_ERROR)
 
     datums_json = json.loads(request.POST.get('arbitrary_datums'))
@@ -258,7 +258,7 @@ def edit_form_actions(request, domain, app_id, form_unique_id):
 
     try:
         _apply_form_actions_change(request, domain, form, actions_json, diff)
-    except FormActionsChangeError:
+    except LockedQuestionError:
         return HttpResponseForbidden(_LOCKED_QUESTION_MAPPING_ERROR)
 
     if old_load_from_form:
@@ -287,7 +287,7 @@ def _apply_advanced_form_actions_change(request, domain, form, new_actions):
     """Assign ``new_actions`` to ``form.actions`` (or ``form.extra_actions``
     for shadow forms).
 
-    :raises FormActionsChangeError: if the change would add, remove, or
+    :raises LockedQuestionError: if the change would add, remove, or
         repoint a case-property mapping bound to a locked question.
     """
     locked_paths = _locked_paths_to_protect(request, domain, form)
@@ -296,7 +296,7 @@ def _apply_advanced_form_actions_change(request, domain, form, new_actions):
         collect_locked_advanced_mappings(current, locked_paths)
         != collect_locked_advanced_mappings(new_actions, locked_paths)
     ):
-        raise FormActionsChangeError
+        raise LockedQuestionError
 
     if form.form_type == "shadow_form":
         form.extra_actions = new_actions
@@ -307,14 +307,14 @@ def _apply_advanced_form_actions_change(request, domain, form, new_actions):
 def _apply_form_actions_change(request, domain, form, actions_json, diff):
     """Apply ``actions_json`` and ``diff`` to ``form.actions``.
 
-    :raises FormActionsChangeError: if the change would add, remove, or
+    :raises LockedQuestionError: if the change would add, remove, or
         repoint a case-property mapping bound to a locked question.
     """
     locked_paths = _locked_paths_to_protect(request, domain, form)
     before = collect_locked_mappings(form.actions, locked_paths)
     update_form_actions(form.actions, actions_json, diff)
     if collect_locked_mappings(form.actions, locked_paths) != before:
-        raise FormActionsChangeError
+        raise LockedQuestionError
 
 
 def _locked_paths_to_protect(request, domain, form):

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -63,6 +63,7 @@ from corehq.apps.app_manager.form_action_diff import (
     from_combined_diff,
     get_case_mappings,
     make_multi,
+    merge_case_mappings,
     update_form_actions,
 )
 from corehq.apps.app_manager.helpers.validators import load_case_reserved_words
@@ -77,6 +78,7 @@ from corehq.apps.app_manager.models import (
     DeleteFormRecord,
     Form,
     FormActionCondition,
+    FormActions,
     FormDatum,
     FormLink,
     IncompatibleFormTypeException,
@@ -329,6 +331,33 @@ def _locked_paths_to_protect(request, domain, form):
     return form.wrapped_xform().locked_question_paths
 
 
+def _check_case_mapping_diff_does_not_touch_locked(request, domain, form, case_mapping_diff):
+    """Reject a save whose ``case_mapping_diff`` would change a case-property
+    mapping bound to a question that is locked.
+
+    Users with ``edit_locked_questions_in_apps`` bypass this check entirely:
+    the UI lock is a safeguard against accidents for them, not an authorization
+    boundary.
+
+    :raises LockedQuestionError: if the diff would change a locked mapping.
+    """
+    if (
+        not case_mapping_diff
+        or request.couch_user.can_edit_locked_questions_in_apps(domain)
+    ):
+        return
+
+    locked_paths = _locked_paths_to_protect(request, domain, form)
+    if not locked_paths:
+        return
+
+    before = collect_locked_mappings(form.actions, locked_paths)
+    actions_copy = FormActions.wrap(form.actions.to_json())
+    merge_case_mappings(case_mapping_diff, actions_copy)
+    if collect_locked_mappings(actions_copy, locked_paths) != before:
+        raise LockedQuestionError
+
+
 @waf_allow('XSS_BODY')
 @csrf_exempt
 @api_domain_view
@@ -421,6 +450,12 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
                 if isinstance(xform, str):
                     xform = xform.encode('utf-8')
                 case_mapping_diff = _get_case_mapping_diff(request, form)
+                try:
+                    _check_case_mapping_diff_does_not_touch_locked(
+                        request, domain, form, case_mapping_diff,
+                    )
+                except LockedQuestionError:
+                    raise Exception(_LOCKED_QUESTION_MAPPING_ERROR)
                 save_xform(app, form, xform, case_mapping_diff)
                 if _case_mapping_diff_has_changes(case_mapping_diff):
                     # form builder is the only client that submits
@@ -622,10 +657,18 @@ def patch_xform(request, domain, app_id, form_unique_id):
         return conflict
 
     xml = apply_patch(patch, form.source)
+    new_xml = xml.encode('utf-8')
     case_mapping_diff = _get_case_mapping_diff(request, form)
 
     try:
-        xml = save_xform(app, form, xml.encode('utf-8'), case_mapping_diff)
+        _check_case_mapping_diff_does_not_touch_locked(
+            request, domain, form, case_mapping_diff,
+        )
+    except LockedQuestionError:
+        return HttpResponseForbidden()
+
+    try:
+        xml = save_xform(app, form, new_xml, case_mapping_diff)
     except XFormException:
         return JsonResponse({'status': 'error'}, status=HttpResponseBadRequest.status_code)
 

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -91,6 +91,19 @@ hashtag_replacements = [
 ]
 
 
+_ITEXT_REF_RE = re.compile(r"""jr:itext\(['"]([^'"]+)['"]\)""")
+
+
+def _itext_refs_in(elem):
+    """Itext IDs referenced from any descendant ``@ref`` of ``elem``."""
+    return {
+        m.group(1)
+        for ref in elem.xpath(".//@ref")
+        for m in [_ITEXT_REF_RE.match(str(ref))]
+        if m is not None
+    }
+
+
 def _make_elem(tag, attr=None):
     attr = attr or {}
     return ET.Element(
@@ -725,6 +738,66 @@ class XForm(WrappedNode):
             for bind in binds
             if bind.attrib.get('{v}lock') == 'all' and bind.attrib.get('nodeset')
         }
+
+    def get_question_signature(self, path):
+        """Canonical, hashable representation of the question at ``path``.
+
+        Includes the bind element, the control element + descendants, the
+        data instance node, and any itext entries referenced from the
+        control's labels/hints/help/items.
+
+        Returns an empty ``set`` if the path isn't present in the form.
+        """
+        if not self.exists():
+            return set()
+
+        parts = set()
+
+        for bind in self.bind_nodes:
+            if bind.attrib.get('nodeset') == path:
+                parts.add(ET.tostring(bind.xml))
+
+        for control in self._controls_for_path(path):
+            parts.add(ET.tostring(control))
+            for itext_id in _itext_refs_in(control):
+                for text_node in self._itext_text_nodes(itext_id):
+                    parts.add(ET.tostring(text_node))
+
+        for data_node in self._data_instance_nodes_for_path(path):
+            parts.add(ET.tostring(data_node))
+
+        return parts
+
+    def _controls_for_path(self, path):
+        """Body elements with ``ref`` or ``nodeset`` matching ``path``."""
+        if self.xml is None:
+            return []
+        return self.xml.xpath(
+            ".//*[@ref=$path or @nodeset=$path]", path=path,
+        )
+
+    def _itext_text_nodes(self, itext_id):
+        """All ``<text id="itext_id">`` elements across translations."""
+        return self.itext_node.xml.xpath(
+            ".//*[local-name()='text' and @id=$id]", id=itext_id,
+        )
+
+    def _data_instance_nodes_for_path(self, path):
+        """Data-instance descendants addressed by ``path`` (e.g. ``/data/q``).
+
+        The data instance lives in the form's own xmlns (registered as
+        ``x`` in :class:`XForm.__init__`); each path step is namespaced.
+        """
+        data = self.data_node
+        steps = [s for s in path.split('/') if s]
+        if not steps or steps[0] != data.tag_name:
+            return []
+        node = data
+        for step in steps[1:]:
+            node = node.find('{x}' + step)
+            if not node.exists():
+                return []
+        return [node.xml]
 
     @property
     @raise_if_none("Can't find <itext>")

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -740,11 +740,12 @@ class XForm(WrappedNode):
         }
 
     def get_question_signature(self, path):
-        """Canonical, hashable representation of the question at ``path``.
+        """Representation of the question at ``path`` for equality comparison.
 
         Includes the bind element, the control element + descendants, the
         data instance node, and any itext entries referenced from the
-        control's labels/hints/help/items.
+        control's labels/hints/help/items. Callers should not rely on the
+        absence or presence of any particular item within this set.
 
         Returns an empty ``set`` if the path isn't present in the form.
         """


### PR DESCRIPTION
## Product Description
No visible changes.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19735

Adds backend enforcement of "locked questions" (questions marked with `vellum:lock="all"`) so that the Vellum form builder's protections cannot be bypassed via crafted POSTs to `patch_xform` or the XForm upload path on `_edit_form_attr`. 

With this PR, for users without `edit_locked_questions_in_apps`:

- Lock removal, content modification, and case-mapping changes against a locked question are rejected.
- Path renames or deletions of locked questions are also caught — they produce a signature mismatch on the old path.

## Feature Flag

`LOCKED_ADMIN_QUESTIONS` (privilege + flag).

## Safety Assurance

### Safety story

Both new checks no-op when the privilege+toggle gate is off; existing behavior is unchanged for domains where the feature is not enabled. They also no-op for users with `edit_locked_questions_in_apps`, who remain authorized to edit locked questions and rely on the UI to keep their actions deliberate.

The case-mapping diff check uses a deep-copy dry-run (`FormActions.wrap(form.actions.to_json())`) so no real state is
mutated even if the dry-run errors. `patch_xform` and `_edit_form_attr` catch `FormActionsChangeError` before any call to `save_xform`, so a rejected save never persists.

HQ XForm-upload 403s carry a hardcoded `gettext_lazy` constant via `messages.error`. No exception text is reflected in any response, avoiding security risk / warnings about stack-trace / exception-information leaks.

Tested locally with a user who does not have locked questions permission, by removing `disabled` attributes from form fields and attempting to make + save changes or a delete a question, and doing the same with Case Management fields in the form builder (which submit case update diffs).

### Automated test coverage

`tests/test_get_questions.py` adds tests for `XForm.get_question_signature`


### QA Plan
No QA is planned for this particular change, but it will be implicitly tested in QA for Locked Admin Questions as a whole.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change