### PR TITLE
Add capabilities and validation for cs endpoints

### DIFF
--- a/corehq/apps/case_search/endpoint_capability.py
+++ b/corehq/apps/case_search/endpoint_capability.py
@@ -1,0 +1,168 @@
+from django.db.models import Prefetch
+
+from corehq.apps.data_dictionary.models import (
+    CaseProperty,
+    CaseType,
+)
+
+FIELD_TYPE_TEXT = 'text'
+FIELD_TYPE_NUMBER = 'number'
+FIELD_TYPE_DATE = 'date'
+FIELD_TYPE_DATETIME = 'datetime'
+FIELD_TYPE_SELECT = 'select'
+FIELD_TYPE_GEOPOINT = 'geopoint'
+
+# DataType -> field type mapping
+_DATA_TYPE_MAP = {
+    CaseProperty.DataType.PLAIN: FIELD_TYPE_TEXT,
+    CaseProperty.DataType.BARCODE: FIELD_TYPE_TEXT,
+    CaseProperty.DataType.PHONE_NUMBER: FIELD_TYPE_TEXT,
+    CaseProperty.DataType.UNDEFINED: FIELD_TYPE_TEXT,
+    CaseProperty.DataType.DATE: FIELD_TYPE_DATE,
+    CaseProperty.DataType.NUMBER: FIELD_TYPE_NUMBER,
+    CaseProperty.DataType.SELECT: FIELD_TYPE_SELECT,
+    CaseProperty.DataType.GPS: FIELD_TYPE_GEOPOINT,
+    # PASSWORD intentionally omitted — returns None
+}
+
+# Field type -> available operations
+_OPERATIONS_BY_TYPE = {
+    FIELD_TYPE_TEXT: [
+        'exact_match', 'not_equals', 'starts_with', 'fuzzy_match',
+        'phonetic_match', 'selected_any', 'selected_all', 'is_empty',
+    ],
+    FIELD_TYPE_NUMBER: [
+        'equals', 'not_equals', 'gt', 'gte', 'lt', 'lte', 'is_empty',
+    ],
+    FIELD_TYPE_DATE: [
+        'equals', 'before', 'after', 'date_range', 'fuzzy_date', 'is_empty',
+    ],
+    FIELD_TYPE_DATETIME: [
+        'equals', 'before', 'after', 'date_range', 'is_empty',
+    ],
+    FIELD_TYPE_SELECT: [
+        'selected_any', 'selected_all', 'exact_match', 'is_empty',
+    ],
+    FIELD_TYPE_GEOPOINT: [
+        'within_distance',
+    ],
+}
+
+COMPONENT_INPUT_SCHEMAS = {
+    'exact_match':    [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+    'not_equals':     [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+    'starts_with':    [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+    'fuzzy_match':    [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+    'phonetic_match': [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+    'selected_any':   [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+    'selected_all':   [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+    'is_empty':       [],
+    'equals':         [{'name': 'value', 'type': 'match_field'}],
+    'gt':             [{'name': 'value', 'type': FIELD_TYPE_NUMBER}],
+    'gte':            [{'name': 'value', 'type': FIELD_TYPE_NUMBER}],
+    'lt':             [{'name': 'value', 'type': FIELD_TYPE_NUMBER}],
+    'lte':            [{'name': 'value', 'type': FIELD_TYPE_NUMBER}],
+    'before':         [{'name': 'value', 'type': 'match_field'}],
+    'after':          [{'name': 'value', 'type': 'match_field'}],
+    'date_range':     [{'name': 'start', 'type': 'match_field'},
+                       {'name': 'end', 'type': 'match_field'}],
+    'fuzzy_date':     [{'name': 'value', 'type': FIELD_TYPE_DATE}],
+    'within_distance': [{'name': 'point', 'type': FIELD_TYPE_GEOPOINT},
+                        {'name': 'distance', 'type': FIELD_TYPE_NUMBER},
+                        {'name': 'unit', 'type': 'choice'}],
+}
+
+_AUTO_VALUES = {
+    FIELD_TYPE_DATE: [
+        {'ref': 'today()', 'label': 'Today'},
+    ],
+    FIELD_TYPE_DATETIME: [
+        {'ref': 'now()', 'label': 'Now'},
+    ],
+    FIELD_TYPE_TEXT: [
+        {'ref': 'user.username', 'label': "Current user's username"},
+        {'ref': 'user.uuid', 'label': "Current user's ID"},
+        {'ref': 'user.location_ids', 'label': "User's location IDs"},
+    ],
+}
+
+
+def get_field_type(data_type):
+    """Map a CaseProperty.DataType to a query builder field type.
+    Returns None for types that should be excluded (e.g. PASSWORD).
+    """
+    return _DATA_TYPE_MAP.get(data_type)
+
+
+def get_operations_for_field_type(field_type):
+    """Return the list of operation names available for a field type."""
+    return list(_OPERATIONS_BY_TYPE.get(field_type, []))
+
+
+def get_capability(domain):
+    """Build the full capability JSON for a domain from the data dictionary.
+
+    :returns: dict with the following structure::
+
+        {
+            'case_types': [
+                {
+                    'name': str,
+                    'fields': [
+                        {
+                            'name': str,
+                            'type': str,
+                            'operations': [str],
+                            'options': [str],      # only present for 'select' fields
+                        },
+                        ...
+                    ],
+                },
+                ...
+            ],
+            'auto_values': {
+                str: [{'ref': str, 'label': str}, ...],  # keyed by FIELD_TYPE_*
+            },
+            'component_input_schemas': {
+                str: [{'name': str, 'type': str}, ...],  # keyed by operation name
+            },
+        }
+    """
+    case_types = CaseType.objects.filter(
+        domain=domain,
+        is_deprecated=False,
+    ).prefetch_related(
+        Prefetch(
+            'properties',
+            queryset=CaseProperty.objects.filter(
+                deprecated=False,
+            ).prefetch_related('allowed_values'),
+            to_attr='active_properties',
+        ),
+    )
+
+    result_case_types = []
+    for ct in case_types:
+        fields = []
+        for prop in ct.active_properties:
+            field_type = get_field_type(prop.data_type)
+            if field_type is None:
+                continue
+            field = {
+                'name': prop.name,
+                'type': field_type,
+                'operations': get_operations_for_field_type(field_type),
+            }
+            if field_type == FIELD_TYPE_SELECT:
+                field['options'] = [av.allowed_value for av in prop.allowed_values.all()]
+            fields.append(field)
+        result_case_types.append({
+            'name': ct.name,
+            'fields': fields,
+        })
+
+    return {
+        'case_types': result_case_types,
+        'auto_values': _AUTO_VALUES,
+        'component_input_schemas': COMPONENT_INPUT_SCHEMAS,
+    }

--- a/corehq/apps/case_search/endpoint_service.py
+++ b/corehq/apps/case_search/endpoint_service.py
@@ -151,6 +151,10 @@ def _validate_component(
     component_name = node.get('component', '')
     inputs = node.get('inputs', {})
 
+    if not isinstance(inputs, dict):
+        errors.append(f"'inputs' must be an object in component '{component_name}'")
+        return
+
     field = fields_by_name.get(field_name)
     if not field:
         errors.append(f"Unknown field: '{field_name}'")
@@ -179,6 +183,9 @@ def _validate_component(
 def _validate_input_value(
     value, slot_name, param_names, auto_value_refs, errors
 ):
+    if not isinstance(value, dict):
+        errors.append(f"Input '{slot_name}' must be an object with a 'type' field")
+        return
     value_type = value.get('type')
     if value_type == 'constant':
         pass  # any value accepted

--- a/corehq/apps/case_search/endpoint_service.py
+++ b/corehq/apps/case_search/endpoint_service.py
@@ -1,6 +1,11 @@
 from django.db import IntegrityError, transaction
 from django.db.models import Max
+from django.http import Http404
 
+from corehq.apps.case_search.endpoint_capability import (
+    COMPONENT_INPUT_SCHEMAS,
+    get_capability,
+)
 from corehq.apps.case_search.models import (
     CaseSearchEndpoint,
     CaseSearchEndpointVersion,
@@ -20,7 +25,8 @@ class EndpointNotFound(Exception):
 @transaction.atomic
 def create_endpoint(domain, name, target_type, target_name, parameters, query):
     """Create a new endpoint with its first version."""
-    errors = []
+    capability = get_capability(domain)
+    errors = validate_filter_spec(query, parameters, target_name, capability)
     if errors:
         raise FilterSpecValidationError(errors)
     try:
@@ -49,7 +55,10 @@ def create_endpoint(domain, name, target_type, target_name, parameters, query):
 @transaction.atomic
 def save_new_version(endpoint, parameters, query):
     """Create a new version for an existing endpoint."""
-    errors = []
+    capability = get_capability(endpoint.domain)
+    errors = validate_filter_spec(
+        query, parameters, endpoint.target_name, capability
+    )
     if errors:
         raise FilterSpecValidationError(errors)
     CaseSearchEndpoint.objects.select_for_update().get(pk=endpoint.pk)
@@ -65,6 +74,127 @@ def save_new_version(endpoint, parameters, query):
     endpoint.current_version = version
     endpoint.save(update_fields=['current_version'])
     return version
+
+
+def validate_filter_spec(spec, parameters, case_type_name, capability):
+    """Validate a filter spec against capability metadata.
+
+    Returns a list of error messages (empty = valid).
+    """
+    errors = []
+    if not all(isinstance(p, dict) and 'name' in p for p in parameters):
+        errors.append("Each parameter must have a 'name' field.")
+        return errors
+    param_names = {p['name'] for p in parameters}
+    auto_value_refs = {
+        auto_value['ref']
+        for avs in capability.get('auto_values', {}).values()
+        for auto_value in avs
+    }
+    case_type = next(
+        (
+            case_type
+            for case_type in capability.get('case_types', [])
+            if case_type['name'] == case_type_name
+        ),
+        None,
+    )
+    fields_by_name = (
+        {field['name']: field for field in case_type['fields']}
+        if case_type
+        else {}
+    )
+
+    _validate_node(spec, fields_by_name, param_names, auto_value_refs, errors)
+    return errors
+
+
+_MAX_QUERY_DEPTH = 3
+
+
+def _validate_node(node, fields_by_name, param_names, auto_value_refs, errors, depth=0):
+    if not isinstance(node, dict):
+        errors.append(f"Invalid node: expected object, got {type(node).__name__}")
+        return
+    if depth > _MAX_QUERY_DEPTH:
+        errors.append(f"Query is nested too deeply (max {_MAX_QUERY_DEPTH} levels)")
+        return
+    node_type = node.get('type')
+
+    if node_type in ('and', 'or'):
+        for child in node.get('children', []):
+            _validate_node(
+                child, fields_by_name, param_names, auto_value_refs, errors, depth + 1
+            )
+    elif node_type == 'not':
+        child = node.get('child')
+        if child:
+            _validate_node(
+                child, fields_by_name, param_names, auto_value_refs, errors, depth + 1
+            )
+        else:
+            errors.append("'not' node must have a 'child'")
+    elif node_type == 'component':
+        _validate_component(
+            node, fields_by_name, param_names, auto_value_refs, errors
+        )
+    else:
+        errors.append(
+            f"Invalid node type: '{node_type}'. Expected 'and', 'or', 'not', or 'component'."
+        )
+
+
+def _validate_component(
+    node, fields_by_name, param_names, auto_value_refs, errors
+):
+    field_name = node.get('field', '')
+    component_name = node.get('component', '')
+    inputs = node.get('inputs', {})
+
+    field = fields_by_name.get(field_name)
+    if not field:
+        errors.append(f"Unknown field: '{field_name}'")
+        return
+
+    if component_name not in field.get('operations', []):
+        errors.append(
+            f"'{component_name}' is not a valid operation for field '{field_name}' "
+            f'(type: {field["type"]})'
+        )
+        return
+
+    schema = COMPONENT_INPUT_SCHEMAS.get(component_name, [])
+    for slot in schema:
+        slot_name = slot['name']
+        if slot_name not in inputs:
+            errors.append(
+                f"Missing required input '{slot_name}' for component '{component_name}'"
+            )
+            continue
+        _validate_input_value(
+            inputs[slot_name], slot_name, param_names, auto_value_refs, errors
+        )
+
+
+def _validate_input_value(
+    value, slot_name, param_names, auto_value_refs, errors
+):
+    value_type = value.get('type')
+    if value_type == 'constant':
+        pass  # any value accepted
+    elif value_type == 'parameter':
+        ref = value.get('ref', '')
+        if ref not in param_names:
+            errors.append(
+                f"Parameter '{ref}' referenced in '{slot_name}' is not defined"
+            )
+    elif value_type == 'auto_value':
+        ref = value.get('ref', '')
+        if ref not in auto_value_refs:
+            errors.append(f"Unknown auto value '{ref}' in '{slot_name}'")
+    else:
+        errors.append(f"Invalid input type '{value_type}' in '{slot_name}'")
+
 
 def list_endpoints(domain):
     """Return active endpoints for a domain."""

--- a/corehq/apps/case_search/tests/test_endpoint_capability.py
+++ b/corehq/apps/case_search/tests/test_endpoint_capability.py
@@ -1,0 +1,142 @@
+from unmagic import fixture, use
+
+from corehq.apps.case_search.endpoint_capability import (
+    COMPONENT_INPUT_SCHEMAS,
+    _AUTO_VALUES,
+    FIELD_TYPE_DATE,
+    FIELD_TYPE_TEXT,
+    get_capability,
+)
+from corehq.apps.data_dictionary.models import (
+    CaseProperty,
+    CasePropertyAllowedValue,
+    CaseType,
+)
+
+
+def test_component_input_schemas_all_values_are_lists():
+    for op, schema in COMPONENT_INPUT_SCHEMAS.items():
+        assert isinstance(schema, list), f"{op}: expected list, got {type(schema)}"
+
+
+def test_component_input_schemas_all_items_have_name_and_type_strings():
+    for op, schema in COMPONENT_INPUT_SCHEMAS.items():
+        for item in schema:
+            assert isinstance(item.get('name'), str), f"{op}: item 'name' must be str"
+            assert isinstance(item.get('type'), str), f"{op}: item 'type' must be str"
+
+
+def test_auto_values_all_values_are_lists():
+    for field_type, values in _AUTO_VALUES.items():
+        assert isinstance(values, list), f"{field_type}: expected list, got {type(values)}"
+
+
+def test_auto_values_all_items_have_ref_and_label_strings():
+    for field_type, values in _AUTO_VALUES.items():
+        for item in values:
+            assert isinstance(item.get('ref'), str), f"{field_type}: item 'ref' must be str"
+            assert isinstance(item.get('label'), str), f"{field_type}: item 'label' must be str"
+
+
+@use('db')
+@fixture
+def patient_case_type():
+    case_type = CaseType.objects.create(domain='test-domain', name='patient')
+    CaseProperty.objects.create(
+        case_type=case_type, name='first_name', data_type=CaseProperty.DataType.PLAIN,
+    )
+    CaseProperty.objects.create(
+        case_type=case_type, name='dob', data_type=CaseProperty.DataType.DATE,
+    )
+    prop_status = CaseProperty.objects.create(
+        case_type=case_type, name='status', data_type=CaseProperty.DataType.SELECT,
+    )
+    CasePropertyAllowedValue.objects.create(case_property=prop_status, allowed_value='active')
+    CasePropertyAllowedValue.objects.create(case_property=prop_status, allowed_value='closed')
+    try:
+        yield case_type
+    finally:
+        case_type.delete()
+
+
+@use(patient_case_type)
+def test_returns_case_types_with_fields():
+    cap = get_capability('test-domain')
+    assert len(cap['case_types']) == 1
+    ct = cap['case_types'][0]
+    assert ct['name'] == 'patient'
+    field_names = [f['name'] for f in ct['fields']]
+    assert 'first_name' in field_names
+    assert 'dob' in field_names
+
+
+@use(patient_case_type)
+def test_field_has_operations():
+    cap = get_capability('test-domain')
+    ct = cap['case_types'][0]
+    name_field = next(f for f in ct['fields'] if f['name'] == 'first_name')
+    assert 'exact_match' in name_field['operations']
+
+
+@use(patient_case_type)
+def test_select_field_has_options():
+    cap = get_capability('test-domain')
+    ct = cap['case_types'][0]
+    status_field = next(f for f in ct['fields'] if f['name'] == 'status')
+    assert set(status_field['options']) == {'active', 'closed'}
+
+
+@use(patient_case_type)
+def test_excludes_deprecated_case_types():
+    deprecated = CaseType.objects.create(domain='test-domain', name='old_type', is_deprecated=True)
+    try:
+        cap = get_capability('test-domain')
+        names = [ct['name'] for ct in cap['case_types']]
+        assert 'old_type' not in names
+    finally:
+        deprecated.delete()
+
+
+@use(patient_case_type)
+def test_excludes_deprecated_properties():
+    case_type = patient_case_type()
+    legacy = CaseProperty.objects.create(
+        case_type=case_type, name='legacy_prop',
+        data_type=CaseProperty.DataType.PLAIN, deprecated=True,
+    )
+    try:
+        cap = get_capability('test-domain')
+        ct = cap['case_types'][0]
+        field_names = [f['name'] for f in ct['fields']]
+        assert 'legacy_prop' not in field_names
+    finally:
+        legacy.delete()
+
+
+@use(patient_case_type)
+def test_excludes_password_fields():
+    case_type = patient_case_type()
+    secret = CaseProperty.objects.create(
+        case_type=case_type, name='secret', data_type=CaseProperty.DataType.PASSWORD,
+    )
+    try:
+        cap = get_capability('test-domain')
+        ct = cap['case_types'][0]
+        field_names = [f['name'] for f in ct['fields']]
+        assert 'secret' not in field_names
+    finally:
+        secret.delete()
+
+
+@use(patient_case_type)
+def test_auto_values_present():
+    cap = get_capability('test-domain')
+    assert FIELD_TYPE_DATE in cap['auto_values']
+    assert FIELD_TYPE_TEXT in cap['auto_values']
+
+
+@use(patient_case_type)
+def test_component_input_schemas_present():
+    cap = get_capability('test-domain')
+    assert 'component_input_schemas' in cap
+    assert 'exact_match' in cap['component_input_schemas']

--- a/corehq/apps/case_search/tests/test_endpoint_service.py
+++ b/corehq/apps/case_search/tests/test_endpoint_service.py
@@ -328,6 +328,30 @@ def test_non_dict_child_node_returns_error():
 
 
 @use(sample_capability)
+def test_non_dict_inputs_returns_error():
+    spec = {
+        'type': 'component',
+        'component': 'exact_match',
+        'field': 'province',
+        'inputs': ['value'],
+    }
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert any('inputs' in e for e in errors)
+
+
+@use(sample_capability)
+def test_non_dict_input_value_returns_error():
+    spec = {
+        'type': 'component',
+        'component': 'exact_match',
+        'field': 'province',
+        'inputs': {'value': 'ON'},
+    }
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert any('value' in e for e in errors)
+
+
+@use(sample_capability)
 def test_deeply_nested_query_returns_error():
     node = {'type': 'and', 'children': []}
     root = node

--- a/corehq/apps/case_search/tests/test_endpoint_service.py
+++ b/corehq/apps/case_search/tests/test_endpoint_service.py
@@ -2,7 +2,14 @@ import pytest
 from unmagic import fixture, use
 
 from corehq.apps.case_search import endpoint_service
+from corehq.apps.case_search.endpoint_service import _MAX_QUERY_DEPTH
 from corehq.apps.case_search.models import CaseSearchEndpoint
+from corehq.apps.case_search.endpoint_capability import (
+    _AUTO_VALUES,
+    FIELD_TYPE_DATE,
+    FIELD_TYPE_TEXT,
+    get_operations_for_field_type,
+)
 
 DOMAIN = 'test-domain'
 EMPTY_QUERY = {'type': 'and', 'children': []}
@@ -120,3 +127,213 @@ def test_deactivate_sets_is_active_false():
     endpoint_service.deactivate_endpoint(ep)
     ep.refresh_from_db()
     assert ep.is_active is False
+
+
+@fixture
+def sample_capability():
+    yield {
+        'case_types': [{
+            'name': 'patient',
+            'fields': [
+                {
+                    'name': 'province',
+                    'type': FIELD_TYPE_TEXT,
+                    'operations': get_operations_for_field_type(FIELD_TYPE_TEXT),
+                },
+                {
+                    'name': 'dob',
+                    'type': FIELD_TYPE_DATE,
+                    'operations': get_operations_for_field_type(FIELD_TYPE_DATE),
+                },
+            ],
+        }],
+        'auto_values': _AUTO_VALUES,
+    }
+
+
+@use(sample_capability)
+def test_valid_simple_spec():
+    spec = {
+        'type': 'and',
+        'children': [{
+            'type': 'component',
+            'component': 'exact_match',
+            'field': 'province',
+            'inputs': {'value': {'type': 'constant', 'value': 'ON'}},
+        }],
+    }
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert errors == []
+
+
+@use(sample_capability)
+def test_valid_date_range_spec():
+    spec = {
+        'type': 'component',
+        'component': 'date_range',
+        'field': 'dob',
+        'inputs': {
+            'start': {'type': 'constant', 'value': '2000-01-01'},
+            'end': {'type': 'auto_value', 'ref': 'today()'},
+        },
+    }
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert errors == []
+
+
+@use(sample_capability)
+def test_invalid_root_type():
+    spec = {'type': 'invalid'}
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert any('type' in e.lower() for e in errors)
+
+
+@use(sample_capability)
+def test_unknown_field():
+    spec = {
+        'type': 'component',
+        'component': 'exact_match',
+        'field': 'nonexistent',
+        'inputs': {'value': {'type': 'constant', 'value': 'x'}},
+    }
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert any('nonexistent' in e for e in errors)
+
+
+@use(sample_capability)
+def test_incompatible_component_for_field():
+    spec = {
+        'type': 'component',
+        'component': 'date_range',
+        'field': 'province',
+        'inputs': {
+            'start': {'type': 'constant', 'value': '2000-01-01'},
+            'end': {'type': 'constant', 'value': '2020-01-01'},
+        },
+    }
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert any('date_range' in e for e in errors)
+
+
+@use(sample_capability)
+def test_missing_required_input_slot():
+    spec = {
+        'type': 'component',
+        'component': 'date_range',
+        'field': 'dob',
+        'inputs': {'start': {'type': 'constant', 'value': '2000-01-01'}},
+    }
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert any('end' in e for e in errors)
+
+
+@use(sample_capability)
+def test_malformed_parameter_returns_error():
+    errors = endpoint_service.validate_filter_spec(
+        {'type': 'and', 'children': []}, [{}], 'patient', sample_capability()
+    )
+    assert any('name' in e for e in errors)
+
+
+@use(sample_capability)
+def test_parameter_ref_must_exist():
+    spec = {
+        'type': 'component',
+        'component': 'exact_match',
+        'field': 'province',
+        'inputs': {'value': {'type': 'parameter', 'ref': 'missing_param'}},
+    }
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert any('missing_param' in e for e in errors)
+
+
+@use(sample_capability)
+def test_parameter_ref_valid():
+    spec = {
+        'type': 'component',
+        'component': 'exact_match',
+        'field': 'province',
+        'inputs': {'value': {'type': 'parameter', 'ref': 'search_province'}},
+    }
+    params = [{'name': 'search_province', 'type': 'text'}]
+    errors = endpoint_service.validate_filter_spec(spec, params, 'patient', sample_capability())
+    assert errors == []
+
+
+@use(sample_capability)
+def test_invalid_auto_value_ref():
+    spec = {
+        'type': 'component',
+        'component': 'exact_match',
+        'field': 'province',
+        'inputs': {'value': {'type': 'auto_value', 'ref': 'nonexistent()'}},
+    }
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert any('nonexistent' in e for e in errors)
+
+
+@use(sample_capability)
+def test_not_node_with_valid_child():
+    spec = {
+        'type': 'not',
+        'child': {
+            'type': 'component',
+            'component': 'exact_match',
+            'field': 'province',
+            'inputs': {'value': {'type': 'constant', 'value': 'ON'}},
+        },
+    }
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert errors == []
+
+
+@use(sample_capability)
+def test_not_node_missing_child():
+    spec = {'type': 'not'}
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert any('child' in e for e in errors)
+
+
+@use(sample_capability)
+def test_nested_and_or():
+    spec = {
+        'type': 'and',
+        'children': [{
+            'type': 'or',
+            'children': [{
+                'type': 'component',
+                'component': 'exact_match',
+                'field': 'province',
+                'inputs': {'value': {'type': 'constant', 'value': 'ON'}},
+            }],
+        }],
+    }
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert errors == []
+
+
+@use(sample_capability)
+def test_empty_children_allowed():
+    spec = {'type': 'and', 'children': []}
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert errors == []
+
+
+@use(sample_capability)
+def test_non_dict_child_node_returns_error():
+    spec = {'type': 'and', 'children': ['not_a_dict']}
+    errors = endpoint_service.validate_filter_spec(spec, [], 'patient', sample_capability())
+    assert errors
+    assert any('str' in e for e in errors)
+
+
+@use(sample_capability)
+def test_deeply_nested_query_returns_error():
+    node = {'type': 'and', 'children': []}
+    root = node
+    for _ in range(_MAX_QUERY_DEPTH + 2):
+        child = {'type': 'and', 'children': []}
+        node['children'] = [child]
+        node = child
+    errors = endpoint_service.validate_filter_spec(root, [], 'patient', sample_capability())
+    assert any('nested too deeply' in e for e in errors)


### PR DESCRIPTION
## Product Description

The capabilities described what kind of queries are allowed on a domain based on the defined data dictionaries.

Use the capabilities to validate the case search endpoint on create and update

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6550

## Feature Flag

None yet. Will introduce one for the UI elements

## Safety Assurance

No user facing changes. Unit tests on service layer

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

Added some tests

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
