### PR TITLE
Prevent stale and mismatched caches while modifying subscriptions

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1280,10 +1280,7 @@ class Subscription(models.Model):
 
     @classmethod
     def clear_caches(cls, domain_name):
-        if settings.UNIT_TESTING:
-            cls._clear_caches(domain_name)
-        else:
-            transaction.on_commit(lambda: cls._clear_caches(domain_name))
+        transaction.on_commit(lambda: cls._clear_caches(domain_name))
 
     @classmethod
     def _clear_caches(cls, domain_name):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1264,11 +1264,9 @@ class Subscription(models.Model):
         """
         Overloaded to update domain pillow with subscription information
         """
-        from corehq.apps.accounting.mixins import get_overdue_invoice
 
         super(Subscription, self).save(*args, **kwargs)
         Subscription.clear_caches(self.subscriber.domain)
-        get_overdue_invoice.clear(self.subscriber.domain)
 
         domain = Domain.get_by_name(self.subscriber.domain)
         # If a subscriber doesn't have a valid domain associated with it
@@ -1282,7 +1280,9 @@ class Subscription(models.Model):
 
     @classmethod
     def clear_caches(cls, domain_name):
+        from corehq.apps.accounting.mixins import get_overdue_invoice
         cls._get_active_subscription_by_domain.clear(cls, domain_name)
+        get_overdue_invoice.clear(domain_name)
 
     @property
     def is_free_edition(self):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1280,6 +1280,13 @@ class Subscription(models.Model):
 
     @classmethod
     def clear_caches(cls, domain_name):
+        if settings.UNIT_TESTING:
+            cls._clear_caches(domain_name)
+        else:
+            transaction.on_commit(lambda: cls._clear_caches(domain_name))
+
+    @classmethod
+    def _clear_caches(cls, domain_name):
         from corehq.apps.accounting.mixins import get_overdue_invoice
         cls._get_active_subscription_by_domain.clear(cls, domain_name)
         get_overdue_invoice.clear(domain_name)

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 from django.core import mail
 from django.db import models
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 
 from unittest import mock
 
@@ -28,6 +28,7 @@ from corehq.apps.accounting.tests.generator import (
     FakeStripeCardManager,
     FakeStripeCustomerManager,
 )
+from corehq.apps.accounting.tests.utils import clear_subscription_caches_on_commit
 from corehq.apps.domain.models import Domain
 from corehq.apps.smsbillables.models import (
     SmsBillable,
@@ -177,10 +178,9 @@ class TestSubscription(BaseAccountingTest):
         domains = Subscription.get_active_domains_for_account(self.account)
         self.assertEqual(list(domains), test_domains)
 
-    # Subscription.clear_caches branches on settings.UNIT_TESTING to avoid
-    # transaction.on_commit, which does not work as usual in tests. We want to
-    # test on_commit behavior here, so temporarily override it to read False.
-    @override_settings(UNIT_TESTING=False)
+    # Subscription.clear_caches is overridden to avoid transaction.on_commit in
+    # tests. We are testing on_commit behavior here, so temporarily set it back.
+    @clear_subscription_caches_on_commit()
     def test_clear_caches_on_commit(self):
         from corehq.apps.accounting.mixins import get_overdue_invoice
 

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -183,10 +183,9 @@ class TestSubscription(BaseAccountingTest):
     @clear_subscription_caches_on_commit()
     def test_clear_caches_on_commit(self):
         from corehq.apps.accounting.mixins import get_overdue_invoice
-
+        # prime caches and see that they have the values we expect
         subscription = Subscription.get_active_subscription_by_domain(self.domain.name)
         overdue_invoice = get_overdue_invoice(self.domain.name)
-
         assert (
             Subscription._get_active_subscription_by_domain.get_cached_value(
                 Subscription, self.domain.name
@@ -194,6 +193,16 @@ class TestSubscription(BaseAccountingTest):
         )
         assert get_overdue_invoice.get_cached_value(self.domain.name) == overdue_invoice
 
+        # clear caches without on_commit callbacks; cached values should not change
+        Subscription.clear_caches(self.domain.name)
+        assert (
+            Subscription._get_active_subscription_by_domain.get_cached_value(
+                Subscription, self.domain.name
+            ) == subscription
+        )
+        assert get_overdue_invoice.get_cached_value(self.domain.name) == overdue_invoice
+
+        # capture and run on_commit callbacks; caches are successfully cleared
         with self.captureOnCommitCallbacks(execute=True):
             Subscription.clear_caches(self.domain.name)
 

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 from django.core import mail
 from django.db import models
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
 from unittest import mock
 
@@ -176,6 +176,34 @@ class TestSubscription(BaseAccountingTest):
         test_domains = ['test']
         domains = Subscription.get_active_domains_for_account(self.account)
         self.assertEqual(list(domains), test_domains)
+
+    # Subscription.clear_caches branches on settings.UNIT_TESTING to avoid
+    # transaction.on_commit, which does not work as usual in tests. We want to
+    # test on_commit behavior here, so temporarily override it to read False.
+    @override_settings(UNIT_TESTING=False)
+    def test_clear_caches_on_commit(self):
+        from corehq.apps.accounting.mixins import get_overdue_invoice
+
+        subscription = Subscription.get_active_subscription_by_domain(self.domain.name)
+        overdue_invoice = get_overdue_invoice(self.domain.name)
+
+        assert (
+            Subscription._get_active_subscription_by_domain.get_cached_value(
+                Subscription, self.domain.name
+            ) == subscription
+        )
+        assert get_overdue_invoice.get_cached_value(self.domain.name) == overdue_invoice
+
+        with self.captureOnCommitCallbacks(execute=True):
+            Subscription.clear_caches(self.domain.name)
+
+        assert (
+            Subscription._get_active_subscription_by_domain.get_cached_value(
+                Subscription, self.domain.name
+            ) is Ellipsis
+        )
+        assert get_overdue_invoice.get_cached_value(self.domain.name) is Ellipsis
+
 
     def tearDown(self):
         self.domain.delete()

--- a/corehq/apps/accounting/tests/utils.py
+++ b/corehq/apps/accounting/tests/utils.py
@@ -24,7 +24,7 @@ _clear_caches_immediately_patch = mock.patch.object(
 
 
 def patch_subscription_clear_caches():
-    """Run Subscription cache clears immediately in tests.
+    """Clear Subscription caches immediately in tests.
 
     `Subscription.clear_caches` schedules `_clear_caches` via
     `transaction.on_commit`, but Django's `TestCase` wraps each test in

--- a/corehq/apps/accounting/tests/utils.py
+++ b/corehq/apps/accounting/tests/utils.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+from django.conf import settings
+
 from corehq.apps.accounting.models import (
     BillingAccount,
     DefaultProductPlan,
@@ -14,6 +16,34 @@ from corehq.apps.accounting.tests.generator import (
     FakeStripeCardManager,
     FakeStripeCustomerManager,
 )
+
+
+_clear_caches_immediately_patch = mock.patch.object(
+    Subscription, 'clear_caches', Subscription._clear_caches
+)
+
+
+def patch_subscription_clear_caches():
+    """Run Subscription cache clears immediately in tests.
+
+    `Subscription.clear_caches` schedules `_clear_caches` via
+    `transaction.on_commit`, but Django's `TestCase` wraps each test in
+    an atomic block that's rolled back, so the callback would never fire.
+    """
+    assert settings.UNIT_TESTING
+    _clear_caches_immediately_patch.__enter__()
+
+
+@contextmanager
+def clear_subscription_caches_on_commit():
+    """Context manager and decorator to use transaction.on_commit behavior for
+    Subscription.clear_caches"""
+    assert settings.UNIT_TESTING
+    _clear_caches_immediately_patch.__exit__(None, None, None)
+    try:
+        yield
+    finally:
+        _clear_caches_immediately_patch.__enter__()
 
 
 class DomainSubscriptionMixin(object):

--- a/corehq/tests/pytest_plugins/patches.py
+++ b/corehq/tests/pytest_plugins/patches.py
@@ -3,6 +3,7 @@ import pytest
 
 @pytest.hookimpl
 def pytest_sessionstart():
+    from corehq.apps.accounting.tests.utils import patch_subscription_clear_caches
     from corehq.apps.domain.tests.test_utils import patch_domain_deletion
     from corehq.form_processor.tests.utils import patch_testcase_databases
     from corehq.util.es.testing import patch_es_user_signals
@@ -17,6 +18,7 @@ def pytest_sessionstart():
     patch_es_user_signals()
     patch_foreign_value_caches()
     patch_domain_deletion()
+    patch_subscription_clear_caches()
 
 
 def patch_unittest_TestCase_doClassCleanup():


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19601
This aims to resolve a rare issue where, as a result of stale cache state, a domain could temporarily have an incorrect level of access to HQ. This fix is targeted at actions in `Subscription.change_plan` but potentially applies to any other database transaction that calls `Subscription.save`.

`get_active_subscription_by_domain`, the primary cache cleared by `Subscription.clear_caches`, is used in middleware and for page context on almost all requests to HQ. Consider a scenario where a user changes their subscription, calling `Subscription.change_plan`. `change_plan` is wrapped in a `transaction.atomic` block and performs several different actions including calling `save()` on multiple `Subscription` objects. 

If, before this transaction has been completed but after `Subscription.save` has been called (clearing caches), HQ receives another request to this domain, `get_active_subscription_by_domain` will be called again and populated with stale data. The expiration of 1 hour is relatively short, but this can still have a real impact on customers in both what plan they _appear_ to be subscribed to and the features they are _actually able to access_ in HQ.

By wrapping the call to `clear_caches` in `transaction.on_commit`, this ensures that the cache is cleared at the _end_ of the transaction and next updated _after_ the transaction has completed. It also keeps us from updating cache state excessively during a database transaction.

`get_overdue_invoice` does not seem to have any reported bugs but is vulnerable to similar issues due to its use in `BillingModalsMixin`, subclassed by both `BaseDomainView` and `DomainDashboardView`. This was also moved to `Subscription.clear_caches`, because it depends on the result of `get_active_subscription_by_domain` and should be refreshed at the same time.

[Django documentation](https://docs.djangoproject.com/en/5.2/topics/db/transactions/#controlling-transactions-explicitly) recommends using `on_commit` in general for cache-clearing inside transactions:
> For example, if the code proactively updates data in the cache after saving an object, it’s recommended to use [transaction.on_commit()](https://docs.djangoproject.com/en/5.2/topics/db/transactions/#performing-actions-after-commit) instead, to defer cache alterations until the transaction is actually committed.

## Safety Assurance

### Safety story
Tested locally that upgrading and subscribing to a new software plan still works as expected. This is a best-practice change (in line with Django documentation) but is in a high-visibility location.

### Automated test coverage
Many automated tests create, upgrade, or otherwise change subscriptions and guard against majorly broken logic. Added a test case, `test_clear_caches_on_commit` to see that caches are cleared correctly with transaction.on_commit.

### QA Plan
Not planning QA for this change.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
