### PR TITLE
Minor fixes for accounting admin filters

### DIFF
--- a/corehq/apps/accounting/filters.py
+++ b/corehq/apps/accounting/filters.py
@@ -86,7 +86,7 @@ class IdPServiceTypeFilter(BaseSingleOptionFilter):
 
 class CreditAdjustmentLinkFilter(BaseSingleOptionFilter):
     slug = 'credit_adjustment_link'
-    label = _("Credit Adjustment Reason")
+    label = _("Credit Adjustment Link")
     default_text = _("Linked to Any Transaction")
     options = (
         ('invoice', "Linked to Invoice"),

--- a/corehq/apps/accounting/filters.py
+++ b/corehq/apps/accounting/filters.py
@@ -220,14 +220,7 @@ class CreatedSubAdjMethodFilter(BaseSingleOptionFilter):
     slug = "sub_adj_method"
     label = _("Created By")
     default_text = _("Anyone")
-    options = (
-        (SubscriptionAdjustmentMethod.INTERNAL, "Operations Created"),
-        (SubscriptionAdjustmentMethod.USER, "User Created"),
-        (SubscriptionAdjustmentMethod.INVOICING, "Created During Invoicing"),
-        (SubscriptionAdjustmentMethod.TASK, "[Deprecated] Created During Invoicing"),
-        (SubscriptionAdjustmentMethod.TRIAL, "30 Day Trial (default signup)"),
-        (SubscriptionAdjustmentMethod.DEFAULT_COMMUNITY, "Defaulted to Community"),
-    )
+    options = SubscriptionAdjustmentMethod.CHOICES
 
 
 class DateRangeFilter(BaseReportFilter):


### PR DESCRIPTION
## Product Description
Ensures all Subscription Adjustment Method options are available to filter Subscriptions by "Created By" in accounting admin UI. As a trade-off for completeness and maintainability, a couple of the options will be slightly more terse, which is okay for an admin-only UI.
Before:
<img width="659" height="279" alt="image" src="https://github.com/user-attachments/assets/e3525b4e-3595-4eea-baaf-9ee729709d03" />

After (not pictured due to scrolling -- "Default to Community", "Invoicing"):
<img width="650" height="288" alt="image" src="https://github.com/user-attachments/assets/632635da-2d1b-4b20-905d-a75742f5bd63" />



Updates the label for CreditAdjustmentLinkFilter to read "Credit Adjustment Link" rather than having two "Credit Adjustment Reason".
Before:
<img width="431" height="98" alt="image" src="https://github.com/user-attachments/assets/e7b936c6-ff30-4ff7-959b-c82763117f55" />

After:
<img width="430" height="95" alt="image" src="https://github.com/user-attachments/assets/e00f7637-5149-4ec9-885a-2b26e77635e7" />


## Technical Summary
This is responsive to Ops looking to pull a list of subscriptions created by automatic renewal. We discovered the automatic renewal option was not available in subscription filters, nor was the auto downgrade option, and the issue was traced to using a hard-coded subset of `SubscriptionAdjustmentMethod`s rather than its tuple of `CHOICES`.

Also noticed the text "Credit Adjustment Reason" was duplicated and should not have been.

## Safety Assurance

### Safety story
Tested locally and on staging to see that filter functionality still works as expected and now includes all subscription adjustment methods, and that filters return the expected subscriptions. The text change was confirmed visually.

### Automated test coverage
I don't believe there are automated tests here.

### QA Plan
Not planning on QA for this minor change.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
