### PR TITLE
Carry over service_type and funding_source when renewing a subscription

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1622,13 +1622,11 @@ class Subscription(models.Model):
             salesforce_contract_id=self.salesforce_contract_id,
             date_start=self.date_end,
             date_end=new_date_end,
+            service_type=service_type if service_type else self.service_type,
+            funding_source=funding_source if funding_source else self.funding_source,
         )
-        if service_type is not None:
-            renewed_subscription.service_type = service_type
         if pro_bono_status is not None:
             renewed_subscription.pro_bono_status = pro_bono_status
-        if funding_source is not None:
-            renewed_subscription.funding_source = funding_source
         if datetime.date.today() == self.date_end:
             renewed_subscription.is_active = True
         renewed_subscription.auto_renew = renewed_subscription.can_auto_renew

--- a/corehq/apps/accounting/tests/test_renew_subscription.py
+++ b/corehq/apps/accounting/tests/test_renew_subscription.py
@@ -55,6 +55,13 @@ class TestRenewSubscriptions(BaseAccountingTest):
         self.assertEqual(self.renewed_subscription.date_end, None)
         self.assertEqual(self.renewed_subscription.date_start, self.subscription.date_end)
         self.assertEqual(self.renewed_subscription.plan_version, self.subscription.plan_version)
+        self.assertEqual(self.renewed_subscription.subscriber, self.subscription.subscriber)
+        self.assertEqual(
+            self.renewed_subscription.salesforce_contract_id,
+            self.subscription.salesforce_contract_id
+        )
+        self.assertEqual(self.renewed_subscription.service_type, self.subscription.service_type)
+        self.assertEqual(self.renewed_subscription.funding_source, self.subscription.funding_source)
 
     def test_change_plan_on_renewal(self):
         new_edition = SoftwarePlanEdition.ADVANCED


### PR DESCRIPTION
## Technical Summary
Raised by Ops, automatically renewed subscriptions were showing up with `service_type=NOT_SET`. We determined that both `service_type` and `funding_source` should be carried over by default when a subscription is renewed.

This correctly sets renewed subscriptions' `service_type` and `funding_source` from the initial subscription, where previously they would have defaulted (to `NOT_SET` and `CLIENT`, respectively). In addition to incorrect reporting, an automatically renewed subscription would get `service_type=NOT_SET`, causing a bug where that subscription would not itself be able to automatically renew because we filter by `PRODUCT` type subscriptions when auto-renewing.

## Safety Assurance

### Safety story
This is a minor change to carry over existing subscription properties to a renewed subscription, and is covered by automated testing.

### Automated test coverage
Added asserts in `TestRenewSubscriptions` to see that these (and other) properties are set as expected when renewing a subscription with no additional arguments.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
