### PR TITLE
Fix dump_domain_data --console

### DIFF
--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
                     raise
                 raise CommandError("Unable to serialize database: %s" % e)
             finally:
-                if stream:
+                if stream and not console:
                     stream.close()
 
             if not console:


### PR DESCRIPTION
## Product Description
None

## Technical Summary
I noticed while working on something an issue with `dump_domain_data --console`. It gives the following error if called with multiple dumpers (the default) because the stdout stream was getting closed mid-write.

```
CommandError: Unable to serialize database: I/O operation on closed file.
```

## Feature Flag
None

## Safety Assurance

### Safety story
The `--console` option is not on the critical path for any real workflow (just for debugging) so even if this broke (and remember it's already broken), that wouldn't be much of an issue. Nonetheless, I ran this locally on a small local domain and it works fine now.

### Automated test coverage

None
### QA Plan

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
