### PR TITLE
Use saved credentials of ConnectionSettings when testing connection if appropriate

### DIFF
--- a/corehq/motech/templates/motech/connection_settings_detail.html
+++ b/corehq/motech/templates/motech/connection_settings_detail.html
@@ -6,7 +6,11 @@
 {% js_entry "motech/js/connection_settings_detail" %}
 
 {% block page_content %}
-  {% registerurl "test_connection_settings" domain %}
+  {% if form.instance.pk %}
+    {% registerurl "test_connection_settings" domain form.instance.pk %}
+  {% else %}
+    {% registerurl "test_connection_settings" domain %}
+  {% endif %}
 
   <h2>{% trans "Add Connection Settings" %}</h2>
   <div class="spacer"></div>

--- a/corehq/motech/tests/test_views.py
+++ b/corehq/motech/tests/test_views.py
@@ -149,7 +149,7 @@ class TestConnectionSettingsView(TestCase):
         requests_instance = mock_get.call_args.args[0]
         assert requests_instance.auth_manager.client_secret == 'form-secret'
 
-    def test_basic_auth_rejects_password_placeholder(self):
+    def test_basic_auth_uses_saved_password_when_placeholder_submitted(self):
         post_data = {
             'name': 'basic-conn',
             'url': 'http://example.com',
@@ -160,15 +160,13 @@ class TestConnectionSettingsView(TestCase):
         }
 
         with patch.object(Requests, 'get', autospec=True) as mock_get:
-            response = self._post(post_data)
+            mock_get.return_value = Mock(status_code=200, text='')
+            self._post(post_data, pk=self.basic_conn.pk)
 
-        assert response.json() == {
-            'success': False,
-            'response': 'Please enter API password again.',
-        }
-        mock_get.assert_not_called()
+        requests_instance = mock_get.call_args.args[0]
+        assert requests_instance.auth_manager.password == 'saved-password'
 
-    def test_oauth2_client_rejects_client_secret_placeholder(self):
+    def test_oauth2_client_uses_saved_secret_when_placeholder_submitted(self):
         post_data = {
             'name': 'oauth-conn',
             'url': 'http://example.com',
@@ -180,10 +178,8 @@ class TestConnectionSettingsView(TestCase):
         }
 
         with patch.object(Requests, 'get', autospec=True) as mock_get:
-            response = self._post(post_data)
+            mock_get.return_value = Mock(status_code=200, text='')
+            self._post(post_data, pk=self.oauth_conn.pk)
 
-        assert response.json() == {
-            'success': False,
-            'response': 'Please enter client secret again.',
-        }
-        mock_get.assert_not_called()
+        requests_instance = mock_get.call_args.args[0]
+        assert requests_instance.auth_manager.client_secret == 'saved-secret'

--- a/corehq/motech/tests/test_views.py
+++ b/corehq/motech/tests/test_views.py
@@ -1,0 +1,125 @@
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+from django.urls import reverse
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import WebUser
+from corehq.motech.const import (
+    BASIC_AUTH,
+    OAUTH2_CLIENT,
+    PASSWORD_PLACEHOLDER,
+)
+from corehq.motech.forms import ConnectionSettingsForm
+from corehq.motech.requests import Requests
+
+DOMAIN = 'test-motech-views'
+USERNAME = 'test@motech-views.com'
+PASSWORD = 'password'
+
+
+class TestConnectionSettingsView(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = create_domain(DOMAIN)
+        cls.addClassCleanup(cls.domain.delete)
+        cls.user = WebUser.create(
+            DOMAIN, USERNAME, PASSWORD, created_by=None, created_via=None,
+        )
+        cls.user.is_superuser = True
+        cls.user.save()
+        cls.addClassCleanup(cls.user.delete, cls.domain.name, None)
+
+        cls.privilege_patch = patch(
+            'corehq.motech.views.has_privilege', return_value=True,
+        )
+        cls.privilege_patch.start()
+        cls.addClassCleanup(cls.privilege_patch.stop)
+
+    def setUp(self):
+        super().setUp()
+        self.client.login(username=USERNAME, password=PASSWORD)
+
+    def _post(self, data):
+        return self.client.post(
+            reverse('test_connection_settings', kwargs={'domain': DOMAIN}),
+            data,
+        )
+
+    def test_basic_auth_uses_password_from_form_data(self):
+        post_data = {
+            'name': 'basic-conn',
+            'url': 'http://example.com',
+            'auth_type': BASIC_AUTH,
+            'username': 'user',
+            'plaintext_password': 'typed-password',
+            'notify_addresses_str': 'ops@example.com',
+        }
+        assert ConnectionSettingsForm(domain=DOMAIN, data=post_data).is_valid()
+
+        with patch.object(Requests, 'get', autospec=True) as mock_get:
+            mock_get.return_value = Mock(status_code=200, text='')
+            self._post(post_data)
+
+        requests_instance = mock_get.call_args.args[0]
+        assert requests_instance.auth_manager.password == 'typed-password'
+
+    def test_oauth2_client_uses_client_secret_from_form_data(self):
+        post_data = {
+            'name': 'oauth-conn',
+            'url': 'http://example.com',
+            'auth_type': OAUTH2_CLIENT,
+            'client_id': 'client-id',
+            'plaintext_client_secret': 'form-secret',
+            'token_url': 'http://example.com/token',
+            'notify_addresses_str': 'ops@example.com',
+        }
+        assert ConnectionSettingsForm(domain=DOMAIN, data=post_data).is_valid()
+
+        with patch.object(Requests, 'get', autospec=True) as mock_get:
+            mock_get.return_value = Mock(status_code=200, text='')
+            self._post(post_data)
+
+        requests_instance = mock_get.call_args.args[0]
+        assert requests_instance.auth_manager.client_secret == 'form-secret'
+
+    def test_basic_auth_rejects_password_placeholder(self):
+        post_data = {
+            'name': 'basic-conn',
+            'url': 'http://example.com',
+            'auth_type': BASIC_AUTH,
+            'username': 'user',
+            'plaintext_password': PASSWORD_PLACEHOLDER,
+            'notify_addresses_str': 'ops@example.com',
+        }
+
+        with patch.object(Requests, 'get', autospec=True) as mock_get:
+            response = self._post(post_data)
+
+        assert response.json() == {
+            'success': False,
+            'response': 'Please enter API password again.',
+        }
+        mock_get.assert_not_called()
+
+    def test_oauth2_client_rejects_client_secret_placeholder(self):
+        post_data = {
+            'name': 'oauth-conn',
+            'url': 'http://example.com',
+            'auth_type': OAUTH2_CLIENT,
+            'client_id': 'client-id',
+            'plaintext_client_secret': PASSWORD_PLACEHOLDER,
+            'token_url': 'http://example.com/token',
+            'notify_addresses_str': 'ops@example.com',
+        }
+
+        with patch.object(Requests, 'get', autospec=True) as mock_get:
+            response = self._post(post_data)
+
+        assert response.json() == {
+            'success': False,
+            'response': 'Please enter client secret again.',
+        }
+        mock_get.assert_not_called()

--- a/corehq/motech/tests/test_views.py
+++ b/corehq/motech/tests/test_views.py
@@ -11,6 +11,7 @@ from corehq.motech.const import (
     PASSWORD_PLACEHOLDER,
 )
 from corehq.motech.forms import ConnectionSettingsForm
+from corehq.motech.models import ConnectionSettings
 from corehq.motech.requests import Requests
 
 DOMAIN = 'test-motech-views'
@@ -38,17 +39,43 @@ class TestConnectionSettingsView(TestCase):
         cls.privilege_patch.start()
         cls.addClassCleanup(cls.privilege_patch.stop)
 
+        cls.basic_conn = ConnectionSettings.objects.create(
+            domain=DOMAIN,
+            name='basic-conn',
+            url='http://example.com',
+            auth_type=BASIC_AUTH,
+            username='user',
+            notify_addresses_str='ops@example.com',
+        )
+        cls.basic_conn.plaintext_password = 'saved-password'
+        cls.basic_conn.save()
+
+        cls.oauth_conn = ConnectionSettings.objects.create(
+            domain=DOMAIN,
+            name='oauth-conn',
+            url='http://example.com',
+            auth_type=OAUTH2_CLIENT,
+            client_id='client-id',
+            token_url='http://example.com/token',
+            notify_addresses_str='ops@example.com',
+        )
+        cls.oauth_conn.plaintext_client_secret = 'saved-secret'
+        cls.oauth_conn.save()
+
     def setUp(self):
         super().setUp()
         self.client.login(username=USERNAME, password=PASSWORD)
 
-    def _post(self, data):
+    def _post(self, data, pk=None):
+        kwargs = {'domain': DOMAIN}
+        if pk is not None:
+            kwargs['pk'] = pk
         return self.client.post(
-            reverse('test_connection_settings', kwargs={'domain': DOMAIN}),
+            reverse('test_connection_settings', kwargs=kwargs),
             data,
         )
 
-    def test_basic_auth_uses_password_from_form_data(self):
+    def test_basic_auth_uses_password_from_form_data_for_new_connection(self):
         post_data = {
             'name': 'basic-conn',
             'url': 'http://example.com',
@@ -66,7 +93,25 @@ class TestConnectionSettingsView(TestCase):
         requests_instance = mock_get.call_args.args[0]
         assert requests_instance.auth_manager.password == 'typed-password'
 
-    def test_oauth2_client_uses_client_secret_from_form_data(self):
+    def test_basic_auth_uses_password_from_form_data_for_existing_connection(self):
+        post_data = {
+            'name': 'basic-conn',
+            'url': 'http://example.com',
+            'auth_type': BASIC_AUTH,
+            'username': 'user',
+            'plaintext_password': 'typed-password',
+            'notify_addresses_str': 'ops@example.com',
+        }
+        assert ConnectionSettingsForm(domain=DOMAIN, data=post_data).is_valid()
+
+        with patch.object(Requests, 'get', autospec=True) as mock_get:
+            mock_get.return_value = Mock(status_code=200, text='')
+            self._post(post_data, pk=self.basic_conn.pk)
+
+        requests_instance = mock_get.call_args.args[0]
+        assert requests_instance.auth_manager.password == 'typed-password'
+
+    def test_oauth2_client_uses_client_secret_from_form_data_for_new_connection(self):
         post_data = {
             'name': 'oauth-conn',
             'url': 'http://example.com',
@@ -81,6 +126,25 @@ class TestConnectionSettingsView(TestCase):
         with patch.object(Requests, 'get', autospec=True) as mock_get:
             mock_get.return_value = Mock(status_code=200, text='')
             self._post(post_data)
+
+        requests_instance = mock_get.call_args.args[0]
+        assert requests_instance.auth_manager.client_secret == 'form-secret'
+
+    def test_oauth2_client_uses_client_secret_from_form_data_for_existing_connection(self):
+        post_data = {
+            'name': 'oauth-conn',
+            'url': 'http://example.com',
+            'auth_type': OAUTH2_CLIENT,
+            'client_id': 'client-id',
+            'plaintext_client_secret': 'form-secret',
+            'token_url': 'http://example.com/token',
+            'notify_addresses_str': 'ops@example.com',
+        }
+        assert ConnectionSettingsForm(domain=DOMAIN, data=post_data).is_valid()
+
+        with patch.object(Requests, 'get', autospec=True) as mock_get:
+            mock_get.return_value = Mock(status_code=200, text='')
+            self._post(post_data, pk=self.oauth_conn.pk)
 
         requests_instance = mock_get.call_args.args[0]
         assert requests_instance.auth_manager.client_secret == 'form-secret'

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -64,6 +64,8 @@ urlpatterns = [
         name=ConnectionSettingsDetailView.urlname),
     url(r'^conn/test/$', test_connection_settings,
         name='test_connection_settings'),
+    url(r'^conn/(?P<pk>\d+)/test/$', test_connection_settings,
+        name='test_connection_settings'),
 
     url(r'^forwarding/$', DomainForwardingOptionsView.as_view(), name=DomainForwardingOptionsView.urlname),
     url(r'^forwarding/new/FormRepeater/$', AddFormRepeaterView.as_view(),

--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -4,6 +4,7 @@ import re
 from datetime import datetime, timedelta
 
 from django.http import Http404, JsonResponse, StreamingHttpResponse
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
@@ -24,7 +25,6 @@ from corehq.apps.hqwebapp.doc_lookup import lookup_doc_id
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
-from corehq.motech.const import PASSWORD_PLACEHOLDER, OAUTH2_CLIENT, OAUTH2_PWD
 from corehq.motech.forms import ConnectionSettingsForm, UnrecognizedHost
 from corehq.motech.models import ConnectionSettings, RequestLog
 from corehq.util.urlvalidate.urlvalidate import PossibleSSRFAttempt
@@ -307,23 +307,13 @@ def test_connection_settings(request, domain, pk=None):
     if not has_privilege(request, privileges.DATA_FORWARDING):
         raise Http404
 
-    # If auth_type is set to None, we ignore this check
-    auth_type = request.POST.get('auth_type')
-    client_secret = request.POST.get('plaintext_client_secret')
-    if auth_type in (OAUTH2_CLIENT, OAUTH2_PWD) and client_secret == PASSWORD_PLACEHOLDER:
-        return JsonResponse({
-            "success": False,
-            "response": _("Please enter client secret again."),
-        })
-    if auth_type and request.POST.get('plaintext_password') == PASSWORD_PLACEHOLDER:
-        # The user is editing an existing instance, and the form is
-        # showing the password placeholder. (We don't tell the user what
-        # the API password is.)
-        return JsonResponse({
-            "success": False,
-            "response": _("Please enter API password again."),
-        })
-    form = ConnectionSettingsForm(domain=domain, data=request.POST)
+    # Load the existing instance so the model setters can preserve saved
+    # secrets (the setters no-op on PASSWORD_PLACEHOLDER). This lets us
+    # test with the real credentials without ever sending them to the browser.
+    instance = None
+    if pk is not None:
+        instance = get_object_or_404(ConnectionSettings, pk=pk, domain=domain)
+    form = ConnectionSettingsForm(domain=domain, data=request.POST, instance=instance)
     if form.is_valid():
         if isinstance(form.cleaned_data['url'], UnrecognizedHost):
             return JsonResponse({"success": False, "response": "Unknown URL"})

--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -303,7 +303,7 @@ class ConnectionSettingsDetailView(BaseProjectSettingsView, ModelFormMixin, Proc
 
 @require_POST
 @require_permission(HqPermissions.edit_motech)
-def test_connection_settings(request, domain):
+def test_connection_settings(request, domain, pk=None):
     if not has_privilege(request, privileges.DATA_FORWARDING):
         raise Http404
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Before

https://www.loom.com/share/a1ef174500e24034afea941ed5bdfe81

After

https://www.loom.com/share/5ab8d1f8c9344e0fa6ca8c77bd86f0cc
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18709

This PR aims to resolve an issue when attempting to use the "Test Connection" button for existing connections. In an effort to minimize sending secrets as plaintext to the frontend, we do not populate the ConnectionSettings form with the actual secret value, but instead use a [placeholder](https://github.com/dimagi/commcare-hq/blob/c331f05d99e0ce13096d0481ffdccd303f8d9f22/corehq/motech/const.py#L86). However when clicking "Test Connection" it is effectively a form submit where commit is set to False, meaning the values from the form would be used in the test request.

To prevent this, we've been [intentionally failing requests](https://github.com/dimagi/commcare-hq/blob/27a45b8120b50170702ceb3b12b9de7f448ebe78/corehq/motech/views.py#L313-L325) when a secret field has the placeholder text set, asking the user to enter the password again.

This PR takes advantage of the [custom setters](https://github.com/dimagi/commcare-hq/blob/27a45b8120b50170702ceb3b12b9de7f448ebe78/corehq/motech/models.py#L136-L160) defined for `plaintext_password` and `plaintext_client_secret`. These setters, which are invoked [here](https://github.com/dimagi/commcare-hq/blob/c331f05d99e0ce13096d0481ffdccd303f8d9f22/corehq/motech/forms.py#L276-L277), are no-ops if the value equals the placeholder text, which means the existing secret value on the instance is preserved, and therefore used to test the connection. If the value is anything other than the placeholder text, the setters work as expected, and the instance's value is overriden by the secret defined in the post request, which is what we want.

Review by commit.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
I've tested this locally. For new connections, I don't see any difference in behavior, and for existing connections, the "Test Connection" works as expected.

There isn't a security concern here, as we are continuing to avoid sending already stored secrets back to the frontend. This change does open up the potential for other users in a domain with access to Data Forwarding to test connections on existing connection settings, whereas they would have previously had to re-enter the secret value. I don't believe that is an issue, but if anyone feels different let me know.

The only other concern would be unintentionally saving changes to the db object, but that isn't happening because test connection settings explicitly sets `commit` to False when [saving the form](https://github.com/dimagi/commcare-hq/blob/c331f05d99e0ce13096d0481ffdccd303f8d9f22/corehq/motech/views.py#L321).

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
I've added tests around behavior with secret values here, which help ensure there were no regression in how secrets are used when testing connections.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA necessary.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
