### PR TITLE
Pluggable archive format for dump_domain_data; default to zstd

### DIFF
--- a/corehq/apps/dump_reload/archive/__init__.py
+++ b/corehq/apps/dump_reload/archive/__init__.py
@@ -1,0 +1,13 @@
+from .single_stream import SimpleSingleStreamWriter
+from .zipped_gzip import (
+    ExtractedDumpExistsError,
+    ZippedGzipArchiveReader,
+    ZippedGzipArchiveWriter,
+)
+
+__all__ = [
+    'ExtractedDumpExistsError',
+    'SimpleSingleStreamWriter',
+    'ZippedGzipArchiveReader',
+    'ZippedGzipArchiveWriter',
+]

--- a/corehq/apps/dump_reload/archive/__init__.py
+++ b/corehq/apps/dump_reload/archive/__init__.py
@@ -1,4 +1,5 @@
 from .single_stream import SimpleSingleStreamWriter
+from .zip_with_zstd import ZipWithZstdArchiveReader, ZipWithZstdArchiveWriter
 from .zipped_gzip import (
     ExtractedDumpExistsError,
     ZippedGzipArchiveReader,
@@ -8,6 +9,8 @@ from .zipped_gzip import (
 __all__ = [
     'ExtractedDumpExistsError',
     'SimpleSingleStreamWriter',
+    'ZipWithZstdArchiveReader',
+    'ZipWithZstdArchiveWriter',
     'ZippedGzipArchiveReader',
     'ZippedGzipArchiveWriter',
 ]

--- a/corehq/apps/dump_reload/archive/base.py
+++ b/corehq/apps/dump_reload/archive/base.py
@@ -1,0 +1,58 @@
+from abc import ABC, abstractmethod
+
+
+class ArchiveWriter(ABC):
+    """Writer used by ``dump_domain_data``."""
+
+    path: str | None
+    """Destination path, or ``None`` if no persisted artifact."""
+
+    meta: dict
+    """``{stream_name: {model: count}}``, accumulated as streams are written."""
+
+    @abstractmethod
+    def __contextmanager__(self):
+        """Lifecycle generator wrapped by ``@contextmanager_class``."""
+
+    @abstractmethod
+    def open_stream(self, stream_name):
+        """Yield a ``WrappedStream`` for writing; caller sets ``stream.meta``
+        before the ``with`` block exits.
+        """
+
+
+class ArchiveReader(ABC):
+    """Reader used by ``load_domain_data``."""
+
+    path: str
+
+    meta: dict
+    """``{stream_name: {model: count}}`` from the archive's metadata."""
+
+    @abstractmethod
+    def __contextmanager__(self):
+        """Lifecycle generator wrapped by ``@contextmanager_class``."""
+
+    @abstractmethod
+    def open_stream(self, stream_name):
+        """Yield a ``WrappedStream`` for reading; ``stream.meta`` carries
+        the per-stream metadata.
+        """
+
+
+class WrappedStream:
+    """Per-call ``.meta`` carrier; isolates state across ``open_stream``
+    calls for writers that reuse one underlying stream (e.g. stdout).
+    """
+
+    META_UNSET = object()
+
+    def __init__(self, stream, meta=META_UNSET):
+        self._stream = stream
+        self.meta = meta
+
+    def __getattr__(self, attr):
+        return getattr(self._stream, attr)
+
+    def __iter__(self):
+        return iter(self._stream)

--- a/corehq/apps/dump_reload/archive/single_stream.py
+++ b/corehq/apps/dump_reload/archive/single_stream.py
@@ -1,0 +1,29 @@
+from contextlib import contextmanager
+
+from .base import ArchiveWriter, WrappedStream
+from .utils import contextmanager_class, validate_stream_meta
+
+
+@contextmanager_class
+class SimpleSingleStreamWriter(ArchiveWriter):
+
+    path = None
+
+    def __init__(self, output_stream):
+        self.meta = {}
+        self._output_stream = output_stream
+
+    def __contextmanager__(self):
+        yield self
+
+    @contextmanager
+    def open_stream(self, stream_name):
+        # The underlying output_stream is intentionally NOT closed
+        # between dumpers — it's owned by the caller (typically stdout).
+        wrapped_stream = WrappedStream(self._output_stream)
+        yield wrapped_stream
+        validate_stream_meta(wrapped_stream, stream_name)
+        self.meta[stream_name] = wrapped_stream.meta
+
+    def __repr__(self):
+        return f"<{type(self).__name__}>"

--- a/corehq/apps/dump_reload/archive/utils.py
+++ b/corehq/apps/dump_reload/archive/utils.py
@@ -1,5 +1,10 @@
 from contextlib import contextmanager
 
+from .base import WrappedStream
+
+
+META_FILENAME = 'meta.json'
+
 
 def contextmanager_class(cls):
     """Enable ``with cls():`` semantics based on ``cls``'s
@@ -25,3 +30,15 @@ def contextmanager_class(cls):
 
 def get_tmp_extract_dir(dump_file_path, specifier=""):
     return f'_tmp_load_{specifier}_{dump_file_path}'
+
+
+def validate_archive_path(archive_path, suffix):
+    if not archive_path.endswith(suffix):
+        raise ValueError(
+            f"archive_path must end with {suffix!r}: {archive_path!r}"
+        )
+
+
+def validate_stream_meta(wrapped_stream, stream_name):
+    if wrapped_stream.meta is WrappedStream.META_UNSET:
+        raise RuntimeError(f"meta not set for stream {stream_name!r}")

--- a/corehq/apps/dump_reload/archive/utils.py
+++ b/corehq/apps/dump_reload/archive/utils.py
@@ -1,2 +1,27 @@
+from contextlib import contextmanager
+
+
+def contextmanager_class(cls):
+    """Enable ``with cls():`` semantics based on ``cls``'s
+    ``__contextmanager__`` method, which must be of the form expected
+    by ``@contextmanager``.
+    """
+    cls.__contextmanager__ = contextmanager(cls.__contextmanager__)
+
+    def __enter__(self):
+        self._cm = self.__contextmanager__()
+        return self._cm.__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        try:
+            return self._cm.__exit__(exc_type, exc_val, exc_tb)
+        finally:
+            self._cm = None
+
+    cls.__enter__ = __enter__
+    cls.__exit__ = __exit__
+    return cls
+
+
 def get_tmp_extract_dir(dump_file_path, specifier=""):
     return f'_tmp_load_{specifier}_{dump_file_path}'

--- a/corehq/apps/dump_reload/archive/utils.py
+++ b/corehq/apps/dump_reload/archive/utils.py
@@ -1,0 +1,2 @@
+def get_tmp_extract_dir(dump_file_path, specifier=""):
+    return f'_tmp_load_{specifier}_{dump_file_path}'

--- a/corehq/apps/dump_reload/archive/zip_with_zstd.py
+++ b/corehq/apps/dump_reload/archive/zip_with_zstd.py
@@ -1,0 +1,102 @@
+import io
+import json
+import sys
+from contextlib import contextmanager
+from functools import cached_property
+
+if sys.version_info >= (3, 14):
+    import zipfile
+else:
+    # Python's stdlib zipfile gained ZIP_ZSTANDARD support in 3.14.
+    # backports.zstd ships the 3.14 zipfile module for older versions.
+    from backports.zstd import zipfile
+
+from .base import ArchiveReader, ArchiveWriter, WrappedStream
+from .utils import (
+    META_FILENAME,
+    contextmanager_class,
+    validate_archive_path,
+    validate_stream_meta,
+)
+
+
+@contextmanager_class
+class ZipWithZstdArchiveWriter(ArchiveWriter):
+    """Streams compression directly into the zip; no intermediate temp
+    files.
+    """
+
+    SUFFIX = '.zip'
+    _zipfile = None
+
+    def __init__(self, archive_path):
+        validate_archive_path(archive_path, self.SUFFIX)
+        self.path = archive_path
+        self.meta = {}
+
+    def __contextmanager__(self):
+        self._zipfile = zipfile.ZipFile(
+            self.path,
+            mode='w',
+            compression=zipfile.ZIP_ZSTANDARD,
+            allowZip64=True,
+        )
+        try:
+            yield self
+            # Only reached on clean exit: write meta.json as the last entry.
+            self._zipfile.writestr(
+                META_FILENAME, json.dumps(self.meta, indent=4),
+            )
+        finally:
+            self._zipfile.close()
+            self._zipfile = None
+
+    @contextmanager
+    def open_stream(self, stream_name):
+        with self._zipfile.open(stream_name, mode='w', force_zip64=True) as entry:
+            text = io.TextIOWrapper(entry, encoding='utf-8', newline='')
+            wrapped_stream = WrappedStream(text)
+            try:
+                yield wrapped_stream
+                validate_stream_meta(wrapped_stream, stream_name)
+                text.flush()
+            finally:
+                text.detach()
+        self.meta[stream_name] = wrapped_stream.meta
+
+    def __repr__(self):
+        return f"<{type(self).__name__} {self.path!r}>"
+
+
+@contextmanager_class
+class ZipWithZstdArchiveReader(ArchiveReader):
+    """Streams decompression directly from the zip; no temp files."""
+
+    SUFFIX = '.zip'
+    _zipfile = None
+
+    def __init__(self, archive_path):
+        validate_archive_path(archive_path, self.SUFFIX)
+        self.path = archive_path
+
+    @cached_property
+    def meta(self):
+        if self._zipfile is None:
+            raise RuntimeError("Archive not opened; use as a context manager")
+        return json.loads(self._zipfile.read(META_FILENAME))
+
+    def __contextmanager__(self):
+        self._zipfile = zipfile.ZipFile(self.path, mode='r')
+        try:
+            yield self
+        finally:
+            self._zipfile.close()
+            self._zipfile = None
+
+    @contextmanager
+    def open_stream(self, stream_name):
+        with self._zipfile.open(stream_name) as stream:
+            yield WrappedStream(stream, meta=self.meta[stream_name])
+
+    def __repr__(self):
+        return f"<{type(self).__name__} {self.path!r}>"

--- a/corehq/apps/dump_reload/archive/zipped_gzip.py
+++ b/corehq/apps/dump_reload/archive/zipped_gzip.py
@@ -1,0 +1,96 @@
+import gzip
+import json
+import os
+import zipfile
+from contextlib import contextmanager
+from functools import cached_property
+
+from .base import ArchiveReader, ArchiveWriter, WrappedStream
+from .utils import (
+    META_FILENAME,
+    contextmanager_class,
+    get_tmp_extract_dir,
+    validate_archive_path,
+    validate_stream_meta,
+)
+
+
+@contextmanager_class
+class ZippedGzipArchiveWriter(ArchiveWriter):
+
+    SUFFIX = '.zip'
+
+    def __init__(self, archive_path):
+        validate_archive_path(archive_path, self.SUFFIX)
+        self.path = archive_path
+        self.meta = {}
+        self._basename = archive_path[:-len(self.SUFFIX)]
+
+    def __contextmanager__(self):
+        yield self
+        # Only reached on clean exit: append meta.json to the zip.
+        with zipfile.ZipFile(self.path, mode='a', allowZip64=True) as z:
+            z.writestr(META_FILENAME, json.dumps(self.meta, indent=4))
+
+    @contextmanager
+    def open_stream(self, stream_name):
+        temp_path = f"{self._basename}-tmp-{stream_name}.gz"
+        stream = gzip.open(temp_path, 'wt')
+        wrapped_stream = WrappedStream(stream)
+        try:
+            yield wrapped_stream
+            validate_stream_meta(wrapped_stream, stream_name)
+        finally:
+            stream.close()
+        with zipfile.ZipFile(self.path, mode='a', allowZip64=True) as z:
+            z.write(temp_path, f"{stream_name}.gz")
+        os.remove(temp_path)
+        self.meta[stream_name] = wrapped_stream.meta
+
+    def __repr__(self):
+        return f"<{type(self).__name__} {self.path!r}>"
+
+
+@contextmanager_class
+class ZippedGzipArchiveReader(ArchiveReader):
+
+    SUFFIX = '.zip'
+    _extracted_dir = None
+
+    def __init__(self, archive_path, use_extracted=False):
+        validate_archive_path(archive_path, self.SUFFIX)
+        self.path = archive_path
+        self._use_extracted = use_extracted
+
+    @cached_property
+    def meta(self):
+        if self._extracted_dir is None:
+            raise RuntimeError("Archive not opened; use as a context manager")
+        with open(os.path.join(self._extracted_dir, META_FILENAME)) as f:
+            return json.load(f)
+
+    def __contextmanager__(self):
+        target_dir = get_tmp_extract_dir(self.path)
+        if os.path.exists(target_dir):
+            if not self._use_extracted:
+                raise ExtractedDumpExistsError(target_dir)
+        else:
+            with zipfile.ZipFile(self.path, 'r') as archive:
+                archive.extractall(target_dir)
+        self._extracted_dir = target_dir
+        yield self
+        # No teardown — extracted dir is preserved for --use-extracted reuse.
+
+    @contextmanager
+    def open_stream(self, stream_name):
+        with gzip.open(os.path.join(self._extracted_dir, f"{stream_name}.gz")) as stream:
+            yield WrappedStream(stream, meta=self.meta[stream_name])
+
+    def __repr__(self):
+        return f"<{type(self).__name__} {self.path!r}>"
+
+
+class ExtractedDumpExistsError(Exception):
+    def __init__(self, path):
+        super().__init__(f"Extracted dump already exists at {path}")
+        self.path = path

--- a/corehq/apps/dump_reload/interface.py
+++ b/corehq/apps/dump_reload/interface.py
@@ -1,5 +1,3 @@
-import gzip
-import os
 import re
 import sys
 import warnings
@@ -57,31 +55,18 @@ class DataLoader(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    def load_from_path(self, extracted_dump_path, dump_meta, force=False, dry_run=False):
-        loaded_object_count = {}
-        for file in os.listdir(extracted_dump_path):
-            path = os.path.join(extracted_dump_path, file)
-            if file.startswith(self.slug) and file.endswith('.gz') and os.path.isfile(path):
-                counts = self.load_from_file(path, dump_meta, force, dry_run)
-                loaded_object_count.update(counts)
-        return loaded_object_count
+    def load_from_stream(self, stream, stream_meta, force=False, dry_run=False):
+        """``stream_meta`` is the per-stream ``{model_name: count}`` mapping
+        from the archive's metadata. Returns ``{self.slug: Counter}``.
+        """
+        self.stdout.write(f"\nLoading '{self.slug}' data loader.")
+        object_strings = with_progress_bar(stream, length=sum(stream_meta.values()))
+        loaded_object_count = self.load_objects(object_strings, force, dry_run)
 
-    def load_from_file(self, file_path, dump_meta, force=False, dry_run=False):
-        if not os.path.isfile(file_path):
-            raise Exception("Dump file not found: {}".format(file_path))
-
-        self.stdout.write(f"\nLoading {file_path} using '{self.slug}' data loader.")
-        meta_slug, _ = os.path.splitext(os.path.basename(file_path))
-        expected_count = sum(dump_meta[meta_slug].values())
-        with gzip.open(file_path) as dump_file:
-            object_strings = with_progress_bar(dump_file, length=expected_count)
-            loaded_object_count = self.load_objects(object_strings, force, dry_run)
-
-        # Warn if the file we loaded contains 0 objects.
         if sum(loaded_object_count.values()) == 0:
             warnings.warn(
-                f"No data found for '{file_path}'. (File format may be invalid.)",
+                f"No data found for '{self.slug}'. (File format may be invalid.)",
                 RuntimeWarning,
             )
 
-        return {meta_slug: loaded_object_count}
+        return {self.slug: loaded_object_count}

--- a/corehq/apps/dump_reload/interface.py
+++ b/corehq/apps/dump_reload/interface.py
@@ -80,9 +80,8 @@ class DataLoader(metaclass=ABCMeta):
         # Warn if the file we loaded contains 0 objects.
         if sum(loaded_object_count.values()) == 0:
             warnings.warn(
-                "No data found for '%s'. (File format may be "
-                "invalid.)" % file_path,
-                RuntimeWarning
+                f"No data found for '{file_path}'. (File format may be invalid.)",
+                RuntimeWarning,
             )
 
         return {meta_slug: loaded_object_count}

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
                  '(use multiple --include to include multiple apps/models).'
         )
         parser.add_argument(
-            '--format', choices=['gzip', 'zstd', 'console'], default='gzip',
+            '--format', choices=['gzip', 'zstd', 'console'], default='zstd',
             help='Archive format. "console" writes all streams to stdout '
                  'instead of producing an archive file.'
         )

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -11,6 +11,9 @@ from corehq.apps.dump_reload.couch import CouchDataDumper
 from corehq.apps.dump_reload.couch.dump import DomainDumper, ToggleDumper
 from corehq.apps.dump_reload.sql import SqlDataDumper
 
+# Domain dumper should be first since it validates that the domain exists.
+DUMPERS = [DomainDumper, SqlDataDumper, CouchDataDumper, ToggleDumper]
+
 
 class Command(BaseCommand):
     # This doesn't include SyncLog data
@@ -47,11 +50,8 @@ class Command(BaseCommand):
 
         self.stdout.ending = None
         meta = {}  # {dumper_slug: {model_name: count}}
-        # domain dumper should be first since it validates domain exists
-        for dumper in [DomainDumper, SqlDataDumper, CouchDataDumper, ToggleDumper]:
-            if requested_dumpers and dumper.slug not in requested_dumpers:
-                continue
-
+        dumpers = [d for d in DUMPERS if not requested_dumpers or d.slug in requested_dumpers]
+        for dumper in dumpers:
             filename = _get_dump_stream_filename(dumper.slug, domain_name, self.utcnow)
             stream = self.stdout if console else gzip.open(filename, 'wt')
             try:

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
         requested_dumpers = options.get('dumpers')
 
         self.utcnow = datetime.utcnow().strftime(DATETIME_FORMAT)
-        zipname = 'data-dump-{}-{}.zip'.format(domain_name, self.utcnow)
+        zipname = f'data-dump-{domain_name}-{self.utcnow}.zip'
 
         self.stdout.ending = None
         meta = {}  # {dumper_slug: {model_name: count}}
@@ -59,14 +59,14 @@ class Command(BaseCommand):
             except Exception as e:
                 if show_traceback:
                     raise
-                raise CommandError("Unable to serialize database: %s" % e)
+                raise CommandError(f"Unable to serialize database: {e}")
             finally:
                 if stream and not console:
                     stream.close()
 
             if not console:
                 with zipfile.ZipFile(zipname, mode='a', allowZip64=True) as z:
-                    z.write(filename, '{}.gz'.format(dumper.slug))
+                    z.write(filename, f'{dumper.slug}.gz')
 
                 os.remove(filename)
 
@@ -75,7 +75,7 @@ class Command(BaseCommand):
                 z.writestr('meta.json', json.dumps(meta, indent=4))
 
         self._print_stats(meta)
-        self.stdout.write('\nData dumped to file: {}'.format(zipname))
+        self.stdout.write(f'\nData dumped to file: {zipname}')
 
     def _print_stats(self, meta):
         self.stdout.ending = '\n'

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -75,7 +75,8 @@ class Command(BaseCommand):
                 z.writestr('meta.json', json.dumps(meta, indent=4))
 
         self._print_stats(meta)
-        self.stdout.write(f'\nData dumped to file: {zipname}')
+        if not console:
+            self.stdout.write(f'\nData dumped to file: {zipname}')
 
     def _print_stats(self, meta):
         self.stdout.ending = '\n'

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -4,6 +4,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 from corehq.apps.dump_reload.archive import (
     SimpleSingleStreamWriter,
+    ZipWithZstdArchiveWriter,
     ZippedGzipArchiveWriter,
 )
 from corehq.apps.dump_reload.const import DATETIME_FORMAT
@@ -32,8 +33,9 @@ class Command(BaseCommand):
                  '(use multiple --include to include multiple apps/models).'
         )
         parser.add_argument(
-            '--console', action='store_true', default=False, dest='console',
-            help='Write output to the console instead of to file.'
+            '--format', choices=['gzip', 'zstd', 'console'], default='gzip',
+            help='Archive format. "console" writes all streams to stdout '
+                 'instead of producing an archive file.'
         )
         parser.add_argument('--dumper', dest='dumpers', action='append', default=[],
                             help='Dumper slug to run (use multiple --dumper to run multiple dumpers).')
@@ -41,18 +43,19 @@ class Command(BaseCommand):
     def handle(self, domain_name, **options):
         excludes = options.get('exclude')
         includes = options.get('include')
-        console = options.get('console')
+        archive_format = options.get('format')
         show_traceback = options.get('traceback')
         requested_dumpers = options.get('dumpers')
 
-        utcnow = datetime.utcnow().strftime(DATETIME_FORMAT)
         self.stdout.ending = None
 
         dumpers = [d for d in DUMPERS if not requested_dumpers or d.slug in requested_dumpers]
-        if console:
+        if archive_format == 'console':
             archive = SimpleSingleStreamWriter(self.stdout)
-        else:
-            archive = ZippedGzipArchiveWriter(f"data-dump-{domain_name}-{utcnow}.zip")
+        elif archive_format == 'gzip':
+            archive = ZippedGzipArchiveWriter(_get_dump_file_name(domain_name))
+        elif archive_format == 'zstd':
+            archive = ZipWithZstdArchiveWriter(_get_dump_file_name(domain_name))
 
         with archive:
             for dumper in dumpers:
@@ -80,3 +83,8 @@ class Command(BaseCommand):
             count for model in meta.values() for count in model.values()
         )))
         self.stdout.write('{0}{0}'.format('-' * 38))
+
+
+def _get_dump_file_name(domain, suffix='zip'):
+    utcnow = datetime.utcnow().strftime(DATETIME_FORMAT)
+    return f'data-dump-{domain}-{utcnow}.{suffix}'

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -1,11 +1,11 @@
-import gzip
-import json
-import os
-import zipfile
 from datetime import datetime
 
 from django.core.management.base import BaseCommand, CommandError
 
+from corehq.apps.dump_reload.archive import (
+    SimpleSingleStreamWriter,
+    ZippedGzipArchiveWriter,
+)
 from corehq.apps.dump_reload.const import DATETIME_FORMAT
 from corehq.apps.dump_reload.couch import CouchDataDumper
 from corehq.apps.dump_reload.couch.dump import DomainDumper, ToggleDumper
@@ -45,38 +45,28 @@ class Command(BaseCommand):
         show_traceback = options.get('traceback')
         requested_dumpers = options.get('dumpers')
 
-        self.utcnow = datetime.utcnow().strftime(DATETIME_FORMAT)
-        zipname = f'data-dump-{domain_name}-{self.utcnow}.zip'
-
+        utcnow = datetime.utcnow().strftime(DATETIME_FORMAT)
         self.stdout.ending = None
-        meta = {}  # {dumper_slug: {model_name: count}}
+
         dumpers = [d for d in DUMPERS if not requested_dumpers or d.slug in requested_dumpers]
-        for dumper in dumpers:
-            filename = _get_dump_stream_filename(dumper.slug, domain_name, self.utcnow)
-            stream = self.stdout if console else gzip.open(filename, 'wt')
-            try:
-                meta[dumper.slug] = dumper(domain_name, excludes, includes).dump(stream)
-            except Exception as e:
-                if show_traceback:
-                    raise
-                raise CommandError(f"Unable to serialize database: {e}")
-            finally:
-                if stream and not console:
-                    stream.close()
+        if console:
+            archive = SimpleSingleStreamWriter(self.stdout)
+        else:
+            archive = ZippedGzipArchiveWriter(f"data-dump-{domain_name}-{utcnow}.zip")
 
-            if not console:
-                with zipfile.ZipFile(zipname, mode='a', allowZip64=True) as z:
-                    z.write(filename, f'{dumper.slug}.gz')
+        with archive:
+            for dumper in dumpers:
+                try:
+                    with archive.open_stream(dumper.slug) as stream:
+                        stream.meta = dumper(domain_name, excludes, includes).dump(stream)
+                except Exception as e:
+                    if show_traceback:
+                        raise
+                    raise CommandError(f"Unable to serialize database: {e}")
 
-                os.remove(filename)
-
-        if not console:
-            with zipfile.ZipFile(zipname, mode='a', allowZip64=True) as z:
-                z.writestr('meta.json', json.dumps(meta, indent=4))
-
-        self._print_stats(meta)
-        if not console:
-            self.stdout.write(f'\nData dumped to file: {zipname}')
+        self._print_stats(archive.meta)
+        if archive.path:
+            self.stdout.write(f'\nData dumped to file: {archive.path}')
 
     def _print_stats(self, meta):
         self.stdout.ending = '\n'
@@ -90,7 +80,3 @@ class Command(BaseCommand):
             count for model in meta.values() for count in model.values()
         )))
         self.stdout.write('{0}{0}'.format('-' * 38))
-
-
-def _get_dump_stream_filename(slug, domain, utcnow):
-    return 'dump-{}-{}-{}.gz'.format(slug, domain, utcnow)

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -18,31 +18,16 @@ LOADERS = [DomainLoader, SqlDataLoader, CouchDataLoader, ToggleLoader]
 
 
 class Command(BaseCommand):
-    """This command expects a ZIP file containing one or more
-    gzip files and a 'meta.json' file containing doc counts for each
-    of the gzip files:
+    """Loads a dump produced by ``dump_domain_data``.
 
-    zip:
-       sql.gz
-       couch.gz
-       sql-other.gz
-       meta.json
+    The archive's ``meta.json`` summarises object counts per loader::
 
-    The filenames of the gzip files must be formatted as <slug><suffix>.gz where
-        -  <slug> is one of 'sql', 'couch', 'domain', 'toggle'
-        -  <suffix> can be anything
-
-    meta.json:
-        Must contain a single JSON object with properties for each of the filnames
-        in the zip file. The value of the properties must be a dict of
-        document counts in the corresponding gzip file:
-
-            {
-                "domain": {"Domain": 1},
-                "sql": {"blobs.BlobMeta": 11, "auth.User": 1},
-                "couch": {"users.CommCareUser": 5},
-                "toggles": {"Toggle": 5},
-            }
+        {
+            "domain": {"Domain": 1},
+            "sql": {"blobs.BlobMeta": 11, "auth.User": 1},
+            "couch": {"users.CommCareUser": 5},
+            "toggles": {"Toggle": 5},
+        }
     """
     help = (
         "Loads data from the given file into the database.\n\n"

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -80,9 +80,9 @@ class Command(BaseCommand):
         self.should_throttle = options.get('throttle')
 
         if not os.path.isfile(dump_file_path):
-            raise CommandError("Dump file not found: {}".format(dump_file_path))
+            raise CommandError(f"Dump file not found: {dump_file_path}")
 
-        self.stdout.write("Loading data from %s." % dump_file_path)
+        self.stdout.write(f"Loading data from {dump_file_path}.")
         extracted_dir = self.extract_dump_archive(dump_file_path)
 
         loaded_meta = {}
@@ -122,7 +122,7 @@ class Command(BaseCommand):
                 archive.extractall(target_dir)
         elif not self.use_extracted:
             raise CommandError(
-                "Extracted dump already exists at {}. Delete it or use --use-extracted".format(target_dir))
+                f"Extracted dump already exists at {target_dir}. Delete it or use --use-extracted")
         return target_dir
 
     def _load_data(self, loader_class, extracted_dump_path, object_filter, dump_meta):
@@ -130,10 +130,10 @@ class Command(BaseCommand):
             loader = loader_class(object_filter, self.stdout, self.stderr, self.chunksize, self.should_throttle)
             return loader.load_from_path(extracted_dump_path, dump_meta, force=self.force, dry_run=self.dry_run)
         except DataExistsException as e:
-            raise CommandError('Some data already exists. Use --force to load anyway: {}'.format(str(e)))
+            raise CommandError(f"Some data already exists. Use --force to load anyway: {e}")
         except Exception as e:
             if not isinstance(e, CommandError):
-                e.args = ("Problem loading data '%s': %s" % (extracted_dump_path, e),)
+                e.args = (f"Problem loading data '{extracted_dump_path}': {e}",)
             raise
 
 

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -5,6 +5,7 @@ import inspect
 
 from django.core.management.base import BaseCommand, CommandError
 
+from corehq.apps.dump_reload.archive.utils import get_tmp_extract_dir
 from corehq.apps.dump_reload.couch.load import (
     CouchDataLoader,
     DomainLoader,
@@ -143,7 +144,3 @@ def _get_dump_meta(extracted_dir):
     meta_path = os.path.join(extracted_dir, 'meta.json')
     with open(meta_path) as f:
         return json.loads(f.read())
-
-
-def get_tmp_extract_dir(dump_file_path, specifier=""):
-    return f'_tmp_load_{specifier}_{dump_file_path}'

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('dump_file_path')
-        parser.add_argument('--format', choices=['gzip', 'zstd'], default='gzip',
+        parser.add_argument('--format', choices=['gzip', 'zstd'], default='zstd',
                             help='Archive format of the input file.')
         parser.add_argument('--use-extracted', action='store_true', default=False, dest='use_extracted',
                             help="Use already extracted dump if it exists "

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -87,12 +87,9 @@ class Command(BaseCommand):
         extracted_dir = self.extract_dump_archive(dump_file_path)
 
         loaded_meta = {}
-        loaders = options.get('loaders')
+        requested_loaders = options.get('loaders')
         object_filter = options.get('object_filter')
-        if loaders:
-            loaders = [loader for loader in LOADERS if loader.slug in loaders]
-        else:
-            loaders = LOADERS
+        loaders = [loader for loader in LOADERS if not requested_loaders or loader.slug in requested_loaders]
 
         dump_meta = _get_dump_meta(extracted_dir)
         for loader in loaders:

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -1,10 +1,12 @@
 import json
 import os
-import zipfile
 
 from django.core.management.base import BaseCommand, CommandError
 
-from corehq.apps.dump_reload.archive.utils import get_tmp_extract_dir
+from corehq.apps.dump_reload.archive import (
+    ExtractedDumpExistsError,
+    ZippedGzipArchiveReader,
+)
 from corehq.apps.dump_reload.couch.load import (
     CouchDataLoader,
     DomainLoader,
@@ -29,6 +31,7 @@ class Command(BaseCommand):
             "toggles": {"Toggle": 5},
         }
     """
+
     help = (
         "Loads data from the given file into the database.\n\n"
         "Use in conjunction with `dump_domain_data`."
@@ -67,31 +70,41 @@ class Command(BaseCommand):
             raise CommandError(f"Dump file not found: {dump_file_path}")
 
         self.stdout.write(f"Loading data from {dump_file_path}.")
-        extracted_dir = self.extract_dump_archive(dump_file_path)
+
+        try:
+            archive = ZippedGzipArchiveReader(dump_file_path, use_extracted=self.use_extracted)
+        except ValueError as e:
+            raise CommandError(str(e))
 
         loaded_meta = {}
         requested_loaders = options.get('loaders')
         object_filter = options.get('object_filter')
         loaders = [loader for loader in LOADERS if not requested_loaders or loader.slug in requested_loaders]
 
-        dump_meta = _get_dump_meta(extracted_dir)
-        for loader in loaders:
-            loaded_meta.update(self._load_data(loader, extracted_dir, object_filter, dump_meta))
+        try:
+            with archive:
+                for loader in loaders:
+                    loaded_meta.update(self._load_data(loader, archive, object_filter))
+        except ExtractedDumpExistsError as e:
+            raise CommandError(
+                f"Extracted dump already exists at {e.path}. Delete it or use --use-extracted"
+            )
 
         if options.get("json_output"):
             return json.dumps(loaded_meta)
         else:
-            self._print_stats(loaded_meta, dump_meta)
+            self._print_stats(loaded_meta, archive.meta)
 
-    def _load_data(self, loader_class, extracted_dump_path, object_filter, dump_meta):
+    def _load_data(self, loader_class, archive, object_filter):
         try:
             loader = loader_class(object_filter, self.stdout, self.stderr, self.chunksize, self.should_throttle)
-            return loader.load_from_path(extracted_dump_path, dump_meta, force=self.force, dry_run=self.dry_run)
+            with archive.open_stream(loader.slug) as stream:
+                return loader.load_from_stream(stream, stream.meta, force=self.force, dry_run=self.dry_run)
         except DataExistsException as e:
             raise CommandError(f"Some data already exists. Use --force to load anyway: {e}")
         except Exception as e:
             if not isinstance(e, CommandError):
-                e.args = (f"Problem loading data '{extracted_dump_path}': {e}",)
+                e.args = (f"Problem loading data '{archive.path}': {e}",)
             raise
 
     def _print_stats(self, loaded_meta, dump_meta):
@@ -106,21 +119,3 @@ class Command(BaseCommand):
         total_object_count = sum(count for model in dump_meta.values() for count in model.values())
         self.stdout.write(f'Loaded {loaded_object_count}/{total_object_count} objects')
         self.stdout.write('{0}{0}'.format('-' * 46))
-
-    def extract_dump_archive(self, dump_file_path):
-        target_dir = get_tmp_extract_dir(dump_file_path)
-        if not os.path.exists(target_dir):
-            with zipfile.ZipFile(dump_file_path, 'r') as archive:
-                archive.extractall(target_dir)
-        elif not self.use_extracted:
-            raise CommandError(
-                f"Extracted dump already exists at {target_dir}. Delete it or use --use-extracted")
-        return target_dir
-
-
-def _get_dump_meta(extracted_dir):
-    # The dump command should have a metadata json file of the form
-    # {dumper_slug: {model_name: count}}
-    meta_path = os.path.join(extracted_dir, 'meta.json')
-    with open(meta_path) as f:
-        return json.loads(f.read())

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -5,6 +5,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 from corehq.apps.dump_reload.archive import (
     ExtractedDumpExistsError,
+    ZipWithZstdArchiveReader,
     ZippedGzipArchiveReader,
 )
 from corehq.apps.dump_reload.couch.load import (
@@ -39,8 +40,11 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('dump_file_path')
+        parser.add_argument('--format', choices=['gzip', 'zstd'], default='gzip',
+                            help='Archive format of the input file.')
         parser.add_argument('--use-extracted', action='store_true', default=False, dest='use_extracted',
-                            help="Use already extracted dump if it exists.")
+                            help="Use already extracted dump if it exists "
+                                 "(gzip format only; ignored otherwise).")
         parser.add_argument('--force', action='store_true', default=False, dest='force',
                             help="Load data for domain that already exists.")
         parser.add_argument('--dry-run', action='store_true', default=False, dest='dry_run',
@@ -71,8 +75,12 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Loading data from {dump_file_path}.")
 
+        archive_format = options.get('format')
         try:
-            archive = ZippedGzipArchiveReader(dump_file_path, use_extracted=self.use_extracted)
+            if archive_format == 'gzip':
+                archive = ZippedGzipArchiveReader(dump_file_path, use_extracted=self.use_extracted)
+            else:
+                archive = ZipWithZstdArchiveReader(dump_file_path)
         except ValueError as e:
             raise CommandError(str(e))
 

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -83,6 +83,17 @@ class Command(BaseCommand):
         else:
             self._print_stats(loaded_meta, dump_meta)
 
+    def _load_data(self, loader_class, extracted_dump_path, object_filter, dump_meta):
+        try:
+            loader = loader_class(object_filter, self.stdout, self.stderr, self.chunksize, self.should_throttle)
+            return loader.load_from_path(extracted_dump_path, dump_meta, force=self.force, dry_run=self.dry_run)
+        except DataExistsException as e:
+            raise CommandError(f"Some data already exists. Use --force to load anyway: {e}")
+        except Exception as e:
+            if not isinstance(e, CommandError):
+                e.args = (f"Problem loading data '{extracted_dump_path}': {e}",)
+            raise
+
     def _print_stats(self, loaded_meta, dump_meta):
         self.stdout.write('{0} Load Stats {0}'.format('-' * 40))
         for loader, models in sorted(loaded_meta.items()):
@@ -105,17 +116,6 @@ class Command(BaseCommand):
             raise CommandError(
                 f"Extracted dump already exists at {target_dir}. Delete it or use --use-extracted")
         return target_dir
-
-    def _load_data(self, loader_class, extracted_dump_path, object_filter, dump_meta):
-        try:
-            loader = loader_class(object_filter, self.stdout, self.stderr, self.chunksize, self.should_throttle)
-            return loader.load_from_path(extracted_dump_path, dump_meta, force=self.force, dry_run=self.dry_run)
-        except DataExistsException as e:
-            raise CommandError(f"Some data already exists. Use --force to load anyway: {e}")
-        except Exception as e:
-            if not isinstance(e, CommandError):
-                e.args = (f"Problem loading data '{extracted_dump_path}': {e}",)
-            raise
 
 
 def _get_dump_meta(extracted_dir):

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -1,7 +1,6 @@
 import json
 import os
 import zipfile
-import inspect
 
 from django.core.management.base import BaseCommand, CommandError
 
@@ -45,11 +44,10 @@ class Command(BaseCommand):
                 "toggles": {"Toggle": 5},
             }
     """
-    help = inspect.cleandoc("""
-        Loads data from the give file into the database.
-
-        Use in conjunction with `dump_domain_data`.
-    """)
+    help = (
+        "Loads data from the given file into the database.\n\n"
+        "Use in conjunction with `dump_domain_data`."
+    )
 
     def add_arguments(self, parser):
         parser.add_argument('dump_file_path')

--- a/corehq/apps/dump_reload/tests/archive/_common.py
+++ b/corehq/apps/dump_reload/tests/archive/_common.py
@@ -1,0 +1,16 @@
+import os
+import tempfile
+from pathlib import Path
+
+from unmagic import fixture
+
+
+@fixture
+def tmp_work_dir():
+    original = os.getcwd()
+    with tempfile.TemporaryDirectory() as tmp:
+        os.chdir(tmp)
+        try:
+            yield Path(tmp)
+        finally:
+            os.chdir(original)

--- a/corehq/apps/dump_reload/tests/archive/test_single_stream.py
+++ b/corehq/apps/dump_reload/tests/archive/test_single_stream.py
@@ -1,0 +1,45 @@
+from io import StringIO
+
+from corehq.apps.dump_reload.archive import SimpleSingleStreamWriter
+
+
+def test_path_is_none():
+    writer = SimpleSingleStreamWriter(StringIO())
+    assert writer.path is None
+
+
+def test_open_stream_emits_to_supplied_stream():
+    out = StringIO()
+    with SimpleSingleStreamWriter(out) as writer:
+        with writer.open_stream("sql") as stream:
+            stream.write("hello\n")
+            stream.meta = {}
+    assert out.getvalue() == "hello\n"
+
+
+def test_does_not_close_underlying_stream_between_dumpers():
+    out = StringIO()
+    with SimpleSingleStreamWriter(out) as writer:
+        for slug in ["a", "b", "c"]:
+            with writer.open_stream(slug) as stream:
+                stream.write(f"{slug}-data\n")
+                stream.meta = {f"{slug}.Model": 1}
+    # Underlying stream still writable after the writer exits.
+    out.write("after\n")
+    text = out.getvalue()
+    assert "a-data" in text
+    assert "b-data" in text
+    assert "c-data" in text
+    assert text.endswith("after\n")
+
+
+def test_meta_round_trips():
+    with SimpleSingleStreamWriter(StringIO()) as writer:
+        with writer.open_stream("sql") as stream:
+            stream.meta = {"auth.User": 5}
+        with writer.open_stream("couch") as stream:
+            stream.meta = {"users.CommCareUser": 1}
+    assert writer.meta == {
+        "sql": {"auth.User": 5},
+        "couch": {"users.CommCareUser": 1},
+    }

--- a/corehq/apps/dump_reload/tests/archive/test_utils.py
+++ b/corehq/apps/dump_reload/tests/archive/test_utils.py
@@ -1,0 +1,12 @@
+from corehq.apps.dump_reload.archive.utils import get_tmp_extract_dir
+
+
+def test_get_tmp_extract_dir_default_specifier():
+    assert get_tmp_extract_dir('data-dump-foo.zip') == '_tmp_load__data-dump-foo.zip'
+
+
+def test_get_tmp_extract_dir_with_specifier():
+    assert (
+        get_tmp_extract_dir('data-dump-foo.zip', specifier='blob_meta')
+        == '_tmp_load_blob_meta_data-dump-foo.zip'
+    )

--- a/corehq/apps/dump_reload/tests/archive/test_zip_with_zstd.py
+++ b/corehq/apps/dump_reload/tests/archive/test_zip_with_zstd.py
@@ -1,0 +1,102 @@
+import os
+
+import pytest
+from unmagic import use
+
+from corehq.apps.dump_reload.archive import (
+    ZipWithZstdArchiveReader,
+    ZipWithZstdArchiveWriter,
+)
+from corehq.apps.dump_reload.archive import zip_with_zstd
+
+from ._common import tmp_work_dir
+
+
+def test_zstd_writer_rejects_path_without_zip_suffix():
+    with pytest.raises(ValueError, match=r"\.zip"):
+        ZipWithZstdArchiveWriter("data-dump-foo")
+
+
+def test_zstd_reader_rejects_path_without_zip_suffix():
+    with pytest.raises(ValueError, match=r"\.zip"):
+        ZipWithZstdArchiveReader("data-dump-foo")
+
+
+@use(tmp_work_dir)
+def test_zstd_writer_round_trips_streams_and_meta():
+    tmp_path = tmp_work_dir()
+    with ZipWithZstdArchiveWriter("data-dump-foo.zip") as writer:
+        with writer.open_stream("sql") as stream:
+            stream.write('{"model": "auth.User"}\n')
+            stream.write('{"model": "auth.User"}\n')
+            stream.meta = {"auth.User": 2}
+        with writer.open_stream("couch") as stream:
+            stream.write('{"doc_type": "CommCareUser"}\n')
+            stream.meta = {"users.CommCareUser": 1}
+
+    with ZipWithZstdArchiveReader(str(tmp_path / "data-dump-foo.zip")) as reader:
+        assert reader.meta == {
+            "sql": {"auth.User": 2},
+            "couch": {"users.CommCareUser": 1},
+        }
+        with reader.open_stream("sql") as stream:
+            assert stream.meta == {"auth.User": 2}
+            assert stream.read() == (
+                b'{"model": "auth.User"}\n'
+                b'{"model": "auth.User"}\n'
+            )
+        with reader.open_stream("couch") as stream:
+            assert stream.read() == b'{"doc_type": "CommCareUser"}\n'
+
+
+@use(tmp_work_dir)
+def test_zstd_writer_uses_zip_zstandard_compression():
+    tmp_path = tmp_work_dir()
+    with ZipWithZstdArchiveWriter("data-dump-foo.zip") as writer:
+        with writer.open_stream("sql") as stream:
+            stream.write('{"model": "auth.User"}\n')
+            stream.meta = {}
+        with writer.open_stream("couch") as stream:
+            stream.write('{"doc_type": "X"}\n')
+            stream.meta = {}
+
+    # Use the same zipfile module the writer used, so we can read the
+    # ZIP_ZSTANDARD compression method.
+    zf_mod = zip_with_zstd.zipfile
+    with zf_mod.ZipFile(tmp_path / "data-dump-foo.zip") as z:
+        assert z.namelist() == ["sql", "couch", "meta.json"]
+        assert z.getinfo("sql").compress_type == zf_mod.ZIP_ZSTANDARD
+        assert z.getinfo("couch").compress_type == zf_mod.ZIP_ZSTANDARD
+
+
+@use(tmp_work_dir)
+def test_zstd_writer_leaves_no_temp_files():
+    tmp_path = tmp_work_dir()
+    with ZipWithZstdArchiveWriter("data-dump-foo.zip") as writer:
+        with writer.open_stream("sql") as stream:
+            stream.write("x\n")
+            stream.meta = {}
+    # Only the .zip on disk — streaming compression never writes a temp file.
+    assert sorted(os.listdir(tmp_path)) == ["data-dump-foo.zip"]
+
+
+@use(tmp_work_dir)
+def test_zstd_writer_raises_when_stream_meta_not_set():
+    tmp_work_dir()
+    with pytest.raises(RuntimeError, match=r"meta not set for stream 'sql'"):
+        with ZipWithZstdArchiveWriter("data-dump-foo.zip") as writer:
+            with writer.open_stream("sql") as stream:
+                stream.write("x\n")
+
+
+@use(tmp_work_dir)
+def test_zstd_reader_open_stream_handle_carries_per_stream_meta():
+    tmp_path = tmp_work_dir()
+    with ZipWithZstdArchiveWriter("data-dump-foo.zip") as writer:
+        with writer.open_stream("sql") as stream:
+            stream.write('{"model": "auth.User"}\n')
+            stream.meta = {"auth.User": 1}
+
+    with ZipWithZstdArchiveReader(str(tmp_path / "data-dump-foo.zip")) as reader:
+        with reader.open_stream("sql") as stream:
+            assert stream.meta == {"auth.User": 1}

--- a/corehq/apps/dump_reload/tests/archive/test_zipped_gzip.py
+++ b/corehq/apps/dump_reload/tests/archive/test_zipped_gzip.py
@@ -1,0 +1,177 @@
+import gzip
+import json
+import os
+import zipfile
+
+import pytest
+from unmagic import use
+
+from corehq.apps.dump_reload.archive import (
+    ExtractedDumpExistsError,
+    ZippedGzipArchiveReader,
+    ZippedGzipArchiveWriter,
+)
+from corehq.apps.dump_reload.archive.utils import get_tmp_extract_dir
+
+from ._common import tmp_work_dir
+
+
+def test_writer_rejects_path_without_zip_suffix():
+    with pytest.raises(ValueError, match=r"\.zip"):
+        ZippedGzipArchiveWriter("data-dump-foo")
+
+
+@use(tmp_work_dir)
+def test_writer_writes_streams_and_meta_to_zip():
+    tmp_path = tmp_work_dir()
+    with ZippedGzipArchiveWriter("data-dump-foo.zip") as writer:
+        with writer.open_stream("sql") as stream:
+            stream.write('{"model": "auth.User"}\n')
+            stream.write('{"model": "auth.User"}\n')
+            stream.meta = {"auth.User": 2}
+        with writer.open_stream("couch") as stream:
+            stream.write('{"doc_type": "CommCareUser"}\n')
+            stream.meta = {"users.CommCareUser": 1}
+
+    archive_path = tmp_path / "data-dump-foo.zip"
+    assert archive_path.exists()
+    with zipfile.ZipFile(archive_path) as z:
+        names = z.namelist()
+        assert names == ["sql.gz", "couch.gz", "meta.json"]
+        with z.open("sql.gz") as raw, gzip.open(raw, "rt") as gz:
+            assert gz.read() == (
+                '{"model": "auth.User"}\n'
+                '{"model": "auth.User"}\n'
+            )
+        with z.open("couch.gz") as raw, gzip.open(raw, "rt") as gz:
+            assert gz.read() == '{"doc_type": "CommCareUser"}\n'
+        meta = json.loads(z.read("meta.json"))
+        assert meta == {
+            "sql": {"auth.User": 2},
+            "couch": {"users.CommCareUser": 1},
+        }
+
+
+@use(tmp_work_dir)
+def test_writer_raises_when_stream_meta_not_set():
+    tmp_work_dir()
+    with pytest.raises(RuntimeError, match=r"meta not set for stream 'sql'"):
+        with ZippedGzipArchiveWriter("data-dump-foo.zip") as writer:
+            with writer.open_stream("sql") as stream:
+                stream.write("x\n")
+                # forgot to set stream.meta
+
+
+@use(tmp_work_dir)
+def test_writer_cleans_up_temp_file_on_success():
+    tmp_path = tmp_work_dir()
+    with ZippedGzipArchiveWriter("data-dump-foo.zip") as writer:
+        with writer.open_stream("sql") as stream:
+            stream.write("x\n")
+            stream.meta = {}
+    # Only the .zip remains in the directory.
+    assert sorted(os.listdir(tmp_path)) == ["data-dump-foo.zip"]
+
+
+@use(tmp_work_dir)
+def test_writer_skips_zip_append_when_inner_block_raises():
+    tmp_path = tmp_work_dir()
+    with pytest.raises(RuntimeError, match="boom"):
+        with ZippedGzipArchiveWriter("data-dump-foo.zip") as writer:
+            with writer.open_stream("sql") as stream:
+                stream.write("partial\n")
+                raise RuntimeError("boom")
+    # The archive should not exist: nothing was appended and meta.json
+    # was never finalized.
+    assert not (tmp_path / "data-dump-foo.zip").exists()
+
+
+@use(tmp_work_dir)
+def test_writer_skips_meta_when_writer_block_raises():
+    tmp_path = tmp_work_dir()
+    with pytest.raises(RuntimeError, match="boom"):
+        with ZippedGzipArchiveWriter("data-dump-foo.zip") as writer:
+            with writer.open_stream("sql") as stream:
+                stream.write("x\n")
+                stream.meta = {}
+            raise RuntimeError("boom")
+    # The first stream was added but meta.json was not.
+    with zipfile.ZipFile(tmp_path / "data-dump-foo.zip") as z:
+        assert z.namelist() == ["sql.gz"]
+
+
+def test_reader_rejects_path_without_zip_suffix():
+    with pytest.raises(ValueError, match=r"\.zip"):
+        ZippedGzipArchiveReader("data-dump-foo")
+
+
+def test_extracted_dump_exists_error_carries_path():
+    err = ExtractedDumpExistsError("/some/path")
+    assert err.path == "/some/path"
+    assert "/some/path" in str(err)
+
+
+def _build_archive(tmp_path, name="data-dump-foo.zip"):
+    """Helper: write a small one-stream archive into tmp_path and return its
+    name. Assumes the caller is already chdir'd to tmp_path.
+    """
+    with ZippedGzipArchiveWriter(name) as writer:
+        with writer.open_stream("sql") as stream:
+            stream.write('{"model": "auth.User"}\n')
+            stream.meta = {"auth.User": 1}
+    return name
+
+
+@use(tmp_work_dir)
+def test_reader_extracts_zip_on_enter():
+    tmp_path = tmp_work_dir()
+    name = _build_archive(tmp_path)
+    with ZippedGzipArchiveReader(name):
+        target_dir = get_tmp_extract_dir(name)
+        assert os.path.isdir(target_dir)
+        assert os.path.isfile(os.path.join(target_dir, "sql.gz"))
+        assert os.path.isfile(os.path.join(target_dir, "meta.json"))
+
+
+@use(tmp_work_dir)
+def test_reader_rejects_existing_dir_without_use_extracted():
+    tmp_path = tmp_work_dir()
+    name = _build_archive(tmp_path)
+    # First open extracts.
+    with ZippedGzipArchiveReader(name):
+        pass
+    # Second open must reject because the extracted dir already exists.
+    with pytest.raises(ExtractedDumpExistsError) as excinfo:
+        with ZippedGzipArchiveReader(name):
+            pass
+    assert excinfo.value.path == get_tmp_extract_dir(name)
+
+
+@use(tmp_work_dir)
+def test_reader_reuses_existing_dir_with_use_extracted():
+    tmp_path = tmp_work_dir()
+    name = _build_archive(tmp_path)
+    with ZippedGzipArchiveReader(name):
+        pass
+    with ZippedGzipArchiveReader(name, use_extracted=True):
+        target_dir = get_tmp_extract_dir(name)
+        assert os.path.isfile(os.path.join(target_dir, "meta.json"))
+
+
+@use(tmp_work_dir)
+def test_reader_open_stream_yields_bytes_lines():
+    tmp_path = tmp_work_dir()
+    name = _build_archive(tmp_path)
+    with ZippedGzipArchiveReader(name) as reader:
+        with reader.open_stream("sql") as stream:
+            lines = list(stream)
+    assert lines == [b'{"model": "auth.User"}\n']
+
+
+@use(tmp_work_dir)
+def test_reader_open_stream_handle_carries_per_stream_meta():
+    tmp_path = tmp_work_dir()
+    name = _build_archive(tmp_path)
+    with ZippedGzipArchiveReader(name) as reader:
+        with reader.open_stream("sql") as stream:
+            assert stream.meta == {"auth.User": 1}

--- a/corehq/blobs/management/commands/export_selected_blobs.py
+++ b/corehq/blobs/management/commands/export_selected_blobs.py
@@ -37,7 +37,8 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('path', help='Path to a file with a list of blob meta JSON to export')
         parser.add_argument('--meta-file-filter', nargs='?',
-                            help='Only export blobs for metadata in files with filenames matching the filter regex.')
+                            help='Only export blobs for metadata in files with filenames'
+                                 ' matching the filter regex.')
         parser.add_argument('--already_exported', dest='already_exported',
                             help='Pass a file with a list of blob names already exported')
         parser.add_argument('--use-extracted', action='store_true', default=False, dest='use_extracted',

--- a/corehq/blobs/management/commands/export_selected_blobs.py
+++ b/corehq/blobs/management/commands/export_selected_blobs.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from django.core.management import BaseCommand, CommandError
 
-from corehq.apps.dump_reload.management.commands.load_domain_data import get_tmp_extract_dir
+from corehq.apps.dump_reload.archive.utils import get_tmp_extract_dir
 from corehq.blobs.export import BlobDbBackendExporter
 from corehq.blobs.management.commands.run_blob_export import get_lines_from_file
 from corehq.util.decorators import change_log_level

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "alembic",
     "architect",
     "attrs>=21.4",
+    "backports.zstd ; python_version < '3.14'",
     "beautifulsoup4", # USH - used for rich text messaging emails, and some tests
     "bleach", # USH - used for rich text messaging emails
     "bleach[css]", # USH - used for rich text messaging emails

--- a/uv.lock
+++ b/uv.lock
@@ -200,6 +200,36 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-zstd"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/05/480d439b482edf59b786bc19b474d990c61942e372f5de3dc14acac8154d/backports_zstd-1.5.0.tar.gz", hash = "sha256:a5e622a82eb183b4fbe18032755ce0a15fa9a82f2adb9b621620b91247aaedb7", size = 998556, upload-time = "2026-05-11T19:54:24.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/e6/252521e3a847eb200bc0a1d528542d651b9c8dc7953e231c39ed2890d5ff/backports_zstd-1.5.0-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:02a57ee8598dd863c0b11c7af00042ce6bc045bf6f4249fa4c322c62614ca1fd", size = 400134, upload-time = "2026-05-11T19:53:24.28Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/27ef105ffa2da3d52218d4a7b2e14037974283953b3ee790358af6e9b4df/backports_zstd-1.5.0-cp313-cp313-android_21_x86_64.whl", hash = "sha256:c56c11eb3173d540e1fb0216f7ab477cbd3a204eca41f5f329059ee8a5d2ad47", size = 454225, upload-time = "2026-05-11T19:53:25.874Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/c9/cdcba1244347500d00567ce2cd6bf04c92d1b0fb6405fb8e13c07715eb46/backports_zstd-1.5.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:ef98f632026aa8e6ce05d786977092798efbe78677aa71219f22d31787809c90", size = 357229, upload-time = "2026-05-11T19:53:27.661Z" },
+    { url = "https://files.pythonhosted.org/packages/df/da/cea04dab3ffb940bde9a59866bde6f2594a7b3ef2948a63fb3898f73d311/backports_zstd-1.5.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:c3712300b18f9d07f788b03594b2f34dfad89d77df96938a640c5007522a6b69", size = 365907, upload-time = "2026-05-11T19:53:29.241Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c4/6a71df2e65033f9b7d8017d77ea2bb572fc2ebc814ea383fdcda4187597a/backports_zstd-1.5.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:bdbc75d1f54df70b65bcfbc8aa0cac21475f79665bb045960af606dc07b56090", size = 446453, upload-time = "2026-05-11T19:53:30.888Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e7/f98ad1a6a249c27884df9d28cf6ebc3c368e0e3288a741c1d51a572bb3d7/backports_zstd-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93d306300d25e59f1cbe98cda494bf295be03a20e8b2c5602ee5ddc03ded29f2", size = 436634, upload-time = "2026-05-11T19:53:32.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/42/d0393ecc64e2ab6ae1b5ca7edbe26e3fe5196885f15d6cc4bce7254e29cd/backports_zstd-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:305d2e4ae9a595d0fd9d5bea5a7a2163306c6c4dcc5eec35ecd5008219d4580e", size = 362867, upload-time = "2026-05-11T19:53:34.385Z" },
+    { url = "https://files.pythonhosted.org/packages/41/fe/87aa9404763bada695d06e5cb9d0575bae033cbf3a2e4e3bd648760178f7/backports_zstd-1.5.0-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:c8f0967bf8d806b250fb1e905a6b8190e7ae83656d5308989243f84e01fa3774", size = 506844, upload-time = "2026-05-11T19:53:36.023Z" },
+    { url = "https://files.pythonhosted.org/packages/56/94/3af7ce637d148e0b0acb1298b61afe9a934ed425bad9ff05e87afbf6766d/backports_zstd-1.5.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76b7314ca9a253171e3e9524960e9e6411997323cf10aecbbc330faa7a90278d", size = 476975, upload-time = "2026-05-11T19:53:37.885Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/6c/dc2aa1b48296ac6effc3bacb5a3061d40ed74bf73082dfe38eed2ba8362b/backports_zstd-1.5.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b1d0bf16bba86b1071731ced389f184e8de61c1afcafa584244f7f726632f92f", size = 582496, upload-time = "2026-05-11T19:53:39.812Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/38/dd49d3dd27eda9b165ccd63d70538fea016a3e9e42923bbbc1d89fae8a43/backports_zstd-1.5.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:96709d27d406008575ef759405169d538040156704b457d8c0ac035127a46b67", size = 643257, upload-time = "2026-05-11T19:53:41.819Z" },
+    { url = "https://files.pythonhosted.org/packages/59/75/78e819272450aec2462f97a1bceb90bde481f9dba435bf9e76d580b4dec4/backports_zstd-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5737402c29b2bd5bc661d4cde08aed531ed326f2b59a7ad98dc07650dc99a2c9", size = 491958, upload-time = "2026-05-11T19:53:43.501Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/d860f9cf21cb59d583a12166353bf71a439538e2b669f4a7736e400ca596/backports_zstd-1.5.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2b65f37ddd375114dbf84658e7dd168e10f5a93394940bfefa7fafc2d3234450", size = 567198, upload-time = "2026-05-11T19:53:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/38/7c/b175d4c9ff60f964c8f6dd43211de905227cfde5a41eb5f654df58483025/backports_zstd-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4fae7825dde4f81c28b4c66b1e997f893e296c3f1668351952b3ed085eb9f8cd", size = 482792, upload-time = "2026-05-11T19:53:47.323Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e3/f7b50cf891a10da5f9c412ed4a9c4a772df4d4186d98a41e75c9b462f148/backports_zstd-1.5.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:3aa10e77c0e712d2dfb950910b50591c2fb11f0f1328814e23acc0b4950766df", size = 510363, upload-time = "2026-05-11T19:53:49.523Z" },
+    { url = "https://files.pythonhosted.org/packages/be/50/e7841fd4a65661d527697a0e2dab97295868965ccd4e3e12474472719a60/backports_zstd-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:518b2ef54ce0fee6d29379cfd64ef66e639456f1b18943466e929b19677f135f", size = 586917, upload-time = "2026-05-11T19:53:51.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/7c/57e985dbd621f0307b8c57cabb258eb976793f2aeaf8a5bc020e15b4a793/backports_zstd-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:673a1e5fdaa6cb0c7a967eb33066b6dd564871b3498a93e11e2972998047d11f", size = 565004, upload-time = "2026-05-11T19:53:53.774Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/8f/855ffcd1ee0fcf44c3fe62e36db8e7362292d450cc7c4b3f43edccbcd37a/backports_zstd-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:1277c07ff2d731586aa05aebd946a1b30184620d886a735dd5d5bf94a4a1061e", size = 633737, upload-time = "2026-05-11T19:53:56.036Z" },
+    { url = "https://files.pythonhosted.org/packages/20/39/c4129a03d268699200dfebe1ccab97c7c332d2794571afb372a62e4ed098/backports_zstd-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:aff334c7c38b4aea2a899f3138a99c1d58f0686ad7815c74bff506ecf4333296", size = 496309, upload-time = "2026-05-11T19:53:57.591Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/33/34152316dd244dcd43d5300ded3cf6e1b46d343e4e92620c23e533fa91df/backports_zstd-1.5.0-cp313-cp313-win32.whl", hash = "sha256:b932834c4d85360f46d1e7fbf3eee1e26ba594e0eb5c3ee1281e89bc1d48d06f", size = 289560, upload-time = "2026-05-11T19:53:59.274Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c5/f759bc87fd77c88f4fdad2d878535fb7e9537c6a05876d206e6690bf33c6/backports_zstd-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:c71dfbeced720326a8917a6edf921c568dc2396228c6432205c6d7e7fe7f3707", size = 314812, upload-time = "2026-05-11T19:54:00.909Z" },
+    { url = "https://files.pythonhosted.org/packages/47/96/d7970dbb2fef34b549b34146090f48f41903cc7268b1ed1c7542eaa1852e/backports_zstd-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:7b5798b20ffff71ee4620a01f56fe0b50271724b4251db08c90a069446cc4752", size = 291411, upload-time = "2026-05-11T19:54:02.541Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
@@ -480,6 +510,7 @@ dependencies = [
     { name = "alembic" },
     { name = "architect" },
     { name = "attrs" },
+    { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "beautifulsoup4" },
     { name = "bleach", extra = ["css"] },
     { name = "boto3" },
@@ -642,6 +673,7 @@ requires-dist = [
     { name = "alembic" },
     { name = "architect" },
     { name = "attrs", specifier = ">=21.4" },
+    { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "beautifulsoup4" },
     { name = "bleach" },
     { name = "bleach", extras = ["css"] },


### PR DESCRIPTION
## Product Description

No user-facing changes, and no changes outside of the dump/restore management commands.

The `dump_domain_data` and `load_domain_data` management commands gain a `--format` option (`gzip` / `zstd` / `console` for dump; `gzip` / `zstd` for load) and now default to the new `zstd` format. Older gzip-format dumps still load with `--format=gzip`. `--console` is gone; use `--format=console`.

## Technical Summary

Today's `dump_domain_data` and `load_domain_data` commands reach directly into `gzip` and `zipfile` to encode the on-disk dump format. The encoding goes through a temp file per stream: write stream → gzip-compress to a temp `.gz` → append that file to the zip → delete the temp. Adding a new format, replacing the temp-file flow with streaming compression, or unit-testing the layout all mean editing the management commands.

This PR pulls the packing/unpacking layer out into a small `archive` package behind `ArchiveWriter` / `ArchiveReader` ABCs and migrates the commands to use it. It then adds a second concrete archive type and flips the default to that.

The two formats differ in more than just the compression algorithm:

- **gzip variant (today's format):** zip containing one `.gz` file per stream plus `meta.json`. Writing each stream is a two-step flow — write a temp `.gz` file, then copy that into the zip — because `zipfile` can't be handed an already-compressed gzip stream directly.
- **zstd variant (new default):** zip whose entries are themselves compressed with ZIP_ZSTANDARD (method 93). The writer opens the zip once and streams each entry into it in a single pass; no intermediate temp files, and each byte is written exactly once.

Still, the main speedup probably comes from the use of zstandard, which in the default configuration is often up to 5x as fast as gzip.

The commit history is structured as follows: style prep → pre-factors → protocol → implementations → migrations → zstd variant → option + default flip. For the few commits that edit existing files, they may be **easier to review using `?w=1`** (ignore whitespace)

A few things worth flagging:

- **The default flip to `zstd` is the one behavior change.** `--format=gzip` still produces today's byte-equivalent output; old gzip dumps still load with `--format=gzip`. zstd-format `.zip`s are readable by anything supporting ZIP_ZSTANDARD (Python 3.14+ stdlib; widely supported by recent zip tools).
- **Drops (unused) support for loading all files that start with `slug`**—the dumper only ever uses exact file names e.g. `{slug}.gz`
- **`backports.zstd` dependency on Python 3.13.** ZIP_ZSTANDARD is stdlib in 3.14. The `backports.zstd` package ships the 3.14 `zipfile` module verbatim for earlier Python; the conditional import in `archive/zip_with_zstd.py` flips to stdlib once we upgrade and the dependency drops out cleanly.
- **`@contextmanager_class` metaprogramming.** Concrete archive classes implement a `__contextmanager__` generator method; the decorator synthesises `__enter__` / `__exit__` from it. A small unusual primitive, but it's why each concrete class fits in ~30 lines.

## Feature Flag

N/A

## Safety Assurance

### Safety story

For `--format=gzip` the produced zip is byte-equivalent to today's — same in-zip entry names, same write order, same `meta.json` contents. The existing Couch round-trip integration tests (`test_couch_dump_load.py`) exercise the full dump → load path through the rewritten commands and pass unchanged. 26 new unit tests in `tests/archive/` cover both archive variants' contracts (round-trip, error paths, partial-failure behavior, `--use-extracted` semantics, the `--console` regression).

### Automated test coverage

`corehq/apps/dump_reload/tests/archive/`: round-trips (both formats), suffix validation, on-disk layout, temp-file cleanup, partial-failure behavior, `--use-extracted` semantics, `--console` close-stdout regression. End-to-end via the existing `test_couch_dump_load.py`.

### QA Plan

Internal refactor + format default change; no separate QA ticket. Coverage is the existing Couch integration tests plus the new unit tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

