### PR TITLE
Unmatched attachments

### DIFF
--- a/corehq/form_processor/app_config.py
+++ b/corehq/form_processor/app_config.py
@@ -6,6 +6,7 @@ class FormProcessorAppConfig(AppConfig):
 
     def ready(self):
         from corehq.form_processor import tasks  # noqa
+        from corehq.form_processor import submission_validation  # noqa
         from psycopg2.extensions import register_adapter
         from corehq.form_processor.utils.sql import (
             form_adapter, form_operation_adapter,

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -618,9 +618,13 @@ class XFormInstance(PartitionedModel, models.Model, RedisLockableMixIn,
         }
 
     @property
-    @memoized
+    @memoized  # TODO: `@memoized` unnecessary if using _form_json
     def form_data(self):
         """Returns the JSON representation of the form XML"""
+        # TODO: Use cached _form_json when available
+        # form_json = getattr(self, '_form_json', None)
+        # if form_json is None:
+        #     ...
         from couchforms import XMLSyntaxError
         from ..utils import convert_xform_to_json, adjust_datetimes
         from corehq.form_processor.utils.metadata import scrub_form_meta
@@ -632,6 +636,7 @@ class XFormInstance(PartitionedModel, models.Model, RedisLockableMixIn,
         adjust_datetimes(form_json)
 
         scrub_form_meta(self.form_id, form_json)
+        #     self._form_json = form_json
         return form_json
 
     @property

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -618,25 +618,23 @@ class XFormInstance(PartitionedModel, models.Model, RedisLockableMixIn,
         }
 
     @property
-    @memoized  # TODO: `@memoized` unnecessary if using _form_json
     def form_data(self):
         """Returns the JSON representation of the form XML"""
-        # TODO: Use cached _form_json when available
-        # form_json = getattr(self, '_form_json', None)
-        # if form_json is None:
-        #     ...
-        from couchforms import XMLSyntaxError
-        from ..utils import convert_xform_to_json, adjust_datetimes
-        from corehq.form_processor.utils.metadata import scrub_form_meta
-        xml = self.get_xml()
-        try:
-            form_json = convert_xform_to_json(xml)
-        except XMLSyntaxError:
-            return {}
-        adjust_datetimes(form_json)
+        form_json = getattr(self, '_form_json', None)
+        if form_json is None:
+            from couchforms import XMLSyntaxError
+            from ..utils import convert_xform_to_json, adjust_datetimes
+            from corehq.form_processor.utils.metadata import scrub_form_meta
 
-        scrub_form_meta(self.form_id, form_json)
-        #     self._form_json = form_json
+            xml = self.get_xml()
+            try:
+                form_json = convert_xform_to_json(xml)
+            except XMLSyntaxError:
+                return {}
+            adjust_datetimes(form_json)
+
+            scrub_form_meta(self.form_id, form_json)
+            self._form_json = form_json
         return form_json
 
     @property

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -9,6 +9,7 @@ from corehq.form_processor.exceptions import MissingFormXml
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import Attachment, XFormInstance
 from corehq.form_processor.utils import convert_xform_to_json, adjust_datetimes
+from corehq.form_processor.utils.metadata import scrub_form_meta
 from corehq.util.soft_assert.api import soft_assert
 from couchforms import XMLSyntaxError
 from couchforms.exceptions import MissingXMLNSError
@@ -108,9 +109,10 @@ def _create_new_xform(domain, instance_xml, attachments=None, auth_context=None,
     xform = interface.new_xform(instance_json)
     xform.domain = domain
     xform.auth_context = auth_context
-    # TODO: Cache `instance_json` on `xform` for when SubmissionPost.run()
-    #       calls `self._invalidate_caches()`, calls `instance.metadata`
-    # xform._form_json = instance_json
+    # Cache `instance_json` on `xform` for when SubmissionPost.run()
+    # calls `self._invalidate_caches()`, which calls `instance.metadata`
+    scrub_form_meta(xform.form_id, instance_json)  # Scrub to mimic `form_data`
+    xform._form_json = instance_json
 
     # Maps all attachments to uniform format and adds form.xml to list before storing
     attachments = [

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -108,6 +108,9 @@ def _create_new_xform(domain, instance_xml, attachments=None, auth_context=None,
     xform = interface.new_xform(instance_json)
     xform.domain = domain
     xform.auth_context = auth_context
+    # TODO: Cache `instance_json` on `xform` for when SubmissionPost.run()
+    #       calls `self._invalidate_caches()`, calls `instance.metadata`
+    # xform._form_json = instance_json
 
     # Maps all attachments to uniform format and adds form.xml to list before storing
     attachments = [

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -74,7 +74,11 @@ def process_xform_xml(domain, instance_xml, attachments=None, auth_context=None,
 
     try:
         return _create_new_xform(
-            domain, instance_xml, attachments=attachments, auth_context=auth_context, instance_json=instance_json
+            domain,
+            instance_xml,
+            attachments=attachments,
+            auth_context=auth_context,
+            instance_json=instance_json,
         )
     except (MissingXMLNSError, XMLSyntaxError) as e:
         return _get_submission_error(domain, instance_xml, e, auth_context)

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -109,9 +109,27 @@ def _create_new_xform(domain, instance_xml, attachments=None, auth_context=None,
     xform = interface.new_xform(instance_json)
     xform.domain = domain
     xform.auth_context = auth_context
-    # Cache `instance_json` on `xform` for when SubmissionPost.run()
-    # calls `self._invalidate_caches()`, which calls `instance.metadata`
-    scrub_form_meta(xform.form_id, instance_json)  # Scrub to mimic `form_data`
+
+    # Call flow:
+    #
+    #     SubmissionPost.run()
+    #     |
+    #     +-- process_xform_xml()
+    #     |   |
+    #     |   +-- _create_new_xform()  <-- you are here
+    #     |
+    #     +-- self._invalidate_caches()
+    #         |
+    #         +-- instance.metadata
+    #             |
+    #             +-- XFormInstance.form_data
+    #                 |
+    #                 +-- XFormInstance._form_json  <-- cached scrubbed instance_json
+    #
+    # Scrub and cache `instance_json` in `XFormInstance._form_json` the way
+    # that `XFormInstance.form_data` does, so that `XFormInstance.form_data`
+    # doesn't have to fetch the form XML and convert it to JSON again.
+    scrub_form_meta(xform.form_id, instance_json)
     xform._form_json = instance_json
 
     # Maps all attachments to uniform format and adds form.xml to list before storing

--- a/corehq/form_processor/submission_validation.py
+++ b/corehq/form_processor/submission_validation.py
@@ -1,0 +1,71 @@
+"""
+Post-submission validation checks that emit Sentry alerts when anomalies
+are detected. These checks are observational only -- they never reject or
+modify the submission.
+"""
+import sentry_sdk
+from django.dispatch import receiver
+
+from couchforms.signals import successful_form_received
+
+IMAGE_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.gif', '.heic', '.heif', '.bmp', '.webp')
+
+
+@receiver(successful_form_received, dispatch_uid='check_image_attachments')
+def check_image_attachments(sender, xform, **kwargs):
+    """
+    Alert when the set of image filenames referenced in form answers does
+    not match the set of image attachments uploaded with the submission.
+
+    See SAAS-19082 for more context.
+    """
+    image_attachments = {
+        name for name in xform.attachments
+        if name.lower().endswith(IMAGE_EXTENSIONS)
+    }
+    image_answers = _collect_image_references(xform.form_data)
+
+    if image_attachments == image_answers:
+        return
+
+    mismatched = image_attachments.symmetric_difference(image_answers)
+    with sentry_sdk.new_scope() as scope:
+        scope.set_tag('domain', xform.domain)
+        scope.set_tag('app_id', xform.app_id)
+        scope.fingerprint = ['form-image-attachment-mismatch']
+        scope.set_extra('form_id', xform.form_id)
+        scope.set_extra('missing_attachments', sorted(image_answers - image_attachments))
+        scope.set_extra('extra_attachments', sorted(image_attachments - image_answers))
+        scope.set_extra('mismatched', sorted(mismatched))
+        sentry_sdk.capture_message(
+            'Form image answers do not match image attachments',
+            level='warning',
+        )
+
+
+def _collect_image_references(form_data):
+    """
+    Return the set of leaf string values in ``form_data`` that look like
+    image filenames.
+
+    We identify image-capture answers by filename extension rather than by
+    consulting the form definition (via app_id + xmlns). Fetching the form
+    definition would let us locate image-capture questions precisely, but
+    this signal handler runs for every successful submission, so the added
+    DB/cache cost is not justified for an observational check.
+    """
+    found = set()
+    _walk(form_data, found)
+    return found
+
+
+def _walk(node, found):
+    if isinstance(node, dict):
+        for value in node.values():
+            _walk(value, found)
+    elif isinstance(node, list):
+        for value in node:
+            _walk(value, found)
+    elif isinstance(node, str):
+        if node.lower().endswith(IMAGE_EXTENSIONS):
+            found.add(node)

--- a/corehq/form_processor/submission_validation.py
+++ b/corehq/form_processor/submission_validation.py
@@ -24,11 +24,9 @@ def check_image_attachments(sender, xform, **kwargs):
         if name.lower().endswith(IMAGE_EXTENSIONS)
     }
     image_answers = _collect_image_references(xform.form_data)
-
     if image_attachments == image_answers:
         return
 
-    mismatched = image_attachments.symmetric_difference(image_answers)
     with sentry_sdk.new_scope() as scope:
         scope.set_tag('domain', xform.domain)
         scope.set_tag('app_id', xform.app_id)
@@ -36,7 +34,6 @@ def check_image_attachments(sender, xform, **kwargs):
         scope.set_extra('form_id', xform.form_id)
         scope.set_extra('missing_attachments', sorted(image_answers - image_attachments))
         scope.set_extra('extra_attachments', sorted(image_attachments - image_answers))
-        scope.set_extra('mismatched', sorted(mismatched))
         sentry_sdk.capture_message(
             'Form image answers do not match image attachments',
             level='warning',
@@ -52,7 +49,7 @@ def _collect_image_references(form_data):
     consulting the form definition (via app_id + xmlns). Fetching the form
     definition would let us locate image-capture questions precisely, but
     this signal handler runs for every successful submission, so the added
-    DB/cache cost is not justified for an observational check.
+    DB/cache cost is not justified.
     """
     found = set()
     _walk(form_data, found)

--- a/corehq/form_processor/tests/test_submission_validation.py
+++ b/corehq/form_processor/tests/test_submission_validation.py
@@ -96,7 +96,7 @@ def test_no_alert_when_form_has_no_images():
 @capture_sentry
 def test_non_image_attachments_are_ignored():
     xform = _stub_xform(
-        attachments={'audio.mp3': object(), 'pic.jpg': object()},
+        attachments={'pic.jpg': object()},  # audio.mp3 missing
         form_data={'photo': 'pic.jpg', 'recording': 'audio.mp3'},
     )
     check_image_attachments(sender=None, xform=xform)

--- a/corehq/form_processor/tests/test_submission_validation.py
+++ b/corehq/form_processor/tests/test_submission_validation.py
@@ -218,21 +218,9 @@ class TestCheckImageAttachmentsCachingFootprint(TestCase):
         )
         try:
             with (
-                patch.object(
-                    form_utils,
-                    'convert_xform_to_json',
-                    spy_convert,
-                ),
-                patch.object(
-                    form_parser,
-                    'convert_xform_to_json',
-                    spy_convert,
-                ),
-                patch.object(
-                    XFormInstance,
-                    'get_attachment',
-                    spy_get_attachment,
-                ),
+                patch.object(form_utils, 'convert_xform_to_json', spy_convert),
+                patch.object(form_parser, 'convert_xform_to_json', spy_convert),
+                patch.object(XFormInstance, 'get_attachment', spy_get_attachment),
             ):
                 submit_form_locally(
                     form_xml,

--- a/corehq/form_processor/tests/test_submission_validation.py
+++ b/corehq/form_processor/tests/test_submission_validation.py
@@ -222,11 +222,7 @@ class TestCheckImageAttachmentsCachingFootprint(TestCase):
                 patch.object(form_parser, 'convert_xform_to_json', spy_convert),
                 patch.object(XFormInstance, 'get_attachment', spy_get_attachment),
             ):
-                submit_form_locally(
-                    form_xml,
-                    self.domain,
-                    attachments=attachments,
-                )
+                submit_form_locally(form_xml, self.domain, attachments=attachments)
         finally:
             successful_form_received.disconnect(
                 dispatch_uid='check_image_attachments_test'

--- a/corehq/form_processor/tests/test_submission_validation.py
+++ b/corehq/form_processor/tests/test_submission_validation.py
@@ -1,0 +1,289 @@
+import uuid
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django.core.files.uploadedfile import UploadedFile
+from django.test import TestCase
+from unmagic import fixture
+
+from corehq.apps.receiverwrapper.util import submit_form_locally
+from corehq.form_processor.models import XFormInstance
+from corehq.form_processor.submission_validation import (
+    _collect_image_references,
+    check_image_attachments,
+)
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
+from corehq.form_processor.utils.xform import (
+    FormSubmissionBuilder,
+    TestFormMetadata,
+)
+
+
+def _stub_xform(
+    attachments,
+    form_data,
+    *,
+    domain='d',
+    app_id='a',
+    form_id='f',
+):
+    return SimpleNamespace(
+        attachments=attachments,
+        form_data=form_data,
+        domain=domain,
+        app_id=app_id,
+        form_id=form_id,
+    )
+
+
+@fixture
+def capture_sentry():
+    with patch(
+        'corehq.form_processor.submission_validation.sentry_sdk'
+    ) as sdk:
+        # `new_scope` is used as a context manager; the test only inspects
+        # `capture_message` calls so we keep the rest minimal.
+        sdk.new_scope.return_value.__enter__.return_value = SimpleNamespace(
+            set_tag=lambda *a, **kw: None,
+            set_extra=lambda *a, **kw: None,
+            fingerprint=None,
+        )
+        yield sdk.capture_message
+
+
+@capture_sentry
+def test_no_alert_when_image_answers_match_attachments():
+    xform = _stub_xform(
+        attachments={'pic1.jpg': object(), 'pic2.png': object()},
+        form_data={'photo_a': 'pic1.jpg', 'photo_b': 'pic2.png'},
+    )
+    check_image_attachments(sender=None, xform=xform)
+    assert capture_sentry().call_count == 0
+
+
+@capture_sentry
+def test_alert_when_referenced_image_is_missing():
+    xform = _stub_xform(
+        attachments={'pic1.jpg': object()},
+        form_data={'photo_a': 'pic1.jpg', 'photo_b': 'deleted.jpg'},
+    )
+    check_image_attachments(sender=None, xform=xform)
+    assert capture_sentry().call_count == 1
+
+
+@capture_sentry
+def test_alert_when_attachment_has_no_matching_answer():
+    xform = _stub_xform(
+        attachments={'pic1.jpg': object(), 'orphan.jpg': object()},
+        form_data={'photo_a': 'pic1.jpg'},
+    )
+    check_image_attachments(sender=None, xform=xform)
+    assert capture_sentry().call_count == 1
+
+
+@capture_sentry
+def test_no_alert_when_form_has_no_images():
+    xform = _stub_xform(
+        attachments={},
+        form_data={'name': 'Alice', 'age': '42'},
+    )
+    check_image_attachments(sender=None, xform=xform)
+    assert capture_sentry().call_count == 0
+
+
+@capture_sentry
+def test_non_image_attachments_are_ignored():
+    xform = _stub_xform(
+        attachments={'audio.mp3': object(), 'pic.jpg': object()},
+        form_data={'photo': 'pic.jpg', 'recording': 'audio.mp3'},
+    )
+    check_image_attachments(sender=None, xform=xform)
+    assert capture_sentry().call_count == 0
+
+
+@pytest.mark.parametrize(
+    'ext', ['.jpg', '.JPG', '.jpeg', '.png', '.gif', '.heic', '.bmp', '.webp']
+)
+def test_image_extensions_are_recognised_case_insensitively(ext):
+    refs = _collect_image_references({'q': f'photo{ext}'})
+    assert refs == {f'photo{ext}'}
+
+
+def test_nested_form_data_is_walked():
+    form_data = {
+        'group': {
+            'subgroup': {'photo': 'nested.jpg'},
+            'gallery': [{'photo': 'one.jpg'}, {'photo': 'two.jpg'}],
+        },
+        'top': 'top.png',
+    }
+    assert _collect_image_references(form_data) == {
+        'nested.jpg',
+        'one.jpg',
+        'two.jpg',
+        'top.png',
+    }
+
+
+@sharded
+class TestCheckImageAttachmentsCachingFootprint(TestCase):
+    """
+    Documents what is cached on the ``xform`` instance at the moment the
+    ``successful_form_received`` signal fires, by counting how often
+    ``convert_xform_to_json`` and ``XFormInstance.get_attachment`` run
+    during submission, and how many additional calls
+    ``check_image_attachments`` itself causes.
+
+    This test exists to surface the TODOs in
+    ``corehq/form_processor/submission_validation.py``: when
+    ``instance_json`` is attached to the xform during processing the
+    handler should no longer trigger an extra XML-to-JSON parse, and the
+    assertions below will need to be updated accordingly.
+    """
+
+    domain = 'submission-validation-tests'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        FormProcessorTestUtils.delete_all_xforms(cls.domain)
+
+    @classmethod
+    def tearDownClass(cls):
+        FormProcessorTestUtils.delete_all_xforms(cls.domain)
+        super().tearDownClass()
+
+    def _build_form_xml(self, form_id):
+        # Reference an image filename as the answer to a question so that
+        # the handler exercises its `form_data` traversal path.
+        return FormSubmissionBuilder(
+            form_id=form_id,
+            metadata=TestFormMetadata(domain=self.domain),
+            form_properties={'photo': 'pic.jpg'},
+        ).as_xml_string()
+
+    def test_caching_footprint_at_signal_time(self):
+        form_id = uuid.uuid4().hex
+        form_xml = self._build_form_xml(form_id)
+        attachments = {
+            'pic.jpg': UploadedFile(
+                BytesIO(b'fake'),
+                'pic.jpg',
+                content_type='image/jpeg',
+                size=4,
+            )
+        }
+
+        convert_calls = []
+        get_attachment_calls = []
+        pre_handler_state = {}
+
+        # `convert_xform_to_json` is re-exported from
+        # `corehq.form_processor.utils` and imported with a module-local
+        # name in `parsers.form`; patch both bindings so every call site
+        # used during submission funnels through the spy.
+        from corehq.form_processor import utils as form_utils
+        from corehq.form_processor.parsers import form as form_parser
+
+        original_convert = form_utils.convert_xform_to_json
+        original_get_attachment = XFormInstance.get_attachment
+
+        def spy_convert(*args, **kwargs):
+            convert_calls.append(args)
+            return original_convert(*args, **kwargs)
+
+        def spy_get_attachment(self, name):
+            get_attachment_calls.append(name)
+            return original_get_attachment(self, name)
+
+        # Wrap the registered receiver so we can snapshot the spy state
+        # *before* the handler does its own work.
+        def wrapped_handler(sender, xform, **kwargs):
+            pre_handler_state['convert'] = list(convert_calls)
+            pre_handler_state['form_xml_fetches'] = [
+                name for name in get_attachment_calls if name == 'form.xml'
+            ]
+            return check_image_attachments(
+                sender=sender, xform=xform, **kwargs
+            )
+
+        from couchforms.signals import successful_form_received
+
+        successful_form_received.disconnect(
+            dispatch_uid='check_image_attachments'
+        )
+        successful_form_received.connect(
+            wrapped_handler,
+            dispatch_uid='check_image_attachments_test',
+        )
+        try:
+            with (
+                patch.object(
+                    form_utils,
+                    'convert_xform_to_json',
+                    spy_convert,
+                ),
+                patch.object(
+                    form_parser,
+                    'convert_xform_to_json',
+                    spy_convert,
+                ),
+                patch.object(
+                    XFormInstance,
+                    'get_attachment',
+                    spy_get_attachment,
+                ),
+            ):
+                submit_form_locally(
+                    form_xml,
+                    self.domain,
+                    attachments=attachments,
+                )
+        finally:
+            successful_form_received.disconnect(
+                dispatch_uid='check_image_attachments_test'
+            )
+            successful_form_received.connect(
+                check_image_attachments,
+                dispatch_uid='check_image_attachments',
+            )
+
+        # Pre-handler state: What processing has already done:
+        # `convert_xform_to_json` is run twice before the signal fires:
+        #
+        # 1. `_create_new_xform` parses the submitted XML directly.
+        # 2. Submission processing accesses `instance.metadata` which
+        #    pulls TAG_META from `form_data`, populating its memoized
+        #    cache on the same xform instance.
+        #
+        # TODO: attaching `instance_json` to the xform during
+        #       `_create_new_xform` would let `form_data` skip the
+        #       second parse, dropping this count to 1.
+        assert len(pre_handler_state['convert']) == 2, (
+            'submission processing currently parses the form twice before '
+            'the signal fires'
+        )
+
+        # The handler reads `xform.form_data`, which is memoized -- since
+        # processing already warmed it, the handler adds no extra parse.
+        handler_convert_calls = len(convert_calls) - len(
+            pre_handler_state['convert']
+        )
+        assert handler_convert_calls == 0, (
+            'handler must not trigger an additional XML-to-JSON parse'
+        )
+
+        # `get_xml` is memoized per-instance and was warmed by the
+        # `form_data` lookup during processing, so the handler does not
+        # re-fetch `form.xml` from blob storage.
+        form_xml_fetches_total = [
+            name for name in get_attachment_calls if name == 'form.xml'
+        ]
+        handler_form_xml_fetches = len(form_xml_fetches_total) - len(
+            pre_handler_state['form_xml_fetches']
+        )
+        assert handler_form_xml_fetches == 0, (
+            'handler must not trigger an additional form.xml blob fetch'
+        )

--- a/corehq/form_processor/tests/test_submission_validation.py
+++ b/corehq/form_processor/tests/test_submission_validation.py
@@ -136,11 +136,9 @@ class TestCheckImageAttachmentsCachingFootprint(TestCase):
     during submission, and how many additional calls
     ``check_image_attachments`` itself causes.
 
-    This test exists to surface the TODOs in
-    ``corehq/form_processor/submission_validation.py``: when
-    ``instance_json`` is attached to the xform during processing the
-    handler should no longer trigger an extra XML-to-JSON parse, and the
-    assertions below will need to be updated accordingly.
+    With ``instance_json`` cached on ``xform._form_json`` during
+    ``_create_new_xform``, the form XML is parsed exactly once per
+    submission and the handler does no I/O of its own.
     """
 
     domain = 'submission-validation-tests'
@@ -251,23 +249,17 @@ class TestCheckImageAttachmentsCachingFootprint(TestCase):
             )
 
         # Pre-handler state: What processing has already done:
-        # `convert_xform_to_json` is run twice before the signal fires:
-        #
-        # 1. `_create_new_xform` parses the submitted XML directly.
-        # 2. Submission processing accesses `instance.metadata` which
-        #    pulls TAG_META from `form_data`, populating its memoized
-        #    cache on the same xform instance.
-        #
-        # TODO: attaching `instance_json` to the xform during
-        #       `_create_new_xform` would let `form_data` skip the
-        #       second parse, dropping this count to 1.
-        assert len(pre_handler_state['convert']) == 2, (
-            'submission processing currently parses the form twice before '
-            'the signal fires'
+        # `_create_new_xform` parses the submitted XML once and caches
+        # the result on `xform._form_json`. Every subsequent access to
+        # `form_data` during processing (e.g. `instance.metadata` in
+        # `_invalidate_caches`) reuses that cached JSON instead of
+        # reparsing.
+        assert len(pre_handler_state['convert']) == 1, (
+            'submission processing should parse the form exactly once '
+            'before the signal fires'
         )
-
-        # The handler reads `xform.form_data`, which is memoized -- since
-        # processing already warmed it, the handler adds no extra parse.
+        # The handler reads `xform.form_data`, which returns the cached
+        # `_form_json`, so the handler adds no extra parse.
         handler_convert_calls = len(convert_calls) - len(
             pre_handler_state['convert']
         )
@@ -275,9 +267,10 @@ class TestCheckImageAttachmentsCachingFootprint(TestCase):
             'handler must not trigger an additional XML-to-JSON parse'
         )
 
-        # `get_xml` is memoized per-instance and was warmed by the
-        # `form_data` lookup during processing, so the handler does not
-        # re-fetch `form.xml` from blob storage.
+        # `_form_json` is populated up-front from the raw XML the
+        # submission was parsed from, so `form_data` never has to call
+        # `get_xml()`. The handler therefore does not trigger any
+        # `form.xml` blob fetch on its own.
         form_xml_fetches_total = [
             name for name in get_attachment_calls if name == 'form.xml'
         ]

--- a/corehq/form_processor/tests/test_submission_validation.py
+++ b/corehq/form_processor/tests/test_submission_validation.py
@@ -198,9 +198,7 @@ class TestCheckImageAttachmentsCachingFootprint(TestCase):
             pre_handler_state['form_xml_fetches'] = [
                 name for name in get_attachment_calls if name == 'form.xml'
             ]
-            return check_image_attachments(
-                sender=sender, xform=xform, **kwargs
-            )
+            return check_image_attachments(sender=sender, xform=xform, **kwargs)
 
         from couchforms.signals import successful_form_received
 

--- a/corehq/form_processor/tests/test_submission_validation.py
+++ b/corehq/form_processor/tests/test_submission_validation.py
@@ -144,11 +144,6 @@ class TestCheckImageAttachmentsCachingFootprint(TestCase):
     domain = 'submission-validation-tests'
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        FormProcessorTestUtils.delete_all_xforms(cls.domain)
-
-    @classmethod
     def tearDownClass(cls):
         FormProcessorTestUtils.delete_all_xforms(cls.domain)
         super().tearDownClass()

--- a/corehq/form_processor/tests/test_submission_validation.py
+++ b/corehq/form_processor/tests/test_submission_validation.py
@@ -94,7 +94,7 @@ def test_no_alert_when_form_has_no_images():
 
 
 @capture_sentry
-def test_non_image_attachments_are_ignored():
+def test_missing_non_image_attachments_are_ignored():
     xform = _stub_xform(
         attachments={'pic.jpg': object()},  # audio.mp3 missing
         form_data={'photo': 'pic.jpg', 'recording': 'audio.mp3'},


### PR DESCRIPTION
## Technical Summary

Opening to hear thoughts about this approach: Ready to review. Not ready to merge.

Jira: [SAAS-19082](https://dimagi.atlassian.net/browse/SAAS-19082)

This change sends an alert to Sentry when form submission image attachments do not match form submission image questions.

The objective is to give us deeper insight into when this happens, with the hope that, along with better logging on mobile, we can diagnose the reasons _why_ this happens.

## Safety Assurance

### Safety story

This adds a signal receiver for a high-volume event. The change keeps the impact to performance to a minimum. (In fact, this change might improve performance by caching form JSON during form processing.)

No other change to functionality.

### Automated test coverage

Yes

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19082]: https://dimagi.atlassian.net/browse/SAAS-19082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ