### PR TITLE
Don't allow groups with blank names by API

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -742,7 +742,8 @@ class GroupResource(v0_4.GroupResource):
     def obj_create(self, bundle, request=None, **kwargs):
         if not Group.by_name(kwargs['domain'], bundle.data.get("name")):
             bundle.obj = Group(bundle.data)
-            bundle.obj.name = bundle.obj.name or ''
+            if not bundle.obj.name:
+                raise AssertionError("Name is required")
             bundle.obj.domain = kwargs['domain']
             bundle.obj.save()
             for user in bundle.obj.users:

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -700,7 +700,7 @@ class GroupResource(v0_4.GroupResource):
                     setattr(bundle.obj, key, value or '')
                     should_save = True
                 else:
-                    raise Exception("A group with this name already exists")
+                    raise BadRequest("A group with name %s already exists" % value)
             if key == 'users' and getattr(bundle.obj, key, None) != value:
                 users_to_add = set(value) - set(bundle.obj.users)
                 users_to_remove = set(bundle.obj.users) - set(value)

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -698,11 +698,11 @@ class GroupResource(v0_4.GroupResource):
             if key == 'name' and getattr(bundle.obj, key, None) != value:
                 if not Group.by_name(bundle.obj.domain, value):
                     if not value:
-                        raise BadRequest("Name may not be blank")
+                        raise BadRequest(_("Name may not be blank"))
                     setattr(bundle.obj, key, value)
                     should_save = True
                 else:
-                    raise BadRequest("A group with name %s already exists" % value)
+                    raise BadRequest(_("A group with name %s already exists") % value)
             if key == 'users' and getattr(bundle.obj, key, None) != value:
                 users_to_add = set(value) - set(bundle.obj.users)
                 users_to_remove = set(bundle.obj.users) - set(value)
@@ -745,13 +745,13 @@ class GroupResource(v0_4.GroupResource):
         if not Group.by_name(kwargs['domain'], bundle.data.get("name")):
             bundle.obj = Group(bundle.data)
             if not bundle.obj.name:
-                raise AssertionError("Name is required")
+                raise AssertionError(_("Name is required"))
             bundle.obj.domain = kwargs['domain']
             bundle.obj.save()
             for user in bundle.obj.users:
                 CommCareUser.get(user).set_groups([bundle.obj._id])
         else:
-            raise AssertionError("A group with name %s already exists" % bundle.data.get("name"))
+            raise AssertionError(_("A group with name %s already exists") % bundle.data.get("name"))
         return bundle
 
     def obj_update(self, bundle, **kwargs):

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -698,7 +698,7 @@ class GroupResource(v0_4.GroupResource):
             if key == 'name' and getattr(bundle.obj, key, None) != value:
                 if not Group.by_name(bundle.obj.domain, value):
                     if not value:
-                        raise BadRequest(_("Name may not be blank"))
+                        raise BadRequest(_("Name must not be blank"))
                     setattr(bundle.obj, key, value)
                     should_save = True
                 else:

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -697,7 +697,9 @@ class GroupResource(v0_4.GroupResource):
         for key, value in bundle.data.items():
             if key == 'name' and getattr(bundle.obj, key, None) != value:
                 if not Group.by_name(bundle.obj.domain, value):
-                    setattr(bundle.obj, key, value or '')
+                    if not value:
+                        raise BadRequest("Name may not be blank")
+                    setattr(bundle.obj, key, value)
                     should_save = True
                 else:
                     raise BadRequest("A group with name %s already exists" % value)

--- a/corehq/apps/api/tests/group_resources.py
+++ b/corehq/apps/api/tests/group_resources.py
@@ -149,6 +149,37 @@ class TestGroupResource(APIResourceTest):
         self.assertEqual(response.status_code, 204, response.content)
         self.assertEqual(0, len(Group.by_domain(self.domain.name)))
 
+    def test_create_rejects_name_already_exists(self):
+        self._add_group(Group({"name": "test group", "domain": self.domain.name}))
+
+        response = self._assert_auth_post_resource(
+            self.list_endpoint,
+            json.dumps({"name": "test group"}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+        response_body = json.loads(response.content)
+        self.assertIn("already exists", response_body["error_message"])
+        self.assertEqual(1, len(Group.by_domain(self.domain.name)))
+
+    def test_update_rejects_name_already_exists(self):
+        group_a = self._add_group(Group({"name": "test a", "domain": self.domain.name}))
+        self._add_group(Group({"name": "test b", "domain": self.domain.name}))
+
+        backend_id = group_a._id
+        response = self._assert_auth_post_resource(
+            self.single_endpoint(backend_id),
+            json.dumps({"name": "test b"}),
+            content_type='application/json',
+            method='PUT',
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+        response_body = json.loads(response.content)
+        self.assertIn("already exists", response_body["error"])
+
+        group_a = Group.get(backend_id)
+        self.assertEqual(group_a.name, "test a")
+
     def _add_group(self, group, send_to_es=False):
         group.save()
         self.addCleanup(group.delete)

--- a/corehq/apps/api/tests/group_resources.py
+++ b/corehq/apps/api/tests/group_resources.py
@@ -202,6 +202,38 @@ class TestGroupResource(APIResourceTest):
         group_a = Group.get(backend_id)
         self.assertEqual(group_a.name, "test a")
 
+    def test_update_rejects_name_empty(self):
+        original_group = self._add_group(Group({"name": "test group", "domain": self.domain.name}))
+
+        backend_id = original_group._id
+        response = self._assert_auth_post_resource(
+            self.single_endpoint(backend_id),
+            json.dumps({"name": ""}),
+            content_type='application/json',
+            method='PUT',
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+        response_body = json.loads(response.content)
+        self.assertIn("may not be blank", response_body["error"])
+
+        modified_group = Group.get(backend_id)
+        self.assertEqual(modified_group.name, "test group")
+
+    def test_update_allows_name_missing(self):
+        original_group = self._add_group(Group({"name": "test", "domain": self.domain.name}))
+
+        backend_id = original_group._id
+        response = self._assert_auth_post_resource(
+            self.single_endpoint(backend_id),
+            json.dumps({"case_sharing": True}),
+            content_type='application/json',
+            method='PUT',
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+        modified_group = Group.get(backend_id)
+        self.assertTrue(modified_group.case_sharing)
+
     def _add_group(self, group, send_to_es=False):
         group.save()
         self.addCleanup(group.delete)

--- a/corehq/apps/api/tests/group_resources.py
+++ b/corehq/apps/api/tests/group_resources.py
@@ -162,6 +162,28 @@ class TestGroupResource(APIResourceTest):
         self.assertIn("already exists", response_body["error_message"])
         self.assertEqual(1, len(Group.by_domain(self.domain.name)))
 
+    def test_create_rejects_name_empty(self):
+        response = self._assert_auth_post_resource(
+            self.list_endpoint,
+            json.dumps({"name": ""}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+        response_body = json.loads(response.content)
+        self.assertIn("is required", response_body["error_message"])
+        self.assertEqual(0, len(Group.by_domain(self.domain.name)))
+
+    def test_create_rejects_name_missing(self):
+        response = self._assert_auth_post_resource(
+            self.list_endpoint,
+            json.dumps({"case_sharing": True}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+        response_body = json.loads(response.content)
+        self.assertIn("is required", response_body["error_message"])
+        self.assertEqual(0, len(Group.by_domain(self.domain.name)))
+
     def test_update_rejects_name_already_exists(self):
         group_a = self._add_group(Group({"name": "test a", "domain": self.domain.name}))
         self._add_group(Group({"name": "test b", "domain": self.domain.name}))

--- a/corehq/apps/api/tests/group_resources.py
+++ b/corehq/apps/api/tests/group_resources.py
@@ -214,7 +214,7 @@ class TestGroupResource(APIResourceTest):
         )
         self.assertEqual(response.status_code, 400, response.content)
         response_body = json.loads(response.content)
-        self.assertIn("may not be blank", response_body["error"])
+        self.assertIn("must not be blank", response_body["error"])
 
         modified_group = Group.get(backend_id)
         self.assertEqual(modified_group.name, "test group")


### PR DESCRIPTION
## Product Description
API change only. This updates the behavior of the Groups API such that:
- a group can no longer be created with no name or an empty string `''` for its name
- a group can no longer be updated so that its name is an empty string `''`

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-13996
We handle validation and errors in different ways in different parts of this API.
`obj_create` is wrapped so that `AssertionError`s are handled and result in returning a `400` response. For creating new groups, we check that name exists and raise an `AssertionError` if not.

`obj_update` / `_update` is not wrapped in this same way, so it needs to know how to return a response on its own. tastypie's built-in `BadRequest` exception is made for doing just this:
```python
class BadRequest(TastypieError):
    """
    A generalized exception for indicating incorrect request parameters.

    Handled specially in that the message tossed by this exception will be
    presented to the end user.
    """
```
In `_update` we check that, if name exists, it is not blank, and raise a `BadRequest` if it is blank.
This also modifies the existing "A group with this name already exists" in `_update` to use `BadRequest`, so it does not result in an uncaught exception, which would incorrectly show a `500` to the user.

These changes are small enough to be reviewed as a whole, or commit-by-commit for more detailed explanation of each change.

## Safety Assurance

### Safety story
The functional code changes here are small and are well-tested in `TestGroupResource`. Tested manually in my local environment by POSTing individual groups, PATCHing a list of groups, and PUTting group updates with:
- name set to a valid string
- name set to an empty string
- name missing

to see expected behavior in each case.

### Automated test coverage
Added sad-path tests in `TestGroupResource` for existing failure modes (group already exists) as well changes to reject blank names. These assert the response status code we expect and the message we hope to see, given the circumstance.

### QA Plan
Not planning QA here.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
