### PR TITLE
Qualify Vellum PR refs in vellum-to-hq change log

### DIFF
--- a/scripts/vellum-to-hq
+++ b/scripts/vellum-to-hq
@@ -11,6 +11,7 @@ instructions), before using this script to push changes to master.
 This script assumes that the vellum-staging branch is in staging.yml.
 """
 import os
+import re
 import subprocess
 import sys
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
@@ -130,8 +131,10 @@ def get_old_vellum_rev(path):
 
 def print_vellum_changes(old_vellum_rev, path):
     git = get_git(path)
+    log = git('log', '--oneline', '--grep', 'Merge', old_vellum_rev + "..HEAD")
+    log = re.sub(r'#(\d+)', r'dimagi/Vellum#\1', str(log))
     print("Vellum Changes Since Last HQ Deploy")
-    print(git('log', '--oneline', '--grep', 'Merge', old_vellum_rev + "..HEAD"))
+    print(log)
 
 
 def update_hq(path, branch, base_branch, vellum_dir, vellum_rev, push, target, dev_mode):


### PR DESCRIPTION
## Product Description
N/A — internal developer script.

## Technical Summary
`scripts/vellum-to-hq` prints a list of Vellum merge commits at the end of a push, intended to be pasted into the HQ PR description. The lines look like:

```
a379c4eb Merge pull request #1249 from dimagi/jc/edit-form-name
```

When pasted into an HQ PR, GitHub interprets bare `#1249` as a commcare-hq PR reference and auto-links to the wrong repo. This PR rewrites `#NNNN` to `dimagi/Vellum#NNNN` in the printed output so cross-repo references resolve correctly.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Pure text-formatting change in a developer-only script. No runtime/user-facing impact.

### Automated test coverage

### QA Plan


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change