### PR TITLE
Auto-bump Vellum in HQ on Vellum master merges

### DIFF
--- a/.github/workflows/vellum-bump.yml
+++ b/.github/workflows/vellum-bump.yml
@@ -1,0 +1,109 @@
+name: Auto-bump Vellum
+
+on:
+  repository_dispatch:
+    types: [vellum-merged]
+  workflow_dispatch:
+
+concurrency:
+  group: vellum-bump
+
+jobs:
+  bump:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout commcare-hq
+        uses: actions/checkout@v5
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Checkout Vellum
+        uses: actions/checkout@v5
+        with:
+          repository: dimagi/Vellum
+          path: vellum
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Vellum build dependencies
+        working-directory: vellum
+        run: |
+          mv package.json package.json.save
+          npm install "yarn@^1"
+          rm package-lock.json
+          mv package.json.save package.json
+          yarn install
+
+      - name: Install script dependencies
+        run: pip install sh
+
+      - name: Configure git identity
+        run: |
+          git config user.name "dimagi-bot"
+          git config user.email "dimagi-bot@dimagi.com"
+
+      - name: Close stale auto-bump PRs
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh pr list --label vellum-bump --state open --json number --jq '.[].number' |
+            while read -r pr; do
+              gh pr close "$pr" --comment "Superseded by a newer Vellum merge." --delete-branch || true
+            done
+
+      - name: Bump Vellum in HQ
+        env:
+          VELLUM_DIR: ${{ github.workspace }}/vellum
+        run: |
+          python scripts/vellum-to-hq master --push --no-test --non-interactive \
+            --vellum-dir="$VELLUM_DIR" \
+            --changelog-out="$RUNNER_TEMP/vellum-changes.txt"
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+          SHORT_SHA="$(git -C vellum rev-parse --short HEAD)"
+          {
+            echo "## Product Description"
+            echo "Auto-bumps Vellum (form designer) to \`$SHORT_SHA\`. Opened by \`.github/workflows/vellum-bump.yml\` on Vellum master merge."
+            echo
+            echo "## Technical Summary"
+            echo "### Vellum Changes Since Last HQ Deploy"
+            echo
+            echo '```'
+            cat "$RUNNER_TEMP/vellum-changes.txt"
+            echo '```'
+            echo
+            echo "## Safety Assurance"
+            echo "### Safety story"
+            echo "Each Vellum PR included above has already passed Vellum's own CI. The bundled artifact is rebuilt from Vellum HEAD by this workflow."
+            echo
+            echo "### Rollback instructions"
+            echo "- [x] This PR can be reverted after deploy with no further considerations"
+          } > "$RUNNER_TEMP/pr-body.md"
+          gh pr create \
+            --draft \
+            --label vellum-bump \
+            --label "DON'T REVIEW YET" \
+            --base master \
+            --head "$BRANCH" \
+            --title "Bump Vellum to $SHORT_SHA" \
+            --body-file "$RUNNER_TEMP/pr-body.md"

--- a/scripts/vellum-to-hq
+++ b/scripts/vellum-to-hq
@@ -51,6 +51,11 @@ def main():
     parser.add_argument("--vellum-dir", default=os.environ.get("VELLUM_DIR"),
         help="Path to Vellum git repo on your local machine. Defaults to the "
              "value of the VELLUM_DIR environment variable.")
+    parser.add_argument("--non-interactive", action="store_true",
+        help="Skip prompts and commit message editing. Intended for CI.")
+    parser.add_argument("--changelog-out", metavar="PATH",
+        help="Write the 'Vellum Changes Since Last HQ Deploy' log to PATH so a "
+             "caller can include it in a PR body. Intended for CI.")
 
     args = parser.parse_args()
 
@@ -78,7 +83,10 @@ def main():
         else:
             vellum_rev = build_vellum(vellum_dir, vellum_branch, not args.no_test, args.dev_mode)
 
-        update_hq(hq_dir, hq_branch, args.hq_base, vellum_dir, vellum_rev, args.push, args.target, args.dev_mode)
+        update_hq(hq_dir, hq_branch, args.hq_base, vellum_dir, vellum_rev,
+                  args.push, args.target, args.dev_mode,
+                  non_interactive=args.non_interactive,
+                  changelog_out=args.changelog_out)
     except sh.ErrorReturnCode as err:
         print("Aborted due to error: {}".format(err))
 
@@ -129,15 +137,23 @@ def get_old_vellum_rev(path):
         return fh.read().strip()
 
 
-def print_vellum_changes(old_vellum_rev, path):
+def get_vellum_changes(old_vellum_rev, path):
     git = get_git(path)
     log = git('log', '--oneline', '--grep', 'Merge', old_vellum_rev + "..HEAD")
-    log = re.sub(r'#(\d+)', r'dimagi/Vellum#\1', str(log))
+    return re.sub(r'#(\d+)', r'dimagi/Vellum#\1', str(log))
+
+
+def print_vellum_changes(old_vellum_rev, path, out_path=None):
+    log = get_vellum_changes(old_vellum_rev, path)
     print("Vellum Changes Since Last HQ Deploy")
     print(log)
+    if out_path:
+        with open(out_path, "w") as fh:
+            fh.write(log)
 
 
-def update_hq(path, branch, base_branch, vellum_dir, vellum_rev, push, target, dev_mode):
+def update_hq(path, branch, base_branch, vellum_dir, vellum_rev, push, target, dev_mode,
+              non_interactive=False, changelog_out=None):
     git = get_git(path)
 
     if not dev_mode:
@@ -184,9 +200,10 @@ def update_hq(path, branch, base_branch, vellum_dir, vellum_rev, push, target, d
             scripts/vellum-to-hq fix-staging --push
         """)
 
-    code = subprocess.call([
-        "git", "commit", "--edit", "--no-verify", "--message={}".format(message)
-    ], cwd=path)
+    commit_args = ["git", "commit", "--no-verify", "--message={}".format(message)]
+    if not non_interactive:
+        commit_args.insert(2, "--edit")
+    code = subprocess.call(commit_args, cwd=path)
     if code != 0:
         sys.exit(code)
 
@@ -201,7 +218,7 @@ def update_hq(path, branch, base_branch, vellum_dir, vellum_rev, push, target, d
         print(f"\nPush '{hq_branch}' to Github, then create a PR:\n")
         print(f"  git push origin {hq_branch}\n")
 
-    print_vellum_changes(old_vellum_rev, vellum_dir)
+    print_vellum_changes(old_vellum_rev, vellum_dir, out_path=changelog_out)
 
 
 def fix_staging(path, push):


### PR DESCRIPTION
## Product Description
N/A — CI automation only. The auto-PR it opens is targeted at the team that today runs `scripts/vellum-to-hq` by hand.

## Technical Summary
Closes the loop between Vellum merges and the HQ bump that pulls them in. When a Vellum PR merges to master, a `repository_dispatch(vellum-merged)` event fires this workflow, which:

1. Closes any open PR labelled `vellum-bump` (and deletes its branch) so only the freshest auto-PR is up for review.
2. Builds Vellum at HEAD and runs `scripts/vellum-to-hq master --push --no-test --non-interactive --changelog-out=…` to drop the new tarball into HQ, commit, and push a `vellum-<rev>` branch.
3. Opens a new draft PR with the Vellum-changes-since-last-deploy log in the body.

Skips `make test` (Vellum's own CI already ran it on the merged PR) to keep the workflow fast.

### Script changes (commit 1)
- `--non-interactive` drops `git commit --edit` so the script can finish in CI.
- `--changelog-out=PATH` writes the changelog to a file the workflow reads when building the PR body.
- Splits changelog capture into `get_vellum_changes()` so callers can grab the string directly.
- Human behaviour is unchanged — both flags default to off.

### Required setup (outside this PR)
On the **HQ** side:
- Create a label `vellum-bump` on `dimagi/commcare-hq`.
- The workflow reuses the existing `APP_ID` / `APP_PRIVATE_KEY` GitHub App secrets (already used by `update-translations.yml`). That app needs `contents: write` + `pull-requests: write` on commcare-hq — verify before enabling.

On the **Vellum** side, add a workflow that fires the dispatch on merge:
```yaml
# .github/workflows/notify-hq-on-merge.yml
name: Notify HQ of Vellum merge
on:
  pull_request:
    types: [closed]
    branches: [master]
jobs:
  dispatch:
    if: github.event.pull_request.merged == true
    runs-on: ubuntu-latest
    steps:
      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
        id: token
        with:
          app_id: ${{ secrets.APP_ID }}
          private_key: ${{ secrets.APP_PRIVATE_KEY }}
      - run: |
          gh api repos/dimagi/commcare-hq/dispatches \
            -f event_type=vellum-merged \
            -f client_payload[pr_number]=${{ github.event.pull_request.number }}
        env:
          GH_TOKEN: ${{ steps.token.outputs.token }}
```
The same GitHub App needs `actions: write` on commcare-hq for `repository_dispatch` (and to be installed on Vellum). If the existing app doesn't have that scope, easiest fix is to grant it on the app config page.

## Feature Flag
N/A

## Safety Assurance

### Safety story
- Workflow runs only on `repository_dispatch` and `workflow_dispatch`. It does not run on `push`, so an attacker can't trigger it by merging code into HQ.
- The PR it opens is a **draft** with `DON'T REVIEW YET` — no auto-merge, no surprise deploys.
- Concurrency group `vellum-bump` serializes runs so rapid merges queue rather than race.
- The script changes are gated behind opt-in flags; existing manual usage is unchanged.
- Tested manually only — see "Test plan" below. End-to-end testing requires the Vellum-side workflow + App permissions; I'd suggest landing this PR, then triggering once via `workflow_dispatch` from the Actions tab before wiring up Vellum.

### Automated test coverage
None — workflow YAML and script flags are exercised by the workflow itself when it runs.

### QA Plan
1. Merge this PR (after #37716).
2. From Actions tab, trigger "Auto-bump Vellum" manually (`workflow_dispatch`) to verify the build + push + PR-open flow end-to-end against current Vellum master.
3. Wire up the Vellum-side workflow.
4. Verify the next Vellum PR merge produces an auto-PR here.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change