### PR TITLE
Fix bulk-user API q parameter being silently ignored

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -165,7 +165,7 @@ def user_es_call(domain, q, fields, size, start_at):
              .size(size)
              .start(start_at))
     if q is not None:
-        query.set_query({"query_string": {"query": q}})
+        query = query.set_query({"query_string": {"query": q}})
     return query.run().hits
 
 

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -1036,6 +1036,55 @@ class TestBulkUserAPI(APIResourceTest):
         self.assertEqual(response.status_code, 200)
 
 
+@es_test(requires=[user_adapter], setup_class=True)
+class TestBulkUserESCall(TestCase):
+    """Exercises the real user_es_call against ES (TestBulkUserAPI mocks it out)."""
+
+    domain = 'bulk-user-q-test'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(domain_obj.delete)
+
+        cls.target = CommCareUser.create(
+            domain=cls.domain, username='alice', password='*****',
+            created_by=None, created_via=None,
+        )
+        cls.addClassCleanup(cls.target.delete, cls.domain, deleted_by=None)
+        cls.other = CommCareUser.create(
+            domain=cls.domain, username='bob', password='*****',
+            created_by=None, created_via=None,
+        )
+        cls.addClassCleanup(cls.other.delete, cls.domain, deleted_by=None)
+
+        for user in [cls.target, cls.other]:
+            user_adapter.index(user, refresh=True)
+
+    def test_q_filters_to_matching_user(self):
+        hits = v0_5.user_es_call(
+            domain=self.domain,
+            q='alice',
+            fields=['_id', 'username'],
+            size=10,
+            start_at=0,
+        )
+        usernames = sorted(h['username'] for h in hits)
+        assert usernames == ['alice'], usernames
+
+    def test_q_none_returns_all_users(self):
+        hits = v0_5.user_es_call(
+            domain=self.domain,
+            q=None,
+            fields=['_id', 'username'],
+            size=10,
+            start_at=0,
+        )
+        usernames = sorted(h['username'] for h in hits)
+        assert usernames == ['alice', 'bob'], usernames
+
+
 @es_test(requires=[user_adapter])
 class TestIdentityResource(APIResourceTest):
     resource = v0_5.IdentityResource


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
A fix for the bulk-user api returning all users instead of filtering for valid users when using query string.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Claude found this while looking for a way to find a CommCare user by username.

UserES.set_query() returns a new cloned query rather than mutating in place, so the existing call discarded the result and ran the unfiltered query — meaning every q value returned every user in the domain. Assign the return value back to query so the query_string filter is actually applied.

Adds TestBulkUserESCall covering the real ES path; the existing TestBulkUserAPI mocks user_es_call entirely, which is why this bug went uncaught.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
It was not working before. Tests were added for the change. The code bug is quite clear and evident.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
