### PR TITLE
Expect commcare_profile in user_data in create mobile worker API

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -133,7 +133,7 @@ from corehq.apps.users.util import (
     log_user_change,
     verify_modify_user_conditions,
 )
-from corehq.apps.users.validation import validate_profile_required
+from corehq.apps.users.validation import validate_profile_id
 from corehq.apps.domain.forms import send_password_reset_email
 from corehq.const import USER_CHANGE_VIA_API
 from corehq.util import get_document_or_404
@@ -280,7 +280,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
         if connect_username and not toggles.COMMCARE_CONNECT.enabled(kwargs['domain']):
             raise BadRequest(_("You don't have permission to use connect_username field"))
         try:
-            validate_profile_required(
+            validate_profile_id(
                 bundle.data.get('user_data', {}).get('commcare_profile'),
                 kwargs['domain'],
             )

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -280,7 +280,10 @@ class CommCareUserResource(v0_1.CommCareUserResource):
         if connect_username and not toggles.COMMCARE_CONNECT.enabled(kwargs['domain']):
             raise BadRequest(_("You don't have permission to use connect_username field"))
         try:
-            validate_profile_required(bundle.data.get('user_profile'), kwargs['domain'])
+            validate_profile_required(
+                bundle.data.get('user_data', {}).get('commcare_profile'),
+                kwargs['domain'],
+            )
         except ValidationError as e:
             raise BadRequest(e.message)
         try:

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -374,7 +374,7 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.content.decode('utf-8'),
-            '{"error": "User data profile not found."}'
+            '{"error": "Profile with id 123456 not found."}'
         )
 
     def test_update(self):

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -360,6 +360,23 @@ class TestCommCareUserResource(APIResourceTest):
             '{"error": "A profile assignment is required for Mobile Workers."}',
         )
 
+    def test_bad_request_profile_not_found(self):
+        user_json = {
+            'username': 'jdoe',
+            'password': 'qwer1234',
+            'user_data': {'commcare_profile': 123456},
+        }
+        response = self._assert_auth_post_resource(
+            self.list_endpoint,
+            json.dumps(user_json),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.content.decode('utf-8'),
+            '{"error": "User data profile not found."}'
+        )
+
     def test_update(self):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",
                                    created_by=None, created_via=None, phone_number="50253311398")

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -340,6 +340,26 @@ class TestCommCareUserResource(APIResourceTest):
                          f'{{"error": "Username \'jdoe@{self.domain.name}.commcarehq.org\' is already taken or '
                          f'reserved."}}')
 
+    def test_bad_request_profile_required_not_included(self):
+        definition = CustomDataFieldsDefinition.get_or_create(self.domain, UserFieldsView.field_type)
+        definition.profile_required_for_user_type = [UserFieldsView.COMMCARE_USER]
+        definition.save()
+
+        user_json = {
+            'username': 'jdoe',
+            'password': 'qwer1234',
+        }
+        response = self._assert_auth_post_resource(
+            self.list_endpoint,
+            json.dumps(user_json),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.content.decode('utf-8'),
+            '{"error": "A profile assignment is required for Mobile Workers."}',
+        )
+
     def test_update(self):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",
                                    created_by=None, created_via=None, phone_number="50253311398")

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -340,7 +340,7 @@ class TestCommCareUserResource(APIResourceTest):
                          f'{{"error": "Username \'jdoe@{self.domain.name}.commcarehq.org\' is already taken or '
                          f'reserved."}}')
 
-    def test_bad_request_profile_required_not_included(self):
+    def test_bad_request_if_profile_required_but_not_included(self):
         definition = CustomDataFieldsDefinition.get_or_create(self.domain, UserFieldsView.field_type)
         definition.profile_required_for_user_type = [UserFieldsView.COMMCARE_USER]
         definition.save()
@@ -360,7 +360,7 @@ class TestCommCareUserResource(APIResourceTest):
             '{"error": "A profile assignment is required for Mobile Workers."}',
         )
 
-    def test_bad_request_profile_not_found(self):
+    def test_bad_request_if_profile_not_found(self):
         user_json = {
             'username': 'jdoe',
             'password': 'qwer1234',

--- a/corehq/apps/api/tests/test_user_updates.py
+++ b/corehq/apps/api/tests/test_user_updates.py
@@ -127,7 +127,7 @@ class TestUpdateUserMethods(TestCase):
     def test_profile_not_found(self):
         with self.assertRaises(UpdateUserException) as cm:
             self.commcare_user_updater.update('user_data', {PROFILE_SLUG: 123456})
-        self.assertEqual(cm.exception.message, "User data profile not found")
+        self.assertEqual(cm.exception.message, "Profile not found")
 
     def test_validation_error_when_profile_required(self):
         self.definition = CustomDataFieldsDefinition.get_or_create(self.domain, UserFieldsView.field_type)

--- a/corehq/apps/users/user_data.py
+++ b/corehq/apps/users/user_data.py
@@ -118,7 +118,7 @@ class UserData:
                 definition__field_type=CUSTOM_USER_DATA_FIELD_TYPE,
             )
         except CustomDataFieldsProfile.DoesNotExist as e:
-            raise UserDataError(_("User data profile not found")) from e
+            raise UserDataError(_("Profile not found")) from e
 
     def remove_unrecognized(self):
         return _remove_unrecognized(self._local_to_user, self._schema_fields)

--- a/corehq/apps/users/validation.py
+++ b/corehq/apps/users/validation.py
@@ -54,7 +54,7 @@ def validate_profile_id(profile_id, domain):
     profiles = CustomDataFieldsDefinition.get(domain, 'UserFields').get_profiles()
     if profile_id and profile_id not in {profile.id for profile in profiles}:
         raise ValidationError(
-            _("User data profile not found.")
+            _("Profile with id {id} not found.").format(id=profile_id)
         )
 
 

--- a/corehq/apps/users/validation.py
+++ b/corehq/apps/users/validation.py
@@ -56,8 +56,8 @@ def validate_profile_required(profile_name, domain):
     )
     if not profile_required_for_user_type_list:
         return
-    profile_assginment_required = UserFieldsView.COMMCARE_USER in profile_required_for_user_type_list
-    if profile_assginment_required and not profile_name:
+    profile_assignment_required = UserFieldsView.COMMCARE_USER in profile_required_for_user_type_list
+    if profile_assignment_required and not profile_name:
         raise ValidationError(
             _("A profile assignment is required for Mobile Workers.")
         )

--- a/corehq/apps/users/validation.py
+++ b/corehq/apps/users/validation.py
@@ -49,6 +49,15 @@ def _validate_complete_username(username, domain):
             _("The username email domain '@{}' should be '@{}'.").format(email_domain, expected_domain))
 
 
+def validate_profile_id(profile_id, domain):
+    validate_profile_required(profile_id, domain)
+    profiles = CustomDataFieldsDefinition.get(domain, 'UserFields').get_profiles()
+    if profile_id and profile_id not in {profile.id for profile in profiles}:
+        raise ValidationError(
+            _("User data profile not found.")
+        )
+
+
 def validate_profile_required(profile_identifier, domain):
     profile_required_for_user_type_list = CustomDataFieldsDefinition.get_profile_required_for_user_type_list(
         domain,

--- a/corehq/apps/users/validation.py
+++ b/corehq/apps/users/validation.py
@@ -49,7 +49,7 @@ def _validate_complete_username(username, domain):
             _("The username email domain '@{}' should be '@{}'.").format(email_domain, expected_domain))
 
 
-def validate_profile_required(profile_name, domain):
+def validate_profile_required(profile_identifier, domain):
     profile_required_for_user_type_list = CustomDataFieldsDefinition.get_profile_required_for_user_type_list(
         domain,
         UserFieldsView.field_type
@@ -57,7 +57,7 @@ def validate_profile_required(profile_name, domain):
     if not profile_required_for_user_type_list:
         return
     profile_assignment_required = UserFieldsView.COMMCARE_USER in profile_required_for_user_type_list
-    if profile_assignment_required and not profile_name:
+    if profile_assignment_required and not profile_identifier:
         raise ValidationError(
             _("A profile assignment is required for Mobile Workers.")
         )


### PR DESCRIPTION
## Product Description
Previously, if a user data profile was required for all mobile workers, there was not a clear way to set one when creating a mobile worker by API. Setting `user_data['commcare_profile']` could set the profile directly, by its ID, but we would validate for the presence of top-level `user_profile` key, which was checked and then thrown away. `user_data['commcare_profile']` was also not validated, so it could have been used with a fake/invalid ID to bypass the requirement of user profiles.

Now, when a user data profile is required for all mobile workers, we will validate for the presence of `user_data['commcare_profile']` and check that the profile actually exists before setting it. The user-facing effect is that mobile workers can now be created by API when a profile is required.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-18607
The preexisting `validate_profile_required` was working as expected - it checks if a profile is required, and if so, checks that the value being used for it is truthy. This is used both when creating and updating users. When updating users, we separately validate that the profile being checked actually exists, but this is too late to return a response to an API call if the profile does not exist.

By adding `validate_profile_id` and checking `user_data['commcare_profile']` for API calls, we can reject requests that provide an invalid profile ID, as well as requests that omit profile ID when one is required.

## Safety Assurance

### Safety story
This change adds validation (it does not remove any), it is limited in scope (no effect on non-API mobile worker creation), and has automated testing added covering its changes.

### Automated test coverage
Added automated tests for both pieces of API functionality: validating that profile id is present if required, and that it maps to a real profile if it is provided.

### QA Plan
Not planning QA.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
