### PR TITLE
Add feature flags for case list perf optimizations

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -1,5 +1,6 @@
 import re
 
+from corehq import toggles
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.suite_xml import const
 from corehq.apps.app_manager.suite_xml import xml_models as sx
@@ -411,6 +412,19 @@ class Enum(FormattedDetailColumn):
             get_value=lambda key: self.id_strings.detail_column_enum_variable(self.module, self.detail_type,
                                                                               self.column, key))
 
+    @property
+    def _template_xpath(self):
+        """The xpath expression to substitute into per-mapping enum templates."""
+        # For calculated-property columns, the ``$calculated_property`` variable is
+        # already defined on the template's xpath text (see ``template``/``sort_node``),
+        # so references to it avoid repeating the (potentially expensive) source
+        # expression once per enum mapping.
+        if (self.column.useXpathExpression  # This is a calculated property
+                # Temporary feature flag for testing purposes:
+                and toggles.ENUM_CALC_VARIABLES.enabled(self.app.domain)):
+            return '$calculated_property'
+        return self.xpath
+
     def _xpath_template(self, type):
         if type == 'sort':
             return "if(selected({xpath}, '{key}'), {i}, "
@@ -457,7 +471,7 @@ class ConditionalEnum(Enum):
 
     def _xpath_template_context(self, type):
         return lambda item, i: {
-            'key_as_condition': item.key_as_condition(self.xpath),
+            'key_as_condition': item.key_as_condition(self._template_xpath),
             'key_as_var_name': item.ref_to_key_variable(i, 'display')
         }
 
@@ -520,7 +534,7 @@ class EnumImage(Enum):
 
     def _xpath_template_context(self, type):
         return lambda item, i: {
-            'key_as_condition': item.key_as_condition(self.xpath),
+            'key_as_condition': item.key_as_condition(self._template_xpath),
             'key_as_var_name': item.ref_to_key_variable(i, type)
         }
 

--- a/corehq/apps/app_manager/tests/test_suite_formats.py
+++ b/corehq/apps/app_manager/tests/test_suite_formats.py
@@ -317,6 +317,91 @@ class SuiteFormatsTest(SimpleTestCase, TestXmlMixin):
             'jr://icons/10-year-old.png'
         )
 
+    def _build_calculated_enum_image_app(self):
+        app = Application.new_app('domain', 'Untitled Application')
+        module = app.add_module(Module.new_module('Untitled Module', None))
+        module.case_type = 'patient'
+
+        column = DetailColumn(
+            header={'en': 'Stars'},
+            model='case',
+            field="if(stars > 4, 'high', 'low')",
+            format='enum-image',
+            enum=[
+                MappingItem(key='high', value={'en': 'jr://icons/star-gold.png'}),
+                MappingItem(key='low', value={'en': 'jr://icons/star-grey.png'}),
+            ],
+        )
+        column.useXpathExpression = True
+        module.case_details.short.columns = [column]
+        return app
+
+    def test_enum_calc_repeats_expression(self, *args):
+        """Without ENUM_CALC_VARIABLES enabled, enum-image columns whose field
+        is a calculated expression repeat the full expression for each mapping
+        rather than referencing the ``$calculated_property`` variable defined
+        alongside. This locks in that pre-flag behavior.
+        """
+        app = self._build_calculated_enum_image_app()
+
+        expected = """
+        <partial>
+          <template form="image" width="13%">
+            <text>
+              <xpath function="if(if(stars &gt; 4, 'high', 'low') = 'high', $khigh, if(if(stars &gt; 4, 'high', 'low') = 'low', $klow, ''))">
+                <variable name="calculated_property">
+                  <xpath function="if(stars &gt; 4, 'high', 'low')"/>
+                </variable>
+                <variable name="khigh">
+                  <locale id="m0.case_short.case_if(stars &gt; 4, 'high', 'low')_1.enum.khigh"/>
+                </variable>
+                <variable name="klow">
+                  <locale id="m0.case_short.case_if(stars &gt; 4, 'high', 'low')_1.enum.klow"/>
+                </variable>
+              </xpath>
+            </text>
+          </template>
+        </partial>
+        """  # noqa: #501
+        self.assertXmlPartialEqual(
+            expected,
+            app.create_suite(),
+            './detail/field/template[@form="image"]',
+        )
+
+    @flag_enabled('ENUM_CALC_VARIABLES')
+    def test_enum_calc_references_variable(self, *args):
+        """With ENUM_CALC_VARIABLES enabled, enum-image columns reference the
+        ``$calculated_property`` variable in each mapping condition instead of
+        repeating the source expression.
+        """
+        app = self._build_calculated_enum_image_app()
+
+        expected = """
+        <partial>
+          <template form="image" width="13%">
+            <text>
+              <xpath function="if($calculated_property = 'high', $khigh, if($calculated_property = 'low', $klow, ''))">
+                <variable name="calculated_property">
+                  <xpath function="if(stars &gt; 4, 'high', 'low')"/>
+                </variable>
+                <variable name="khigh">
+                  <locale id="m0.case_short.case_if(stars &gt; 4, 'high', 'low')_1.enum.khigh"/>
+                </variable>
+                <variable name="klow">
+                  <locale id="m0.case_short.case_if(stars &gt; 4, 'high', 'low')_1.enum.klow"/>
+                </variable>
+              </xpath>
+            </text>
+          </template>
+        </partial>
+        """
+        self.assertXmlPartialEqual(
+            expected,
+            app.create_suite(),
+            './detail/field/template[@form="image"]',
+        )
+
     def test_case_detail_alt_text_mapping(self, *args):
         factory = AppFactory(domain='domain', name='Case list field actions', build_version='2.54.0')
         m0, f0 = factory.new_basic_module("module1", "case")

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1011,6 +1011,14 @@ GEOCODER_USER_PROXIMITY = StaticToggle(
     """,
 )
 
+FORMPLAYER_SKIP_FIELD_CACHING = StaticToggle(
+    'formplayer_skip_field_caching',
+    'Formplayer: Skip Field Caching',
+    TAG_INTERNAL,
+    description="Instruct formplayer to try out an alternative field caching workflow for performance testing.",
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 USH_EMPTY_CASE_LIST_TEXT = StaticToggle(
     'empty_case_list_text',
     "USH: Allow customizing the text displayed when case list contains no cases in web apps",

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1026,6 +1026,18 @@ USH_EMPTY_CASE_LIST_TEXT = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN]
 )
 
+ENUM_CALC_VARIABLES = StaticToggle(
+    'enum_calc_variables',
+    'Switch Enum Fields to Variables',
+    TAG_INTERNAL,
+    description="""
+    Switch enum field types to reference the calculated_property variable
+    rather than repeat the expression for each mapping.  This is a performance
+    optimization for when the expression is expensive to compute.
+    """,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 HIDE_SYNC_BUTTON = StaticToggle(
     "hide_sync_button",
     "USH: Hide Sync Button in Web Apps",


### PR DESCRIPTION
## Product Description
No user-facing changes by default. Two new internal feature flags gate performance-related changes that are opt-in per domain.

## Technical Summary
Adds two perf-testing feature flags so we can validate impact in a real environment with limited blast radius:

- `FORMPLAYER_SKIP_FIELD_CACHING` — instructs formplayer to try an alternative field-caching workflow.
- `ENUM_CALC_VARIABLES` — switches `conditional-enum` / `enum-image` / `clickable-icon` columns whose field is a calculated XPath expression to reference the existing `$calculated_property` variable in each per-mapping condition, instead of repeating the full expression. This matters when the expression is expensive (e.g. casedb lookups).

`Enum._template_xpath` is the shared helper that gates the substitution behind the flag + `useXpathExpression=True`. Base `Enum` already referenced `$calculated_property`; `ConditionalEnum` and `EnumImage` (which `ClickableIcon` inherits from) did not. This PR closes that gap behind the flag.

## Feature Flag
- `FORMPLAYER_SKIP_FIELD_CACHING`
- `ENUM_CALC_VARIABLES`

## Safety Assurance

### Safety story
Both flags are off by default and scoped per-domain. Behavior change is limited to opt-in domains. The `ENUM_CALC_VARIABLES` change preserves the suite XML's `<variable name="calculated_property">` definition — only the body of the xpath function changes to reference it.

### Automated test coverage
Added paired tests in `test_suite_formats.py` that lock in pre-flag behavior (expression repeated per mapping) and assert flag-enabled behavior (`$calculated_property` referenced). The formplayer flag is read by formplayer itself, not by HQ.

### QA Plan
- Enable `ENUM_CALC_VARIABLES` on a staging domain whose case list uses a calculated `clickable-icon` column; verify the generated suite.xml uses `$calculated_property` and the case list renders correctly on mobile.
- For `FORMPLAYER_SKIP_FIELD_CACHING`, coordinated rollout in tandem with the formplayer-side change.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change