### PR TITLE
Use <button> instead of <a> for print button

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/views.js
@@ -1571,13 +1571,7 @@ const printBehavior = Marionette.Behavior.extend({
         selectPrint: ".print-button",
     },
     events: {
-        "keydown @ui.selectPrint": "printKeyAction",
         "click @ui.selectPrint": "print",
-    },
-    printKeyAction: function (e) {
-        if (e.keyCode === 13) {
-            this.print();
-        }
     },
     print: function () {
         window.print();

--- a/corehq/apps/cloudcare/templates/cloudcare/partials/menu/dropdown.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/partials/menu/dropdown.html
@@ -8,10 +8,10 @@
       <span class="sr-only">{% trans 'Dropdown toggle' %}</span>
     </button>
     <ul class="dropdown-menu dropdown-menu-end noprint-sub-container" aria-label="Dropdown">
-      <li tabindex="0" class="print-button">
-        <a href="#" class="dropdown-item">
+      <li>
+        <button class="print-button dropdown-item fw-normal" type="button">
           {% trans "Print" %}
-        </a>
+        </button>
       </li>
       <% if (languageOptionsEnabled) { %>
       <li><hr class="dropdown-divider"></li>


### PR DESCRIPTION
## Product Description
Fixes a bug where clicking the Print button in web apps would break breadcrumb navigation. No visual changes.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19440
Replaces the print link `<a>` with a print button `<button>` in web apps.

## Safety Assurance

### Safety story
This is a safe change that does not affect functionality. Tested locally to see that the button looks the same and is still keyboard-focusable; print works with a click, enter, or spacebar press; and that navigation breadcrumbs are no longer broken after clicking Print.

### Automated test coverage
Not here.

### QA Plan
Not planning it.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
