### PR TITLE
Let dump_domain_data and run_blob_export write to a chosen directory

### DIFF
--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -28,11 +28,12 @@ class Command(BaseCommand):
             help='An app_label, app_label.ModelName or CouchDB doc_type to include '
                  '(use multiple --include to include multiple apps/models).'
         )
-        parser.add_argument(
+        output_group = parser.add_mutually_exclusive_group()
+        output_group.add_argument(
             '--console', action='store_true', default=False, dest='console',
             help='Write output to the console instead of to file.'
         )
-        parser.add_argument(
+        output_group.add_argument(
             '--dir', dest='dir',
             help='Optionally specify a directory to write the file to. '
                  'The directory will be created if it does not exist.',
@@ -48,7 +49,7 @@ class Command(BaseCommand):
         requested_dumpers = options.get('dumpers')
         output_dir = options.get('dir')
 
-        if output_dir and not console:
+        if output_dir:
             os.makedirs(output_dir, exist_ok=True)
 
         self.utcnow = datetime.utcnow().strftime(DATETIME_FORMAT)

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -32,6 +32,11 @@ class Command(BaseCommand):
             '--console', action='store_true', default=False, dest='console',
             help='Write output to the console instead of to file.'
         )
+        parser.add_argument(
+            '--dir', dest='dir',
+            help='Optionally specify a directory to write the file to. '
+                 'The directory will be created if it does not exist.',
+        )
         parser.add_argument('--dumper', dest='dumpers', action='append', default=[],
                             help='Dumper slug to run (use multiple --dumper to run multiple dumpers).')
 
@@ -41,9 +46,15 @@ class Command(BaseCommand):
         console = options.get('console')
         show_traceback = options.get('traceback')
         requested_dumpers = options.get('dumpers')
+        output_dir = options.get('dir')
+
+        if output_dir and not console:
+            os.makedirs(output_dir, exist_ok=True)
 
         self.utcnow = datetime.utcnow().strftime(DATETIME_FORMAT)
         zipname = 'data-dump-{}-{}.zip'.format(domain_name, self.utcnow)
+        if output_dir:
+            zipname = os.path.join(output_dir, zipname)
 
         self.stdout.ending = None
         meta = {}  # {dumper_slug: {model_name: count}}
@@ -52,7 +63,7 @@ class Command(BaseCommand):
             if requested_dumpers and dumper.slug not in requested_dumpers:
                 continue
 
-            filename = _get_dump_stream_filename(dumper.slug, domain_name, self.utcnow)
+            filename = _get_dump_stream_filename(dumper.slug, domain_name, self.utcnow, path=output_dir)
             stream = self.stdout if console else gzip.open(filename, 'wt')
             try:
                 meta[dumper.slug] = dumper(domain_name, excludes, includes).dump(stream)
@@ -91,5 +102,8 @@ class Command(BaseCommand):
         self.stdout.write('{0}{0}'.format('-' * 38))
 
 
-def _get_dump_stream_filename(slug, domain, utcnow):
-    return 'dump-{}-{}-{}.gz'.format(slug, domain, utcnow)
+def _get_dump_stream_filename(slug, domain, utcnow, path=None):
+    filename = 'dump-{}-{}-{}.gz'.format(slug, domain, utcnow)
+    if path:
+        return os.path.join(path, filename)
+    return filename

--- a/corehq/apps/dump_reload/tests/test_dump_domain_data.py
+++ b/corehq/apps/dump_reload/tests/test_dump_domain_data.py
@@ -3,9 +3,13 @@ import tempfile
 import zipfile
 from contextlib import contextmanager
 
+import pytest
+
 from django.core.management import call_command
+from django.core.management.base import CommandError
 
 from corehq.apps.dump_reload.management.commands.dump_domain_data import (
+    Command,
     _get_dump_stream_filename,
 )
 
@@ -57,17 +61,13 @@ class TestDumpDomainDataDirFlag:
             with zipfile.ZipFile(os.path.join(target, zips[0])) as z:
                 assert z.namelist() == ['meta.json']
 
-    def test_dir_skipped_in_console_mode(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            unused = os.path.join(tmp, 'not-created')
-            call_command(
-                'dump_domain_data',
-                'mydomain',
-                dir=unused,
-                console=True,
-                dumpers=['__none__'],
-            )
-            assert not os.path.exists(unused)
+    def test_dir_rejected_in_console_mode(self):
+        # The CLI rejects --dir + --console via argparse's mutually
+        # exclusive group. Use the parser directly: call_command()
+        # bypasses argparse mutex validation for kwargs.
+        parser = Command().create_parser('manage.py', 'dump_domain_data')
+        with pytest.raises(CommandError, match='not allowed with argument --console'):
+            parser.parse_args(['mydomain', '--console', '--dir=/tmp/x'])
 
     def test_no_dir_writes_to_cwd(self):
         with tempfile.TemporaryDirectory() as tmp, chdir(tmp):

--- a/corehq/apps/dump_reload/tests/test_dump_domain_data.py
+++ b/corehq/apps/dump_reload/tests/test_dump_domain_data.py
@@ -1,0 +1,80 @@
+import os
+import tempfile
+import zipfile
+from contextlib import contextmanager
+
+from django.core.management import call_command
+
+from corehq.apps.dump_reload.management.commands.dump_domain_data import (
+    _get_dump_stream_filename,
+)
+
+
+@contextmanager
+def chdir(path):
+    """Change cwd within a block, restoring on exit."""
+    prev = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev)
+
+
+class TestGetDumpStreamFilename:
+    def test_without_path(self):
+        assert _get_dump_stream_filename('sql', 'mydomain', '2026-05-18') == \
+            'dump-sql-mydomain-2026-05-18.gz'
+
+    def test_with_path(self):
+        assert _get_dump_stream_filename('sql', 'mydomain', '2026-05-18', path='/tmp/out') == \
+            '/tmp/out/dump-sql-mydomain-2026-05-18.gz'
+
+
+class TestDumpDomainDataDirFlag:
+    """Tests for the --dir flag on the dump_domain_data command.
+
+    Passes ``--dumper=__none__`` so no dumpers run — this avoids needing a
+    real database while still exercising the directory-handling code path
+    and verifying the final zip lands in the requested directory.
+    """
+
+    def test_creates_missing_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, 'nested', 'subdir')
+            assert not os.path.exists(target)
+
+            call_command(
+                'dump_domain_data',
+                'mydomain',
+                dir=target,
+                dumpers=['__none__'],
+            )
+
+            assert os.path.isdir(target)
+            zips = [f for f in os.listdir(target) if f.endswith('.zip')]
+            assert len(zips) == 1
+            with zipfile.ZipFile(os.path.join(target, zips[0])) as z:
+                assert z.namelist() == ['meta.json']
+
+    def test_dir_skipped_in_console_mode(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            unused = os.path.join(tmp, 'not-created')
+            call_command(
+                'dump_domain_data',
+                'mydomain',
+                dir=unused,
+                console=True,
+                dumpers=['__none__'],
+            )
+            assert not os.path.exists(unused)
+
+    def test_no_dir_writes_to_cwd(self):
+        with tempfile.TemporaryDirectory() as tmp, chdir(tmp):
+            call_command(
+                'dump_domain_data',
+                'mydomain',
+                dumpers=['__none__'],
+            )
+            zips = [f for f in os.listdir(tmp) if f.endswith('.zip')]
+            assert len(zips) == 1

--- a/corehq/blobs/management/commands/run_blob_export.py
+++ b/corehq/blobs/management/commands/run_blob_export.py
@@ -32,7 +32,8 @@ class Command(BaseCommand):
         parser.add_argument(
             '--dir',
             dest='dir',
-            help="Optionally specify a directory to write the file to",
+            help="Optionally specify a directory to write the file to. "
+                 "The directory will be created if it does not exist.",
         )
         parser.add_argument('--chunk-size', type=int, default=100,
                             help='Maximum number of records to read from couch at once.')
@@ -58,6 +59,9 @@ class Command(BaseCommand):
 
         if not domain:
             raise CommandError(USAGE)
+
+        if dir:
+            os.makedirs(dir, exist_ok=True)
 
         self.stdout.write("\nRunning blob exporter\n{}".format('-' * 50))
         export_filename = _get_export_filename(

--- a/corehq/blobs/tests/test_run_blob_export.py
+++ b/corehq/blobs/tests/test_run_blob_export.py
@@ -1,0 +1,50 @@
+import os
+import tempfile
+from contextlib import contextmanager
+from unittest import mock
+
+from django.core.management import call_command
+
+
+@contextmanager
+def chdir(path):
+    """Change cwd within a block, restoring on exit."""
+    prev = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev)
+
+
+class TestRunBlobExportDirFlag:
+    """Tests for the --dir flag on the run_blob_export command.
+
+    ``BlobExporter`` is mocked so the test does not depend on the blob DB.
+    """
+
+    def test_creates_missing_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, 'nested', 'subdir')
+            assert not os.path.exists(target)
+
+            with mock.patch(
+                'corehq.blobs.management.commands.run_blob_export.BlobExporter'
+            ) as mock_exporter:
+                mock_exporter.return_value.migrate.return_value = (0, 0)
+                call_command('run_blob_export', 'mydomain', dir=target)
+
+            assert os.path.isdir(target)
+            export_filename = mock_exporter.return_value.migrate.call_args.args[0]
+            assert export_filename.startswith(target + os.sep)
+
+    def test_no_dir_writes_to_cwd(self):
+        with tempfile.TemporaryDirectory() as tmp, chdir(tmp):
+            with mock.patch(
+                'corehq.blobs.management.commands.run_blob_export.BlobExporter'
+            ) as mock_exporter:
+                mock_exporter.return_value.migrate.return_value = (0, 0)
+                call_command('run_blob_export', 'mydomain')
+
+            export_filename = mock_exporter.return_value.migrate.call_args.args[0]
+            assert os.sep not in export_filename


### PR DESCRIPTION
## Product Description
No user-facing change.

## Technical Summary

`dump_domain_data` now accepts a `--dir <path>` flag (it previously
always wrote to cwd), and `run_blob_export`'s existing `--dir` flag
now creates the target directory if missing. Both behaviors use
`mkdir -p` semantics.

Passing `--dir` together with `--console` raises `CommandError`, since
no file would be written. Intermediate `.gz` streams that
`dump_domain_data` creates per dumper are also written into `--dir`,
so temp files don't clutter the caller's working directory.

## Safety Assurance

### Safety story

Opt-in flag; default behavior (write to cwd) is unchanged. No schema
or data changes. Both commands are operator-run management commands,
so any regression has narrow blast radius.

### Automated test coverage

7 unit tests cover the path-joining helper and verify each command
creates missing directories, preserves default cwd behavior, and that
`dump_domain_data` rejects `--dir` combined with `--console`.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

