### PR TITLE
Simplify payments report filters and remove ES timeout helper

### DIFF
--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -35,7 +35,6 @@ from corehq.apps.es.transient_util import doc_adapter_from_cname
 from corehq.util.dates import iso_string_to_datetime
 
 from . import filters, queries
-from .aggregations import TermsAggregation, FilterAggregation, NestedAggregation
 from .cases import case_adapter
 from .client import BulkActionItem, ElasticDocumentAdapter, create_document_adapter
 from .const import (
@@ -410,51 +409,6 @@ def external_id(external_id):
 
 def indexed_on(gt=None, gte=None, lt=None, lte=None):
     return filters.date_range(INDEXED_ON, gt, gte, lt, lte)
-
-
-def get_case_property_unique_values(domain, case_type, property_name, include_empty=False):
-    """
-    Gets unique values for a specific case property for given domain and case type.
-    Notes:
-    - Uses an ES terms aggregation (avoid high-cardinality fields like UUIDs or datetimes).
-    - Empty string values are returned as '' if include_empty=True.
-    """
-    terms_agg = TermsAggregation(
-        'unique_values',
-        'case_properties.value.exact'
-    )
-
-    filter_agg = FilterAggregation(
-        'property_filter',
-        filters.term('case_properties.key.exact', property_name)
-    ).aggregation(terms_agg)
-
-    nested_agg = NestedAggregation(
-        'nested_case_props',
-        'case_properties'
-    ).aggregation(filter_agg)
-
-    query = (
-        CaseSearchES()
-        .domain(domain)
-        .case_type(case_type)
-        .aggregation(nested_agg)
-        .size(0)
-    )
-
-    results = query.run()
-
-    buckets = (
-        results.aggregations
-        .nested_case_props
-        .property_filter
-        .unique_values
-        .normalized_buckets
-    )
-    if include_empty:
-        return [b['key'] for b in buckets]
-    else:
-        return [b['key'] for b in buckets if b['key'] != '']
 
 
 def wrap_case_search_hit(hit, include_score=False):

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -23,7 +23,6 @@ from corehq.apps.es.case_search import (
     case_property_starts_with,
     case_property_text_query,
     case_search_adapter,
-    get_case_property_unique_values,
     wrap_case_search_hit,
 )
 from corehq.apps.es.const import SIZE_LIMIT
@@ -595,39 +594,6 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             "starts-with(ssn, '100')",
             ['c5', 'c6', 'c2']
         )
-
-    def test_get_case_property_unique_values(self):
-        self._bootstrap_cases_in_es_for_domain(self.domain, [
-            {'_id': 'c1', 'status': 'active'},
-            {'_id': 'c2', 'status': 'inactive'},
-            {'_id': 'c3', 'status': 'active'},
-            {'_id': 'c5', 'status': ''},  # empty value
-            {'_id': 'c6'},  # missing property
-        ])
-
-        unique_values = get_case_property_unique_values(self.domain, self.case_type, 'status')
-        expected_values = ['active', 'inactive']
-        self.assertEqual(sorted(unique_values), expected_values)
-
-    def test_get_case_property_unique_values_with_empty(self):
-        self._bootstrap_cases_in_es_for_domain(self.domain, [
-            {'_id': 'c1', 'status': 'active'},
-            {'_id': 'c2', 'status': 'inactive'},
-            {'_id': 'c3', 'status': 'active'},
-            {'_id': 'c5', 'status': ''},  # empty value
-            {'_id': 'c6'},  # missing property
-        ])
-
-        unique_values_with_empty = get_case_property_unique_values(
-            self.domain, self.case_type, 'status', include_empty=True
-        )
-        expected_values_with_empty = ['', 'active', 'inactive']
-        self.assertEqual(sorted(unique_values_with_empty), expected_values_with_empty)
-
-    def test_get_case_property_unique_values_no_cases(self):
-        unique_values = get_case_property_unique_values(self.domain, self.case_type, 'nonexistent')
-        self.assertEqual(unique_values, [])
-
 
 class TestForwardTimezoneAdjustment(TestCase):
 

--- a/corehq/apps/integration/payments/filters.py
+++ b/corehq/apps/integration/payments/filters.py
@@ -34,24 +34,31 @@ class PaymentCaseListFilter(CaseListFilter):
     default_selections = [("all_data", _("[All Data]"))]
 
 
+_CASE_SENSITIVE_HELP = gettext_lazy('Case-sensitive exact match.')
+
+
 class BatchNumberFilter(BaseSimpleFilter):
     slug = 'batch_number'
     label = gettext_lazy('Batch number')
+    help_inline = _CASE_SENSITIVE_HELP
 
 
 class CampaignFilter(BaseSimpleFilter):
     slug = 'campaign'
     label = gettext_lazy('Campaign')
+    help_inline = _CASE_SENSITIVE_HELP
 
 
 class ActivityFilter(BaseSimpleFilter):
     slug = 'activity'
     label = gettext_lazy('Activity')
+    help_inline = _CASE_SENSITIVE_HELP
 
 
 class FunderFilter(BaseSimpleFilter):
     slug = 'funder'
     label = gettext_lazy('Funder')
+    help_inline = _CASE_SENSITIVE_HELP
 
 
 class PhoneNumberFilter(BaseSimpleFilter):

--- a/corehq/apps/integration/payments/filters.py
+++ b/corehq/apps/integration/payments/filters.py
@@ -1,13 +1,8 @@
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
-from corehq.apps.case_importer.const import MOMO_PAYMENT_CASE_TYPE
-from corehq.apps.es.case_search import get_case_property_unique_values
 from corehq.apps.es.users import UserES
-from corehq.apps.integration.payments.const import (
-    PaymentProperties,
-    PaymentStatus,
-)
+from corehq.apps.integration.payments.const import PaymentStatus
 from corehq.apps.reports.filters.base import (
     BaseSimpleFilter,
     BaseSingleOptionFilter,
@@ -39,44 +34,24 @@ class PaymentCaseListFilter(CaseListFilter):
     default_selections = [("all_data", _("[All Data]"))]
 
 
-class BaseCasePropertyFilter(BaseSingleOptionFilter):
-    default_text = _("Show all")
-    case_property = None
-
-    @property
-    def options(self):
-        if not self.case_property:
-            raise NotImplementedError("Subclasses must define 'case_property'")
-        values = get_case_property_unique_values(
-            self.domain,
-            MOMO_PAYMENT_CASE_TYPE,
-            self.case_property,
-        )
-        return [(value, value) for value in sorted(values)]
+class BatchNumberFilter(BaseSimpleFilter):
+    slug = 'batch_number'
+    label = gettext_lazy('Batch number')
 
 
-class BatchNumberFilter(BaseCasePropertyFilter):
-    slug = "batch_number"
-    label = _("Batch number")
-    case_property = PaymentProperties.BATCH_NUMBER
-
-
-class CampaignFilter(BaseCasePropertyFilter):
+class CampaignFilter(BaseSimpleFilter):
     slug = 'campaign'
-    label = _('Campaign')
-    case_property = PaymentProperties.CAMPAIGN
+    label = gettext_lazy('Campaign')
 
 
-class ActivityFilter(BaseCasePropertyFilter):
+class ActivityFilter(BaseSimpleFilter):
     slug = 'activity'
-    label = _('Activity')
-    case_property = PaymentProperties.ACTIVITY
+    label = gettext_lazy('Activity')
 
 
-class FunderFilter(BaseCasePropertyFilter):
+class FunderFilter(BaseSimpleFilter):
     slug = 'funder'
-    label = _('Funder')
-    case_property = PaymentProperties.FUNDER
+    label = gettext_lazy('Funder')
 
 
 class PhoneNumberFilter(BaseSimpleFilter):

--- a/corehq/apps/integration/payments/tests/test_views.py
+++ b/corehq/apps/integration/payments/tests/test_views.py
@@ -21,7 +21,6 @@ from corehq.apps.integration.payments.const import (
     PaymentStatus,
 )
 from corehq.apps.integration.payments.filters import (
-    BatchNumberFilter,
     CampaignFilter,
     PaymentVerifiedByFilter,
 )
@@ -126,7 +125,6 @@ class TestPaymentsVerificationReportView(BaseTestPaymentsView):
         assert response.status_code == 403
 
     @flag_enabled('MOBILE_MONEY_INTEGRATION')
-    @patch.object(BatchNumberFilter, 'options', [("b001", "b001")])
     @patch.object(PaymentVerifiedByFilter, 'options', [('test-user', 'test-user')])
     def test_user_with_access(self):
         self.client.login(username=self.user_with_access.username, password=self.password)
@@ -134,7 +132,6 @@ class TestPaymentsVerificationReportView(BaseTestPaymentsView):
         assert response.status_code == 200
 
     @flag_enabled('MOBILE_MONEY_INTEGRATION')
-    @patch.object(BatchNumberFilter, 'options', [("b001", "b001")])
     @patch.object(PaymentVerifiedByFilter, 'options', [('test-user', 'test-user')])
     def test_success(self):
         response = self._make_request()

--- a/corehq/apps/integration/payments/views.py
+++ b/corehq/apps/integration/payments/views.py
@@ -55,9 +55,9 @@ REVERT_VERIFICATION_REQUEST_SLUG = 'revert_verification'
 class PaymentsFiltersMixin:
     fields = [
         'corehq.apps.integration.payments.filters.PaymentCaseListFilter',
-        'corehq.apps.integration.payments.filters.BatchNumberFilter',
-        'corehq.apps.integration.payments.filters.PaymentVerifiedByFilter',
         'corehq.apps.integration.payments.filters.PaymentStatusFilter',
+        'corehq.apps.integration.payments.filters.PaymentVerifiedByFilter',
+        'corehq.apps.integration.payments.filters.BatchNumberFilter',
         'corehq.apps.integration.payments.filters.CampaignFilter',
         'corehq.apps.integration.payments.filters.ActivityFilter',
         'corehq.apps.integration.payments.filters.FunderFilter',


### PR DESCRIPTION
## Product Description

The Payments Verification Report's **Batch Number**, **Campaign**, **Activity**, and **Funder** filters were dropdowns whose options came from enumerating every unique value of the corresponding case property. The ES terms aggregation that built those options was timing out in production, breaking the report page.

This PR simplifies the four filters to plain text inputs — users type the value they're looking for. Search semantics in the view are unchanged. Each input has a small inline "Case-sensitive exact match." note.

The filter panel order was also tidied so **Verified By** and **Payment Status** sit immediately after **Case Owner**.

Screenshot:

<img width="1748" height="1236" alt="image" src="https://github.com/user-attachments/assets/9648f6f9-640c-4c96-b177-3822954e746f" />



## Technical Summary

- **Root cause:** `BaseCasePropertyFilter` called `get_case_property_unique_values()` from `corehq/apps/es/case_search.py`, which ran a nested ES terms aggregation on `case_properties` per filter at every page render. On domains with many cases this timed out.
- **Fix:** Drop the dropdown approach. `BatchNumberFilter`, `CampaignFilter`, `ActivityFilter`, and `FunderFilter` now extend `BaseSimpleFilter` (text input). The view's `_apply_filters` already filtered with `case_property_query(...)` against the same properties, so no query-side change was needed.
- **Cleanup:** `get_case_property_unique_values` had no other callers. Removed along with its unused aggregation imports.

Split into three commits for review:
1. Switch payments report filters to plain text inputs
2. Remove unused `get_case_property_unique_values` helper
3. Tidy payments report filter panel (reorder + inline help)

## Feature Flag

`MOBILE_MONEY_INTEGRATION` (gates the report; no flag added or removed).

## Safety Assurance

### Safety story

Search semantics are unchanged — the view still calls `case_property_query` against the same case properties with the same submitted values. Only the widget changes (dropdown → text input). The removed helper was the only consumer of the aggregation that was timing out, so deleting it can't regress anything.

No data migrations, no model changes, no schema impact.

### Automated test coverage

- `corehq/apps/integration/payments/tests/test_views.py` — 39 tests pass locally, including the per-filter cases (`test_batch_number_filter*`, `test_campaign_filter`, `test_activity_filter`, `test_funder_filter`, `test_phone_number_filter`) which confirm the filter parameters still narrow the case search correctly.
- `corehq/apps/es/tests/test_case_search_es.py` — 27 tests pass locally; the three tests for `get_case_property_unique_values` are removed alongside the helper.

### QA Plan

- [ ] Open the Payments Verification Report on a domain with `MOBILE_MONEY_INTEGRATION` enabled.
- [ ] Confirm filter order: Case Owner → Verified By → Payment Status → Batch Number → Campaign → Activity → Funder → Phone Number.
- [ ] Type an existing batch number value, click Apply, confirm matching cases appear.
- [ ] Type a non-existent value, confirm no results.
- [ ] Confirm the inline "Case-sensitive exact match." note shows under Batch Number / Campaign / Activity / Funder.
- [ ] Search with a lower-cased value against a mixed-case stored value — confirm it does *not* match (case-sensitive behaviour preserved).

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations