### PR TITLE
Simplify `XFormInstance.objects.hard_delete_forms`

### DIFF
--- a/corehq/apps/cleanup/management/commands/delete_forms.py
+++ b/corehq/apps/cleanup/management/commands/delete_forms.py
@@ -15,9 +15,6 @@ class Command(BaseCommand):
         parser.add_argument('domain', help='Domain name that owns the forms to be deleted')
         parser.add_argument('filename', help='path to the CSV file')
         parser.add_argument('--resume_id', help='form ID to start at, within the CSV file')
-        parser.add_argument(
-            '--permanent', action='store_true', default=False, help='Hard delete forms. Defaults to soft deletion.'
-        )
 
     def handle(self, domain, filename, resume_id=None, permanent=False, **options):
         # expects the filename to have a CSV with a header containing a "Form ID" field
@@ -44,25 +41,11 @@ class Command(BaseCommand):
         for chunk in chunked(rows, CHUNK_SIZE):
             form_ids = [row[INDEX_FORM_ID] for row in chunk]
             try:
-                if permanent:
-                    num_deleted += self.hard_delete_forms(domain, form_ids)
-                else:
-                    num_deleted += self.soft_delete_forms(domain, form_ids)
+                num_deleted += self.soft_delete_forms(domain, form_ids)
             except Exception:
                 print('Failed whilte attempting to delete:', form_ids)
                 raise
-        deletion_type = 'hard' if permanent else 'soft'
-        print(f'Completed {deletion_type} deletion of {num_deleted} forms')
-
-    def hard_delete_forms(self, domain, form_ids):
-        deleted_form_ids = set(XFormInstance.objects.hard_delete_forms(domain, form_ids, return_ids=True))
-        for form_id in form_ids:
-            if form_id in deleted_form_ids:
-                print('Hard deleted:', form_id)
-            else:
-                print('Not found:', form_id)
-
-        return len(deleted_form_ids)
+        print(f'Completed soft deletion of {num_deleted} forms')
 
     def soft_delete_forms(self, domain, form_ids):
         print("Soft deleted chunk:", form_ids)

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -389,8 +389,7 @@ class XFormInstanceManager(RequireDBManager):
 
         return count
 
-    def hard_delete_forms(
-            self, domain, form_ids, return_ids=False, *, publish_changes=True):
+    def hard_delete_forms(self, domain, form_ids, *, publish_changes=True):
         """Delete forms permanently
 
         :param publish_changes: Flag for change feed publication.
@@ -399,17 +398,12 @@ class XFormInstanceManager(RequireDBManager):
         assert isinstance(form_ids, list)
 
         deleted_count = 0
-        deleted_ids = []
         for db_name, split_form_ids in split_list_by_db_partition(form_ids):
             # cascade should delete the operations
             query = self.using(db_name).filter(domain=domain, form_id__in=split_form_ids)
             with transaction.atomic():
-                if return_ids:
-                    found_forms = list(query.values_list('form_id', flat=True))
                 _, deleted_models = query.delete()
             deleted_count += deleted_models.get(self.model._meta.label, 0)
-            if return_ids:
-                deleted_ids.extend(found_forms)
 
         if deleted_count:
             if deleted_count != len(form_ids):
@@ -427,7 +421,7 @@ class XFormInstanceManager(RequireDBManager):
         if publish_changes:
             self.publish_deleted_forms(domain, form_ids)
 
-        return deleted_ids if return_ids else deleted_count
+        return deleted_count
 
     @staticmethod
     def publish_deleted_forms(domain, form_ids):

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -390,7 +390,7 @@ class XFormInstanceManager(RequireDBManager):
         return count
 
     def hard_delete_forms(
-            self, domain, form_ids, return_ids=False, delete_attachments=True, *, publish_changes=True):
+            self, domain, form_ids, return_ids=False, *, publish_changes=True):
         """Delete forms permanently
 
         :param publish_changes: Flag for change feed publication.
@@ -411,7 +411,7 @@ class XFormInstanceManager(RequireDBManager):
             if return_ids:
                 deleted_ids.extend(found_forms)
 
-        if delete_attachments and deleted_count:
+        if deleted_count:
             if deleted_count != len(form_ids):
                 # in the unlikely event that we didn't delete all forms (because they weren't all
                 # in the specified domain), only delete attachments for forms that were deleted.

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -359,22 +359,6 @@ class XFormInstanceManagerTest(TestCase):
         self.assertEqual(1, len(forms))
         self.assertEqual(form_ids[0], forms[0].form_id)
 
-    def test_hard_delete_forms_returns_forms_found(self):
-        for i in range(3):
-            create_form_for_test(DOMAIN, form_id=str(i))
-
-        deleted_form_ids = set(XFormInstance.objects.hard_delete_forms(DOMAIN, ['0', '1', '2'], return_ids=True))
-
-        self.assertEqual(deleted_form_ids, {'0', '1', '2'})
-
-    def test_hard_delete_forms_does_not_include_missing_form_ids(self):
-        create_form_for_test(DOMAIN, form_id='1')
-        create_form_for_test(DOMAIN, form_id='3')
-
-        deleted_form_ids = set(XFormInstance.objects.hard_delete_forms(DOMAIN, ['1', '2', '3'], return_ids=True))
-
-        self.assertEqual(deleted_form_ids, {'1', '3'})
-
     def assert_form_xml_attachment(self, form):
         attachments = XFormInstance.objects.get_attachments(form.form_id)
         self.assertEqual([a.name for a in attachments], ["form.xml"])


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Not inherently part of any ticket, though related to https://dimagi.atlassian.net/browse/SAAS-19704. Motivated by work on tombstones since that will add a kwarg to the `hard_delete_forms` method. These kwargs are not necessary, so I'm removing them.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
One of these kwargs was not in use at all, and the other was only used in a management command that we use to manually soft delete forms. We intentionally have avoided hard deleting forms via that command by defaulting to soft deletion, and this just takes that a step further by removing the option altogether.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
We have tests for hard_delete_forms that cover use cases we care about.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
