### PR TITLE
Create tombstones in hard_delete_forms

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -206,7 +206,9 @@ def delete_all_forms(domain_name):
     logger.info('Deleting forms...')
     form_ids = iter_ids(XFormInstance, 'form_id', domain_name)
     for chunk in chunked(form_ids, 1000, list):
-        XFormInstance.objects.hard_delete_forms(domain_name, chunk, publish_changes=False)
+        XFormInstance.objects.hard_delete_forms(
+            domain_name, chunk, publish_changes=False, leave_tombstone=False
+        )
     _delete_es_docs(FormES, domain_name)
     logger.info('Deleting forms complete.')
 

--- a/corehq/apps/tombstones/models.py
+++ b/corehq/apps/tombstones/models.py
@@ -1,7 +1,17 @@
 from django.db import models
 
+from corehq.sql_db.models import PartitionedModel, RequireDBManager
+from corehq.sql_db.util import split_list_by_db_partition
 
-from corehq.sql_db.models import PartitionedModel
+
+class TombstoneObjectManager(RequireDBManager):
+    def get_tombstones(self, doc_ids):
+        tombstones = []
+        for db_name, split_doc_ids in split_list_by_db_partition(doc_ids):
+            tombstones.extend(
+                self.using(db_name).filter(doc_id__in=split_doc_ids)
+            )
+        return tombstones
 
 
 class Tombstone(PartitionedModel):
@@ -19,3 +29,5 @@ class Tombstone(PartitionedModel):
                 name='tombstone_unique_id_and_type',
             )
         ]
+
+    objects = TombstoneObjectManager()

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -62,7 +62,7 @@ class FormProcessorSQL(object):
     @classmethod
     def hard_delete_case_and_forms(cls, domain, case, xforms):
         form_ids = [xform.form_id for xform in xforms]
-        XFormInstance.objects.hard_delete_forms(domain, form_ids)
+        XFormInstance.objects.hard_delete_forms(domain, form_ids, leave_tombstone=False)
         CommCareCase.objects.hard_delete_cases(domain, [case.case_id])
 
     @classmethod

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -399,10 +399,8 @@ class XFormInstanceManager(RequireDBManager):
 
         deleted_count = 0
         for db_name, split_form_ids in split_list_by_db_partition(form_ids):
-            # cascade should delete the operations
             query = self.using(db_name).filter(domain=domain, form_id__in=split_form_ids)
-            with transaction.atomic():
-                _, deleted_models = query.delete()
+            deleted_models = self._hard_delete_queryset(query)
             deleted_count += deleted_models.get(self.model._meta.label, 0)
 
         if deleted_count:
@@ -422,6 +420,12 @@ class XFormInstanceManager(RequireDBManager):
             self.publish_deleted_forms(domain, form_ids)
 
         return deleted_count
+
+    def _hard_delete_queryset(self, queryset):
+        with transaction.atomic():
+            _, model_map = queryset.delete()
+
+        return model_map
 
     @staticmethod
     def publish_deleted_forms(domain, form_ids):

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -404,17 +404,8 @@ class XFormInstanceManager(RequireDBManager):
             deleted_count += deleted_models.get(self.model._meta.label, 0)
 
         if deleted_count:
-            if deleted_count != len(form_ids):
-                # in the unlikely event that we didn't delete all forms (because they weren't all
-                # in the specified domain), only delete attachments for forms that were deleted.
-                deleted_forms = [
-                    form_id for form_id in form_ids
-                    if not self.form_exists(form_id)
-                ]
-            else:
-                deleted_forms = form_ids
-            metas = get_blob_db().metadb.get_for_parents(deleted_forms)
-            get_blob_db().bulk_delete(metas=metas)
+            count_mismatch = deleted_count != len(form_ids)
+            self._hard_delete_blobs(form_ids, verify_deleted=count_mismatch)
 
         if publish_changes:
             self.publish_deleted_forms(domain, form_ids)
@@ -426,6 +417,14 @@ class XFormInstanceManager(RequireDBManager):
             _, model_map = queryset.delete()
 
         return model_map
+
+    def _hard_delete_blobs(self, form_ids, verify_deleted=False):
+        if verify_deleted:
+            deleted_forms = [f for f in form_ids if not self.form_exists(f)]
+        else:
+            deleted_forms = form_ids
+        metas = get_blob_db().metadb.get_for_parents(deleted_forms)
+        get_blob_db().bulk_delete(metas=metas)
 
     @staticmethod
     def publish_deleted_forms(domain, form_ids):

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -21,6 +21,7 @@ from dimagi.utils.couch.safe_index import safe_index
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 
 from corehq.apps.cleanup.utils import get_cutoff_date_for_data_deletion
+from corehq.apps.tombstones.models import Tombstone
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.models import BlobMeta
@@ -50,6 +51,7 @@ from .util import attach_prefetch_models, fetchall_as_namedtuple, sort_with_id_l
 log = logging.getLogger(__name__)
 
 ARCHIVE_FORM = "archive_form"
+BATCH_SIZE = 2000
 
 
 class XFormInstanceManager(RequireDBManager):
@@ -413,10 +415,30 @@ class XFormInstanceManager(RequireDBManager):
         return deleted_count
 
     def _hard_delete_queryset(self, queryset):
-        with transaction.atomic():
-            _, model_map = queryset.delete()
+        deleted_total = {}
+        while forms := queryset[:BATCH_SIZE]:
+            form_ids = []
+            tombstones = []
+            for form in forms:
+                form_ids.append(form.form_id)
+                tombstones.append(
+                    Tombstone(
+                        doc_id=form.form_id,
+                        object_class_path=f'{XFormInstance.__module__}.{XFormInstance.__qualname__}',
+                        domain=form.domain,
+                        deleted_on=form.deleted_on or datetime.utcnow(),
+                    )
+                )
 
-        return model_map
+            with transaction.atomic(using=queryset.db):
+                Tombstone.objects.using(queryset.db).bulk_create(
+                    tombstones, ignore_conflicts=True
+                )
+                _, model_map = queryset.filter(form_id__in=form_ids).delete()
+
+            deleted_total = Counter(deleted_total) + Counter(model_map)
+
+        return deleted_total
 
     def _hard_delete_blobs(self, form_ids, verify_deleted=False):
         if verify_deleted:

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -204,14 +204,14 @@ class XFormInstanceManager(RequireDBManager):
         :return: dictionary of count of deleted forms
         """
         expiration_date = get_cutoff_date_for_data_deletion()
-        total_count = {}
+        total_count = Counter({})
         for db_name in get_db_aliases_for_partitioned_query():
             queryset = self.using(db_name).filter(deleted_on__lt=expiration_date)
             if commit:
                 deleted_counts = queryset.delete()[1]
             else:
                 deleted_counts = {'form_processor.XFormInstance': queryset.count()}
-            total_count = Counter(total_count) + Counter(deleted_counts)
+            total_count += Counter(deleted_counts)
         return total_count
 
     def iter_form_ids_by_xmlns(self, domain, xmlns=None):
@@ -423,7 +423,7 @@ class XFormInstanceManager(RequireDBManager):
                 _, model_map = queryset.delete()
             return model_map
 
-        deleted_total = {}
+        deleted_total = Counter({})
         while forms := queryset[:BATCH_SIZE]:
             form_ids = []
             tombstones = []
@@ -444,7 +444,7 @@ class XFormInstanceManager(RequireDBManager):
                 )
                 _, model_map = queryset.filter(form_id__in=form_ids).delete()
 
-            deleted_total = Counter(deleted_total) + Counter(model_map)
+            deleted_total += Counter(model_map)
 
         return deleted_total
 

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -391,18 +391,21 @@ class XFormInstanceManager(RequireDBManager):
 
         return count
 
-    def hard_delete_forms(self, domain, form_ids, *, publish_changes=True):
+    def hard_delete_forms(self, domain, form_ids, *, publish_changes=True, leave_tombstone=True):
         """Delete forms permanently
 
         :param publish_changes: Flag for change feed publication.
             Documents in Elasticsearch will not be deleted if this is false.
+        :param leave_tombstone: If adding a new usage, DO NOT SET THIS TO FALSE.
+            The user location mapping case and domain deletion are the only valid
+            use cases for not leaving tombstones.
         """
         assert isinstance(form_ids, list)
 
         deleted_count = 0
         for db_name, split_form_ids in split_list_by_db_partition(form_ids):
             query = self.using(db_name).filter(domain=domain, form_id__in=split_form_ids)
-            deleted_models = self._hard_delete_queryset(query)
+            deleted_models = self._hard_delete_queryset(query, leave_tombstone=leave_tombstone)
             deleted_count += deleted_models.get(self.model._meta.label, 0)
 
         if deleted_count:
@@ -414,7 +417,12 @@ class XFormInstanceManager(RequireDBManager):
 
         return deleted_count
 
-    def _hard_delete_queryset(self, queryset):
+    def _hard_delete_queryset(self, queryset, leave_tombstone=True):
+        if not leave_tombstone:
+            with transaction.atomic(using=queryset.db):
+                _, model_map = queryset.delete()
+            return model_map
+
         deleted_total = {}
         while forms := queryset[:BATCH_SIZE]:
             form_ids = []

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -462,7 +462,7 @@ class HardDeleteQueryset(TestCase):
         for _ in range(5):
             create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 1))
 
-        total_counts = {}
+        total_counts = Counter({})
         for db_name in get_db_aliases_for_partitioned_query():
             qs = (
                 XFormInstance.objects.using(db_name)
@@ -471,7 +471,7 @@ class HardDeleteQueryset(TestCase):
             )
             with mock.patch('corehq.form_processor.models.forms.BATCH_SIZE', 1):
                 actual_counts = XFormInstance.objects._hard_delete_queryset(qs)
-            total_counts = Counter(total_counts) + Counter(actual_counts)
+            total_counts += Counter(actual_counts)
 
         assert total_counts == {'form_processor.XFormInstance': 5}
 
@@ -498,12 +498,12 @@ class HardDeleteQueryset(TestCase):
             )
             for _ in range(10)
         ]
-        total_counts = {}
+        total_counts = Counter({})
         for db_name, form_ids in split_list_by_db_partition([f.form_id for f in forms]):
             qs = XFormInstance.objects.using(db_name).filter(form_id__in=form_ids)
             actual_counts = XFormInstance.objects._hard_delete_queryset(qs, leave_tombstone=False)
             tombstones = Tombstone.objects.get_tombstones(form_ids)
-            total_counts = Counter(total_counts) + Counter(actual_counts)
+            total_counts += Counter(actual_counts)
             assert len(tombstones) == 0
 
         assert total_counts == {'form_processor.XFormInstance': 10}

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -1,16 +1,23 @@
 import pytest
 import uuid
+from collections import Counter
 from datetime import datetime
 from time_machine import travel
+from unittest import mock
 
 from django.conf import settings
 from django.core.files.uploadedfile import UploadedFile
 from django.db import transaction
 from django.test import TestCase, override_settings
 
+from corehq.apps.tombstones.models import Tombstone
 from corehq.blobs import NotFound as BlobNotFound, get_blob_db
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB, TemporaryS3BlobDB
-from corehq.sql_db.util import get_db_alias_for_partitioned_doc
+from corehq.sql_db.util import (
+    get_db_alias_for_partitioned_doc,
+    get_db_aliases_for_partitioned_query,
+    split_list_by_db_partition,
+)
 from corehq.util.test_utils import trap_extra_setup
 
 from ..backends.sql.processor import FormProcessorSQL
@@ -435,6 +442,50 @@ class TestHardDeleteExpiredForms(TestCase):
 
         assert dry_run_counts == {'form_processor.XFormInstance': 5}
         assert actual_counts == {'form_processor.XFormInstance': 5}
+
+
+@sharded
+class HardDeleteQueryset(TestCase):
+
+    def setUp(self):
+        self.domain = 'test_hard_delete_queryset'
+
+    def tearDown(self):
+        if settings.USE_PARTITIONED_DATABASE:
+            FormProcessorTestUtils.delete_all_sql_forms(self.domain)
+            FormProcessorTestUtils.delete_all_sql_cases(self.domain)
+        super().tearDown()
+
+    def test_returned_counts_across_chunks(self):
+        for _ in range(5):
+            create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 1))
+
+        total_counts = {}
+        for db_name in get_db_aliases_for_partitioned_query():
+            qs = (
+                XFormInstance.objects.using(db_name)
+                .filter(deleted_on__lt=datetime(2020, 1, 5))
+                .order_by('form_id')
+            )
+            with mock.patch('corehq.form_processor.models.forms.BATCH_SIZE', 1):
+                actual_counts = XFormInstance.objects._hard_delete_queryset(qs)
+            total_counts = Counter(total_counts) + Counter(actual_counts)
+
+        assert total_counts == {'form_processor.XFormInstance': 5}
+
+    def test_tombstones_are_created(self):
+        forms = [
+            create_form_for_test(
+                self.domain, deleted_on=datetime(2020, 1, 1)
+            )
+            for _ in range(10)
+        ]
+        for db_name, form_ids in split_list_by_db_partition([f.form_id for f in forms]):
+            qs = XFormInstance.objects.using(db_name).filter(form_id__in=form_ids)
+            actual_counts = XFormInstance.objects._hard_delete_queryset(qs)
+            tombstones = Tombstone.objects.get_tombstones(form_ids)
+            assert len(tombstones) == actual_counts['form_processor.XFormInstance']
+            assert {t.doc_id for t in tombstones} == set(form_ids)
 
 
 class DeleteAttachmentsFSDBTests(TestCase):

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -18,6 +18,7 @@ from corehq.sql_db.util import (
     get_db_aliases_for_partitioned_query,
     split_list_by_db_partition,
 )
+from corehq.tests.pytest_plugins.patches import suspend
 from corehq.util.test_utils import trap_extra_setup
 
 from ..backends.sql.processor import FormProcessorSQL
@@ -27,6 +28,7 @@ from ..models import CaseTransaction, XFormInstance, XFormOperation
 from ..tests.utils import (
     FormProcessorTestUtils,
     create_form_for_test,
+    force_queryset_no_tombstone_patch,
     sharded,
 )
 from ..parsers.form import apply_deprecation
@@ -473,6 +475,7 @@ class HardDeleteQueryset(TestCase):
 
         assert total_counts == {'form_processor.XFormInstance': 5}
 
+    @suspend(force_queryset_no_tombstone_patch)
     def test_tombstones_are_created(self):
         forms = [
             create_form_for_test(
@@ -486,6 +489,24 @@ class HardDeleteQueryset(TestCase):
             tombstones = Tombstone.objects.get_tombstones(form_ids)
             assert len(tombstones) == actual_counts['form_processor.XFormInstance']
             assert {t.doc_id for t in tombstones} == set(form_ids)
+
+    @suspend(force_queryset_no_tombstone_patch)
+    def test_tombstones_are_not_created(self):
+        forms = [
+            create_form_for_test(
+                self.domain, deleted_on=datetime(2020, 1, 1)
+            )
+            for _ in range(10)
+        ]
+        total_counts = {}
+        for db_name, form_ids in split_list_by_db_partition([f.form_id for f in forms]):
+            qs = XFormInstance.objects.using(db_name).filter(form_id__in=form_ids)
+            actual_counts = XFormInstance.objects._hard_delete_queryset(qs, leave_tombstone=False)
+            tombstones = Tombstone.objects.get_tombstones(form_ids)
+            total_counts = Counter(total_counts) + Counter(actual_counts)
+            assert len(tombstones) == 0
+
+        assert total_counts == {'form_processor.XFormInstance': 10}
 
 
 class DeleteAttachmentsFSDBTests(TestCase):

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -13,12 +13,12 @@ from django.test import TestCase, override_settings
 from corehq.apps.tombstones.models import Tombstone
 from corehq.blobs import NotFound as BlobNotFound, get_blob_db
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB, TemporaryS3BlobDB
+
 from corehq.sql_db.util import (
     get_db_alias_for_partitioned_doc,
     get_db_aliases_for_partitioned_query,
     split_list_by_db_partition,
 )
-from corehq.tests.pytest_plugins.patches import suspend
 from corehq.util.test_utils import trap_extra_setup
 
 from ..backends.sql.processor import FormProcessorSQL
@@ -28,7 +28,7 @@ from ..models import CaseTransaction, XFormInstance, XFormOperation
 from ..tests.utils import (
     FormProcessorTestUtils,
     create_form_for_test,
-    force_queryset_no_tombstone_patch,
+    leave_tombstones_on_form_deletion,
     sharded,
 )
 from ..parsers.form import apply_deprecation
@@ -475,7 +475,7 @@ class HardDeleteQueryset(TestCase):
 
         assert total_counts == {'form_processor.XFormInstance': 5}
 
-    @suspend(force_queryset_no_tombstone_patch)
+    @leave_tombstones_on_form_deletion
     def test_tombstones_are_created(self):
         forms = [
             create_form_for_test(
@@ -490,7 +490,7 @@ class HardDeleteQueryset(TestCase):
             assert len(tombstones) == actual_counts['form_processor.XFormInstance']
             assert {t.doc_id for t in tombstones} == set(form_ids)
 
-    @suspend(force_queryset_no_tombstone_patch)
+    @leave_tombstones_on_form_deletion
     def test_tombstones_are_not_created(self):
         forms = [
             create_form_for_test(

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -27,6 +27,7 @@ from corehq.form_processor.models import (
     XFormInstance,
 )
 from corehq.sql_db.models import PartitionedModel
+from corehq.tests.util.context import testcontextmanager
 from corehq.util.test_utils import unit_testing_only
 
 from .json2xml import convert_form_to_xml
@@ -407,3 +408,20 @@ def patch_form_deletion():
     assert settings.UNIT_TESTING
     force_no_tombstone_patch.__enter__()
     force_queryset_no_tombstone_patch.__enter__()
+
+
+@testcontextmanager
+def leave_tombstones_on_form_deletion():
+    from corehq.apps.tombstones.models import Tombstone
+    from corehq.sql_db.util import get_db_aliases_for_partitioned_query
+
+    assert settings.UNIT_TESTING
+    force_no_tombstone_patch.__exit__(None, None, None)
+    force_queryset_no_tombstone_patch.__exit__(None, None, None)
+    try:
+        yield
+    finally:
+        force_no_tombstone_patch.__enter__()
+        force_queryset_no_tombstone_patch.__enter__()
+        for db in get_db_aliases_for_partitioned_query():
+            Tombstone.objects.using(db).all().delete()

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -375,3 +375,35 @@ def delete_all_xforms_and_cases(domain):
     assert settings.UNIT_TESTING
     FormProcessorTestUtils.delete_all_xforms(domain)
     FormProcessorTestUtils.delete_all_cases(domain)
+
+
+_original_hard_delete_forms = XFormInstance.objects.__class__.hard_delete_forms
+def _hard_delete_forms_no_tombstone(self, domain, form_ids, *, publish_changes=True, leave_tombstone=True):
+    return _original_hard_delete_forms(
+        self, domain, form_ids, publish_changes=publish_changes, leave_tombstone=False
+    )
+
+force_no_tombstone_patch = patch.object(
+    XFormInstance.objects.__class__, "hard_delete_forms", _hard_delete_forms_no_tombstone
+)
+
+_original_hard_delete_queryset = XFormInstance.objects.__class__._hard_delete_queryset
+def _hard_delete_queryset_no_tombstone(self, queryset, leave_tombstone=True):
+    return _original_hard_delete_queryset(
+        self, queryset, leave_tombstone=False
+    )
+
+force_queryset_no_tombstone_patch = patch.object(
+    XFormInstance.objects.__class__, "_hard_delete_queryset", _hard_delete_queryset_no_tombstone
+)
+
+def patch_form_deletion():
+    """Setup form deletion for tests
+
+    - Default to not leaving tombstones to ease cleanup
+
+    """
+    # Use __enter__ and __exit__ to start/stop so patch.stopall() does not stop it.
+    assert settings.UNIT_TESTING
+    force_no_tombstone_patch.__enter__()
+    force_queryset_no_tombstone_patch.__enter__()

--- a/corehq/tests/pytest_plugins/patches.py
+++ b/corehq/tests/pytest_plugins/patches.py
@@ -5,7 +5,7 @@ import pytest
 def pytest_sessionstart():
     from corehq.apps.accounting.tests.utils import patch_subscription_clear_caches
     from corehq.apps.domain.tests.test_utils import patch_domain_deletion
-    from corehq.form_processor.tests.utils import patch_testcase_databases
+    from corehq.form_processor.tests.utils import patch_form_deletion, patch_testcase_databases
     from corehq.util.es.testing import patch_es_user_signals
     from corehq.util.test_utils import patch_foreign_value_caches
     from pillowtop.tests.utils import pillow_connection_cleanup_patch
@@ -19,6 +19,7 @@ def pytest_sessionstart():
     patch_foreign_value_caches()
     patch_domain_deletion()
     patch_subscription_clear_caches()
+    patch_form_deletion()
 
 
 def patch_unittest_TestCase_doClassCleanup():


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19704

When hard deleting forms, we want to make sure we are creating tombstones. We have the `Tombstone` partitioned table to capture this data, and this is the first place we are actually creating `Tombstone` rows in HQ.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The main concern is in the two workflows that depend on hard form deletion right now which are domain deletion and location user mapping cases. An issue with domain deletion wouldn't be too bad, just annoying for the dev that handles a delete domain request. The user location mapping case workflow getting messed up could result in stale location mappings on device, but I wouldn't expect much more of an impact than that.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
We have existing tests for hard form deletion, and have added some where necessary.
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
