### PR TITLE
Add WIP case search endpoint testing view (behind feature flag)

### DIFF
--- a/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
+++ b/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
@@ -1,0 +1,12 @@
+{% extends 'hqwebapp/bootstrap5/base_section.html' %}
+{% load hq_shared_tags %}
+{% load i18n %}
+{% js_entry "hqwebapp/js/htmx_and_alpine" %}
+
+{% block page_title %}
+  {{ current_page.title }}
+{% endblock %}
+
+{% block page_content %}
+<!-- TODO -->
+{% endblock %}

--- a/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
+++ b/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
@@ -9,6 +9,10 @@
 
 {% block page_content %}
   <form method="post"
+        hx-post="{{ request.path_info }}"
+        hq-hx-action="search"
+        hx-target="#results"
+        hx-swap="innerHTML"
         x-data="{
           params: [{ id: 0}],
           nextId: 1,
@@ -83,4 +87,11 @@
       {% trans "Submit" %}
     </button>
   </form>
+
+  <div id="results" class="mt-3"></div>
 {% endblock %}
+
+{% block modals %}
+  {% include "hqwebapp/htmx/error_modal.html" %}
+  {{ block.super }}
+{% endblock modals %}

--- a/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
+++ b/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
@@ -8,5 +8,79 @@
 {% endblock %}
 
 {% block page_content %}
-<!-- TODO -->
+  <form method="post"
+        x-data="{
+          params: [{ id: 0}],
+          nextId: 1,
+        }">
+    {% csrf_token %}
+
+    <div class="card mb-3">
+      <div class="card-header">
+        <strong>{% trans "Endpoint Configuration" %}</strong>
+      </div>
+      <div class="card-body">
+        <div class="mb-3">
+          <label class="form-label" for="endpoint_name">
+            {% trans "Endpoint Name" %}
+          </label>
+          <input type="text"
+                 class="form-control"
+                 id="endpoint_name"
+                 name="endpoint_name"
+                 required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="case_type">
+            {% trans "Case Type" %}
+          </label>
+          <input type="text"
+                 class="form-control"
+                 id="case_type"
+                 name="case_type"
+                 required>
+        </div>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <div class="card-header">
+        <strong>{% trans "Query Parameters" %}</strong>
+      </div>
+      <div class="card-body">
+        <template x-for="(param, index) in params" :key="param.id">
+          <div class="row mb-2 align-items-center">
+            <div class="col">
+              <input type="text"
+                     class="form-control"
+                     name="param_key"
+                     placeholder="{% trans_html_attr 'Key' %}">
+            </div>
+            <div class="col">
+              <input type="text"
+                     class="form-control"
+                     name="param_value"
+                     placeholder="{% trans_html_attr 'Value' %}">
+            </div>
+            <div class="col-auto">
+              <button type="button"
+                      class="btn btn-outline-danger"
+                      @click="params.splice(index, 1)">
+                <i class="fa fa-trash-can"></i>
+              </button>
+            </div>
+          </div>
+        </template>
+        <button type="button"
+                class="btn btn-outline-primary"
+                @click="params.push({ id: nextId++ })">
+          <i class="fa fa-plus"></i> {% trans "Add Parameter" %}
+        </button>
+      </div>
+    </div>
+
+    <button type="submit" class="btn btn-primary">
+      {% trans "Submit" %}
+    </button>
+  </form>
 {% endblock %}

--- a/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
+++ b/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
@@ -27,6 +27,13 @@
         <strong>{% trans "Endpoint Configuration" %}</strong>
       </div>
       <div class="card-body">
+        <div class="alert alert-info" role="alert">
+          <i class="fa fa-info-circle"></i>
+          {% blocktrans %}
+          This box contains the config that will be stored as part of the
+          endpoint and managed entirely server-side
+          {% endblocktrans %}
+        </div>
         <div class="mb-3">
           <label class="form-label" for="endpoint_name">
             {% trans "Endpoint Name" %}
@@ -81,6 +88,10 @@
         <strong>{% trans "Query Parameters" %}</strong>
       </div>
       <div class="card-body">
+        <div class="alert alert-info" role="alert">
+          <i class="fa fa-info-circle"></i>
+          {% trans "Use this section to mimic a request from an application" %}
+        </div>
         <template x-for="(param, index) in params" :key="param.id">
           <div class="row mb-2 align-items-center">
             <div class="col">
@@ -113,7 +124,7 @@
     </div>
 
     <button type="submit" class="btn btn-primary">
-      {% trans "Submit" %}
+      {% trans "Try it out!" %}
     </button>
   </form>
   </div></div>

--- a/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
+++ b/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
@@ -8,6 +8,7 @@
 {% endblock %}
 
 {% block page_content %}
+  <div class="row"><div class="col-lg-8">
   <form method="post"
         hx-post="{{ request.path_info }}"
         hq-hx-action="search"
@@ -86,6 +87,7 @@
       {% trans "Submit" %}
     </button>
   </form>
+  </div></div>
 
   <div id="results" class="mt-3"></div>
 {% endblock %}

--- a/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
+++ b/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
@@ -31,8 +31,7 @@
           <input type="text"
                  class="form-control"
                  id="endpoint_name"
-                 name="endpoint_name"
-                 required>
+                 name="endpoint_name">
         </div>
         <div class="mb-3">
           <label class="form-label" for="case_type">

--- a/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
+++ b/corehq/apps/case_search/templates/case_search/case_search_endpoint.html
@@ -15,8 +15,10 @@
         hx-target="#results"
         hx-swap="innerHTML"
         x-data="{
-          params: [{ id: 0}],
-          nextId: 1,
+          params: [{ id: 0 }],
+          nextParamId: 1,
+          filters: [{ id: 0 }],
+          nextFilterId: 1,
         }">
     {% csrf_token %}
 
@@ -43,6 +45,33 @@
                  id="case_type"
                  name="case_type"
                  required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">
+            {% trans "Server-Side Filters" %}
+          </label>
+          <template x-for="(filter, index) in filters" :key="filter.id">
+            <div class="row mb-2 align-items-center">
+              <div class="col">
+                <input type="text"
+                       class="form-control"
+                       name="filter_expr"
+                       placeholder="{% trans_html_attr 'CSQL Expression' %}">
+              </div>
+              <div class="col-auto">
+                <button type="button"
+                        class="btn btn-outline-danger"
+                        @click="filters.splice(index, 1)">
+                  <i class="fa fa-trash-can"></i>
+                </button>
+              </div>
+            </div>
+          </template>
+          <button type="button"
+                  class="btn btn-outline-primary"
+                  @click="filters.push({ id: nextFilterId++ })">
+            <i class="fa fa-plus"></i> {% trans "Add Filter" %}
+          </button>
         </div>
       </div>
     </div>
@@ -77,7 +106,7 @@
         </template>
         <button type="button"
                 class="btn btn-outline-primary"
-                @click="params.push({ id: nextId++ })">
+                @click="params.push({ id: nextParamId++ })">
           <i class="fa fa-plus"></i> {% trans "Add Parameter" %}
         </button>
       </div>

--- a/corehq/apps/case_search/templates/case_search/case_search_endpoint_results.html
+++ b/corehq/apps/case_search/templates/case_search/case_search_endpoint_results.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+<h2>{% trans "Results" %}</h2>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      {% for col in header %}
+        <th>{{ col }}</th>
+      {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+      <tr>
+        {% for cell in row %}
+          <td>{{ cell }}</td>
+        {% endfor %}
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/corehq/apps/case_search/urls.py
+++ b/corehq/apps/case_search/urls.py
@@ -1,12 +1,16 @@
 from django.urls import re_path as url
 
 from corehq.apps.case_search.views import (
-    CaseSearchView, CSQLFixtureExpressionView, ProfileCaseSearchView
+    CaseSearchView,
+    CaseSearchEndpoint,
+    CSQLFixtureExpressionView,
+    ProfileCaseSearchView,
 )
 
 urlpatterns = [
     url(r'^search/$', CaseSearchView.as_view(), name=CaseSearchView.urlname),
     url(r'^profile/$', ProfileCaseSearchView.as_view(), name=ProfileCaseSearchView.urlname),
     url(r'^csql_fixture_configuration/$', CSQLFixtureExpressionView.as_view(),
-    name=CSQLFixtureExpressionView.urlname),
+        name=CSQLFixtureExpressionView.urlname),
+    url(r'^case_search_endpoint/$', CaseSearchEndpoint.as_view(), name=CaseSearchEndpoint.urlname),
 ]

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -218,3 +218,18 @@ class CaseSearchEndpoint(HqHtmxActionMixin, BaseProjectDataView):
     urlname = 'case_search_endpoint'
     page_title = gettext_lazy('Configurable Case Search Endpoint')
     template_name = 'case_search/case_search_endpoint.html'
+
+    @hq_hx_action('post')
+    def search(self, request, *args, **kwargs):
+        header = ['case_id', 'name']
+        rows = [
+            ['abc123', 'Jane Doe'],
+            ['def456', 'John Smith'],
+            ['ghi789', 'Alice Johnson'],
+            ['jkl012', 'Bob Williams'],
+            ['mno345', 'Carol Brown'],
+        ]
+        return render(request, 'case_search/case_search_endpoint_results.html', {
+            'header': header,
+            'rows': rows,
+        })

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -236,11 +236,15 @@ class CaseSearchEndpoint(HqHtmxActionMixin, BaseProjectDataView):
         })
 
     def _get_results(self, query_dict):
-        criteria = [SearchCriteria(k, v) for k, v in zip(
+        criteria = [
+            SearchCriteria('_xpath_query', expr)
+            for expr in query_dict.getlist('filter_expr') if expr
+        ]
+        criteria.extend(SearchCriteria(k, v) for k, v in zip(
             query_dict.getlist('param_key'),
             query_dict.getlist('param_value'),
             strict=True,
-        ) if k]
+        ) if k)
         for search_criteria in criteria:
             search_criteria.validate()
         return get_case_search_results(

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -14,14 +14,18 @@ from corehq import toggles
 from corehq.apps.case_importer.views import require_can_edit_data
 from corehq.apps.case_search.forms import (
     CSQLFixtureExpressionForm,
-    UserDataCriteriaForm,
     CSQLFixtureFilterForm,
+    UserDataCriteriaForm,
 )
 from corehq.apps.case_search.models import (
     CSQLFixtureExpression,
+    SearchCriteria,
     case_search_enabled_for_domain,
 )
-from corehq.apps.case_search.utils import get_case_search_results_from_request
+from corehq.apps.case_search.utils import (
+    get_case_search_results,
+    get_case_search_results_from_request,
+)
 from corehq.apps.domain.decorators import cls_require_superuser_or_contractor
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqadmin.utils import get_download_url
@@ -223,13 +227,24 @@ class CaseSearchEndpoint(HqHtmxActionMixin, BaseProjectDataView):
     def search(self, request, *args, **kwargs):
         header = ['case_id', 'name']
         rows = [
-            ['abc123', 'Jane Doe'],
-            ['def456', 'John Smith'],
-            ['ghi789', 'Alice Johnson'],
-            ['jkl012', 'Bob Williams'],
-            ['mno345', 'Carol Brown'],
+            [case_.case_id, case_.name]
+            for case_ in self._get_results(self.request.POST)
         ]
         return render(request, 'case_search/case_search_endpoint_results.html', {
             'header': header,
             'rows': rows,
         })
+
+    def _get_results(self, query_dict):
+        criteria = [SearchCriteria(k, v) for k, v in zip(
+            query_dict.getlist('param_key'),
+            query_dict.getlist('param_value'),
+            strict=True,
+        ) if k]
+        for search_criteria in criteria:
+            search_criteria.validate()
+        return get_case_search_results(
+            self.domain,
+            query_dict['case_type'],
+            criteria,
+        )

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -208,3 +208,13 @@ class CSQLFixtureExpressionView(HqHtmxActionMixin, BaseProjectDataView):
             form.save()
             return HttpResponse(form.render())
         raise AssertionError("The user shouldn't be able to submit an invalid form")
+
+
+@method_decorator([
+    use_bootstrap5,
+    require_can_edit_data,
+], name='dispatch')
+class CaseSearchEndpoint(HqHtmxActionMixin, BaseProjectDataView):
+    urlname = 'case_search_endpoint'
+    page_title = gettext_lazy('Configurable Case Search Endpoint')
+    template_name = 'case_search/case_search_endpoint.html'

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -216,6 +216,7 @@ class CSQLFixtureExpressionView(HqHtmxActionMixin, BaseProjectDataView):
 
 @method_decorator([
     use_bootstrap5,
+    toggles.CASE_SEARCH_ENDPOINTS.required_decorator(),
     require_can_edit_data,
 ], name='dispatch')
 class CaseSearchEndpoint(HqHtmxActionMixin, BaseProjectDataView):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -993,6 +993,13 @@ CASE_SEARCH_RELATED_LOOKUPS = StaticToggle(
     parent_toggles=[CASE_SEARCH_ADVANCED],
 )
 
+CASE_SEARCH_ENDPOINTS = StaticToggle(
+    'case_search_endpoints',
+    'Case Search Endpoints: configurable query builder for case search',
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN],
+)
+
 GEOCODER_MY_LOCATION_BUTTON = StaticToggle(
     "geocoder_my_location_button",
     "USH: Add button to geocoder to populate search with the user's current location",


### PR DESCRIPTION
## Product Description

Adds a new internal admin page at `/a/<domain>/case_search/case_search_endpoint/` that lets superusers / data editors configure server-side filters and request-time query parameters, then run them through the existing case search backend and view the results inline.

This is the testing/UI scaffolding for the configurable Case Search Endpoints work — it's intentionally minimal and incomplete.  I pulled the most basic parts of https://github.com/dimagi/commcare-hq/pull/37385 and the FF from somewhere else.  Just wanted to get some core stuff into `master` so we can more easily put up incremental PRs.

## Technical Summary

<img width="1663" height="1511" alt="image" src="https://github.com/user-attachments/assets/ef6be98c-29fd-43b3-89ee-dd97cb68f306" />

- New `CaseSearchEndpoint` HTMX view that lets you add server-side filtering (only hardcoded for now) and mimic request parameters from the app, then running a query to verify the results.
- New `CASE_SEARCH_ENDPOINTS` static toggle (`TAG_INTERNAL`, domain namespace) gates both the URL and the view.

## Feature Flag

`CASE_SEARCH_ENDPOINTS`

## Safety Assurance

### Safety story

- Pure additive change: one new view, one new URL, one new toggle, two new templates. No model, migration, or existing-view changes.
- View is gated by the new `CASE_SEARCH_ENDPOINTS` toggle and additionally requires `require_can_edit_data`, so it is unreachable on any domain that doesn't have the toggle enabled.
- Backend work is delegated to the existing, well-exercised `get_case_search_results` path.

### Automated test coverage

None yet — this is WIP scaffolding. Tests will land alongside the real query builder semantics rather than against this throwaway form layout.

### QA Plan

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change