### PR TITLE
Add case search endpoint selector to module config

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2259,6 +2259,7 @@ class CaseSearch(DocumentSchema):
     - search_filter: Removed with USH_SEARCH_FILTER toggle (Apr 2026)
       These fields may still exist in CouchDB documents but are no longer used.
     """
+    case_search_endpoint_id = IntegerProperty(exclude_if_none=True)
     search_button_label = LabelProperty(default={'en': 'Search All Cases'})
     properties = SchemaListProperty(CaseSearchProperty)
     auto_launch = BooleanProperty(default=False)        # if true, skip the casedb case list

--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -207,7 +207,7 @@ var searchConfigKeys = [
     'title_label', 'description', 'search_button_display_condition',
     'data_registry', 'data_registry_workflow', 'additional_registry_cases',
     'custom_related_case_property', 'inline_search', 'instance_name', 'include_all_related_cases',
-    'search_on_clear',
+    'search_on_clear', 'case_search_endpoint_id',
 ];
 var searchConfigModel = function (options, lang, saveButton) {
     assertProperties.assertRequired(options, searchConfigKeys);

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -305,7 +305,10 @@ class RemoteRequestFactory(object):
                     ref=f"'{','.join(refs)}'",
                 )
             )
-        if self.module.search_config.case_search_endpoint_id:
+        if (
+            toggles.CASE_SEARCH_ENDPOINTS.enabled(self.app.domain)
+            and self.module.search_config.case_search_endpoint_id
+        ):
             datums.append(
                 QueryData(
                     key=CASE_SEARCH_ENDPOINT_ID_KEY,

--- a/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/remote_requests.py
@@ -82,6 +82,7 @@ from corehq.apps.case_search.const import COMMCARE_PROJECT, EXCLUDE_RELATED_CASE
 from corehq.apps.case_search.models import (
     CASE_SEARCH_BLACKLISTED_OWNER_ID_KEY,
     CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY,
+    CASE_SEARCH_ENDPOINT_ID_KEY,
     CASE_SEARCH_REGISTRY_ID_KEY,
     CASE_SEARCH_INCLUDE_ALL_RELATED_CASES_KEY,
     CASE_SEARCH_SORT_KEY,
@@ -302,6 +303,13 @@ class RemoteRequestFactory(object):
                 QueryData(
                     key=CASE_SEARCH_SORT_KEY,
                     ref=f"'{','.join(refs)}'",
+                )
+            )
+        if self.module.search_config.case_search_endpoint_id:
+            datums.append(
+                QueryData(
+                    key=CASE_SEARCH_ENDPOINT_ID_KEY,
+                    ref=f"'{self.module.search_config.case_search_endpoint_id}'",
                 )
             )
         if module_uses_inline_search_with_parent_relationship_parent_select(self.module):

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_search_properties.html
@@ -12,6 +12,31 @@
     <div class="panel panel-appmanager">
       <div class="panel-heading">
         <h4 class="panel-title panel-title-nolink">
+          {% trans "Backend" %}
+        </h4>
+      </div>
+      <div class="panel-body">
+        <div class="row">
+          <div class="col-sm-6">
+            <label>
+              {% trans "Case Search Endpoint" %}
+            </label>
+            <select
+              class="form-control"
+              data-bind="value: searchConfig.case_search_endpoint_id"
+            >
+              <option value>{% trans "-- None --" %}</option>
+              {% for endpoint in case_search_endpoints %}
+                <option value="{{ endpoint.id }}">{{ endpoint.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="panel panel-appmanager">
+      <div class="panel-heading">
+        <h4 class="panel-title panel-title-nolink">
           {% trans "Search Properties" %}
         </h4>
       </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap3/case_search_properties.html
@@ -9,31 +9,33 @@
     {% trans "Add at least one search property to activate case search for this case list" %}
   </div>
   <form>
-    <div class="panel panel-appmanager">
-      <div class="panel-heading">
-        <h4 class="panel-title panel-title-nolink">
-          {% trans "Backend" %}
-        </h4>
-      </div>
-      <div class="panel-body">
-        <div class="row">
-          <div class="col-sm-6">
-            <label>
-              {% trans "Case Search Endpoint" %}
-            </label>
-            <select
-              class="form-control"
-              data-bind="value: searchConfig.case_search_endpoint_id"
-            >
-              <option value>{% trans "-- None --" %}</option>
-              {% for endpoint in case_search_endpoints %}
-                <option value="{{ endpoint.id }}">{{ endpoint.name }}</option>
-              {% endfor %}
-            </select>
+    {% if request|toggle_enabled:'CASE_SEARCH_ENDPOINTS' %}
+      <div class="panel panel-appmanager">
+        <div class="panel-heading">
+          <h4 class="panel-title panel-title-nolink">
+            {% trans "Backend" %}
+          </h4>
+        </div>
+        <div class="panel-body">
+          <div class="row">
+            <div class="col-sm-6">
+              <label>
+                {% trans "Case Search Endpoint" %}
+              </label>
+              <select
+                class="form-control"
+                data-bind="value: searchConfig.case_search_endpoint_id"
+              >
+                <option value>{% trans "-- None --" %}</option>
+                {% for endpoint in case_search_endpoints %}
+                  <option value="{{ endpoint.id }}">{{ endpoint.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="panel panel-appmanager">
       <div class="panel-heading">
         <h4 class="panel-title panel-title-nolink">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_search_properties.html
@@ -9,31 +9,33 @@
     {% trans "Add at least one search property to activate case search for this case list" %}
   </div>
   <form>
-    <div class="card panel-appmanager">  {# todo B5: css-panel #}
-      <div class="card-header">
-        <h4 class="card-title card-title-nolink">
-          {% trans "Backend" %}
-        </h4>
-      </div>
-      <div class="card-body">
-        <div class="row">
-          <div class="col-md-6">
-            <label>
-              {% trans "Case Search Endpoint" %}
-            </label>
-            <select
-              class="form-select"
-              data-bind="value: searchConfig.case_search_endpoint_id"
-            >
-              <option value>{% trans "-- None --" %}</option>
-              {% for endpoint in case_search_endpoints %}
-                <option value="{{ endpoint.id }}">{{ endpoint.name }}</option>
-              {% endfor %}
-            </select>
+    {% if request|toggle_enabled:'CASE_SEARCH_ENDPOINTS' %}
+      <div class="card panel-appmanager">  {# todo B5: css-panel #}
+        <div class="card-header">
+          <h4 class="card-title card-title-nolink">
+            {% trans "Backend" %}
+          </h4>
+        </div>
+        <div class="card-body">
+          <div class="row">
+            <div class="col-md-6">
+              <label>
+                {% trans "Case Search Endpoint" %}
+              </label>
+              <select
+                class="form-select"
+                data-bind="value: searchConfig.case_search_endpoint_id"
+              >
+                <option value>{% trans "-- None --" %}</option>
+                {% for endpoint in case_search_endpoints %}
+                  <option value="{{ endpoint.id }}">{{ endpoint.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="card panel-appmanager">  {# todo B5: css-panel #}
       <div class="card-header">
         <h4 class="card-title card-title-nolink">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_search_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/bootstrap5/case_search_properties.html
@@ -12,6 +12,31 @@
     <div class="card panel-appmanager">  {# todo B5: css-panel #}
       <div class="card-header">
         <h4 class="card-title card-title-nolink">
+          {% trans "Backend" %}
+        </h4>
+      </div>
+      <div class="card-body">
+        <div class="row">
+          <div class="col-md-6">
+            <label>
+              {% trans "Case Search Endpoint" %}
+            </label>
+            <select
+              class="form-select"
+              data-bind="value: searchConfig.case_search_endpoint_id"
+            >
+              <option value>{% trans "-- None --" %}</option>
+              {% for endpoint in case_search_endpoints %}
+                <option value="{{ endpoint.id }}">{{ endpoint.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card panel-appmanager">  {# todo B5: css-panel #}
+      <div class="card-header">
+        <h4 class="card-title card-title-nolink">
           {% trans "Search Properties" %}
         </h4>
       </div>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -213,7 +213,8 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
     def test_remote_request_endpoint_id(self):
         """
         case_search_endpoint_id is emitted as an x_commcare_endpoint_id data
-        element on the remote-request query, and is omitted when unset.
+        element on the remote-request query only when the CASE_SEARCH_ENDPOINTS
+        toggle is enabled and the field is set.
         """
         xpath = f"./remote-request/session/query/data[@key='{CASE_SEARCH_ENDPOINT_ID_KEY}']"
 
@@ -222,6 +223,10 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
 
         self.module.search_config.case_search_endpoint_id = 42
         suite = self.app.create_suite()
+        self.assertXmlDoesNotHaveXpath(suite, xpath)
+
+        with flag_enabled('CASE_SEARCH_ENDPOINTS'):
+            suite = self.app.create_suite()
         self.assertXmlHasXpath(suite, xpath)
         [element] = parse_normalize(suite, to_string=False).xpath(xpath)
         self.assertEqual(element.get('ref'), "'42'")

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -38,6 +38,7 @@ from corehq.apps.app_manager.tests.util import (
 )
 from corehq.apps.builds.models import BuildSpec
 from corehq.apps.case_search.const import EXCLUDE_RELATED_CASES_FILTER
+from corehq.apps.case_search.models import CASE_SEARCH_ENDPOINT_ID_KEY
 from corehq.util.test_utils import flag_enabled
 
 DOMAIN = 'test_domain'
@@ -208,6 +209,22 @@ class RemoteRequestSuiteTest(SimpleTestCase, SuiteMixin):
             suite,
             "./remote-request[1]"
         )
+
+    def test_remote_request_endpoint_id(self):
+        """
+        case_search_endpoint_id is emitted as an x_commcare_endpoint_id data
+        element on the remote-request query, and is omitted when unset.
+        """
+        xpath = f"./remote-request/session/query/data[@key='{CASE_SEARCH_ENDPOINT_ID_KEY}']"
+
+        suite = self.app.create_suite()
+        self.assertXmlDoesNotHaveXpath(suite, xpath)
+
+        self.module.search_config.case_search_endpoint_id = 42
+        suite = self.app.create_suite()
+        self.assertXmlHasXpath(suite, xpath)
+        [element] = parse_normalize(suite, to_string=False).xpath(xpath)
+        self.assertEqual(element.get('ref'), "'42'")
 
     def test_remote_request_custom_detail(self):
         """Remote requests for modules with custom details point to the custom detail

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -236,7 +236,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
             .filter(domain=app.domain, is_active=True)
             .order_by('name')
             .values('id', 'name')
-        ),
+        ) if toggles.CASE_SEARCH_ENDPOINTS.enabled(app.domain) else [],
         'data_registry_workflow_choices': (
             (REGISTRY_WORKFLOW_LOAD_CASE, _("Load external case into form")),
             (REGISTRY_WORKFLOW_SMART_LINK, _("Smart link to external domain")),
@@ -1348,8 +1348,11 @@ def _gather_and_update_search_properties(params, app, module, lang):
                 "'{}' is an invalid instance name. It can contain only letters, numbers, and underscores."
             ).format(instance_name))
 
-        endpoint_id_raw = search_properties.get('case_search_endpoint_id')
-        case_search_endpoint_id = int(endpoint_id_raw) if endpoint_id_raw else None
+        if toggles.CASE_SEARCH_ENDPOINTS.enabled(app.domain):
+            endpoint_id_raw = search_properties.get('case_search_endpoint_id')
+            case_search_endpoint_id = int(endpoint_id_raw) if endpoint_id_raw else None
+        else:
+            case_search_endpoint_id = None
 
         module.search_config = CaseSearch(
             title_label=title_label,

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -106,7 +106,10 @@ from corehq.apps.app_manager.views.utils import (
 )
 from corehq.apps.app_manager.xform import CaseError
 from corehq.apps.app_manager.xpath_validator import validate_xpath
-from corehq.apps.case_search.models import case_search_enabled_for_domain
+from corehq.apps.case_search.models import (
+    CaseSearchEndpoint,
+    case_search_enabled_for_domain,
+)
 from corehq.apps.domain.decorators import (
     LoginAndDomainMixin,
     track_domain_request,
@@ -228,6 +231,12 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
         'session_endpoints_enabled': toggles.SESSION_ENDPOINTS.enabled(app.domain),
         'data_registry_enabled': app.supports_data_registry,
         'data_registries': get_data_registry_dropdown_options(app.domain, required_case_types=case_types),
+        'case_search_endpoints': list(
+            CaseSearchEndpoint.objects
+            .filter(domain=app.domain, is_active=True)
+            .order_by('name')
+            .values('id', 'name')
+        ),
         'data_registry_workflow_choices': (
             (REGISTRY_WORKFLOW_LOAD_CASE, _("Load external case into form")),
             (REGISTRY_WORKFLOW_SMART_LINK, _("Smart link to external domain")),
@@ -274,6 +283,7 @@ def _get_shared_module_view_context(request, app, module, case_property_builder,
                 'instance_name': module.search_config.instance_name or "",
                 'include_all_related_cases': module.search_config.include_all_related_cases,
                 'search_on_clear': module.search_config.search_on_clear,
+                'case_search_endpoint_id': module.search_config.case_search_endpoint_id or "",
             },
         },
     }
@@ -1338,6 +1348,9 @@ def _gather_and_update_search_properties(params, app, module, lang):
                 "'{}' is an invalid instance name. It can contain only letters, numbers, and underscores."
             ).format(instance_name))
 
+        endpoint_id_raw = search_properties.get('case_search_endpoint_id')
+        case_search_endpoint_id = int(endpoint_id_raw) if endpoint_id_raw else None
+
         module.search_config = CaseSearch(
             title_label=title_label,
             description=description,
@@ -1363,6 +1376,7 @@ def _gather_and_update_search_properties(params, app, module, lang):
             instance_name=instance_name,
             include_all_related_cases=search_properties.get('include_all_related_cases', False),
             search_on_clear=search_properties.get('search_on_clear', False),
+            case_search_endpoint_id=case_search_endpoint_id,
         )
 
 

--- a/corehq/apps/case_search/models.py
+++ b/corehq/apps/case_search/models.py
@@ -35,6 +35,7 @@ CASE_SEARCH_REGISTRY_ID_KEY = 'x_commcare_data_registry'
 CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY = 'x_commcare_custom_related_case_property'
 CASE_SEARCH_INCLUDE_ALL_RELATED_CASES_KEY = 'x_commcare_include_all_related_cases'
 CASE_SEARCH_MODULE_NAME_TAG_KEY = "x_commcare_tag_module_name"
+CASE_SEARCH_ENDPOINT_ID_KEY = 'x_commcare_endpoint_id'
 
 CONFIG_KEYS_MAPPING = {
     CASE_SEARCH_CASE_TYPE_KEY: "case_types",
@@ -42,6 +43,7 @@ CONFIG_KEYS_MAPPING = {
     CASE_SEARCH_CUSTOM_RELATED_CASE_PROPERTY_KEY: "custom_related_case_property",
     CASE_SEARCH_INCLUDE_ALL_RELATED_CASES_KEY: "include_all_related_cases",
     CASE_SEARCH_SORT_KEY: "commcare_sort",
+    CASE_SEARCH_ENDPOINT_ID_KEY: "endpoint_id",
 }
 
 CASE_SEARCH_TAGS_MAPPING = {
@@ -191,6 +193,7 @@ class CaseSearchRequestConfig:
     custom_related_case_property = attr.ib(kw_only=True, default=None, converter=_flatten_singleton_list)
     include_all_related_cases = attr.ib(kw_only=True, default=None, converter=_flatten_singleton_list)
     commcare_sort = attr.ib(kw_only=True, default=None, converter=_parse_commcare_sort_properties)
+    endpoint_id = attr.ib(kw_only=True, default=None, converter=_flatten_singleton_list)
 
     @case_types.validator
     def _require_case_type(self, attribute, value):

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -26,6 +26,7 @@ from corehq.apps.es.tests.utils import (
     es_test,
 )
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
+from corehq.util.test_utils import flag_enabled
 
 from ..utils import get_case_search_results
 
@@ -110,12 +111,14 @@ class TestCaseSearchEndpoint(TestCase):
             ("Villanueva", "true"),
         ])
 
+    @flag_enabled('CASE_SEARCH_ENDPOINTS')
     def test_endpoint_id_runs_query(self):
         endpoint = CaseSearchEndpoint.objects.create(
             domain=self.domain, name='people', target_name='elasticsearch')
         res = self._run_query(['person'], [SearchCriteria('family', 'Ramos')], endpoint_id=endpoint.id)
         self.assertItemsEqual(["Jane"], [case.name for case in res])
 
+    @flag_enabled('CASE_SEARCH_ENDPOINTS')
     def test_unknown_endpoint_id_raises(self):
         with self.assertRaises(CaseSearchUserError):
             self._run_query(['person'], [], endpoint_id=404)

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -12,7 +12,11 @@ from corehq.apps.app_manager.models import (
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.case_search.const import IS_RELATED_CASE
-from corehq.apps.case_search.models import CaseSearchConfig, SearchCriteria
+from corehq.apps.case_search.models import (
+    CaseSearchConfig,
+    CaseSearchRequestConfig,
+    SearchCriteria,
+)
 from corehq.apps.domain.shortcuts import create_user
 from corehq.apps.es.case_search import case_search_adapter
 from corehq.apps.es.tests.utils import (
@@ -71,23 +75,27 @@ class TestCaseSearchEndpoint(TestCase):
         FormProcessorTestUtils.delete_all_cases()
         super().tearDownClass()
 
+    def _run_query(self, case_types, criteria, app_id=None):
+        config = CaseSearchRequestConfig(criteria=criteria, case_types=case_types)
+        return get_case_search_results(self.domain, config, app_id=app_id)
+
     def test_basic(self):
-        res = get_case_search_results(self.domain, ['person'], [])
+        res = self._run_query(['person'], [])
         self.assertItemsEqual(["Jane", "Xiomara", "Alba", "Rogelio", "Jane"], [
             case.name for case in res
         ])
 
     def test_case_id_criteia(self):
-        res = get_case_search_results(self.domain, ['household'], [SearchCriteria('case_id', self.household_1)])
+        res = self._run_query(['household'], [SearchCriteria('case_id', self.household_1)])
         self.assertItemsEqual(["Villanueva"], [case.name for case in res])
 
     def test_dynamic_property(self):
-        res = get_case_search_results(self.domain, ['person'], [SearchCriteria('family', 'Ramos')])
+        res = self._run_query(['person'], [SearchCriteria('family', 'Ramos')])
         self.assertItemsEqual(["Jane"], [case.name for case in res])
 
     def test_app_aware_related_cases(self):
         with mock.patch('corehq.apps.case_search.utils.get_app_cached', new=lambda _, __: self.factory.app):
-            res = get_case_search_results(self.domain, ['person'], [], app_id='fake_app_id')
+            res = self._run_query(['person'], [], app_id='fake_app_id')
         self.assertItemsEqual([
             (case.name, case.get_case_property(IS_RELATED_CASE)) for case in res
         ], [

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -12,8 +12,10 @@ from corehq.apps.app_manager.models import (
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.case_search.const import IS_RELATED_CASE
+from corehq.apps.case_search.exceptions import CaseSearchUserError
 from corehq.apps.case_search.models import (
     CaseSearchConfig,
+    CaseSearchEndpoint,
     CaseSearchRequestConfig,
     SearchCriteria,
 )
@@ -75,8 +77,9 @@ class TestCaseSearchEndpoint(TestCase):
         FormProcessorTestUtils.delete_all_cases()
         super().tearDownClass()
 
-    def _run_query(self, case_types, criteria, app_id=None):
-        config = CaseSearchRequestConfig(criteria=criteria, case_types=case_types)
+    def _run_query(self, case_types, criteria, app_id=None, endpoint_id=None):
+        config = CaseSearchRequestConfig(
+            criteria=criteria, case_types=case_types, endpoint_id=endpoint_id)
         return get_case_search_results(self.domain, config, app_id=app_id)
 
     def test_basic(self):
@@ -106,3 +109,13 @@ class TestCaseSearchEndpoint(TestCase):
             ("Jane", None),
             ("Villanueva", "true"),
         ])
+
+    def test_endpoint_id_runs_query(self):
+        endpoint = CaseSearchEndpoint.objects.create(
+            domain=self.domain, name='people', target_name='elasticsearch')
+        res = self._run_query(['person'], [SearchCriteria('family', 'Ramos')], endpoint_id=endpoint.id)
+        self.assertItemsEqual(["Jane"], [case.name for case in res])
+
+    def test_unknown_endpoint_id_raises(self):
+        with self.assertRaises(CaseSearchUserError):
+            self._run_query(['person'], [], endpoint_id=404)

--- a/corehq/apps/case_search/tests/test_case_search_registry.py
+++ b/corehq/apps/case_search/tests/test_case_search_registry.py
@@ -14,6 +14,7 @@ from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.case_search.const import COMMCARE_PROJECT
 from corehq.apps.case_search.models import (
     CaseSearchConfig,
+    CaseSearchRequestConfig,
     SearchCriteria,
     criteria_dict_to_criteria_list,
 )
@@ -156,7 +157,9 @@ class TestCaseSearchRegistry(TestCase):
 
     def _run_query(self, domain, case_types, criteria_dict, registry_slug):
         criteria = criteria_dict_to_criteria_list(criteria_dict)
-        results = get_case_search_results(domain, case_types, criteria, registry_slug=registry_slug)
+        config = CaseSearchRequestConfig(
+            criteria=criteria, case_types=case_types, data_registry=registry_slug)
+        results = get_case_search_results(domain, config)
         return [(case.name, case.domain) for case in results]
 
     def test_query_all_domains_in_registry(self):
@@ -277,9 +280,11 @@ class TestCaseSearchRegistry(TestCase):
     def test_includes_project_property(self):
         results = get_case_search_results(
             self.domain_1,
-            ["person"],
-            [SearchCriteria("name", "Jane")],
-            registry_slug=self.registry_slug
+            CaseSearchRequestConfig(
+                criteria=[SearchCriteria("name", "Jane")],
+                case_types=["person"],
+                data_registry=self.registry_slug,
+            ),
         )
         self.assertItemsEqual([
             ("Jane", self.domain_1, self.domain_1),
@@ -295,10 +300,12 @@ class TestCaseSearchRegistry(TestCase):
         with patch_get_app_cached:
             results = get_case_search_results(
                 self.domain_1,
-                ["creative_work"],
-                [SearchCriteria("name", "Jane Eyre")],  # from domain 2
+                CaseSearchRequestConfig(
+                    criteria=[SearchCriteria("name", "Jane Eyre")],  # from domain 2
+                    case_types=["creative_work"],
+                    data_registry=self.registry_slug,
+                ),
                 app_id="mock_app_id",
-                registry_slug=self.registry_slug
             )
         self.assertItemsEqual([
             ("Charlotte Brontë", "creator", self.domain_2),

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -86,14 +86,9 @@ def get_case_search_results_from_request(domain, app_id, couch_user, request_dic
         config = extract_search_request_config(request_dict)
         cases = get_case_search_results(
             domain,
-            config.case_types,
-            config.criteria,
+            config,
             app_id=app_id,
             couch_user=couch_user,
-            registry_slug=config.data_registry,
-            custom_related_case_property=config.custom_related_case_property,
-            include_all_related_cases=config.include_all_related_cases,
-            commcare_sort=config.commcare_sort,
             profiler=profiler,
         )
         with profiler.timing_context('CaseDBFixture.fixture'):
@@ -101,18 +96,17 @@ def get_case_search_results_from_request(domain, app_id, couch_user, request_dic
     return fixtures, profiler
 
 
-def get_case_search_results(domain, case_types, criteria,
-                            app_id=None, couch_user=None, registry_slug=None, custom_related_case_property=None,
-                            include_all_related_cases=None, commcare_sort=None, profiler=None):
-    helper = _get_helper(couch_user, domain, case_types, registry_slug)
+def get_case_search_results(domain, config, app_id=None, couch_user=None, profiler=None):
+    helper = _get_helper(couch_user, domain, config.case_types, config.data_registry)
     if profiler:
         helper.profiler = profiler
 
-    cases = get_primary_case_search_results(helper, case_types, criteria, commcare_sort)
+    cases = get_primary_case_search_results(helper, config.case_types, config.criteria, config.commcare_sort)
     helper.profiler.primary_count = len(cases)
     if app_id:
-        related_cases = get_and_tag_related_cases(helper, app_id, case_types, cases,
-                                                  custom_related_case_property, include_all_related_cases)
+        related_cases = get_and_tag_related_cases(helper, app_id, config.case_types, cases,
+                                                  config.custom_related_case_property,
+                                                  config.include_all_related_cases)
         helper.profiler.related_count = len(related_cases)
         cases.extend(related_cases)
     return cases

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -102,7 +102,7 @@ def get_case_search_results(domain, config, app_id=None, couch_user=None, profil
     if profiler:
         helper.profiler = profiler
 
-    if config.endpoint_id:
+    if config.endpoint_id and toggles.CASE_SEARCH_ENDPOINTS.enabled(domain):
         return get_endpoint_results(helper, config)
     else:
         return get_unconfigured_endpoint_results(helper, config, app_id)

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -36,6 +36,7 @@ from corehq.apps.case_search.models import (
     CASE_SEARCH_XPATH_QUERY_KEY,
     UNSEARCHABLE_KEYS,
     CaseSearchConfig,
+    CaseSearchEndpoint,
     extract_search_request_config,
 )
 from corehq.apps.es import HQESQuery, case_search
@@ -101,14 +102,29 @@ def get_case_search_results(domain, config, app_id=None, couch_user=None, profil
     if profiler:
         helper.profiler = profiler
 
+    if config.endpoint_id:
+        return get_endpoint_results(helper, config)
+    else:
+        return get_unconfigured_endpoint_results(helper, config, app_id)
+
+
+def get_endpoint_results(helper, config):
+    try:
+        CaseSearchEndpoint.objects.get(domain=helper.domain, id=config.endpoint_id)
+    except (CaseSearchEndpoint.DoesNotExist, ValueError):
+        raise CaseSearchUserError(_("Endpoint '{}' not found").format(config.endpoint_id))
+    # TODO use the endpoint to process the CaseSearchRequestConfig object
+    return get_primary_case_search_results(helper, config.case_types, config.criteria, config.commcare_sort)
+
+
+def get_unconfigured_endpoint_results(helper, config, app_id):
     cases = get_primary_case_search_results(helper, config.case_types, config.criteria, config.commcare_sort)
-    helper.profiler.primary_count = len(cases)
     if app_id:
-        related_cases = get_and_tag_related_cases(helper, app_id, config.case_types, cases,
-                                                  config.custom_related_case_property,
-                                                  config.include_all_related_cases)
-        helper.profiler.related_count = len(related_cases)
-        cases.extend(related_cases)
+        cases.extend(get_and_tag_related_cases(
+            helper, app_id, config.case_types, cases,
+            config.custom_related_case_property,
+            config.include_all_related_cases,
+        ))
     return cases
 
 
@@ -128,6 +144,7 @@ def get_primary_case_search_results(helper, case_types, criteria, commcare_sort=
     results = search_es.run()
     with helper.profiler.timing_context('wrap_cases'):
         cases = [helper.wrap_case(hit, include_score=True) for hit in results.raw_hits]
+    helper.profiler.primary_count = len(cases)
     return cases
 
 
@@ -362,6 +379,7 @@ def get_and_tag_related_cases(helper, app_id, case_types, cases,
     with helper.profiler.timing_context('_tag_is_related_case'):
         for case in results:
             _tag_is_related_case(case)
+    helper.profiler.related_count = len(results)
     return results
 
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -102,7 +102,9 @@ def get_case_search_results(domain, config, app_id=None, couch_user=None, profil
     if profiler:
         helper.profiler = profiler
 
-    if config.endpoint_id and toggles.CASE_SEARCH_ENDPOINTS.enabled(domain):
+    if config.endpoint_id:
+        if not toggles.CASE_SEARCH_ENDPOINTS.enabled(domain):
+            raise CaseSearchUserError(_("Configurable Endpoints are not available"))
         return get_endpoint_results(helper, config)
     else:
         return get_unconfigured_endpoint_results(helper, config, app_id)

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_search_properties.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/modules/case_search_properties.html.diff.txt
@@ -1,9 +1,36 @@
 --- 
 +++ 
-@@ -9,44 +9,44 @@
-     {% trans "Add at least one search property to activate case search for this case list" %}
+@@ -10,20 +10,20 @@
    </div>
    <form>
+     {% if request|toggle_enabled:'CASE_SEARCH_ENDPOINTS' %}
+-      <div class="panel panel-appmanager">
+-        <div class="panel-heading">
+-          <h4 class="panel-title panel-title-nolink">
++      <div class="card panel-appmanager">  {# todo B5: css-panel #}
++        <div class="card-header">
++          <h4 class="card-title card-title-nolink">
+             {% trans "Backend" %}
+           </h4>
+         </div>
+-        <div class="panel-body">
++        <div class="card-body">
+           <div class="row">
+-            <div class="col-sm-6">
++            <div class="col-md-6">
+               <label>
+                 {% trans "Case Search Endpoint" %}
+               </label>
+               <select
+-                class="form-control"
++                class="form-select"
+                 data-bind="value: searchConfig.case_search_endpoint_id"
+               >
+                 <option value>{% trans "-- None --" %}</option>
+@@ -36,44 +36,44 @@
+         </div>
+       </div>
+     {% endif %}
 -    <div class="panel panel-appmanager">
 -      <div class="panel-heading">
 -        <h4 class="panel-title panel-title-nolink">
@@ -58,7 +85,7 @@
              >
                <span class="caret"></span>
              </button>
-@@ -59,29 +59,29 @@
+@@ -86,29 +86,29 @@
          </div>
        </div>
      </div>
@@ -97,7 +124,7 @@
                >
                  <input
                    class="form-control"
-@@ -95,7 +95,7 @@
+@@ -122,7 +122,7 @@
                    {% trans "A property is not allowed both here and Search Properties. Please remove from one of the lists" %}
                  </div>
                </td>
@@ -106,7 +133,7 @@
                  <textarea
                    class="form-control vertical-resize"
                    rows="1"
-@@ -103,9 +103,9 @@
+@@ -130,9 +130,9 @@
                    spellcheck="false"
                  ></textarea>
                </td>
@@ -118,7 +145,7 @@
                    class="fa fa-remove"
                    data-bind="click: $parent.removeDefaultProperty"
                  ></i>
-@@ -116,7 +116,7 @@
+@@ -143,7 +143,7 @@
          <p>
            <button
              type="button"
@@ -127,7 +154,7 @@
              data-bind="click: addDefaultProperty"
            >
              <i class="fa fa-plus"></i> {% trans "Add default search property" %}
-@@ -125,13 +125,13 @@
+@@ -152,13 +152,13 @@
        </div>
      </div>
      {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
@@ -145,7 +172,7 @@
            <p>
              {% trans "Sort search results by case property before filtering. These will affect the priority in which results are returned and are hidden from the user." %}
            </p>
-@@ -153,7 +153,7 @@
+@@ -180,7 +180,7 @@
                  <td>
                    <i class="grip fa-solid fa-up-down icon-blue"></i>
                  </td>
@@ -154,7 +181,7 @@
                    <input
                      class="form-control"
                      type="text"
-@@ -161,14 +161,14 @@
+@@ -188,14 +188,14 @@
                    />
                  </td>
                  <td>
@@ -171,7 +198,7 @@
                      <option value="ascending">{% trans "Ascending" %}</option>
                      <option value="descending">{% trans "Descending" %}</option>
                    </select>
-@@ -181,9 +181,9 @@
+@@ -208,9 +208,9 @@
                </tr>
              </tbody>
            </table>
@@ -183,7 +210,7 @@
                data-bind="click: addCustomSortProperty"
              >
                <i class="fa fa-plus"></i>
-@@ -193,19 +193,19 @@
+@@ -220,19 +220,19 @@
          </div>
        </div>
      {% endif %}
@@ -210,7 +237,7 @@
                    for="search-workflow"
                    data-bind="hidden: restrictWorkflowForDataRegistry"
                  >
-@@ -218,7 +218,7 @@
+@@ -245,7 +245,7 @@
                    </span>
                  </label>
                  <label
@@ -219,7 +246,7 @@
                    for="search-workflow"
                    data-bind="visible: restrictWorkflowForDataRegistry"
                  >
-@@ -231,7 +231,7 @@
+@@ -258,7 +258,7 @@
                    </span>
                  </label>
                  <div class="{% css_field_class %}">
@@ -228,7 +255,7 @@
                      class="form-control"
                      data-bind="value: workflow"
                      id="search-workflow"
-@@ -257,10 +257,10 @@
+@@ -284,10 +284,10 @@
            </div>
            {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
              <div
@@ -241,7 +268,7 @@
                  {% trans "Make search input available after search" %}
                  <span
                    class="hq-help-template"
-@@ -269,9 +269,9 @@
+@@ -296,9 +296,9 @@
                  >
                  </span>
                </label>
@@ -253,7 +280,7 @@
                    <input
                      type="hidden"
                      name="search-input"
-@@ -283,8 +283,8 @@
+@@ -310,8 +310,8 @@
                  </p>
                </div>
              </div>
@@ -264,7 +291,7 @@
                  {% trans "Search Input Instance Name" %}
                  <span
                    class="hq-help-template"
-@@ -304,16 +304,16 @@
+@@ -331,16 +331,16 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'SYNC_SEARCH_CASE_CLAIM' %}
@@ -284,7 +311,7 @@
                  >
                  </span>
                </label>
-@@ -321,10 +321,10 @@
+@@ -348,10 +348,10 @@
                  {% input_trans module.search_config.title_label langs input_name='title_label' input_id='title_label' data_bind="value: title_label" %}
                </div>
              </div>
@@ -297,7 +324,7 @@
                >
                  {% trans "Search Screen Subtitle" %}
                  <span
-@@ -339,10 +339,10 @@
+@@ -366,10 +366,10 @@
                </div>
              </div>
            {% endif %}
@@ -310,7 +337,7 @@
              >
                {% trans "Display Condition" %}
                <span
-@@ -368,10 +368,10 @@
+@@ -395,10 +395,10 @@
                ></textarea>
              </div>
            </div>
@@ -323,7 +350,7 @@
              >
                {% trans "Don't search cases owned by the following ids" %}
                <span
-@@ -404,10 +404,10 @@
+@@ -431,10 +431,10 @@
              </div>
            </div>
            {% if data_registry_enabled %}
@@ -336,7 +363,7 @@
                >
                  {% trans "Data Registry" %}
                  <span
-@@ -418,7 +418,7 @@
+@@ -445,7 +445,7 @@
                  </span>
                </label>
                <div class="{% css_field_class %}">
@@ -345,7 +372,7 @@
                    class="form-control"
                    id="data-registry"
                    data-bind="value: data_registry"
-@@ -432,15 +432,15 @@
+@@ -459,15 +459,15 @@
                  </select>
                </div>
              </div>
@@ -364,7 +391,7 @@
                    class="form-control"
                    data-bind="value: data_registry_workflow"
                  >
-@@ -451,12 +451,12 @@
+@@ -478,12 +478,12 @@
                </div>
              </div>
              <div
@@ -379,7 +406,7 @@
                >
                  {% trans "Load Additional Data Registry Cases" %}
                  <span
-@@ -478,8 +478,8 @@
+@@ -505,8 +505,8 @@
                      data-bind="visible: additional_registry_cases().length > 0"
                    >
                      <tr>
@@ -390,7 +417,7 @@
                      </tr>
                    </thead>
                    <tbody
-@@ -501,7 +501,7 @@
+@@ -528,7 +528,7 @@
                        </td>
                        <td>
                          <i
@@ -399,7 +426,7 @@
                            class="fa fa-remove"
                            data-bind="click: $parent.removeRegistryQuery"
                          ></i>
-@@ -511,7 +511,7 @@
+@@ -538,7 +538,7 @@
                  </table>
                  <button
                    type="button"
@@ -408,7 +435,7 @@
                    data-bind="click: addRegistryQuery"
                  >
                    <i class="fa fa-plus"></i>
-@@ -521,10 +521,10 @@
+@@ -548,10 +548,10 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}
@@ -421,7 +448,7 @@
                >
                  {% trans "Case property with additional case id to add to results" %}
                  <span
-@@ -554,15 +554,15 @@
+@@ -581,15 +581,15 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_RELATED_LOOKUPS' %}
@@ -441,7 +468,7 @@
                        data-bind="checked: include_all_related_cases"
                      />
                    </label>
-@@ -571,18 +571,18 @@
+@@ -598,18 +598,18 @@
              </div>
            {% endif %}
            {% if request|toggle_enabled:'CASE_SEARCH_ADVANCED' %}


### PR DESCRIPTION
## Product Description
Adds a "Backend" panel at the top of the "Case Search and Claim" section of the module config in app manager, with a dropdown to pick one of the domain's configured endpoints.

When a module specifies an endpoint, case search requests from that module now route through it on HQ. The endpoint does not yet shape the query — that's future work — but the request is validated against it.

<img width="1330" height="737" alt="image" src="https://github.com/user-attachments/assets/f7ec936c-26ad-4174-a2d0-df625095a3e5" />

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6553

1. **UI + persistence.** Adds endoint widget to app manager and saves to the app doc.
2. **Suite file changes** Adds `CASE_SEARCH_ENDPOINT_ID_KEY = 'x_commcare_endpoint_id'` to the suite file such that formplayer passes it through to the case search request
3. **HQ-side consumption.** The case search endpoint extracts the endpoint ID from the request and routes to a stub handler which will later be extended to return an appropriate set of cases.

### Still TODO
- The endpoint is loaded and validated but not yet used to shape the query (see the `TODO` in `get_endpoint_results`).
- **The endpoint version still needs to be passed through.** Each `CaseSearchEndpoint` has versioned `CaseSearchEndpointVersion` rows (the `query`/`parameters` live there), so resolving an endpoint to a specific query requires the requested version, which is not yet plumbed from the app/suite through to HQ.

## Feature Flag
Gated behind new CASE_SEARCH_ENDPOINTS flag

## Safety Assurance

### Safety story
The endpoint defaults to unset, leaving the existing (non-endpoint) path unchanged.  Everything else is feature flagged.

### Automated test coverage
- `test_remote_request_endpoint_id` in `test_suite_remote_request.py` covers both the present and absent cases of suite emission.
- `test_case_search_endpoint.py` covers the config-object signature, the endpoint happy path, and the unknown-endpoint-id error.

### QA Plan

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
