### PR TITLE
Decouple "Allow" placeholder checkbox from edit_commcare_users

### DIFF
--- a/corehq/apps/users/static/users/js/edit_role.js
+++ b/corehq/apps/users/static/users/js/edit_role.js
@@ -311,6 +311,9 @@ Alpine.data('initRole', (roleJson) => {
                     set allowCheckboxPermission(value) { // Add this setter
                         self.role.permissions.edit_users_in_groups = value;
                     },
+                    get allowCheckboxImpliedEnabled() {
+                        return self.role.permissions.edit_commcare_users;
+                    },
                 },
                 {
                     showOption: true,
@@ -341,6 +344,9 @@ Alpine.data('initRole', (roleJson) => {
                     },
                     set allowCheckboxPermission(value) { // Add this setter
                         self.role.permissions.edit_users_in_locations = value;
+                    },
+                    get allowCheckboxImpliedEnabled() {
+                        return self.role.permissions.edit_commcare_users;
                     },
                 },
                 {
@@ -477,6 +483,7 @@ Alpine.data('initRole', (roleJson) => {
                     set allowCheckboxPermission(value) {
                         self.role.permissions.edit_locked_questions_in_apps = value;
                     },
+                    allowCheckboxImpliedEnabled: false,
                 },
                 {
                     get showOption() {

--- a/corehq/apps/users/templates/users/edit_role.html
+++ b/corehq/apps/users/templates/users/edit_role.html
@@ -208,10 +208,10 @@
                     </div>
                     <div class="col-md-10 form-label">
                       <div x-html="area.text"></div>
-                      {# PLACEHOLDER checkbox when edit_commcare_users and editPermission() is true #}
+                      {# PLACEHOLDER checkbox when implicitly enabled by another permission and editPermission() is true #}
                       <div
                         class="form-check"
-                        x-show="role.permissions.edit_commcare_users && area.editPermission && area.showAllowCheckbox"
+                        x-show="area.allowCheckboxImpliedEnabled && area.editPermission && area.showAllowCheckbox"
                       >
                         <input
                           class="form-check-input"
@@ -230,7 +230,7 @@
                       {# REAL checkbox for allowCheckboxPermission #}
                       <div
                         class="form-check"
-                        x-show="!role.permissions.edit_commcare_users && area.editPermission && area.showAllowCheckbox"
+                        x-show="!area.allowCheckboxImpliedEnabled && area.editPermission && area.showAllowCheckbox"
                       >
                         <input
                           class="form-check-input"


### PR DESCRIPTION
## Product Description
Fixes "Allow locking and unlocking questions in forms" permission to not appear automatically enabled when "Edit Mobile Workers" permission is checked.

## Technical Summary
HQ side of https://dimagi.atlassian.net/browse/SAAS-19552
When implementing the user permission in https://github.com/dimagi/commcare-hq/pull/37631/changes/645210e190ded2a6dd96749724cdbe796ab67126, I missed that any "allow" checkbox could be implicitly enabled if `edit_commcare_users` was `true`. This adds `allowCheckboxImpliedEnabled` to decide which other permission, if any, should be able to implicitly enable the "allow" checkbox.

## Feature Flag
LOCKED_ADMIN_QUESTIONS

## Safety Assurance

### Safety story
Tested locally and on staging.

### Automated test coverage
Not here.

### QA Plan
QA raised this bug and have reviewed the fix on staging.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
