### PR TITLE
Riese/hook up query builder and project db

### DIFF
--- a/corehq/apps/case_search/endpoint_capability.py
+++ b/corehq/apps/case_search/endpoint_capability.py
@@ -9,6 +9,8 @@ FIELD_TYPE_DATE = 'date'
 FIELD_TYPE_DATETIME = 'datetime'
 FIELD_TYPE_SELECT = 'select'
 FIELD_TYPE_GEOPOINT = 'geopoint'
+SCHEMA = 'schema'
+TO_SQL = 'toSql'
 
 # DataType -> field type mapping
 _DATA_TYPE_MAP = {
@@ -46,29 +48,89 @@ _OPERATIONS_BY_TYPE = {
     ],
 }
 
-COMPONENT_INPUT_SCHEMAS = {
-    'exact_match':    [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
-    'not_equals':     [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
-    'starts_with':    [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
-    'fuzzy_match':    [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
-    'phonetic_match': [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
-    'selected_any':   [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
-    'selected_all':   [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
-    'is_empty':       [],
-    'equals':         [{'name': 'value', 'type': 'match_field'}],
-    'gt':             [{'name': 'value', 'type': FIELD_TYPE_NUMBER}],
-    'gte':            [{'name': 'value', 'type': FIELD_TYPE_NUMBER}],
-    'lt':             [{'name': 'value', 'type': FIELD_TYPE_NUMBER}],
-    'lte':            [{'name': 'value', 'type': FIELD_TYPE_NUMBER}],
-    'before':         [{'name': 'value', 'type': 'match_field'}],
-    'after':          [{'name': 'value', 'type': 'match_field'}],
-    'date_range':     [{'name': 'start', 'type': 'match_field'},
-                       {'name': 'end', 'type': 'match_field'}],
-    'fuzzy_date':     [{'name': 'value', 'type': FIELD_TYPE_DATE}],
-    'within_distance': [{'name': 'point', 'type': FIELD_TYPE_GEOPOINT},
-                        {'name': 'distance', 'type': FIELD_TYPE_NUMBER},
-                        {'name': 'unit', 'type': 'choice'}],
+COMPONENT_INPUT_SCHEMAS_AND_FUNCTIONS = {
+    'exact_match': {
+        SCHEMA: [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+        TO_SQL: lambda field, inputs: f"\"prop__{field}\" = '{inputs['value']}'"
+    },
+    'not_equals': {
+        SCHEMA: [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+        TO_SQL: lambda field, inputs: f"\"prop__{field}\" != '{inputs['value']}'"
+    },
+    'starts_with': {
+        SCHEMA: [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+        TO_SQL: lambda field, inputs: f"\"prop__{field}\" LIKE '{inputs['value']}%'"
+    },
+    'fuzzy_match': {
+        SCHEMA: [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+        TO_SQL: lambda field, inputs: 'not implemented'
+    },
+    'phonetic_match': {
+        SCHEMA: [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+        TO_SQL: lambda field, inputs: 'not implemented'
+    },
+    'selected_any': {
+        SCHEMA: [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+        TO_SQL: lambda field, inputs: 'not implemented'
+    },
+    'selected_all': {
+        SCHEMA: [{'name': 'value', 'type': FIELD_TYPE_TEXT}],
+        TO_SQL: lambda field, inputs: 'not implemented'
+    },
+    'is_empty': {
+        SCHEMA: [],
+        TO_SQL: lambda field, inputs: f"(\"prop__{field}\" = '' OR \"prop__{field}\" IS NULL)"
+    },
+    'equals': {
+        SCHEMA: [{'name': 'value', 'type': 'match_field'}],
+        TO_SQL: lambda field, inputs: f"\"prop__{field}__numeric\" = {inputs['value']}"
+    },
+    'gt': {
+        SCHEMA: [{'name': 'value', 'type': FIELD_TYPE_NUMBER}],
+        TO_SQL: lambda field, inputs: f"\"prop__{field}__numeric\" > {inputs['value']}"
+    },
+    'gte': {
+        SCHEMA: [{'name': 'value', 'type': FIELD_TYPE_NUMBER}],
+        TO_SQL: lambda field, inputs: f"\"prop__{field}__numeric\" >= {inputs['value']}"
+    },
+    'lt': {
+        SCHEMA: [{'name': 'value', 'type': FIELD_TYPE_NUMBER}],
+        TO_SQL: lambda field, inputs: f"\"prop__{field}__numeric\" < {inputs['value']}"
+    },
+    'lte': {
+        SCHEMA: [{'name': 'value', 'type': FIELD_TYPE_NUMBER}],
+        TO_SQL: lambda field, inputs: f"\"prop__{field}__numeric\" <= {inputs['value']}"
+    },
+    'before': {
+        SCHEMA: [{'name': 'value', 'type': 'match_field'}],
+        TO_SQL: lambda field, inputs: f"\"prop__{field}__date\" < '{inputs['value']}'"
+    },
+    'after': {
+        SCHEMA: [{'name': 'value', 'type': 'match_field'}],
+        TO_SQL: lambda field, inputs: f"\"prop__{field}__date\" > '{inputs['value']}'"
+    },
+    'date_range': {
+        SCHEMA: [{'name': 'start', 'type': 'match_field'},
+                 {'name': 'end', 'type': 'match_field'}],
+        TO_SQL: lambda field, inputs: (
+            f"\"prop__{field}__date\" > '{inputs['start']}'"
+            f" and \"prop__{field}__date\" < '{inputs['end']}'"
+        )
+    },
+    'fuzzy_date': {
+        SCHEMA: [{'name': 'value', 'type': FIELD_TYPE_DATE}],
+        TO_SQL: lambda field, inputs: 'not implemented'
+    },
+    'within_distance': {
+        SCHEMA: [{'name': 'point', 'type': FIELD_TYPE_GEOPOINT},
+                 {'name': 'distance', 'type': FIELD_TYPE_NUMBER},
+                 {'name': 'unit', 'type': 'choice'}],
+        TO_SQL: lambda field, inputs: 'not implemented'
+    },
 }
+
+COMPONENT_INPUT_SCHEMAS = { k: v[SCHEMA] for k, v in COMPONENT_INPUT_SCHEMAS_AND_FUNCTIONS.items() }
+COMPONENT_INPUT_FUNCTIONS = { k: v[TO_SQL] for k, v in COMPONENT_INPUT_SCHEMAS_AND_FUNCTIONS.items() }
 
 _AUTO_VALUES = {
     FIELD_TYPE_DATE: [

--- a/corehq/apps/case_search/endpoint_service.py
+++ b/corehq/apps/case_search/endpoint_service.py
@@ -1,8 +1,11 @@
+import datetime
+
 from django.db import transaction
 from django.db.models import Max
 from django.http import Http404
 
 from corehq.apps.case_search.endpoint_capability import (
+    COMPONENT_INPUT_FUNCTIONS,
     COMPONENT_INPUT_SCHEMAS,
     get_capability,
 )
@@ -10,6 +13,7 @@ from corehq.apps.case_search.models import (
     CaseSearchEndpoint,
     CaseSearchEndpointVersion,
 )
+from corehq.const import SERVER_DATE_FORMAT
 
 
 class FilterSpecValidationError(Exception):
@@ -63,6 +67,82 @@ def save_new_version(endpoint, parameters, query):
     endpoint.current_version = version
     endpoint.save(update_fields=['current_version'])
     return version
+
+
+def test_query(domain, target_type, target_name, parameters, query):
+    """Test a query. First validate it then run it and return the results"""
+    capability = get_capability(domain)
+    errors = validate_filter_spec(query, parameters, target_name, capability)
+    if errors:
+        raise FilterSpecValidationError(errors)
+
+
+    import sqlalchemy
+    from corehq.apps.project_db.schema import (
+        get_project_db_engine,
+        get_schema_name,
+        set_local_search_path,
+    )
+
+    parameter_values = {p['name']: p['value'] for p in parameters}
+    sql_base = f"SELECT * FROM {target_name} WHERE {_build_where_clause(query, parameter_values)}"
+    sql_limit = f"{sql_base} LIMIT 10;"
+
+    if "not implemented" in sql_limit:
+        return {
+            'sql': sql_base,
+            'columns': [],
+            'rows': [],
+            'errors': ["parts of the query to sql convertion is not implemented yet"]
+        }
+
+    engine = get_project_db_engine()
+    schema_name = get_schema_name(domain)
+
+    inspector = sqlalchemy.inspect(engine)
+    if schema_name not in inspector.get_schema_names():
+        return
+
+    with engine.begin() as conn:
+        # Use execution_options postgresql_readonly in sqlalchemy 1.4+
+        conn.execute(sqlalchemy.text('SET TRANSACTION READ ONLY'))
+        set_local_search_path(conn, domain)
+        result = conn.execute(sqlalchemy.text(sql_limit))
+        rows = [list(r) for r in result.fetchall()]
+        columns = list(result.keys())
+
+        return {
+            'sql': sql_base,
+            'columns': columns,
+            'rows': rows,
+            'errors': [],
+        }
+
+
+def _materialize_value(input, parameter_values):
+    if input['type'] == 'constant':
+        return input['value']
+    if input['type'] == 'parameter':
+        return parameter_values[input['ref']]
+    if input['type'] == 'auto_value':
+        if input['ref'] == 'today()':
+            return datetime.datetime.now(datetime.timezone.utc).strftime(SERVER_DATE_FORMAT)
+
+def _materialize_values(inputs, parameter_values):
+    return {k: _materialize_value(v, parameter_values) for k, v in inputs.items()}
+
+def _build_where_clause(query, parameter_values):
+    if query['type'] == 'and':
+        return f"({' AND '.join([_build_where_clause(c, parameter_values) for c in query["children"]])})"
+    if query['type'] == 'or':
+        return f"({' OR '.join([_build_where_clause(c, parameter_values) for c in query["children"]])})"
+    if query['type'] == 'component':
+        toSql = COMPONENT_INPUT_FUNCTIONS[query['component']]
+        field = query['field']
+        inputs = query['inputs']
+        return toSql(field, _materialize_values(inputs, parameter_values))
+
+    return 'not implemented'
 
 
 def validate_filter_spec(spec, parameters, case_type_name, capability):

--- a/corehq/apps/case_search/endpoint_views.py
+++ b/corehq/apps/case_search/endpoint_views.py
@@ -15,6 +15,7 @@ from corehq.apps.case_search.endpoint_service import (
     get_version,
     list_endpoints,
     save_new_version,
+    test_query,
 )
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.settings.views import BaseProjectDataView
@@ -169,6 +170,7 @@ class CaseSearchEndpointEditView(CaseSearchEndpointMixin, BaseProjectDataView):
             'initial_parameters': current_version.parameters,
             'initial_query': current_version.query,
             'post_url': reverse(self.urlname, args=[self.domain, endpoint.id]),
+            'test_url': reverse(CaseSearchEndpointTestView.urlname, args=[self.domain]),
             'display_version_number': current_version.version_number,
             'current_version_number': current_version.version_number,
             'versions_with_urls': versions_with_urls,
@@ -268,6 +270,39 @@ class CaseSearchEndpointVersionView(
             'current_version_number': current_version.version_number,
             'versions_with_urls': versions_with_urls,
         }
+
+
+@method_decorator(_ENDPOINT_DECORATORS, name='dispatch')
+class CaseSearchEndpointTestView(
+    CaseSearchEndpointMixin, BaseProjectDataView
+):
+    urlname = 'case_search_endpoint_test'
+    http_method_names = ['post']
+
+    @property
+    def page_url(self):
+        return reverse(
+            self.urlname, args=[self.domain]
+        )
+
+
+    def post(self, request, *args, **kwargs):
+        try:
+            data = json.loads(request.body)
+        except json.JSONDecodeError:
+            return JsonResponse({'errors': ['Invalid JSON']}, status=400)
+        try:
+            return JsonResponse(
+                test_query(
+                    domain=self.domain,
+                    target_type=data.get('target_type', 'project_db'),
+                    target_name=data.get('target_name', ''),
+                    parameters=data.get('parameters', []),
+                    query=data.get('query', {'type': 'and', 'children': []}),
+                )
+            )
+        except FilterSpecValidationError as e:
+            return JsonResponse({'errors': e.errors}, status=400)
 
 
 @method_decorator(_ENDPOINT_DECORATORS, name='dispatch')

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -8,6 +8,7 @@ function _getJson(id) {
 Alpine.data("endpointForm", () => {
   const mode = _getJson("endpoint-mode");
   const postUrl = _getJson("endpoint-post-url");
+  const testUrl = _getJson("endpoint-test-url");
 
   return {
     name: _getJson("initial-name"),
@@ -15,6 +16,9 @@ Alpine.data("endpointForm", () => {
     parameters: _getJson("initial-parameters"),
     query: _getJson("initial-query"),
     capability: _getJson("capability-data"),
+    sqlQuery: "",
+    columns: [],
+    rows: [],
     errors: [],
     submitting: false,
     mode: mode,
@@ -220,6 +224,39 @@ Alpine.data("endpointForm", () => {
 
     async testQuery() {
       console.log("testing query ...");
+      try {
+        const payload = {
+          name: this.name.trim(),
+          target_type: "project_db",
+          target_name: this.targetCasetype,
+          parameters: this.parameters.filter((p) => p.name.trim()),
+          query: this.query,
+        };
+
+        const resp = await fetch(testUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRFToken": this._getCsrfToken(),
+          },
+          body: JSON.stringify(payload),
+        });
+
+        const data = await resp.json();
+        if (resp.ok) {
+            console.log("done");
+            this.sqlQuery = data.sql;
+            this.columns = data.columns;
+            this.rows = data.rows;
+            this.testErrors = data.errors;
+        } else {
+          this.testErrors = data.errors || [_getJson("msg-unexpected-error")];
+        }
+      } catch {
+        this.testErrors = [_getJson("msg-network-error")];
+      } finally {
+
+      }
     },
 
     _getCsrfToken() {

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -2,214 +2,230 @@ import "commcarehq";
 import Alpine from "alpinejs";
 
 function _getJson(id) {
-    return JSON.parse(document.getElementById(id).textContent);
+  return JSON.parse(document.getElementById(id).textContent);
 }
 
 Alpine.data("endpointForm", () => {
-    const mode = _getJson("endpoint-mode");
-    const postUrl = _getJson("endpoint-post-url");
+  const mode = _getJson("endpoint-mode");
+  const postUrl = _getJson("endpoint-post-url");
 
-    return {
-        name: _getJson("initial-name"),
-        targetCasetype: _getJson("initial-target-name"),
-        parameters: _getJson("initial-parameters"),
-        query: _getJson("initial-query"),
-        capability: _getJson("capability-data"),
-        errors: [],
-        submitting: false,
-        mode: mode,
-        _nextId: 1,
+  return {
+    name: _getJson("initial-name"),
+    targetCasetype: _getJson("initial-target-name"),
+    parameters: _getJson("initial-parameters"),
+    query: _getJson("initial-query"),
+    capability: _getJson("capability-data"),
+    errors: [],
+    submitting: false,
+    mode: mode,
+    _nextId: 1,
 
-        get currentFields() {
-            if (!this.targetCasetype) {return [];}
-            const ct = this.capability.case_types.find(
-                (c) => c.name === this.targetCasetype,
-            );
-            return ct ? ct.fields : [];
-        },
+    get currentFields() {
+      if (!this.targetCasetype) {
+        return [];
+      }
+      const ct = this.capability.case_types.find(
+        (c) => c.name === this.targetCasetype,
+      );
+      return ct ? ct.fields : [];
+    },
 
-        getFieldDef(fieldName) {
-            return this.currentFields.find((f) => f.name === fieldName) || null;
-        },
+    getFieldDef(fieldName) {
+      return this.currentFields.find((f) => f.name === fieldName) || null;
+    },
 
-        getOperationsForField(fieldName) {
-            const f = this.getFieldDef(fieldName);
-            return f ? f.operations : [];
-        },
+    getOperationsForField(fieldName) {
+      const f = this.getFieldDef(fieldName);
+      return f ? f.operations : [];
+    },
 
-        getInputSchemaForOperation(operation) {
-            return this.capability.component_input_schemas[operation] || [];
-        },
+    getInputSchemaForOperation(operation) {
+      return this.capability.component_input_schemas[operation] || [];
+    },
 
-        getAutoValuesForFieldType(fieldType) {
-            return this.capability.auto_values[fieldType] || [];
-        },
+    getAutoValuesForFieldType(fieldType) {
+      return this.capability.auto_values[fieldType] || [];
+    },
 
-        getFieldType(fieldName) {
-            const f = this.getFieldDef(fieldName);
-            return f ? f.type : "";
-        },
+    getFieldType(fieldName) {
+      const f = this.getFieldDef(fieldName);
+      return f ? f.type : "";
+    },
 
-        typeIconClass(type) {
-            return (
-                {
-                    text: "fa-solid fa-font",
-                    number: "fa-solid fa-hashtag",
-                    date: "fa-solid fa-calendar-days",
-                    datetime: "fa-solid fa-calendar-days",
-                    select: "fa-solid fa-list",
-                    geopoint: "fa-solid fa-location-dot",
-                }[type] || "fa-solid fa-circle"
-            );
-        },
+    typeIconClass(type) {
+      return (
+        {
+          text: "fa-solid fa-font",
+          number: "fa-solid fa-hashtag",
+          date: "fa-solid fa-calendar-days",
+          datetime: "fa-solid fa-calendar-days",
+          select: "fa-solid fa-list",
+          geopoint: "fa-solid fa-location-dot",
+        }[type] || "fa-solid fa-circle"
+      );
+    },
 
-        initializeIds(node) {
-            node._id = this._nextId++;
-            if (node.children) {
-                node.children.forEach((child) => this.initializeIds(child));
-            }
-            if (node.child) {
-                this.initializeIds(node.child);
-            }
-        },
+    initializeIds(node) {
+      node._id = this._nextId++;
+      if (node.children) {
+        node.children.forEach((child) => this.initializeIds(child));
+      }
+      if (node.child) {
+        this.initializeIds(node.child);
+      }
+    },
 
-        init() {
-            this.initializeIds(this.query);
-        },
+    init() {
+      this.initializeIds(this.query);
+    },
 
-        onCasetypeChange() {
-            this.query = { type: "and", children: [] };
-        },
+    onCasetypeChange() {
+      this.query = { type: "and", children: [] };
+    },
 
-        addParameter() {
-            this.parameters.push({ name: "", type: "text", required: false });
-        },
+    addParameter() {
+      this.parameters.push({ name: "", type: "text", required: false });
+    },
 
-        removeParameter(idx) {
-            this.parameters.splice(idx, 1);
-        },
+    removeParameter(idx) {
+      this.parameters.splice(idx, 1);
+    },
 
-        addCondition(group) {
-            if (!group.children) {group.children = [];}
-            group.children.push({
-                _id: this._nextId++,
-                type: "component",
-                field: "",
-                component: "",
-                inputs: {},
-            });
-        },
+    addCondition(group) {
+      if (!group.children) {
+        group.children = [];
+      }
+      group.children.push({
+        _id: this._nextId++,
+        type: "component",
+        field: "",
+        component: "",
+        inputs: {},
+      });
+    },
 
-        addGroup(parentGroup, type) {
-            if (!parentGroup.children) {parentGroup.children = [];}
-            parentGroup.children.push({
-                _id: this._nextId++,
-                type: type,
-                children: [],
-            });
-        },
+    addGroup(parentGroup, type) {
+      if (!parentGroup.children) {
+        parentGroup.children = [];
+      }
+      parentGroup.children.push({
+        _id: this._nextId++,
+        type: type,
+        children: [],
+      });
+    },
 
-        addNotGroup(parentGroup) {
-            if (!parentGroup.children) {parentGroup.children = [];}
-            parentGroup.children.push({
-                _id: this._nextId++,
-                type: "not",
-                child: { _id: this._nextId++, type: "and", children: [] },
-            });
-        },
+    addNotGroup(parentGroup) {
+      if (!parentGroup.children) {
+        parentGroup.children = [];
+      }
+      parentGroup.children.push({
+        _id: this._nextId++,
+        type: "not",
+        child: { _id: this._nextId++, type: "and", children: [] },
+      });
+    },
 
-        removeNode(parentGroup, idx) {
-            parentGroup.children.splice(idx, 1);
-        },
+    removeNode(parentGroup, idx) {
+      parentGroup.children.splice(idx, 1);
+    },
 
-        onFieldChange(node) {
-            node.component = "";
-            node.inputs = {};
-        },
+    onFieldChange(node) {
+      node.component = "";
+      node.inputs = {};
+    },
 
-        onComponentChange(node) {
-            const schema = this.getInputSchemaForOperation(node.component);
-            if (schema.every((slot) => slot.name in (node.inputs || {}))) {return;}
-            node.inputs = {};
-            for (const slot of schema) {
-                node.inputs[slot.name] = { type: "constant", value: "" };
-            }
-        },
+    onComponentChange(node) {
+      const schema = this.getInputSchemaForOperation(node.component);
+      if (schema.every((slot) => slot.name in (node.inputs || {}))) {
+        return;
+      }
+      node.inputs = {};
+      for (const slot of schema) {
+        node.inputs[slot.name] = { type: "constant", value: "" };
+      }
+    },
 
-        getInputValue(node, slotName) {
-            if (!node.inputs[slotName]) {
-                node.inputs[slotName] = { type: "constant", value: "" };
-            }
-            return node.inputs[slotName];
-        },
+    getInputValue(node, slotName) {
+      if (!node.inputs[slotName]) {
+        node.inputs[slotName] = { type: "constant", value: "" };
+      }
+      return node.inputs[slotName];
+    },
 
-        setInputType(node, slotName, valueType) {
-            const current = node.inputs[slotName] || {};
-            if (valueType === "constant") {
-                node.inputs[slotName] = {
-                    type: "constant",
-                    value: current.value || "",
-                };
-            } else if (valueType === "parameter") {
-                node.inputs[slotName] = {
-                    type: "parameter",
-                    ref: current.ref || "",
-                };
-            } else if (valueType === "auto_value") {
-                node.inputs[slotName] = {
-                    type: "auto_value",
-                    ref: current.ref || "",
-                };
-            }
-        },
+    setInputType(node, slotName, valueType) {
+      const current = node.inputs[slotName] || {};
+      if (valueType === "constant") {
+        node.inputs[slotName] = {
+          type: "constant",
+          value: current.value || "",
+        };
+      } else if (valueType === "parameter") {
+        node.inputs[slotName] = {
+          type: "parameter",
+          ref: current.ref || "",
+        };
+      } else if (valueType === "auto_value") {
+        node.inputs[slotName] = {
+          type: "auto_value",
+          ref: current.ref || "",
+        };
+      }
+    },
 
-        async submitForm() {
-            this.errors = [];
+    async submitForm() {
+      this.errors = [];
 
-            if (!this.name.trim()) {
-                this.errors.push(_getJson("msg-name-required"));
-            }
-            if (!this.targetCasetype) {
-                this.errors.push(_getJson("msg-case-type-required"));
-            }
-            if (this.errors.length > 0) {return;}
+      if (!this.name.trim()) {
+        this.errors.push(_getJson("msg-name-required"));
+      }
+      if (!this.targetCasetype) {
+        this.errors.push(_getJson("msg-case-type-required"));
+      }
+      if (this.errors.length > 0) {
+        return;
+      }
 
-            this.submitting = true;
-            try {
-                const payload = {
-                    name: this.name.trim(),
-                    target_type: "project_db",
-                    target_name: this.targetCasetype,
-                    parameters: this.parameters.filter((p) => p.name.trim()),
-                    query: this.query,
-                };
+      this.submitting = true;
+      try {
+        const payload = {
+          name: this.name.trim(),
+          target_type: "project_db",
+          target_name: this.targetCasetype,
+          parameters: this.parameters.filter((p) => p.name.trim()),
+          query: this.query,
+        };
 
-                const resp = await fetch(postUrl, {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                        "X-CSRFToken": this._getCsrfToken(),
-                    },
-                    body: JSON.stringify(payload),
-                });
+        const resp = await fetch(postUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRFToken": this._getCsrfToken(),
+          },
+          body: JSON.stringify(payload),
+        });
 
-                const data = await resp.json();
-                if (resp.ok && data.redirect) {
-                    window.location.href = data.redirect;
-                } else {
-                    this.errors = data.errors || [_getJson("msg-unexpected-error")];
-                }
-            } catch {
-                this.errors = [_getJson("msg-network-error")];
-            } finally {
-                this.submitting = false;
-            }
-        },
+        const data = await resp.json();
+        if (resp.ok && data.redirect) {
+          window.location.href = data.redirect;
+        } else {
+          this.errors = data.errors || [_getJson("msg-unexpected-error")];
+        }
+      } catch {
+        this.errors = [_getJson("msg-network-error")];
+      } finally {
+        this.submitting = false;
+      }
+    },
 
-        _getCsrfToken() {
-            return _getJson("csrf-token");
-        },
-    };
+    async testQuery() {
+      console.log("testing query ...");
+    },
+
+    _getCsrfToken() {
+      return _getJson("csrf-token");
+    },
+  };
 });
 
 Alpine.start();

--- a/corehq/apps/case_search/templates/case_search/endpoint_edit.html
+++ b/corehq/apps/case_search/templates/case_search/endpoint_edit.html
@@ -258,7 +258,7 @@
 
     {# Actions #}
     {% if mode != 'readonly' %}
-      <div class="mt-3 d-flex gap-2">
+      <div class="mb-3 d-flex gap-2">
         <button
           type="button"
           class="btn btn-primary btn-sm"
@@ -283,7 +283,7 @@
         >
       </div>
     {% else %}
-      <div class="mt-3">
+      <div class="mb-3">
         <a
           href="{% url 'case_search_endpoints' domain %}"
           class="btn btn-outline-secondary btn-sm"
@@ -291,5 +291,16 @@
         >
       </div>
     {% endif %}
+
+    {# ── Tester card ── #}
+    <div class="card mb-3">
+      <div class="card-header">
+        <i class="fa-solid fa-mangifying-glass me-1"></i
+        >{% trans "Test query" %}
+      </div>
+      <div class="card-body">
+        {% include "case_search/partials/query_tester.html" %}
+      </div>
+    </div>
   </div>
 {% endblock page_content %}

--- a/corehq/apps/case_search/templates/case_search/endpoint_edit.html
+++ b/corehq/apps/case_search/templates/case_search/endpoint_edit.html
@@ -45,6 +45,7 @@
   {{ initial_target_name|json_script:"initial-target-name" }}
   {{ mode|json_script:"endpoint-mode" }}
   {{ post_url|json_script:"endpoint-post-url" }}
+  {{ test_url|json_script:"endpoint-test-url" }}
   {% trans "Name is required." as msg_name_required %}
   {% trans "Case type is required." as msg_case_type_required %}
   {% trans "An unexpected error occurred." as msg_unexpected_error %}

--- a/corehq/apps/case_search/templates/case_search/partials/query_builder.html
+++ b/corehq/apps/case_search/templates/case_search/partials/query_builder.html
@@ -896,7 +896,7 @@
 
   <textarea
     class="form-control font-monospace mt-3"
-    rows="20"
+    rows="8"
     readonly
     x-text="JSON.stringify(query, null, 2)"
   ></textarea>

--- a/corehq/apps/case_search/templates/case_search/partials/query_tester.html
+++ b/corehq/apps/case_search/templates/case_search/partials/query_tester.html
@@ -16,6 +16,7 @@
             class="form-control"
             type="text"
             :id="'param-name-' + param.name"
+            x-model="param.value"
           />
         </div>
       </div>
@@ -26,10 +27,43 @@
     <span>{% trans "Generate query" %}</span>
   </button>
 
+  <template x-if="testErrors.length > 0">
+    <div class="alert alert-danger mt-3" role="alert">
+      <ul class="mb-0">
+        <template x-for="(err, idx) in testErrors" :key="idx">
+          <li x-text="err"></li>
+        </template>
+      </ul>
+    </div>
+  </template>
+
   <textarea
     class="form-control font-monospace mt-3"
-    rows="5"
+    rows="3"
     readonly
-    x-text="JSON.stringify(query, null, 2)"
+    x-text="sqlQuery"
   ></textarea>
+
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <template x-for="column in columns">
+            <th x-text="column">h</th>
+          </template>
+
+        </tr>
+      </thead>
+      <tbody>
+        <template x-for="row in rows">
+          <tr>
+            <template x-for="col in row">
+              <td x-text="col"></td>
+            </template>
+          </tr>
+        </template>
+
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/corehq/apps/case_search/templates/case_search/partials/query_tester.html
+++ b/corehq/apps/case_search/templates/case_search/partials/query_tester.html
@@ -1,0 +1,35 @@
+{% load i18n %}
+{# Query builder partial — rendered inside an Alpine.js x-data="endpointForm()" context. #}
+
+<div class="filter-tree">
+  <div>
+    <template x-for="param in parameters" :key="param.name">
+      <div class="row mb-3">
+        <label
+          class="col-sm-2 form-label fw-semibold"
+          x-text="param.name"
+          :for="'param-name-' + param.name"
+        >
+        </label>
+        <div class="col-sm-10">
+          <input
+            class="form-control"
+            type="text"
+            :id="'param-name-' + param.name"
+          />
+        </div>
+      </div>
+    </template>
+  </div>
+
+  <button type="button" class="btn btn-primary btn-sm" @click="testQuery()">
+    <span>{% trans "Generate query" %}</span>
+  </button>
+
+  <textarea
+    class="form-control font-monospace mt-3"
+    rows="5"
+    readonly
+    x-text="JSON.stringify(query, null, 2)"
+  ></textarea>
+</div>

--- a/corehq/apps/case_search/urls.py
+++ b/corehq/apps/case_search/urls.py
@@ -9,6 +9,7 @@ from corehq.apps.case_search.endpoint_views import (
     CaseSearchEndpointEditView,
     CaseSearchEndpointNewView,
     CaseSearchEndpointsView,
+    CaseSearchEndpointTestView,
     CaseSearchEndpointVersionView,
 )
 
@@ -53,5 +54,10 @@ urlpatterns = [
         r'^endpoints/(?P<endpoint_id>\d+)/deactivate/$',
         CaseSearchEndpointDeactivateView.as_view(),
         name=CaseSearchEndpointDeactivateView.urlname,
+    ),
+    url(
+        r'^endpoints/test/$',
+        CaseSearchEndpointTestView.as_view(),
+        name=CaseSearchEndpointTestView.urlname,
     ),
 ]


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code. Pay particular attention to _backward incompatible_ operations like `RemoveField`, `RenameField`, `RemoveConstraint`, and [others described here](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md) that can cause errors when migrations are applied to a live database.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
