### PR TITLE
Ensure corehq/ex-submodules are detected by pyright language server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,3 +244,8 @@ ignore = ["F403"]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/**" = ["E", "F", "W"]
+
+[tool.pyright]
+extraPaths = [
+    "corehq/ex-submodules",
+]


### PR DESCRIPTION
Not everyone uses pyright but there is no one size fits all solution

## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

Currently when use pyright, it is unable to resolve imports from `corehq/ex-submodules`. We think this is because of how we init the python path for [this module at the source root](https://github.com/dimagi/commcare-hq/blob/ceff653bc6c0ea090bb756f1163eedac39da3c07/manage.py#L90-L94), but are able to resolve imports for other modules defined in that function like `submodules`, so not convinced that is why.

This change fixes the issue, and only applies to those that use pyright. We are not aware of a way to do this that will generally work across different language servers, and this feels low impact enough that it is fine to add.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe. Only for editor. It's a no-op for people who don't use pyright.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
