### PR TITLE
Source payments filter dropdowns from lookup tables

### DIFF
--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -35,7 +35,6 @@ from corehq.apps.es.transient_util import doc_adapter_from_cname
 from corehq.util.dates import iso_string_to_datetime
 
 from . import filters, queries
-from .aggregations import TermsAggregation, FilterAggregation, NestedAggregation
 from .cases import case_adapter
 from .client import BulkActionItem, ElasticDocumentAdapter, create_document_adapter
 from .const import (
@@ -410,51 +409,6 @@ def external_id(external_id):
 
 def indexed_on(gt=None, gte=None, lt=None, lte=None):
     return filters.date_range(INDEXED_ON, gt, gte, lt, lte)
-
-
-def get_case_property_unique_values(domain, case_type, property_name, include_empty=False):
-    """
-    Gets unique values for a specific case property for given domain and case type.
-    Notes:
-    - Uses an ES terms aggregation (avoid high-cardinality fields like UUIDs or datetimes).
-    - Empty string values are returned as '' if include_empty=True.
-    """
-    terms_agg = TermsAggregation(
-        'unique_values',
-        'case_properties.value.exact'
-    )
-
-    filter_agg = FilterAggregation(
-        'property_filter',
-        filters.term('case_properties.key.exact', property_name)
-    ).aggregation(terms_agg)
-
-    nested_agg = NestedAggregation(
-        'nested_case_props',
-        'case_properties'
-    ).aggregation(filter_agg)
-
-    query = (
-        CaseSearchES()
-        .domain(domain)
-        .case_type(case_type)
-        .aggregation(nested_agg)
-        .size(0)
-    )
-
-    results = query.run()
-
-    buckets = (
-        results.aggregations
-        .nested_case_props
-        .property_filter
-        .unique_values
-        .normalized_buckets
-    )
-    if include_empty:
-        return [b['key'] for b in buckets]
-    else:
-        return [b['key'] for b in buckets if b['key'] != '']
 
 
 def wrap_case_search_hit(hit, include_score=False):

--- a/corehq/apps/es/tests/test_case_search_es.py
+++ b/corehq/apps/es/tests/test_case_search_es.py
@@ -23,7 +23,6 @@ from corehq.apps.es.case_search import (
     case_property_starts_with,
     case_property_text_query,
     case_search_adapter,
-    get_case_property_unique_values,
     wrap_case_search_hit,
 )
 from corehq.apps.es.const import SIZE_LIMIT
@@ -595,39 +594,6 @@ class TestCaseSearchLookups(BaseCaseSearchTest):
             "starts-with(ssn, '100')",
             ['c5', 'c6', 'c2']
         )
-
-    def test_get_case_property_unique_values(self):
-        self._bootstrap_cases_in_es_for_domain(self.domain, [
-            {'_id': 'c1', 'status': 'active'},
-            {'_id': 'c2', 'status': 'inactive'},
-            {'_id': 'c3', 'status': 'active'},
-            {'_id': 'c5', 'status': ''},  # empty value
-            {'_id': 'c6'},  # missing property
-        ])
-
-        unique_values = get_case_property_unique_values(self.domain, self.case_type, 'status')
-        expected_values = ['active', 'inactive']
-        self.assertEqual(sorted(unique_values), expected_values)
-
-    def test_get_case_property_unique_values_with_empty(self):
-        self._bootstrap_cases_in_es_for_domain(self.domain, [
-            {'_id': 'c1', 'status': 'active'},
-            {'_id': 'c2', 'status': 'inactive'},
-            {'_id': 'c3', 'status': 'active'},
-            {'_id': 'c5', 'status': ''},  # empty value
-            {'_id': 'c6'},  # missing property
-        ])
-
-        unique_values_with_empty = get_case_property_unique_values(
-            self.domain, self.case_type, 'status', include_empty=True
-        )
-        expected_values_with_empty = ['', 'active', 'inactive']
-        self.assertEqual(sorted(unique_values_with_empty), expected_values_with_empty)
-
-    def test_get_case_property_unique_values_no_cases(self):
-        unique_values = get_case_property_unique_values(self.domain, self.case_type, 'nonexistent')
-        self.assertEqual(unique_values, [])
-
 
 class TestForwardTimezoneAdjustment(TestCase):
 

--- a/corehq/apps/integration/payments/filters.py
+++ b/corehq/apps/integration/payments/filters.py
@@ -1,5 +1,4 @@
-from django.utils.translation import gettext as _
-from django.utils.translation import gettext_lazy
+from django.utils.translation import gettext_lazy as _
 
 from corehq.apps.es.users import UserES
 from corehq.apps.fixtures.models import LookupTableRow
@@ -101,4 +100,4 @@ class FunderFilter(BaseLookupTableFilter):
 
 class PhoneNumberFilter(BaseSimpleFilter):
     slug = 'phone_number'
-    label = gettext_lazy('Phone number')
+    label = _('Phone number')

--- a/corehq/apps/integration/payments/filters.py
+++ b/corehq/apps/integration/payments/filters.py
@@ -1,9 +1,8 @@
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
-from corehq.apps.case_importer.const import MOMO_PAYMENT_CASE_TYPE
-from corehq.apps.es.case_search import get_case_property_unique_values
 from corehq.apps.es.users import UserES
+from corehq.apps.fixtures.models import LookupTableRow
 from corehq.apps.integration.payments.const import (
     PaymentProperties,
     PaymentStatus,
@@ -13,6 +12,22 @@ from corehq.apps.reports.filters.base import (
     BaseSingleOptionFilter,
 )
 from corehq.apps.reports.filters.case_list import CaseListFilter
+
+LOOKUP_TABLE_TAG_PREFIX = 'payments_'
+
+
+def get_lookup_table_values(domain, tag, column):
+    """Return values from ``column`` of the lookup table tagged ``tag`` in
+    ``domain``, in the table's natural ``sort_key`` order. Duplicates are
+    preserved; callers decide how to present them. Returns ``[]`` if the
+    table is not configured.
+    """
+    values = []
+    for row in LookupTableRow.objects.iter_rows(domain, tag=tag):
+        field_values = row.fields.get(column, [])
+        if field_values:
+            values.append(field_values[0].value)
+    return values
 
 
 class PaymentVerifiedByFilter(BaseSingleOptionFilter):
@@ -39,7 +54,14 @@ class PaymentCaseListFilter(CaseListFilter):
     default_selections = [("all_data", _("[All Data]"))]
 
 
-class BaseCasePropertyFilter(BaseSingleOptionFilter):
+class BaseLookupTableFilter(BaseSingleOptionFilter):
+    """Filter whose options are sourced from a per-domain lookup table.
+
+    The lookup table's tag is ``LOOKUP_TABLE_TAG_PREFIX + case_property`` and
+    its row column name is ``case_property``. The prefix namespaces these
+    tables so they don't collide with unrelated lookup tables a domain may
+    already have under the bare case-property name.
+    """
     default_text = _("Show all")
     case_property = None
 
@@ -47,33 +69,31 @@ class BaseCasePropertyFilter(BaseSingleOptionFilter):
     def options(self):
         if not self.case_property:
             raise NotImplementedError("Subclasses must define 'case_property'")
-        values = get_case_property_unique_values(
-            self.domain,
-            MOMO_PAYMENT_CASE_TYPE,
-            self.case_property,
-        )
-        return [(value, value) for value in sorted(values)]
+        column = self.case_property.value
+        tag = LOOKUP_TABLE_TAG_PREFIX + column
+        values = get_lookup_table_values(self.domain, tag, column)
+        return [(v, v) for v in sorted({v for v in values if v})]
 
 
-class BatchNumberFilter(BaseCasePropertyFilter):
+class BatchNumberFilter(BaseLookupTableFilter):
     slug = "batch_number"
     label = _("Batch number")
     case_property = PaymentProperties.BATCH_NUMBER
 
 
-class CampaignFilter(BaseCasePropertyFilter):
+class CampaignFilter(BaseLookupTableFilter):
     slug = 'campaign'
     label = _('Campaign')
     case_property = PaymentProperties.CAMPAIGN
 
 
-class ActivityFilter(BaseCasePropertyFilter):
+class ActivityFilter(BaseLookupTableFilter):
     slug = 'activity'
     label = _('Activity')
     case_property = PaymentProperties.ACTIVITY
 
 
-class FunderFilter(BaseCasePropertyFilter):
+class FunderFilter(BaseLookupTableFilter):
     slug = 'funder'
     label = _('Funder')
     case_property = PaymentProperties.FUNDER

--- a/corehq/apps/integration/payments/filters.py
+++ b/corehq/apps/integration/payments/filters.py
@@ -56,46 +56,42 @@ class PaymentCaseListFilter(CaseListFilter):
 class BaseLookupTableFilter(BaseSingleOptionFilter):
     """Filter whose options are sourced from a per-domain lookup table.
 
-    The lookup table's tag is ``LOOKUP_TABLE_TAG_PREFIX + case_property`` and
-    its row column name is ``case_property``. The prefix namespaces these
-    tables so they don't collide with unrelated lookup tables a domain may
-    already have under the bare case-property name.
+    Each subclass sets ``slug`` to its underlying case-property name. That
+    same value is the lookup-table row's column name, and prefixed with
+    ``LOOKUP_TABLE_TAG_PREFIX`` it is the table's tag. The prefix
+    namespaces these tables so they don't collide with unrelated lookup
+    tables a domain may already have under the bare case-property name.
     """
     default_text = _("Show all")
-    case_property = None
 
     @property
     def options(self):
-        if not self.case_property:
-            raise NotImplementedError("Subclasses must define 'case_property'")
-        column = self.case_property.value
+        if not self.slug:
+            raise NotImplementedError("Subclasses must define 'slug'")
+        column = self.slug
         tag = LOOKUP_TABLE_TAG_PREFIX + column
         values = get_lookup_table_values(self.domain, tag, column)
         return [(v, v) for v in sorted({v for v in values if v})]
 
 
 class BatchNumberFilter(BaseLookupTableFilter):
-    slug = "batch_number"
+    slug = PaymentProperties.BATCH_NUMBER.value
     label = _("Batch number")
-    case_property = PaymentProperties.BATCH_NUMBER
 
 
 class CampaignFilter(BaseLookupTableFilter):
-    slug = 'campaign'
+    slug = PaymentProperties.CAMPAIGN.value
     label = _('Campaign')
-    case_property = PaymentProperties.CAMPAIGN
 
 
 class ActivityFilter(BaseLookupTableFilter):
-    slug = 'activity'
+    slug = PaymentProperties.ACTIVITY.value
     label = _('Activity')
-    case_property = PaymentProperties.ACTIVITY
 
 
 class FunderFilter(BaseLookupTableFilter):
-    slug = 'funder'
+    slug = PaymentProperties.FUNDER.value
     label = _('Funder')
-    case_property = PaymentProperties.FUNDER
 
 
 class PhoneNumberFilter(BaseSimpleFilter):

--- a/corehq/apps/integration/payments/tests/test_filters.py
+++ b/corehq/apps/integration/payments/tests/test_filters.py
@@ -142,10 +142,9 @@ class TestLookupTableFilters(TestCase):
         ).save()
         assert self._build(CampaignFilter).options == []
 
-    def test_subclass_without_case_property_raises(self):
+    def test_subclass_without_slug_raises(self):
         class _MisconfiguredFilter(BaseLookupTableFilter):
-            slug = 'misconfigured'
             label = 'Misconfigured'
 
         with pytest.raises(NotImplementedError):
-            self._build(_MisconfiguredFilter).options
+            self._build(_MisconfiguredFilter)

--- a/corehq/apps/integration/payments/tests/test_filters.py
+++ b/corehq/apps/integration/payments/tests/test_filters.py
@@ -1,0 +1,151 @@
+import pytest
+from django.test import RequestFactory, TestCase
+
+from corehq.apps.fixtures.models import (
+    Field,
+    LookupTable,
+    LookupTableRow,
+    TypeField,
+)
+from corehq.apps.integration.payments.filters import (
+    LOOKUP_TABLE_TAG_PREFIX,
+    ActivityFilter,
+    BaseLookupTableFilter,
+    BatchNumberFilter,
+    CampaignFilter,
+    FunderFilter,
+    get_lookup_table_values,
+)
+
+
+def _create_table(domain, tag, values, *, column=None, addCleanup=None):
+    column = column or tag
+    table = LookupTable(
+        domain=domain,
+        tag=tag,
+        fields=[TypeField(column)],
+    )
+    table.save()
+    if addCleanup is not None:
+        addCleanup(table.delete)
+    for sort_key, value in enumerate(values):
+        LookupTableRow(
+            domain=domain,
+            table=table,
+            fields={column: [Field(value=value)]},
+            sort_key=sort_key,
+        ).save()
+    return table
+
+
+class TestGetLookupTableValues(TestCase):
+
+    domain = 'payments-lookup-values-test'
+
+    def test_returns_empty_when_table_missing(self):
+        assert get_lookup_table_values(self.domain, 'payments_batch_number', 'batch_number') == []
+
+    def test_returns_values_in_row_order_with_duplicates(self):
+        _create_table(
+            self.domain, 'payments_campaign',
+            ['Gamma', 'Alpha', 'Beta', 'Alpha'],
+            column='campaign', addCleanup=self.addCleanup,
+        )
+        assert get_lookup_table_values(self.domain, 'payments_campaign', 'campaign') == [
+            'Gamma', 'Alpha', 'Beta', 'Alpha',
+        ]
+
+    def test_ignores_rows_missing_the_column(self):
+        table = _create_table(
+            self.domain, 'payments_funder', ['ACME'],
+            column='funder', addCleanup=self.addCleanup,
+        )
+        LookupTableRow(
+            domain=self.domain,
+            table=table,
+            fields={'other_column': [Field(value='ignored')]},
+            sort_key=99,
+        ).save()
+        assert get_lookup_table_values(self.domain, 'payments_funder', 'funder') == ['ACME']
+
+
+class TestLookupTableFilters(TestCase):
+
+    domain = 'payments-filters-test'
+
+    def _seed(self, case_property, values):
+        tag = f'{LOOKUP_TABLE_TAG_PREFIX}{case_property}'
+        _create_table(
+            self.domain, tag, values,
+            column=case_property, addCleanup=self.addCleanup,
+        )
+
+    def _build(self, filter_cls):
+        request = RequestFactory().get('/')
+        return filter_cls(request=request, domain=self.domain, timezone=None)
+
+    def test_batch_number_options_from_lookup_table(self):
+        self._seed('batch_number', ['B-2', 'B-1'])
+        assert self._build(BatchNumberFilter).options == [('B-1', 'B-1'), ('B-2', 'B-2')]
+
+    def test_campaign_options_from_lookup_table(self):
+        self._seed('campaign', ['Vaccination', 'Outreach'])
+        assert self._build(CampaignFilter).options == [
+            ('Outreach', 'Outreach'),
+            ('Vaccination', 'Vaccination'),
+        ]
+
+    def test_activity_options_from_lookup_table(self):
+        self._seed('activity', ['Door-to-door'])
+        assert self._build(ActivityFilter).options == [('Door-to-door', 'Door-to-door')]
+
+    def test_funder_options_from_lookup_table(self):
+        self._seed('funder', ['ACME'])
+        assert self._build(FunderFilter).options == [('ACME', 'ACME')]
+
+    def test_options_dedupe_and_sort_at_filter(self):
+        self._seed('campaign', ['Gamma', 'Alpha', 'Beta', 'Alpha'])
+        assert self._build(CampaignFilter).options == [
+            ('Alpha', 'Alpha'),
+            ('Beta', 'Beta'),
+            ('Gamma', 'Gamma'),
+        ]
+
+    def test_options_drops_empty_string_values(self):
+        self._seed('campaign', ['Alpha', '', 'Beta'])
+        assert self._build(CampaignFilter).options == [
+            ('Alpha', 'Alpha'),
+            ('Beta', 'Beta'),
+        ]
+
+    def test_options_empty_when_table_missing(self):
+        assert self._build(BatchNumberFilter).options == []
+        assert self._build(CampaignFilter).options == []
+        assert self._build(ActivityFilter).options == []
+        assert self._build(FunderFilter).options == []
+
+    def test_options_empty_when_unprefixed_table_exists(self):
+        # A pre-existing 'campaign' table (no payments_ prefix) must not be
+        # picked up by CampaignFilter.
+        unprefixed = LookupTable(
+            domain=self.domain,
+            tag='campaign',
+            fields=[TypeField('campaign')],
+        )
+        unprefixed.save()
+        self.addCleanup(unprefixed.delete)
+        LookupTableRow(
+            domain=self.domain,
+            table=unprefixed,
+            fields={'campaign': [Field(value='Should-Not-Appear')]},
+            sort_key=0,
+        ).save()
+        assert self._build(CampaignFilter).options == []
+
+    def test_subclass_without_case_property_raises(self):
+        class _MisconfiguredFilter(BaseLookupTableFilter):
+            slug = 'misconfigured'
+            label = 'Misconfigured'
+
+        with pytest.raises(NotImplementedError):
+            self._build(_MisconfiguredFilter).options


### PR DESCRIPTION
## Product Description

The Batch Number / Campaign / Activity / Funder filter dropdowns on the Payments report now read their options from per-domain lookup tables (Table IDs `payments_batch_number`, `payments_campaign`, `payments_activity`, `payments_funder`) instead of an ES terms aggregation.

This is an alternate appproach to https://github.com/dimagi/commcare-hq/pull/37730 which just changed these filters to text based search.

Project teams must create the 4 lookup tables before the dropdowns populate. 
## Technical Summary

The previous implementation (`get_case_property_unique_values`) ran an ES nested terms aggregation over `case_properties.value.exact`. On large domains this timed out and broke the report.

This PR sources options from a per-domain lookup table via `LookupTableRow.objects.iter_rows(domain, tag=tag)` — one indexed point lookup per filter. Each filter's `case_property` is paired with a `payments_`-prefixed table tag (e.g. `payments_campaign`); the prefix namespaces these tables to avoid collisions with unrelated tables a domain may already have. The filter class dedupes, drops empty values, and alphabetizes for the dropdown.

The `get_case_property_unique_values` helper had only the payments report as caller and is removed.

## Feature Flag

MOBILE_MONEY_INTEGRATION

## Safety Assurance

### Safety story

- View-side code path (`views.py:_apply_filters`) is unchanged — it still reads `request.GET` directly, so existing bookmarked URLs continue to filter data.
- Domains without the 4 lookup tables see empty dropdowns and the report continues to render (failure mode is a no-op filter, not a crash).

### Automated test coverage

- `corehq/apps/integration/payments/tests/test_filters.py` — 12 tests covering option resolution, dedupe + sort, empty-string handling, missing-table fallback, tag-prefix isolation, and misconfigured subclass.

### QA Plan

- Add the necessary look up tables
- Verify dropdowns show curated values, alphabetized.
- Verify filter applies correctly when an option is selected.
- Verify dropdowns are empty (not error) when a table is absent.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review

- Risk label: low
- Reviewers: appropriate for backend filter changes