### PR TITLE
Replace use of deprecated python function in _get_unique_key

### DIFF
--- a/corehq/apps/celery/serial.py
+++ b/corehq/apps/celery/serial.py
@@ -85,8 +85,9 @@ def _get_unique_key(format_str, fn, *args, **kwargs):
     Lines args and kwargs up with those specified in the definition of fn and
     passes the result to `format_str.format()`.
     """
-    callargs = inspect.getcallargs(fn, *args, **kwargs)
-    return ("{}-" + format_str).format(fn.__name__, **callargs)
+    bound = inspect.signature(fn).bind(*args, **kwargs)
+    bound.apply_defaults()  # ensures bound.arguments includes default values
+    return ("{}-" + format_str).format(fn.__name__, **bound.arguments)
 
 
 class CouldNotAcquireLockError(Exception):

--- a/corehq/apps/celery/serial.py
+++ b/corehq/apps/celery/serial.py
@@ -79,11 +79,14 @@ def serial_task(
     return decorator
 
 
-# Sorry this is so magic
 def _get_unique_key(format_str, fn, *args, **kwargs):
     """
-    Lines args and kwargs up with those specified in the definition of fn and
-    passes the result to `format_str.format()`.
+    Builds a unique key from the function name and ``format_str``.
+
+    Binds args and kwargs to the function's signature which enables
+    referencing any arg or kwarg by name in ``format_str``
+
+    See corehq.apps.celery.tests.test_get_unique_key for more details.
     """
     bound = inspect.signature(fn).bind(*args, **kwargs)
     bound.apply_defaults()  # ensures bound.arguments includes default values

--- a/corehq/apps/celery/serial.py
+++ b/corehq/apps/celery/serial.py
@@ -87,7 +87,7 @@ def _get_unique_key(format_str, fn, *args, **kwargs):
     """
     bound = inspect.signature(fn).bind(*args, **kwargs)
     bound.apply_defaults()  # ensures bound.arguments includes default values
-    return ("{}-" + format_str).format(fn.__name__, **bound.arguments)
+    return f"{fn.__name__}-{format_str.format(**bound.arguments)}"
 
 
 class CouldNotAcquireLockError(Exception):

--- a/corehq/apps/celery/tests/test_get_unique_key.py
+++ b/corehq/apps/celery/tests/test_get_unique_key.py
@@ -1,0 +1,60 @@
+import pytest
+
+from corehq.apps.celery.serial import _get_unique_key
+
+
+def my_func(domain, count=100):
+    pass
+
+
+def test_constant_format_string():
+    key = _get_unique_key('some-constant-value', my_func, 'test')
+    assert key == 'my_func-some-constant-value'
+
+
+def test_template_format_string():
+    key = _get_unique_key('{domain}', my_func, 'test')
+    assert key == 'my_func-test'
+
+
+def test_multiple_template_format_string():
+    key = _get_unique_key('{domain}-{count}', my_func, 'test', count=99)
+    assert key == 'my_func-test-99'
+
+
+def test_default_value_applied():
+    key = _get_unique_key('{domain}-{count}', my_func, 'test')
+    assert key == 'my_func-test-100'
+
+
+def test_arg_passed_as_kwarg():
+    key = _get_unique_key('{domain}-{count}', my_func, domain='test', count=99)
+    assert key == 'my_func-test-99'
+
+
+def test_varargs_function():
+    def varargs_fn(*args, **kwargs):
+        pass
+
+    key = _get_unique_key('{args}', varargs_fn, 1, 2, 3)
+    assert key == 'varargs_fn-(1, 2, 3)'
+
+    key = _get_unique_key('{kwargs}', varargs_fn, domain='test')
+    assert key == "varargs_fn-{'domain': 'test'}"
+
+
+@pytest.mark.parametrize(
+    'args, kwargs',
+    [
+        (('test', 'extra'), {'count': 1}),
+        (('test',), {'invalid': 1}),
+    ],
+)
+def test_raises_type_error_on_signature_mismatch(args, kwargs):
+    with pytest.raises(TypeError):
+        _ = _get_unique_key('constant', my_func, *args, **kwargs)
+
+
+def test_raises_key_error():
+    with pytest.raises(KeyError):
+        _ = _get_unique_key('{invalid-key}', my_func, 'test', count=99)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Planning to make use of this function in a new decorator similar to `serial_task`, and noticed it relied on a deprecated function, [inspect.getcallargs](https://docs.python.org/3/library/inspect.html#inspect.getcallargs).

This is one less thing we will eventually have to do when upgrading to a version of python that removes support for `inspect.getcallargs` entirely.

## AI Disclosure
The inspiration for this PR came from seeing that `getcallargs` was deprecated _and_ always feeling the friction when attempting to understand what this function was doing. So I asked Claude what it _would_ do it fix it, saw that there seemed to be a reasonable alternative to `getcallargs`, and then went about adding my own tests to cover the existing function, asking Claude to think of any test cases I missed. In the commit to replace `getcallargs`, I took Claude's suggestion, minimizing what code needed change, and then followed up with a mixture of my and Claude's opinion on making things more readable/clear.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
`_get_unique_key` is only used by the `serial_task` decorator at the moment, though we use that in quite a few places. To ensure this is safe, I added a suite of tests prior to making any changes to the function which give me confidence that this will not cause any issues.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests in corehq/apps/celery/tests/test_get_unique_key.py prior to any changes.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
