### PR TITLE
Add concurrent_task decorator

### DIFF
--- a/corehq/apps/celery/__init__.py
+++ b/corehq/apps/celery/__init__.py
@@ -6,6 +6,7 @@ from corehq.apps.celery.analytics import analytics_task  # noqa F401;
 
 # Imported to give an idea of where decorators are defined and
 # we will be importing these decorators from this file in tasks
+from corehq.apps.celery.concurrent import concurrent_task  # noqa F401;
 from corehq.apps.celery.periodic import (  # noqa F401;
     periodic_task,
     periodic_task_when_true,

--- a/corehq/apps/celery/concurrent.py
+++ b/corehq/apps/celery/concurrent.py
@@ -1,3 +1,4 @@
+import random
 from functools import wraps
 
 from corehq.apps.celery.locking import (
@@ -66,8 +67,11 @@ def concurrent_task(
         @wraps(fn)
         def _inner(self, *args, **kwargs):
             key = get_unique_key(unique_key, fn, *args, **kwargs)
+            # Randomize starting slot to avoid contention
+            start = random.randrange(concurrency)
             for i in range(concurrency):
-                slot_key = f'{key}:{i}'
+                slot_index = (start + i) % concurrency
+                slot_key = f'{key}:{slot_index}'
                 try:
                     return run_with_lock(
                         slot_key, fn, timeout, *args, **kwargs

--- a/corehq/apps/celery/concurrent.py
+++ b/corehq/apps/celery/concurrent.py
@@ -1,0 +1,84 @@
+from functools import wraps
+
+from corehq.apps.celery.locking import (
+    CouldNotAcquireLockError,
+    get_unique_key,
+    run_with_lock,
+)
+from corehq.apps.celery.shared_task import task
+
+
+def concurrent_task(
+    unique_key,
+    concurrency,
+    default_retry_delay=30,
+    timeout=5 * 60,
+    max_retries=3,
+    queue='background_queue',
+    ignore_result=True,
+    serializer=None,
+    durable=False,
+):
+    """
+    Define a task that allows up to ``concurrency`` simultaneous runs per
+    resolved key. If all slots are taken, the task retries after a delay.
+
+    Slots are implemented as ``concurrency`` named Redis locks per key:
+    ``{key}:0``, ``{key}:1``, ..., ``{key}:concurrency-1``. Each slot lock
+    inherits the same TTL-based crash safety as :func:`serial_task` -- a
+    worker killed before releasing its slot will have that slot auto-expire
+    after ``timeout``.
+
+    :param unique_key: Format string used to derive the per-call key. May
+        reference any of the wrapped function's arguments. See
+        :func:`serial_task` for the format string conventions.
+    :param concurrency: Maximum number of simultaneous runs allowed per
+        resolved key. Must be >= 1.
+    :param default_retry_delay: Seconds to wait before retrying when no slot
+        is available.
+    :param timeout: Lock TTL in seconds. Must exceed the maximum expected
+        task duration so a still-running task does not have its slot
+        auto-released.
+
+    Usage::
+
+        @concurrent_task("{domain}", concurrency=5, default_retry_delay=10)
+        def rebuild_thing(domain, case_id):
+            ...
+    """
+    if concurrency < 1:
+        raise ValueError('concurrency must be >= 1')
+
+    task_kwargs = {}
+    if serializer:
+        task_kwargs['serializer'] = serializer
+
+    def decorator(fn):
+        @task(
+            bind=True,
+            queue=queue,
+            ignore_result=ignore_result,
+            default_retry_delay=default_retry_delay,
+            max_retries=max_retries,
+            durable=durable,
+            **task_kwargs,
+        )
+        @wraps(fn)
+        def _inner(self, *args, **kwargs):
+            key = get_unique_key(unique_key, fn, *args, **kwargs)
+            for i in range(concurrency):
+                slot_key = f'{key}:{i}'
+                try:
+                    return run_with_lock(
+                        slot_key, fn, timeout, *args, **kwargs
+                    )
+                except CouldNotAcquireLockError:
+                    if i == concurrency - 1:
+                        msg = (
+                            "Could not acquire any of {} slots for key '{}' (task '{}')."
+                        ).format(concurrency, key, fn.__name__)
+                        self.retry(exc=CouldNotAcquireLockError(msg))
+
+        return _inner
+
+    return decorator

--- a/corehq/apps/celery/concurrent.py
+++ b/corehq/apps/celery/concurrent.py
@@ -77,11 +77,11 @@ def concurrent_task(
                         slot_key, fn, timeout, *args, **kwargs
                     )
                 except CouldNotAcquireLockError:
-                    if i == concurrency - 1:
-                        msg = (
-                            "Could not acquire any of {} slots for key '{}' (task '{}')."
-                        ).format(concurrency, key, fn.__name__)
-                        self.retry(exc=CouldNotAcquireLockError(msg))
+                    pass
+            msg = (
+                "Could not acquire any of {} slots for key '{}' (task '{}')."
+            ).format(concurrency, key, fn.__name__)
+            self.retry(exc=CouldNotAcquireLockError(msg))
 
         return _inner
 

--- a/corehq/apps/celery/locking.py
+++ b/corehq/apps/celery/locking.py
@@ -1,0 +1,33 @@
+import inspect
+
+
+class CouldNotAcquireLockError(Exception):
+    """Raised when a serial_task or concurrent_task can't acquire its lock."""
+
+
+def get_unique_key(format_str, fn, *args, **kwargs):
+    """
+    Builds a unique key from the function name and ``format_str``.
+
+    Binds args and kwargs to the function's signature which enables
+    referencing any arg or kwarg by name in ``format_str``
+
+    See corehq.apps.celery.tests.test_get_unique_key for more details.
+    """
+    bound = inspect.signature(fn).bind(*args, **kwargs)
+    bound.apply_defaults()  # ensures bound.arguments includes default values
+    return f'{fn.__name__}-{format_str.format(**bound.arguments)}'
+
+
+def run_with_lock(key, fn, timeout, *args, **kwargs):
+    from dimagi.utils.couch import get_redis_lock, release_lock
+
+    lock = get_redis_lock(key, timeout=timeout, name=fn.__name__)
+    if lock.acquire(blocking=False):
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            release_lock(lock, True)
+    else:
+        msg = f"Could not acquire lock '{key}' for task '{fn.__name__}'"
+        raise CouldNotAcquireLockError(msg)

--- a/corehq/apps/celery/serial.py
+++ b/corehq/apps/celery/serial.py
@@ -1,6 +1,10 @@
-import inspect
 from functools import wraps
 
+from corehq.apps.celery.locking import (
+    CouldNotAcquireLockError,
+    get_unique_key,
+    run_with_lock,
+)
 from corehq.apps.celery.shared_task import task
 
 
@@ -53,44 +57,12 @@ def serial_task(
         )
         @wraps(fn)
         def _inner(self, *args, **kwargs):
-            key = _get_unique_key(unique_key, fn, *args, **kwargs)
+            key = get_unique_key(unique_key, fn, *args, **kwargs)
             try:
-                return _run_with_lock(key, fn, timeout, *args, **kwargs)
+                return run_with_lock(key, fn, timeout, *args, **kwargs)
             except CouldNotAcquireLockError as e:
                 self.retry(exc=e)
 
         return _inner
 
     return decorator
-
-
-def _run_with_lock(key, fn, timeout, *args, **kwargs):
-    from dimagi.utils.couch import get_redis_lock, release_lock
-
-    lock = get_redis_lock(key, timeout=timeout, name=fn.__name__)
-    if lock.acquire(blocking=False):
-        try:
-            return fn(*args, **kwargs)
-        finally:
-            release_lock(lock, True)
-    else:
-        msg = f"Could not acquire lock '{key}' for task '{fn.__name__}'"
-        raise CouldNotAcquireLockError(msg)
-
-
-def _get_unique_key(format_str, fn, *args, **kwargs):
-    """
-    Builds a unique key from the function name and ``format_str``.
-
-    Binds args and kwargs to the function's signature which enables
-    referencing any arg or kwarg by name in ``format_str``
-
-    See corehq.apps.celery.tests.test_get_unique_key for more details.
-    """
-    bound = inspect.signature(fn).bind(*args, **kwargs)
-    bound.apply_defaults()  # ensures bound.arguments includes default values
-    return f"{fn.__name__}-{format_str.format(**bound.arguments)}"
-
-
-class CouldNotAcquireLockError(Exception):
-    """Used when a serial_task is unable to obtain lock to run"""

--- a/corehq/apps/celery/tests/test_concurrent_task.py
+++ b/corehq/apps/celery/tests/test_concurrent_task.py
@@ -86,8 +86,14 @@ def test_acquires_lock_if_slot_available():
     assert lock.acquire(blocking=False)
 
     try:
-        task_with_concurrency.apply(args=['test'])
-        assert _task_calls == ['test']
+        with patch(
+            'dimagi.utils.couch.get_redis_lock', wraps=get_redis_lock
+        ) as mock_get_lock:
+            task_with_concurrency.apply(args=['test'])
+            keys_requested = [
+                call.args[0] for call in mock_get_lock.call_args_list
+            ]
+            assert 'task_with_concurrency-test:1' in keys_requested
     finally:
         release_lock(lock, True)
 

--- a/corehq/apps/celery/tests/test_concurrent_task.py
+++ b/corehq/apps/celery/tests/test_concurrent_task.py
@@ -1,0 +1,111 @@
+import pytest
+from unittest.mock import patch
+from unmagic import fixture, use
+
+from dimagi.utils.couch import get_redis_lock, release_lock
+
+from corehq.apps.celery.locking import CouldNotAcquireLockError
+from corehq.apps.celery.concurrent import concurrent_task
+from corehq.apps.celery.tests.utils import run_with_lock_patch
+from corehq.tests.pytest_plugins.patches import suspend
+
+_task_calls = []
+
+
+@concurrent_task('test', 2)
+def task_with_concurrency(arg):
+    _task_calls.append(arg)
+
+
+@fixture
+def task_calls():
+    yield _task_calls
+    _task_calls.clear()
+
+
+def test_celery_specific_kwargs_bind_to_task():
+    @concurrent_task(
+        'test', 2, max_retries=5, default_retry_delay=50, queue='custom'
+    )
+    def task_no_arg():
+        pass
+
+    assert task_no_arg.max_retries == 5
+    assert task_no_arg.default_retry_delay == 50
+    assert task_no_arg.queue == 'custom'
+
+
+def test_concurrency_minimum():
+    with pytest.raises(ValueError):
+
+        @concurrent_task('test', 0)
+        def too_little_concurrency():
+            pass
+
+
+@use(task_calls)
+@suspend(run_with_lock_patch)
+def test_runs_and_releases_lock():
+    task_with_concurrency.apply(args=['test'])
+    assert _task_calls == ['test']
+    lock = get_redis_lock(
+        'task_with_concurrency-test:0', timeout=5, name='task_with_concurrency'
+    )
+    assert lock.acquire(blocking=False)
+    release_lock(lock, True)
+
+
+@suspend(run_with_lock_patch)
+def test_fails_and_releases_lock():
+    @concurrent_task('test', 2)
+    def raising_task():
+        raise ValueError('error')
+
+    result = raising_task.apply()
+    assert result.failed()
+
+    lock = get_redis_lock(
+        'raising_task-test:0', timeout=5, name='raising_task'
+    )
+    assert lock.acquire(blocking=False)
+    release_lock(lock, True)
+
+
+@use(task_calls)
+@suspend(run_with_lock_patch)
+def test_acquires_lock_if_slot_available():
+    lock = get_redis_lock(
+        'task_with_concurrency-test:0', timeout=5, name='task_with_concurrency'
+    )
+    assert lock.acquire(blocking=False)
+
+    try:
+        task_with_concurrency.apply(args=['test'])
+        assert _task_calls == ['test']
+    finally:
+        release_lock(lock, True)
+
+
+@use(task_calls)
+@suspend(run_with_lock_patch)
+def test_fails_to_acquire_lock():
+    lock1 = get_redis_lock(
+        'task_with_concurrency-test:0', timeout=5, name='task_with_concurrency'
+    )
+    assert lock1.acquire(blocking=False)
+
+    lock2 = get_redis_lock(
+        'task_with_concurrency-test:1', timeout=5, name='task_with_concurrency'
+    )
+    assert lock2.acquire(blocking=False)
+
+    try:
+        with patch.object(task_with_concurrency, 'retry') as retry:
+            task_with_concurrency.apply(args=['test'])
+        assert retry.called
+        exc = retry.call_args.kwargs['exc']
+        assert isinstance(exc, CouldNotAcquireLockError)
+        assert _task_calls == []
+    finally:
+        release_lock(lock1, True)
+        release_lock(lock2, True)

--- a/corehq/apps/celery/tests/test_concurrent_task.py
+++ b/corehq/apps/celery/tests/test_concurrent_task.py
@@ -48,11 +48,15 @@ def test_concurrency_minimum():
 def test_runs_and_releases_lock():
     task_with_concurrency.apply(args=['test'])
     assert _task_calls == ['test']
-    lock = get_redis_lock(
-        'task_with_concurrency-test:0', timeout=5, name='task_with_concurrency'
-    )
-    assert lock.acquire(blocking=False)
-    release_lock(lock, True)
+    # check both slots since initial call could select either
+    for i in range(2):
+        lock = get_redis_lock(
+            f'task_with_concurrency-test:{i}',
+            timeout=5,
+            name='task_with_concurrency',
+        )
+        assert lock.acquire(blocking=False)
+        release_lock(lock, True)
 
 
 @suspend(run_with_lock_patch)
@@ -64,11 +68,13 @@ def test_fails_and_releases_lock():
     result = raising_task.apply()
     assert result.failed()
 
-    lock = get_redis_lock(
-        'raising_task-test:0', timeout=5, name='raising_task'
-    )
-    assert lock.acquire(blocking=False)
-    release_lock(lock, True)
+    # check both slots since initial call could select either
+    for i in range(2):
+        lock = get_redis_lock(
+            f'raising_task-test:{i}', timeout=5, name='raising_task'
+        )
+        assert lock.acquire(blocking=False)
+        release_lock(lock, True)
 
 
 @use(task_calls)

--- a/corehq/apps/celery/tests/test_get_unique_key.py
+++ b/corehq/apps/celery/tests/test_get_unique_key.py
@@ -1,6 +1,6 @@
 import pytest
 
-from corehq.apps.celery.serial import get_unique_key
+from corehq.apps.celery.locking import get_unique_key
 
 
 def my_func(domain, count=100):

--- a/corehq/apps/celery/tests/test_get_unique_key.py
+++ b/corehq/apps/celery/tests/test_get_unique_key.py
@@ -1,6 +1,6 @@
 import pytest
 
-from corehq.apps.celery.serial import _get_unique_key
+from corehq.apps.celery.serial import get_unique_key
 
 
 def my_func(domain, count=100):
@@ -8,27 +8,27 @@ def my_func(domain, count=100):
 
 
 def test_constant_format_string():
-    key = _get_unique_key('some-constant-value', my_func, 'test')
+    key = get_unique_key('some-constant-value', my_func, 'test')
     assert key == 'my_func-some-constant-value'
 
 
 def test_template_format_string():
-    key = _get_unique_key('{domain}', my_func, 'test')
+    key = get_unique_key('{domain}', my_func, 'test')
     assert key == 'my_func-test'
 
 
 def test_multiple_template_format_string():
-    key = _get_unique_key('{domain}-{count}', my_func, 'test', count=99)
+    key = get_unique_key('{domain}-{count}', my_func, 'test', count=99)
     assert key == 'my_func-test-99'
 
 
 def test_default_value_applied():
-    key = _get_unique_key('{domain}-{count}', my_func, 'test')
+    key = get_unique_key('{domain}-{count}', my_func, 'test')
     assert key == 'my_func-test-100'
 
 
 def test_arg_passed_as_kwarg():
-    key = _get_unique_key('{domain}-{count}', my_func, domain='test', count=99)
+    key = get_unique_key('{domain}-{count}', my_func, domain='test', count=99)
     assert key == 'my_func-test-99'
 
 
@@ -36,10 +36,10 @@ def test_varargs_function():
     def varargs_fn(*args, **kwargs):
         pass
 
-    key = _get_unique_key('{args}', varargs_fn, 1, 2, 3)
+    key = get_unique_key('{args}', varargs_fn, 1, 2, 3)
     assert key == 'varargs_fn-(1, 2, 3)'
 
-    key = _get_unique_key('{kwargs}', varargs_fn, domain='test')
+    key = get_unique_key('{kwargs}', varargs_fn, domain='test')
     assert key == "varargs_fn-{'domain': 'test'}"
 
 
@@ -52,9 +52,9 @@ def test_varargs_function():
 )
 def test_raises_type_error_on_signature_mismatch(args, kwargs):
     with pytest.raises(TypeError):
-        _ = _get_unique_key('constant', my_func, *args, **kwargs)
+        _ = get_unique_key('constant', my_func, *args, **kwargs)
 
 
 def test_raises_key_error():
     with pytest.raises(KeyError):
-        _ = _get_unique_key('{invalid-key}', my_func, 'test', count=99)
+        _ = get_unique_key('{invalid-key}', my_func, 'test', count=99)

--- a/corehq/apps/celery/tests/test_serial_task.py
+++ b/corehq/apps/celery/tests/test_serial_task.py
@@ -3,7 +3,8 @@ from unmagic import fixture, use
 
 from dimagi.utils.couch import get_redis_lock, release_lock
 
-from corehq.apps.celery.serial import CouldNotAcquireLockError, serial_task
+from corehq.apps.celery.locking import CouldNotAcquireLockError
+from corehq.apps.celery.serial import serial_task
 from corehq.apps.celery.tests.utils import run_with_lock_patch
 from corehq.tests.pytest_plugins.patches import suspend
 

--- a/corehq/apps/celery/tests/utils.py
+++ b/corehq/apps/celery/tests/utils.py
@@ -8,7 +8,7 @@ def _bypass_run_with_lock(key, fn, timeout, *args, **kwargs):
 
 
 run_with_lock_patch = patch(
-    'corehq.apps.celery.serial._run_with_lock', _bypass_run_with_lock
+    'corehq.apps.celery.locking.run_with_lock', _bypass_run_with_lock
 )
 
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-18551

We currently have a `serial_task` decorator, which ensures that only one task of a given type and unique key will be handled at a time. This can be used to limit a task across the entire environment (e.g., [queue_scheduled_reports](https://github.com/dimagi/commcare-hq/blob/a99fa598a42eb7187c738d5d8f074780cd8874d9/corehq/apps/locations/tasks.py#L50-L52)) or to limit a task for a specific domain (e.g., [import_locations_async](https://github.com/dimagi/commcare-hq/blob/a99fa598a42eb7187c738d5d8f074780cd8874d9/corehq/apps/saved_reports/tasks.py#L94-L95)).

This builds on that idea, but allows for running multiple tasks of a given type and unique key at a time, up to some limit. This does go against the philosophy of "if we have the capacity to process a domain's request, we should do it" since this has a hard cap on concurrency. However I think it makes for simpler code and more predictable workloads which can be beneficial. All that to say, we should be considerate of when we are using this decorator versus other options we have (rate limiting, etc) for keeping workloads in check.

Notably, setting concurrency to 1 effectively replaces `serial_task`. In a followup PR, I plan to make `serial_task` a pass through to this logic since the clear naming is still helpful, but we don't need two implementations.  
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Not in use yet, so this PR alone is very safe, but the PR that introduces the first usage of this will be in uncharted territory (will test this on staging of course though).

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Added tests for this task similar to the existing tests for `serial_task`. Tests are in corehq/apps/celery/tests/test_concurrent_task.py. 

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
