### PR TITLE
Unconditionally require api key for api access for all SSO users

### DIFF
--- a/corehq/apps/api/odata/tests/test_auth.py
+++ b/corehq/apps/api/odata/tests/test_auth.py
@@ -36,7 +36,6 @@ class TestOdataAuth(TestCase, CaseOdataTestMixin):
         cls.idp = sso_generator.create_idp('odata-sso-test', cls.account)
         cls.idp.is_active = True
         cls.idp.login_enforcement_type = LoginEnforcementType.GLOBAL
-        cls.idp.require_api_key_for_api_access = True
         cls.idp.save()
         cls.addClassCleanup(cls.idp.delete)
         cls.sso_email_domain = AuthenticatedEmailDomain.objects.create(

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -550,7 +550,7 @@ def _sso_required(request):
     username = couch_user.username if couch_user else None
     if username:
         idp = IdentityProvider.get_required_identity_provider(username)
-        if idp and idp.require_api_key_for_api_access:
+        if idp:
             return True
     return False
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -531,11 +531,9 @@ def sso_check(view_func, api_key):
     def _outer(fn):
         @wraps(fn)
         def _inner(request, domain, *args, **kwargs):
-            domain_obj = Domain.get_by_name(domain)
             _ensure_request_couch_user(request)
             if (
                 not api_key
-                and domain_obj
                 and not getattr(request, 'api_key_authenticated', False)
                 and _sso_required(request)
             ):

--- a/corehq/apps/domain/tests/test_api_key_auth.py
+++ b/corehq/apps/domain/tests/test_api_key_auth.py
@@ -108,7 +108,6 @@ class SSOApiAuthenticationTest(AuthenticationTestBase):
         cls.idp = sso_generator.create_idp('sso-api-test', cls.account)
         cls.idp.is_active = True
         cls.idp.login_enforcement_type = LoginEnforcementType.GLOBAL
-        cls.idp.require_api_key_for_api_access = True
         cls.idp.save()
         AuthenticatedEmailDomain.objects.create(
             email_domain='ssocompany.com',


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Unconditionally require api key for api access for all SSO users.
The field was added initially for one specific customer who make the request, and to keep the api auth behavior unchanged for other customers.
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
A preliminary step of removing `require_api_key_for_api_access` field

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Just remove the check so api key will always be required for all SSO users. Given `require_api_key_for_api_access` has already been set to `True` manually for all identity providers for a while. Thus this change actually has no user impact.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations
If revert, [the migration PR that removes the field from Django](https://github.com/dimagi/commcare-hq/pull/37766) has to be reverted and deployed first.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
