### PR TITLE
Enable daily cleanup of soft deleted forms after 90 days

### DIFF
--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -26,8 +26,8 @@ logger = logging.getLogger(__name__)
 SENTINEL_DOMAIN = object()
 
 
-# @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
-def purge_expired_data(dry_run=True):
+@periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
+def purge_expired_data(dry_run=False):
     """
     Permanently delete data with a ``deleted_on`` value older than
     ``settings.DATA_RETENTION_WINDOW`` days.

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -27,24 +27,17 @@ SENTINEL_DOMAIN = object()
 
 
 # @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
-def permanently_delete_eligible_data(dry_run=True):
+def purge_expired_data(dry_run=True):
     """
-    Permanently delete database objects that are eligible for hard deletion.
-    To be eligible an object must have a ``deleted_on`` value
-    older than the settings.DATA_RETENTION_WINDOW
+    Permanently delete data with a ``deleted_on`` value older than
+    ``settings.DATA_RETENTION_WINDOW`` days.
     :param dry_run: if True, no changes will be committed to the database
-    """
-    """
-    NOTE: Do not delete this function! In the interest of keeping deletion records for future reference,
-    data won't be completely hard deleted until the domain is deleted. Instead, they'll be converted
-    into a tombstone after the 90 day safety period. This task will be restructured to do that once a day
-    in a future PR coming soon (Q1 2024).
     """
     dry_run_tag = '[DRY RUN] ' if dry_run else ''
     commit = not dry_run
     form_counts = XFormInstance.objects.hard_delete_expired_forms(commit=commit)
     logger.info(
-        f"{dry_run_tag}'permanently_delete_eligible_data' deleted {form_counts} XFormInstance objects."
+        f"{dry_run_tag}'purge_expired_data' deleted {form_counts} XFormInstance objects."
     )
 
 

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -43,10 +43,9 @@ def permanently_delete_eligible_data(dry_run=True):
     dry_run_tag = '[DRY RUN] ' if dry_run else ''
     commit = not dry_run
     form_counts = XFormInstance.objects.hard_delete_expired_forms(commit=commit)
-
-    logger.info(f"{dry_run_tag}'permanently_delete_eligible_data' ran with the following results:\n")
-    for table, count in form_counts.items():
-        logger.info(f"{dry_run_tag}{count} {table} objects were deleted.")
+    logger.info(
+        f"{dry_run_tag}'permanently_delete_eligible_data' deleted {form_counts} XFormInstance objects."
+    )
 
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))

--- a/corehq/apps/cleanup/tests/test_tasks.py
+++ b/corehq/apps/cleanup/tests/test_tasks.py
@@ -5,27 +5,26 @@ from time_machine import travel
 
 from django.test import TestCase, override_settings
 
-from corehq.apps.cleanup.tasks import permanently_delete_eligible_data
+from corehq.apps.cleanup.tasks import purge_expired_data
 from corehq.form_processor.exceptions import XFormNotFound
 from corehq.form_processor.models import XFormInstance
 from corehq.form_processor.tests.utils import create_form_for_test
 
 
-class TestPermanentlyDeleteEligibleData(TestCase):
+class TestPurgeExpiredData(TestCase):
     """
-    This serves as a general smoke test. To see specific tests, see:
-    - corehq.form_processor.tests.test_forms.TestHardDeleteFormsBeforeCutoff
+    This serves as a general smoke test. More comprehensive tests should
+    exist for each table that is eligible for hard deletion.
+    (e.g., corehq.form_processor.tests.test_forms.TestHardDeleteExpiredForms)
     """
-
-    def setUp(self):
-        self.domain = 'test_permanently_delete_eligible_data'
+    domain = 'test_purge_expired_data'
 
     @travel('2020-01-10')
     def test_deletes_data_outside_of_retention_window(self):
         form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 2))
 
         with override_settings(DATA_RETENTION_WINDOW=7):
-            permanently_delete_eligible_data(dry_run=False)
+            purge_expired_data(dry_run=False)
 
         with pytest.raises(XFormNotFound):
             XFormInstance.objects.get_form(form.form_id)
@@ -35,7 +34,7 @@ class TestPermanentlyDeleteEligibleData(TestCase):
         form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 4))
 
         with override_settings(DATA_RETENTION_WINDOW=7):
-            permanently_delete_eligible_data(dry_run=False)
+            purge_expired_data(dry_run=False)
 
         assert XFormInstance.objects.get_form(form.form_id) is not None
 
@@ -44,6 +43,6 @@ class TestPermanentlyDeleteEligibleData(TestCase):
         form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 2))
 
         with override_settings(DATA_RETENTION_WINDOW=7):
-            permanently_delete_eligible_data(dry_run=True)
+            purge_expired_data(dry_run=True)
 
         assert XFormInstance.objects.get_form(form.form_id) is not None

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -1,5 +1,6 @@
 import logging
-from collections import Counter, defaultdict
+from collections import defaultdict
+
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from io import BytesIO
@@ -380,15 +381,23 @@ class XFormInstanceManager(RequireDBManager):
         :param commit: defaults to False. If True, will delete expired forms
         :return: dictionary of count of deleted forms
         """
+        from corehq.apps.cleanup.tasks import SENTINEL_DOMAIN
+
         expiration_date = get_cutoff_date_for_data_deletion()
-        total_count = Counter({})
+        total_count = 0
         for db_name in get_db_aliases_for_partitioned_query():
-            queryset = self.using(db_name).filter(deleted_on__lt=expiration_date)
+            queryset = (
+                self.using(db_name)
+                .filter(deleted_on__lt=expiration_date)
+                .values_list('form_id', flat=True)
+            )
             if commit:
-                deleted_counts = queryset.delete()[1]
+                deleted_count = self.hard_delete_forms(
+                    SENTINEL_DOMAIN, list(queryset)
+                )
             else:
-                deleted_counts = {'form_processor.XFormInstance': queryset.count()}
-            total_count += Counter(deleted_counts)
+                deleted_count = queryset.count()
+            total_count += deleted_count
         return total_count
 
     def hard_delete_forms(self, domain, form_ids, *, publish_changes=True, leave_tombstones=True):

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -390,7 +390,7 @@ class TestHardDeleteExpiredForms(TestCase):
         with override_settings(DATA_RETENTION_WINDOW=7):
             count = XFormInstance.objects.hard_delete_expired_forms(commit=True)
 
-        assert count == {'form_processor.XFormInstance': 1}
+        assert count == 1
         assert XFormInstance.objects.partitioned_get(valid_form.form_id)
         assert XFormInstance.objects.partitioned_get(soft_deleted_form.form_id)
         with pytest.raises(XFormInstance.DoesNotExist):
@@ -405,7 +405,7 @@ class TestHardDeleteExpiredForms(TestCase):
         with override_settings(DATA_RETENTION_WINDOW=7):
             count = XFormInstance.objects.hard_delete_expired_forms()
 
-        assert count == {'form_processor.XFormInstance': 1}
+        assert count == 1
         assert XFormInstance.objects.partitioned_get(valid_form.form_id)
         assert XFormInstance.objects.partitioned_get(soft_deleted_form.form_id)
         assert XFormInstance.objects.partitioned_get(expired_form.form_id)
@@ -423,8 +423,8 @@ class TestHardDeleteExpiredForms(TestCase):
             dry_run_counts = XFormInstance.objects.hard_delete_expired_forms()
             actual_counts = XFormInstance.objects.hard_delete_expired_forms(commit=True)
 
-        assert dry_run_counts == {'form_processor.XFormInstance': 5}
-        assert actual_counts == {'form_processor.XFormInstance': 5}
+        assert dry_run_counts == 5
+        assert actual_counts == 5
 
 
 @sharded


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15221

This is an intentionally less efficient implementation in that we fetch the form ids for forms deleted more than 90 days ago, and then pass that into `hard_delete_forms` which then calls delete. This could be done in one db delete request, but the goal is to keep the shared code simple and consistent to ensure when forms are deleted, tombstones are created, and blobs are deleted.

I toyed with passing the queryset down before execution from both entry points, where one queryset filters by deleted_on and the other by form_ids, but since we have to iterate over each form being deleted to create a tombstone anyway, the added complexity didn't seem worth it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
