### PR TITLE
Survive transient DB disconnects during long batch iterations

### DIFF
--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -110,10 +110,10 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False):
 
     pk_field = model_cls._meta.pk.name
     queryset = queryset.order_by(pk_field)
-    docs = queryset[:limit]
-    while docs:
-        for doc in docs:
+    chunk = queryset[:limit]
+    while chunk:
+        for doc in chunk:
             yield doc
 
         last_doc_pk = getattr(doc, pk_field)
-        docs = queryset.filter(**{pk_field + "__gt": last_doc_pk})[:limit]
+        chunk = queryset.filter(**{pk_field + "__gt": last_doc_pk})[:limit]

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -110,10 +110,21 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False):
 
     pk_field = model_cls._meta.pk.name
     queryset = queryset.order_by(pk_field)
-    chunk = queryset[:limit]
-    while chunk:
+    last_doc_pk = None
+    while True:
+        if last_doc_pk is None:
+            chunk_qs = queryset
+        else:
+            chunk_qs = queryset.filter(**{pk_field + "__gt": last_doc_pk})
+        chunk = _fetch_chunk(chunk_qs, limit)
+        if not chunk:
+            return
         for doc in chunk:
             yield doc
 
         last_doc_pk = getattr(doc, pk_field)
-        chunk = queryset.filter(**{pk_field + "__gt": last_doc_pk})[:limit]
+
+
+def _fetch_chunk(queryset, limit):
+    """Materialize one page of ``queryset``. Patch point for tests."""
+    return list(queryset[:limit])

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -1,8 +1,17 @@
+import logging
 import re
+import time
 
 from django.core.paginator import Paginator
 from django.core.paginator import EmptyPage
-from django.db import DEFAULT_DB_ALIAS
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.utils import InterfaceError, OperationalError
+
+logger = logging.getLogger(__name__)
+
+_CHUNK_RETRY_EXCEPTIONS = (OperationalError, InterfaceError)
+# Tuned for batch jobs: rides out a DB outage of up to ~31 minutes total.
+_CHUNK_RETRY_DELAYS = (1, 2, 4, 8, 15, 30, 60, 2 * 60, 4 * 60, 8 * 60, 15 * 60)
 
 
 def fast_distinct(model_cls, column, using=DEFAULT_DB_ALIAS):
@@ -103,6 +112,9 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False):
     """
     Pull from queryset in chunks. This is suitable for deep pagination, but
     cannot be used with ordered querysets (results will be sorted by pk).
+
+    Retries on transient database connection failures (bounded at ~31
+    minutes total) so long-running iterations survive brief outages.
     """
     if queryset.ordered and not ignore_ordering:
         raise AssertionError("queryset_to_iterator does not respect ordering.  "
@@ -116,7 +128,7 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False):
             chunk_qs = queryset
         else:
             chunk_qs = queryset.filter(**{pk_field + "__gt": last_doc_pk})
-        chunk = _fetch_chunk(chunk_qs, limit)
+        chunk = _fetch_chunk_with_retry(chunk_qs, limit, model_cls, last_doc_pk)
         if not chunk:
             return
         for doc in chunk:
@@ -128,3 +140,27 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False):
 def _fetch_chunk(queryset, limit):
     """Materialize one page of ``queryset``. Patch point for tests."""
     return list(queryset[:limit])
+
+
+def _fetch_chunk_with_retry(queryset, limit, model_cls, last_doc_pk):
+    max_attempts = len(_CHUNK_RETRY_DELAYS) + 1
+    for attempt in range(max_attempts):
+        try:
+            return _fetch_chunk(queryset, limit)
+        except _CHUNK_RETRY_EXCEPTIONS as exc:
+            if attempt == max_attempts - 1:
+                logger.error(
+                    f"queryset_to_iterator: giving up on {model_cls.__name__} "
+                    f"after {attempt + 1} attempts "
+                    f"(last_doc_pk={last_doc_pk!r}): {exc}"
+                )
+                raise
+            delay = _CHUNK_RETRY_DELAYS[attempt]
+            logger.warning(
+                f"queryset_to_iterator: {type(exc).__name__} fetching "
+                f"{model_cls.__name__} chunk (last_doc_pk={last_doc_pk!r}, "
+                f"attempt {attempt + 1}/{max_attempts}); closing connection "
+                f"and retrying in {delay}s: {exc}"
+            )
+            connections[queryset.db].close()
+            time.sleep(delay)

--- a/corehq/util/tests/test_queries.py
+++ b/corehq/util/tests/test_queries.py
@@ -1,6 +1,11 @@
+from unittest.mock import patch
+
 from django.contrib.auth.models import User
+from django.db import connections
+from django.db.utils import InterfaceError, OperationalError
 from django.test.testcases import TestCase
 
+from corehq.util import queries
 from corehq.util.queries import queryset_to_iterator
 
 
@@ -47,3 +52,80 @@ class TestQuerysetToIterator(TestCase):
             [u.username for u in all_users],
             [u.username for u in self.users],
         )
+
+    def test_retries_chunk_fetch_on_operational_error(self):
+        query = User.objects.filter(last_name="Tenenbaum")
+        real_fetch = queries._fetch_chunk
+        calls = []
+
+        def flaky_fetch(queryset, limit):
+            calls.append(1)
+            if len(calls) == 1:
+                raise OperationalError("simulated pgbouncer disconnect")
+            return real_fetch(queryset, limit)
+
+        with patch.object(queries, '_fetch_chunk', side_effect=flaky_fetch), \
+                patch.object(queries.time, 'sleep') as mock_sleep, \
+                patch.object(connections['default'], 'close') as mock_close:
+            result = list(queryset_to_iterator(query, User, limit=4))
+
+        assert len(result) == 10
+        assert len(calls) >= 2  # at least one retry happened
+        mock_close.assert_called()
+        mock_sleep.assert_called_with(1)  # first backoff
+
+    def test_retries_resume_from_last_doc_pk_without_duplicates(self):
+        query = User.objects.filter(last_name="Tenenbaum")
+        real_fetch = queries._fetch_chunk
+        calls = []
+
+        def flaky_fetch(queryset, limit):
+            calls.append(1)
+            # Fail on the 2nd chunk fetch, succeed on retry
+            if len(calls) == 2:
+                raise OperationalError("disconnect mid-iteration")
+            return real_fetch(queryset, limit)
+
+        with patch.object(queries, '_fetch_chunk', side_effect=flaky_fetch), \
+                patch.object(queries.time, 'sleep'), \
+                patch.object(connections['default'], 'close'):
+            result = list(queryset_to_iterator(query, User, limit=4))
+
+        assert [u.username for u in result] == [u.username for u in self.users]
+
+    def test_gives_up_after_max_attempts(self):
+        query = User.objects.filter(last_name="Tenenbaum")
+
+        def always_fail(queryset, limit):
+            raise OperationalError("permanent failure")
+
+        with patch.object(queries, '_fetch_chunk', side_effect=always_fail), \
+                patch.object(queries.time, 'sleep') as mock_sleep, \
+                patch.object(connections['default'], 'close') as mock_close, \
+                self.assertRaises(OperationalError):
+            list(queryset_to_iterator(query, User, limit=4))
+
+        # One sleep + one close between each pair of attempts, none after the last.
+        assert mock_sleep.call_count == len(queries._CHUNK_RETRY_DELAYS)
+        assert mock_close.call_count == len(queries._CHUNK_RETRY_DELAYS)
+        # And the full backoff schedule was walked in order.
+        actual_delays = [call.args[0] for call in mock_sleep.call_args_list]
+        assert actual_delays == list(queries._CHUNK_RETRY_DELAYS)
+
+    def test_retries_on_interface_error(self):
+        query = User.objects.filter(last_name="Tenenbaum")
+        real_fetch = queries._fetch_chunk
+        calls = []
+
+        def flaky_fetch(queryset, limit):
+            calls.append(1)
+            if len(calls) == 1:
+                raise InterfaceError("connection already closed")
+            return real_fetch(queryset, limit)
+
+        with patch.object(queries, '_fetch_chunk', side_effect=flaky_fetch), \
+                patch.object(queries.time, 'sleep'), \
+                patch.object(connections['default'], 'close'):
+            result = list(queryset_to_iterator(query, User, limit=4))
+
+        assert len(result) == 10


### PR DESCRIPTION
## Product Description

Long-running batch commands that iterate large SQL tables — `dump_domain_data`, `run_blob_export`, the deactivate-mobile-worker celery task, and similar — now survive transient pgBouncer disconnects instead of dying part-way through and forcing a from-scratch re-run.

## Technical Summary

Currently, both `dump_domain_data` and `run_blob_export` die on `OperationalError: server closed the connection unexpectedly` if the connection to pgBouncer drops mid-query (machine restart, network blip).

`queryset_to_iterator` already paginates with `pk > last_doc_pk LIMIT n`, making each chunk independently re-issuable; this PR wraps each chunk fetch in a bounded retry (up to 12 attempts, backoff 1s → 15m, ~31 min total budget). Between attempts the cached Django connection is closed so the next try opens a fresh socket to pgBouncer — same pattern as the existing `corehq.sql_db.util.handle_connection_failure`. Because retries re-issue the same `pk > last_doc_pk` query, they resume without duplicates or gaps.

The three commits split rename → refactor → behavior change so each is reviewable in isolation.

## Feature Flag

N/A.

## Safety Assurance

### Safety story

- Only retries on `OperationalError` / `InterfaceError`; programming errors still surface immediately.
- Bounded at 12 attempts / ~31 min total sleep — long enough to ride out a real pgBouncer outage, short enough that a permanent outage doesn't hang forever.
- Used by batch jobs only (dump/reload, celery tasks, management commands); long waits are appropriate there.

### Automated test coverage

Four new tests in `corehq/util/tests/test_queries.py` covering: transient `OperationalError` recovered; failure mid-iteration resumes without duplicates; permanent failure gives up after walking the full backoff schedule; `InterfaceError` also recovered. All 7 tests in the file pass locally.

### QA Plan

No QA needed — internal infrastructure exercised the next time a large dump runs.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
