### PR TITLE
Stop setting SPLIT_SCREEN_CASE_SEARCH by default

### DIFF
--- a/corehq/apps/hqwebapp/session_details_endpoint/tests.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/tests.py
@@ -32,7 +32,7 @@ class SessionDetailsViewTest(TestCase):
             'authToken': None,
             'domains': [cls.domain.name],
             'anonymous': False,
-            'enabled_toggles': ['SPLIT_SCREEN_CASE_SEARCH'],
+            'enabled_toggles': [],
             'enabled_previews': [],
         }
         cls.url = reverse('session_details')
@@ -213,7 +213,7 @@ class SessionDetailsViewTest(TestCase):
         response = _post_with_hmac(self.url, data, content_type="application/json")
         self.assertEqual(200, response.status_code)
         expected_response = self.expected_response.copy()
-        expected_response['enabled_toggles'] = ['SECURE_SESSION_TIMEOUT', 'SPLIT_SCREEN_CASE_SEARCH']
+        expected_response['enabled_toggles'] = ['SECURE_SESSION_TIMEOUT']
         expected_response['enabled_previews'] = ['CALC_XPATHS']
         self.assertJSONEqual(response.content, expected_response)
 

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -75,8 +75,6 @@ class SessionDetailsView(View):
             domains.update(EnterprisePermissions.get_domains(member_domain))
 
         enabled_toggles = toggles_enabled_for_user(user.username) | toggles_enabled_for_domain(domain)
-        # This is being released, add here until formplayer references are removed:
-        enabled_toggles.add('SPLIT_SCREEN_CASE_SEARCH')
         enabled_previews = previews_enabled_for_domain(domain)
         end_time = datetime.now()
         metrics_histogram("commcare.session_details.processing_time",


### PR DESCRIPTION
## Product Description

No user facing changes

## Technical Summary

Formplayer has been updated and does not check for the FF anymore. So there is no need to set it.

https://dimagi.atlassian.net/browse/USH-6544

## Feature Flag

None

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

Updated tests

### QA Plan

Check that split screen case search still works on staging

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
