### PR TITLE
Remove require_api_key_for_api_access field

### DIFF
--- a/corehq/apps/sso/migrations/0010_remove_identityprovider_require_api_key_for_api_access.py
+++ b/corehq/apps/sso/migrations/0010_remove_identityprovider_require_api_key_for_api_access.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('sso', '0009_identityprovider_require_api_key_for_api_access'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name='identityprovider',
+                    name='require_api_key_for_api_access',
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE sso_identityprovider "
+                        "ALTER COLUMN require_api_key_for_api_access SET DEFAULT FALSE;",
+                    reverse_sql="ALTER TABLE sso_identityprovider "
+                                "ALTER COLUMN require_api_key_for_api_access DROP DEFAULT;",
+                ),
+            ],
+        ),
+    ]

--- a/corehq/apps/sso/models.py
+++ b/corehq/apps/sso/models.py
@@ -168,7 +168,6 @@ class IdentityProvider(models.Model):
     max_days_until_user_api_key_expiration = models.IntegerField(
         default=None, null=True, blank=True, choices=VALID_API_EXPIRATION_OPTIONS
     )
-    require_api_key_for_api_access = models.BooleanField(default=False)
 
     class Meta:
         app_label = 'sso'

--- a/migrations.lock
+++ b/migrations.lock
@@ -1238,6 +1238,7 @@ sso
  0007_add_multi_view_api_fields
  0008_alter_identityprovider_idp_type
  0009_identityprovider_require_api_key_for_api_access
+ 0010_remove_identityprovider_require_api_key_for_api_access
 start_enterprise
  0001_initial
 stock


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
After https://github.com/dimagi/commcare-hq/pull/37761, this field is no longer used thus can be removed.

I'm adopting a two-phase approach [as described in this post](https://www.snopoke.com/2026/01/21/django-field-removal/)
This PR is just Phase 1: Remove from Django, Keep in Database

> In order for Phase 1 to work, the field in the database must be nullable or have a default value configured in the DB (you have to use [db_default](https://docs.djangoproject.com/en/dev/ref/models/fields/#db-default) in Django to set this). Without this any inserts into the table from between Phase 1 and Phase 2 will result in an error.

And because the field doesn't have a default value in db level, so in this migration I also set a default value.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Have tried locally. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code. Pay particular attention to _backward incompatible_ operations like `RemoveField`, `RenameField`, `RemoveConstraint`, and [others described here](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md) that can cause errors when migrations are applied to a live database.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

To revert this PR, [the PR that delete the column from db level](https://github.com/dimagi/commcare-hq/pull/37769) has to be reverted and deployed first.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
