### PR TITLE
UI improvement for the "Temporarily disable two-factor authentication" page

### DIFF
--- a/corehq/apps/hqadmin/forms.py
+++ b/corehq/apps/hqadmin/forms.py
@@ -228,11 +228,12 @@ class DisableTwoFactorForm(forms.Form):
         help_text="If you verified the request via someone else please enter their email address."
     )
     disable_for_days = forms.IntegerField(
-        label=_("Days to allow access"),
+        label=_("Days of temporary access"),
         min_value=0,
         max_value=30,
         help_text=_(
-            "Number of days the user can access CommCare HQ before needing to re-enable two-factor auth."
+            "Number of days the user can access a Two-Factor Authentication enforced domain without "
+            "setting up two-factor authentication again. "
             "This is useful if someone has lost their phone and can't immediately re-setup two-factor auth.")
     )
 

--- a/corehq/apps/hqadmin/forms.py
+++ b/corehq/apps/hqadmin/forms.py
@@ -250,13 +250,10 @@ class DisableTwoFactorForm(forms.Form):
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
 
         self.helper.layout = crispy.Layout(
-            crispy.Fieldset(
-                _("Basic Information"),
-                crispy.Field('username'),
-                crispy.Field('verification_mode'),
-                crispy.Field('via_who'),
-                crispy.Field('disable_for_days'),
-            ),
+            crispy.Field('username'),
+            crispy.Field('verification_mode'),
+            crispy.Field('via_who'),
+            crispy.Field('disable_for_days'),
             hqcrispy.FormActions(
                 crispy.Submit(
                     "disable",

--- a/corehq/apps/hqadmin/forms.py
+++ b/corehq/apps/hqadmin/forms.py
@@ -259,7 +259,7 @@ class DisableTwoFactorForm(forms.Form):
             hqcrispy.FormActions(
                 crispy.Submit(
                     "disable",
-                    _("Disable"),
+                    _("Reset Two-Factor Authentication"),
                     css_class="btn btn-danger",
                 ),
                 css_class='modal-footer',

--- a/corehq/apps/hqadmin/templates/hqadmin/disable_two_factor.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/disable_two_factor.html
@@ -5,9 +5,12 @@
 {% block title %}{{ current_page.page_name }}{% endblock %}
 
 {% block page_content %}
-  <p>{% blocktrans %}You are about to reset two-factor authentication for {{ username }}. This permanently
-    deletes the user's existing two-factor authentication and cannot be undone, so it compromises their account
-    security. Are you sure?{% endblocktrans %}</p>
+  <div class="alert alert-danger">
+    <i class="fa fa-warning"></i>
+    {% blocktrans %}You are about to reset two-factor authentication for <strong>{{ username }}</strong>. This
+    permanently deletes the user's existing two-factor authentication and cannot be undone, so it compromises
+    their account security. Are you sure?{% endblocktrans %}
+  </div>
   <div class="alert alert-warning">
     <p>When resetting Two-Factor Auth it is important to verify that the request was made by the owner of the account (and not faked by someone else).</p>
     <p>Please follow the <a href="https://confluence.dimagi.com/pages/viewpage.action?pageId=27362739#Two-StepAuthentication(2FA)-StepsforsupporttoresetCommCareHQaccount">guidelines on the wiki</a>.</p>

--- a/corehq/apps/hqadmin/templates/hqadmin/disable_two_factor.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/disable_two_factor.html
@@ -5,10 +5,11 @@
 {% block title %}{{ current_page.page_name }}{% endblock %}
 
 {% block page_content %}
-  <p>{% blocktrans %}You are about to temporarily disable two-factor authentication for {{ username }}. This
-    compromises their account security, are you sure?{% endblocktrans %}</p>
+  <p>{% blocktrans %}You are about to reset two-factor authentication for {{ username }}. This permanently
+    deletes the user's existing two-factor authentication and cannot be undone, so it compromises their account
+    security. Are you sure?{% endblocktrans %}</p>
   <div class="alert alert-warning">
-    <p>When temporarily disabling and resetting Two-Factor Auth it is important to verify that the request was made by the owner of the account (and not faked by someone else).</p>
+    <p>When resetting Two-Factor Auth it is important to verify that the request was made by the owner of the account (and not faked by someone else).</p>
     <p>Please follow the <a href="https://confluence.dimagi.com/pages/viewpage.action?pageId=27362739#Two-StepAuthentication(2FA)-StepsforsupporttoresetCommCareHQaccount">guidelines on the wiki</a>.</p>
   </div>
   {% crispy form %}

--- a/corehq/apps/hqadmin/templates/hqadmin/disable_two_factor.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/disable_two_factor.html
@@ -13,7 +13,7 @@
   </div>
   <div class="alert alert-warning">
     <p>When resetting Two-Factor Auth it is important to verify that the request was made by the owner of the account (and not faked by someone else).</p>
-    <p>Please follow the <a href="https://confluence.dimagi.com/pages/viewpage.action?pageId=27362739#Two-StepAuthentication(2FA)-StepsforsupporttoresetCommCareHQaccount">guidelines on the wiki</a>.</p>
+    <p>Please follow the <a href="https://dimagi.atlassian.net/wiki/spaces/cc/pages/2146611542/Validating+Requests+Resetting+External+Users+2FA+-+Support+Steps">guidelines on the wiki</a>.</p>
   </div>
   {% crispy form %}
 {% endblock %}

--- a/corehq/apps/hqadmin/templates/hqadmin/email/two_factor_reset_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email/two_factor_reset_email.html
@@ -1,8 +1,10 @@
-<p>Two-Factor authentication for your account on CommCare has been reset.</p>
+<p>Two-Factor authentication for your account on CommCare has been reset. Your previous
+  two-factor device has been removed.</p>
 
 <p>
   {% if until %}
-    You have until <b>{{ until }}</b> to re-enable Two-Factor Authentication
+    You can log in to two-factor-required projects without a token until <b>{{ until }}</b>.
+    Please set up Two-Factor Authentication again before then.
   {% else %}
     You will need to reconfigure Two-Factor Authentication before you can start using CommCare again.
   {% endif %}

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -47,17 +47,17 @@
       <a
         class="btn btn-default"
         href="{{ audit_report_url }}?username={{ web_user.username|urlencode }}"
-        >View User Audit Report</a
+        >{% trans "View User Audit Report" %}</a
       >
       <a
         class="btn btn-default"
         href="{% url 'disable_user' %}?username={{ web_user.username|urlencode }}"
-        >Disable/Enable User Account</a
+        >{% trans "Disable/Enable User Account" %}</a
       >
       <a
         class="btn btn-default {% if not has_two_factor %}disabled{% endif %}"
         href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}"
-        >Reset Two-Factor Authentication</a
+        >{% trans "Reset Two-Factor Authentication" %}</a
       >
       {% if web_user.is_staff %}
         <button

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -57,7 +57,7 @@
       <a
         class="btn btn-default {% if not has_two_factor %}disabled{% endif %}"
         href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}"
-        >Temporarily Disable Two-Factor Authentication</a
+        >Reset Two-Factor Authentication</a
       >
       {% if web_user.is_staff %}
         <button

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -739,7 +739,7 @@ class DisableTwoFactorView(FormView):
 
     def render_to_response(self, context, **response_kwargs):
         context.update({
-            **get_breadcrumbs('Temporarily Disable Two-factor Authentication', self.urlname),
+            **get_breadcrumbs('Reset Two-Factor Authentication', self.urlname),
             'username': self.request.GET.get("q"),
         })
         return super().render_to_response(context, **response_kwargs)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Before
<img width="645" height="506" alt="Screenshot 2026-05-28 at 10 14 06 AM" src="https://github.com/user-attachments/assets/281ee9b6-9cd0-43ab-b42f-09eace3aa1f0" />

After
<img width="564" height="300" alt="Screenshot 2026-05-28 at 10 18 28 AM" src="https://github.com/user-attachments/assets/bc64c46c-4fd3-4826-9d10-0fab97b0e4ac" />


Before

<img width="1280" height="717" alt="Screenshot 2026-05-27 at 5 18 31 PM" src="https://github.com/user-attachments/assets/759078e7-7ea1-4ff7-8ada-d5c01238e2b9" />

After
<img width="1280" height="715" alt="Screenshot 2026-05-27 at 5 17 54 PM" src="https://github.com/user-attachments/assets/205393d6-a345-4d21-85ac-f9f3b929e47c" />

The old text mislead support to think that the 2FA will be restored after the temporarily disable window, if new 2FA is not set up. This PR is to update the text so it correctly reflects the actual behavior.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19813

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
No functional change. Just change the text.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
