### PR TITLE
Drop require_api_key_for_api_access column from db

### DIFF
--- a/corehq/apps/sso/migrations/0011_drop_identityprovider_require_api_key_for_api_access.py
+++ b/corehq/apps/sso/migrations/0011_drop_identityprovider_require_api_key_for_api_access.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('sso', '0010_remove_identityprovider_require_api_key_for_api_access'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="ALTER TABLE sso_identityprovider "
+                "DROP COLUMN require_api_key_for_api_access;",
+            reverse_sql="ALTER TABLE sso_identityprovider "
+                        "ADD COLUMN require_api_key_for_api_access "
+                        "BOOLEAN NOT NULL DEFAULT FALSE;",
+        ),
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -1239,6 +1239,7 @@ sso
  0008_alter_identityprovider_idp_type
  0009_identityprovider_require_api_key_for_api_access
  0010_remove_identityprovider_require_api_key_for_api_access
+ 0011_drop_identityprovider_require_api_key_for_api_access
 start_enterprise
  0001_initial
 stock


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Follow up of https://github.com/dimagi/commcare-hq/pull/37766

I'm adopting a two-phase approach [as described in this post](https://www.snopoke.com/2026/01/21/django-field-removal/)
This PR is Phase 2: Drop the Database Column

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe, no code is referencing this column

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code. Pay particular attention to _backward incompatible_ operations like `RemoveField`, `RenameField`, `RemoveConstraint`, and [others described here](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md) that can cause errors when migrations are applied to a live database.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
