### PR TITLE
Remove LOCKED_ADMIN_QUESTIONS feature flag

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -324,10 +324,7 @@ def _get_vellum_plugins(domain, form, module, options):
         vellum_plugins.append("saveToCase")
     if toggles.COMMCARE_CONNECT.enabled(domain):
         vellum_plugins.append("commcareConnect")
-    if (
-        toggles.LOCKED_ADMIN_QUESTIONS.enabled(domain, namespace=toggles.NAMESPACE_DOMAIN)
-        and domain_has_privilege(domain, privileges.LOCKED_ADMIN_QUESTIONS)
-    ):
+    if domain_has_privilege(domain, privileges.LOCKED_ADMIN_QUESTIONS):
         vellum_plugins.append("lock")
 
     form_uses_case = (

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -329,10 +329,7 @@ def _locked_paths_to_protect(request, domain, form):
     """Set of locked question paths whose case-property mappings must be
     preserved on this request, or empty set if the feature is off.
     """
-    if not (
-        domain_has_privilege(domain, "locked_admin_questions")
-        and toggles.LOCKED_ADMIN_QUESTIONS.enabled_for_request(request)
-    ):
+    if not domain_has_privilege(domain, "locked_admin_questions"):
         return set()
     return form.wrapped_xform().locked_question_paths
 
@@ -836,10 +833,7 @@ def get_form_questions(request, domain, app_id):
         lang, langs = get_langs(request, app)
     except FormNotFoundException:
         raise Http404()
-    include_locked_status = (
-        domain_has_privilege(domain, "locked_admin_questions")
-        and toggles.LOCKED_ADMIN_QUESTIONS.enabled_for_request(request)
-    )
+    include_locked_status = domain_has_privilege(domain, "locked_admin_questions")
     xform_questions = form.get_questions(langs, include_triggers=True, include_locked_status=include_locked_status)
     return json_response(xform_questions)
 
@@ -921,10 +915,7 @@ def get_form_view_context(
             )
 
         try:
-            include_locked_status = (
-                domain_has_privilege(domain, "locked_admin_questions")
-                and toggles.LOCKED_ADMIN_QUESTIONS.enabled_for_request(request)
-            )
+            include_locked_status = domain_has_privilege(domain, "locked_admin_questions")
             xform_questions = xform.get_questions(
                 langs, include_triggers=True, include_locked_status=include_locked_status
             )
@@ -1138,10 +1129,7 @@ def get_form_view_context(
 
 
 def _allow_xform_upload(request, domain, has_locked_questions):
-    if not (
-        domain_has_privilege(domain, "locked_admin_questions")
-        and toggles.LOCKED_ADMIN_QUESTIONS.enabled_for_request(request)
-    ):
+    if not domain_has_privilege(domain, "locked_admin_questions"):
         return True
     if request.couch_user.can_edit_locked_questions_in_apps(domain):
         return True

--- a/corehq/apps/translations/app_translations/upload_form.py
+++ b/corehq/apps/translations/app_translations/upload_form.py
@@ -19,7 +19,6 @@ from corehq.apps.translations.app_translations.utils import (
     get_unicode_dicts,
 )
 from corehq.apps.translations.exceptions import BulkAppTranslationsException
-from corehq.toggles import LOCKED_ADMIN_QUESTIONS, NAMESPACE_DOMAIN
 
 
 class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
@@ -88,10 +87,7 @@ class BulkAppTranslationFormUpdater(BulkAppTranslationUpdater):
 
         locked_label_ids = set()
         warned_locked_labels = set()
-        if (
-            domain_has_privilege(self.app.domain, 'locked_admin_questions')
-            and LOCKED_ADMIN_QUESTIONS.enabled(self.app.domain, namespace=NAMESPACE_DOMAIN)
-        ):
+        if domain_has_privilege(self.app.domain, 'locked_admin_questions'):
             locked_label_ids = self._get_locked_label_ids(rows)
 
         # Update the translations

--- a/corehq/apps/users/static/users/js/edit_role.js
+++ b/corehq/apps/users/static/users/js/edit_role.js
@@ -474,7 +474,7 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-apps-checkbox",
                     screenReaderEditAndViewText: gettext("Edit & View Apps"),
                     screenReaderViewOnlyText: gettext("View-Only Applications"),
-                    showAllowCheckbox: toggles.toggleEnabled("LOCKED_ADMIN_QUESTIONS") && privileges.hasPrivilege("locked_admin_questions"),
+                    showAllowCheckbox: privileges.hasPrivilege("locked_admin_questions"),
                     allowCheckboxText: gettext("Allow locking and unlocking questions in forms."),
                     allowCheckboxId: "edit-locked-questions-checkbox",
                     get allowCheckboxPermission() {

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1177,15 +1177,6 @@ VELLUM_ALLOW_BULK_FORM_ACTIONS = StaticToggle(
                 "the Form Builder's main dropdown menu.",
 )
 
-LOCKED_ADMIN_QUESTIONS = FeatureRelease(
-    'locked_admin_questions',
-    "Locked Admin Questions",
-    TAG_RELEASE,
-    [NAMESPACE_DOMAIN],
-    owner="Evan Joseph-Pinero",
-    description="Enables Locked Admin Questions workflows in HQ and the form builder.",
-)
-
 CACHE_AND_INDEX = StaticToggle(
     'cache_and_index',
     'REC: Enable the "Cache and Index" format option when choosing sort properties '


### PR DESCRIPTION
## Product Description
No visible changes now that the feature has been released (by setting the feature flag's randomness to 1).

## Technical Summary
Removes a feature flag and its uses, GA-ing the Locked Admin Questions feature. It is still gated by privilege to Advanced plans and above.

## Feature Flag
Removes `LOCKED_ADMIN_QUESTIONS`.

## Safety Assurance

### Safety story
The features gated by this flag have been tested explicitly by QA and have been made generally available on production environments without issue. This feature flag is safe to remove.

### Automated test coverage
Nope.

### QA Plan
Nope.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
