### PR TITLE
Speed up `dump_domain_data` for form/case child tables

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -8,7 +8,9 @@ from django.db import router
 from corehq.apps.dump_reload.exceptions import DomainDumpError
 from corehq.apps.dump_reload.interface import DataDumper
 from corehq.apps.dump_reload.sql.filters import (
+    CaseIDFilter,
     FilteredModelIteratorBuilder,
+    FormIDFilter,
     ManyFilters,
     MultimediaBlobMetaFilter,
     SimpleFilter,
@@ -29,14 +31,14 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('blobs.BlobMeta', MultimediaBlobMetaFilter()),
 
     FilteredModelIteratorBuilder('form_processor.XFormInstance', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('form_processor.XFormOperation', SimpleFilter('form__domain')),
+    FilteredModelIteratorBuilder('form_processor.XFormOperation', FormIDFilter('form_id')),
 
     FilteredModelIteratorBuilder('form_processor.CommCareCase', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.CommCareCaseIndex', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('form_processor.CaseAttachment', SimpleFilter('case__domain')),
-    FilteredModelIteratorBuilder('form_processor.CaseTransaction', SimpleFilter('case__domain')),
+    FilteredModelIteratorBuilder('form_processor.CaseAttachment', CaseIDFilter('case_id')),
+    FilteredModelIteratorBuilder('form_processor.CaseTransaction', CaseIDFilter('case_id')),
     FilteredModelIteratorBuilder('form_processor.LedgerValue', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('form_processor.LedgerTransaction', SimpleFilter('case__domain')),
+    FilteredModelIteratorBuilder('form_processor.LedgerTransaction', CaseIDFilter('case_id')),
 
     FilteredModelIteratorBuilder('case_search.DomainsNotInCaseSearchIndex', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('case_search.CaseSearchConfig', SimpleFilter('domain')),

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -118,6 +118,24 @@ class CaseIDFilter(IDFilter):
         )
 
 
+class FormIDFilter(IDFilter):
+    """Filter dependents of XFormInstance (e.g., XFormOperation) by the form_ids
+    that belong to the given domain on the given shard. Avoids the JOIN that
+    SimpleFilter('form__domain') forces."""
+
+    def __init__(self, form_id_field, chunksize=1000):
+        super().__init__(form_id_field, None, chunksize=chunksize)
+
+    def get_ids(self, domain_name, db_alias=None):
+        from corehq.form_processor.models import XFormInstance
+        return list(
+            XFormInstance.objects.using(db_alias)
+            .filter(domain=domain_name)
+            .order_by('form_id')
+            .values_list('form_id', flat=True)
+        )
+
+
 class MultimediaBlobMetaFilter(IDFilter):
     """
     BlobMeta for multimedia references the "<shared>" domain which is not the domain being dumped.

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -100,6 +100,24 @@ class UserIDFilter(IDFilter):
         return get_all_user_ids_by_domain(domain_name, include_web_users=self.include_web_users)
 
 
+class CaseIDFilter(IDFilter):
+    """Filter dependents of CommCareCase (e.g., CaseTransaction, CaseAttachment,
+    LedgerTransaction) by the case_ids that belong to the given domain on the
+    given shard. Avoids the JOIN that SimpleFilter('case__domain') forces."""
+
+    def __init__(self, case_id_field, chunksize=1000):
+        super().__init__(case_id_field, None, chunksize=chunksize)
+
+    def get_ids(self, domain_name, db_alias=None):
+        from corehq.form_processor.models import CommCareCase
+        return list(
+            CommCareCase.objects.using(db_alias)
+            .filter(domain=domain_name)
+            .order_by('case_id')
+            .values_list('case_id', flat=True)
+        )
+
+
 class MultimediaBlobMetaFilter(IDFilter):
     """
     BlobMeta for multimedia references the "<shared>" domain which is not the domain being dumped.

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -1,11 +1,16 @@
 from django.db import router
 from django.test import TestCase
 
-from corehq.apps.dump_reload.sql.filters import MultimediaBlobMetaFilter, FilteredModelIteratorBuilder
+from corehq.apps.dump_reload.sql.filters import (
+    CaseIDFilter,
+    FilteredModelIteratorBuilder,
+    MultimediaBlobMetaFilter,
+)
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.blobs.models import BlobMeta
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
-from corehq.sql_db.util import get_db_aliases_for_partitioned_query
+from corehq.form_processor.tests.utils import create_case
+from corehq.sql_db.util import get_db_alias_for_partitioned_doc, get_db_aliases_for_partitioned_query
 from corehq.motech.repeaters.models import Repeater
 from corehq.motech.models import ConnectionSettings
 from corehq.apps.dump_reload.sql.filters import SimpleFilter
@@ -103,3 +108,44 @@ class TestMultimediaBlobMetaFilter(TestCase):
         cls.addClassCleanup(cls.db.close)
         cls.domain = 'test-multimedia'
         cls.db_alias = get_db_aliases_for_partitioned_query()[0]
+
+
+class TestCaseIDFilter(TestCase):
+
+    domain = 'test-case-id-filter'
+
+    def test_returns_case_ids_in_the_domain_on_the_given_shard(self):
+        case = create_case(self.domain, save=True)
+        self.addCleanup(case.delete)
+        db_alias = get_db_alias_for_partitioned_doc(case.case_id)
+
+        filter = CaseIDFilter('case_id')
+        ids = filter.get_ids(self.domain, db_alias=db_alias)
+
+        assert case.case_id in ids
+
+    def test_does_not_return_case_ids_in_other_domains(self):
+        case = create_case('other-domain', save=True)
+        self.addCleanup(case.delete)
+        db_alias = get_db_alias_for_partitioned_doc(case.case_id)
+
+        filter = CaseIDFilter('case_id')
+        ids = filter.get_ids(self.domain, db_alias=db_alias)
+
+        assert case.case_id not in ids
+
+    def test_get_filters_yields_chunked_in_clauses(self):
+        # Force chunksize=2 so we don't have to create thousands of cases.
+        filter = CaseIDFilter('case_id', chunksize=2)
+        filter._test_ids = ['a', 'b', 'c', 'd', 'e']
+        # Patch get_ids to return our test fixture without hitting the DB.
+        filter.get_ids = lambda domain_name, db_alias=None: filter._test_ids
+
+        filters = list(filter.get_filters('any-domain'))
+
+        assert len(filters) == 3  # ceil(5 / 2)
+        # Each yielded Q should be `case_id__in=<chunk>`.
+        # Q internals: children is [('case_id__in', (...))]; chunked() yields tuples.
+        assert filters[0].children == [('case_id__in', ('a', 'b'))]
+        assert filters[1].children == [('case_id__in', ('c', 'd'))]
+        assert filters[2].children == [('case_id__in', ('e',))]

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -4,12 +4,13 @@ from django.test import TestCase
 from corehq.apps.dump_reload.sql.filters import (
     CaseIDFilter,
     FilteredModelIteratorBuilder,
+    FormIDFilter,
     MultimediaBlobMetaFilter,
 )
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.blobs.models import BlobMeta
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
-from corehq.form_processor.tests.utils import create_case
+from corehq.form_processor.tests.utils import create_case, create_form_for_test
 from corehq.sql_db.util import get_db_alias_for_partitioned_doc, get_db_aliases_for_partitioned_query
 from corehq.motech.repeaters.models import Repeater
 from corehq.motech.models import ConnectionSettings
@@ -149,3 +150,44 @@ class TestCaseIDFilter(TestCase):
         assert filters[0].children == [('case_id__in', ('a', 'b'))]
         assert filters[1].children == [('case_id__in', ('c', 'd'))]
         assert filters[2].children == [('case_id__in', ('e',))]
+
+
+class TestFormIDFilter(TestCase):
+
+    domain = 'test-form-id-filter'
+
+    def test_returns_form_ids_in_the_domain_on_the_given_shard(self):
+        form = create_form_for_test(self.domain)
+        self.addCleanup(form.delete)
+        db_alias = get_db_alias_for_partitioned_doc(form.form_id)
+
+        filter = FormIDFilter('form_id')
+        ids = filter.get_ids(self.domain, db_alias=db_alias)
+
+        assert form.form_id in ids
+
+    def test_does_not_return_form_ids_in_other_domains(self):
+        form = create_form_for_test('other-domain')
+        self.addCleanup(form.delete)
+        db_alias = get_db_alias_for_partitioned_doc(form.form_id)
+
+        filter = FormIDFilter('form_id')
+        ids = filter.get_ids(self.domain, db_alias=db_alias)
+
+        assert form.form_id not in ids
+
+    def test_get_filters_yields_chunked_in_clauses(self):
+        # Force chunksize=2 so we don't have to create thousands of forms.
+        filter = FormIDFilter('form_id', chunksize=2)
+        filter._test_ids = ['a', 'b', 'c', 'd', 'e']
+        # Patch get_ids to return our test fixture without hitting the DB.
+        filter.get_ids = lambda domain_name, db_alias=None: filter._test_ids
+
+        filters = list(filter.get_filters('any-domain'))
+
+        assert len(filters) == 3  # ceil(5 / 2)
+        # Each yielded Q should be `form_id__in=<chunk>`.
+        # Q internals: children is [('form_id__in', (...))]; chunked() yields tuples.
+        assert filters[0].children == [('form_id__in', ('a', 'b'))]
+        assert filters[1].children == [('form_id__in', ('c', 'd'))]
+        assert filters[2].children == [('form_id__in', ('e',))]


### PR DESCRIPTION
## Product Description

Backend perf improvement on the `dump_domain_data` management command. No user-facing change. Domain dumps on tenants with millions of cases/forms currently take days; this is the largest single contributor to that runtime, so this PR should move multi-day dumps into the hours range.

## Technical Summary

Four child tables — `XFormOperation`, `CaseAttachment`, `CaseTransaction`, `LedgerTransaction` — have no `domain` column. Today they're filtered by traversing the FK to the parent's domain: `SimpleFilter('case__domain')` / `SimpleFilter('form__domain')`. That produces SQL like

```sql
SELECT casetransaction.* FROM casetransaction
JOIN commcarecase ON casetransaction.case_id = commcarecase.case_id
WHERE commcarecase.domain = 'X' AND casetransaction.id > <last_pk>
ORDER BY casetransaction.id LIMIT 500;
```

This query is re-issued for every 500-row page. Postgres can't push the `domain='X'` filter into `casetransaction` (no domain column there), so each page either hash-joins all of `commcarecase` against `casetransaction` or nested-loops from a PK walk and looks up each row's case to check its domain. The work is redone every page, and at multi-million-row scale this is what makes dumps take days.

This PR introduces `CaseIDFilter` and `FormIDFilter` (mirroring the existing `UserIDFilter`). Each dependent table is now filtered in two stages:

1. Once per shard, fetch the parent IDs for the domain (`commcarecase.objects.filter(domain='X').order_by('case_id').values_list('case_id', flat=True)`). Uses an existing `(domain, *)` composite index on the parent.
2. Iterate dependents in chunks of 1000 parent IDs with `WHERE case_id IN (...)`. Uses the leading-`case_id` composite indexes that already exist on each child (`(case, server_date, sync_log_id)` on `CaseTransaction`, `(case, name)` on `CaseAttachment`, `(case, section_id, entry_id)` on `LedgerTransaction`, auto-FK index on `xformoperation.form_id`).

No JOIN per page, no parent-table scan per page. Same set of rows dumped (verified — see Safety story below); ordering changes (the stream is now grouped by parent-ID chunk rather than globally by dependent PK) but is deterministic across runs thanks to the `.order_by(case_id)` / `.order_by(form_id)` on Stage 1.

Tables with a direct `domain` column (`XFormInstance`, `CommCareCase`, `CommCareCaseIndex`, `LedgerValue`) are unchanged — they already filter efficiently with `SimpleFilter('domain')`.

### Out of scope (deliberately deferred)

- **Memory.** Stage 1 materializes all parent IDs for the domain on a shard into a Python list. For typical domains (≤1M cases/shard) that's ~100 MB; for the giant tenants it could be ~1 GB/shard. `UserIDFilter` has the same shape and hasn't caused problems in practice. If it does, the follow-up is to stream via `queryset.iterator()` and override `count()` to return `None`.
- **Covering indexes.** Adding `(domain, case_id)` / `(domain, form_id)` on parents and `(case_id, id)` / `(form_id, id)` on children would make these queries index-only end-to-end and would also kill the within-chunk pagination amplification. That's a separate, schema-level PR.
- **Resume / checkpointing.** This PR is a prerequisite for the parallel resume-design work; it doesn't add resume support itself.

## Feature Flag

N/A.

## Safety Assurance

### Safety story

- Pure read-side change to a maintenance command. No production code paths affected.
- No schema changes, no new domain-scoped models.
- Behavioral equivalence rests on two verified points:
  - **Partition alignment.** `CaseAttachment`, `CaseTransaction`, `LedgerTransaction` all have `partition_attr = 'case_id'`, matching `CommCareCase.partition_attr`. `XFormOperation.partition_attr = 'form_id'`, matching `XFormInstance.partition_attr`. So fetching parent IDs from a shard guarantees the dependents live on the same shard.
  - **Manager equivalence.** `CommCareCaseManager` and `XFormInstanceManager` inherit from `RequireDBManager`, which doesn't override `get_queryset()` to filter rows. So `Model.objects.filter(domain='X').values_list(...)` returns the same row set the old JOIN-against-the-table would have produced (including soft-deleted parents).
- **Local round-trip testing is incomplete:** `test_sql_dump_load.py` (the dump/reload round-trip suite) can't run on macOS + Python 3.13 due to a pre-existing `AppRegistryNotReady` crash inside `ProcessPoolExecutor` workers. Verified by re-running on `master` baseline — same 23 failures. The crash happens before reaching any code this PR touches. CI on Linux is the real round-trip gate.

### Automated test coverage

- New unit tests in `corehq/apps/dump_reload/tests/test_sql_filters.py`: 3 per filter (positive lookup, cross-domain isolation, chunked-IN clause shape). 11/11 tests in the file pass locally.
- `corehq/apps/dump_reload/tests/test_dump_domain_data.py`: 5/5 pass locally.
- End-to-end round-trip via `test_sql_dump_load.py` will be exercised on CI.

### QA Plan

Dump a non-prod domain that includes forms, cases, attachments, and ledger data. Compare row counts of the dumped child tables (`xformoperation`, `caseattachment`, `casetransaction`, `ledgertransaction`) against direct SQL counts of those tables filtered through the parent's domain. They should match.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

Pure code change, no migrations, no data state. Reverting restores the old FK-traversal filtering and the dumper continues to work (slowly).

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change