### PR TITLE
Fix Select Parent First with custom index identifiers

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -204,6 +204,10 @@ class EntriesHelper(object):
         return f"instance('{instance_name}')/{root_element}/case[{case_type_filter}][@status='open']{filter_xpath}"
 
     @staticmethod
+    def get_parent_filter(parent_id):
+        return f"[index/*[not(@relationship='extension')]={session_var(parent_id)}]"
+
+    @staticmethod
     def get_parent_filter_by_ref_id(reference_id, parent_id):
         if reference_id is None:
             return ""
@@ -568,10 +572,8 @@ class EntriesHelper(object):
         for i, datum in enumerate(datums_meta):
             # get the session var for the previous datum if there is one
             parent_id = datums_meta[i - 1]['session_var'] if i >= 1 else ''
-            if parent_id:
-                parent_filter = EntriesHelper.get_parent_filter_by_ref_id(
-                    datum['module'].parent_select.relationship, parent_id
-                )
+            if parent_id and datum['module'].parent_select.relationship == 'parent':
+                parent_filter = EntriesHelper.get_parent_filter(parent_id)
             else:
                 parent_filter = ''
 

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -207,11 +207,7 @@ class EntriesHelper(object):
     def get_parent_filter_by_ref_id(reference_id, parent_id):
         if reference_id is None:
             return ""
-        else:
-            return "[index/{reference_id}=instance('commcaresession')/session/data/{parent_id}]".format(
-                reference_id=reference_id,
-                parent_id=parent_id,
-            )
+        return f"[index/{reference_id}={session_var(parent_id)}]"
 
     @staticmethod
     def get_userdata_autoselect(key, session_id, mode):

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -204,7 +204,7 @@ class EntriesHelper(object):
         return f"instance('{instance_name}')/{root_element}/case[{case_type_filter}][@status='open']{filter_xpath}"
 
     @staticmethod
-    def get_parent_filter(relationship, parent_id):
+    def get_parent_filter_by_ref_id(relationship, parent_id):
         if relationship is None:
             return ""
         else:
@@ -573,7 +573,7 @@ class EntriesHelper(object):
             # get the session var for the previous datum if there is one
             parent_id = datums_meta[i - 1]['session_var'] if i >= 1 else ''
             if parent_id:
-                parent_filter = EntriesHelper.get_parent_filter(
+                parent_filter = EntriesHelper.get_parent_filter_by_ref_id(
                     datum['module'].parent_select.relationship, parent_id
                 )
             else:
@@ -816,7 +816,7 @@ class EntriesHelper(object):
         if action.case_tag:
             if action.case_index.tag:
                 parent_action = form.actions.actions_meta_by_tag[action.case_index.tag]['action']
-                parent_filter = EntriesHelper.get_parent_filter(
+                parent_filter = EntriesHelper.get_parent_filter_by_ref_id(
                     action.case_index.reference_id,
                     parent_action.case_session_var
                 )
@@ -951,7 +951,7 @@ class EntriesHelper(object):
             else:
                 if action.case_index.tag:
                     parent_action = form.actions.actions_meta_by_tag[action.case_index.tag]['action']
-                    parent_filter = EntriesHelper.get_parent_filter(
+                    parent_filter = EntriesHelper.get_parent_filter_by_ref_id(
                         action.case_index.reference_id,
                         parent_action.case_session_var
                     )

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -204,12 +204,12 @@ class EntriesHelper(object):
         return f"instance('{instance_name}')/{root_element}/case[{case_type_filter}][@status='open']{filter_xpath}"
 
     @staticmethod
-    def get_parent_filter_by_ref_id(relationship, parent_id):
-        if relationship is None:
+    def get_parent_filter_by_ref_id(reference_id, parent_id):
+        if reference_id is None:
             return ""
         else:
-            return "[index/{relationship}=instance('commcaresession')/session/data/{parent_id}]".format(
-                relationship=relationship,
+            return "[index/{reference_id}=instance('commcaresession')/session/data/{parent_id}]".format(
+                reference_id=reference_id,
                 parent_id=parent_id,
             )
 

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-advanced.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-advanced.xml
@@ -201,7 +201,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
         <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='house'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
-        <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m2_case_short" detail-confirm="m2_case_long"/>
+        <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m2_case_short" detail-confirm="m2_case_long"/>
     </session>
   </entry>
   <menu id="m0">

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-basic.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-basic.xml
@@ -213,7 +213,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
         <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='house'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
-        <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m2_case_short" detail-confirm="m2_case_long"/>
+        <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m2_case_short" detail-confirm="m2_case_long"/>
     </session>
   </entry>
   <menu id="m0">

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-submodule-basic.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-submodule-basic.xml
@@ -281,7 +281,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
         <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='house'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
-        <datum id="case_id_person" nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open'][index/parent=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
+        <datum id="case_id_person" nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
     </session>
   </entry>
   <menu id="m0">

--- a/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-submodule-mixed.xml
+++ b/corehq/apps/app_manager/tests/data/case_list_form/case-list-form-suite-parent-child-submodule-mixed.xml
@@ -281,7 +281,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
         <datum id="case_id_load_house_0" nodeset="instance('casedb')/casedb/case[@case_type='house'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
-        <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open'][index/parent=instance('commcaresession')/session/data/case_id_load_house_0]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
+        <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/case_id_load_house_0]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
     </session>
   </entry>
   <menu id="m0">

--- a/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module-in-root.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module-in-root.xml
@@ -91,7 +91,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m1_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
     </session>
     <stack>
       <create>
@@ -111,7 +111,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m1_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
     </session>
     <stack>
       <create>

--- a/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-module.xml
@@ -96,7 +96,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m1_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
     </session>
     <stack>
       <create>
@@ -114,7 +114,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m1_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
     </session>
     <stack>
       <create>

--- a/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-previous.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-previous.xml
@@ -101,7 +101,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m1_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
     </session>
     <stack>
       <create>
@@ -121,7 +121,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m1_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
     </session>
     <stack>
       <create>

--- a/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-root.xml
+++ b/corehq/apps/app_manager/tests/data/form_workflow/suite-workflow-root.xml
@@ -84,7 +84,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m1_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
     </session>
     <stack>
       <create/>
@@ -100,7 +100,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m1_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m3_case_short" detail-confirm="m3_case_long"/>
     </session>
     <stack>
       <create/>

--- a/corehq/apps/app_manager/tests/data/suite/advanced_module_parent.xml
+++ b/corehq/apps/app_manager/tests/data/suite/advanced_module_parent.xml
@@ -10,7 +10,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='parent'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
     </session>
   </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/data/suite/advanced_module_parent_filters.xml
+++ b/corehq/apps/app_manager/tests/data/suite/advanced_module_parent_filters.xml
@@ -10,7 +10,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='parent'][@status='open'][parent_filter = 1]" value="./@case_id" detail-select="m0_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][child_filter = 1][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][child_filter = 1][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
     </session>
   </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/data/suite/child-module-entry-datums-added-basic.xml
+++ b/corehq/apps/app_manager/tests/data/suite/child-module-entry-datums-added-basic.xml
@@ -22,7 +22,7 @@
     <session>
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
       <datum id="case_id_new_guppy_0" function="uuid()" />
-      <datum id="case_id_guppy" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/parent=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
+      <datum id="case_id_guppy" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
     </session>
   </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/data/suite/child-module-entry-datums-added-usercase.xml
+++ b/corehq/apps/app_manager/tests/data/suite/child-module-entry-datums-added-usercase.xml
@@ -31,7 +31,7 @@
       <datum id="case_id_new_guppy_0" function="uuid()" />
       <datum id="usercase_id" function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id"/>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
     </session>
     <assertions>
       <assert test="count(instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]) = 1">

--- a/corehq/apps/app_manager/tests/data/suite/child-module-form-workflow-previous.xml
+++ b/corehq/apps/app_manager/tests/data/suite/child-module-form-workflow-previous.xml
@@ -22,7 +22,7 @@
     <session>
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
       <datum id="case_id_new_guppy_0" function="uuid()" />
-      <datum id="case_id_guppy" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/parent=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
+      <datum id="case_id_guppy" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
     </session>
     <stack>
       <create>

--- a/corehq/apps/app_manager/tests/data/suite/child-module-grandchild-case.xml
+++ b/corehq/apps/app_manager/tests/data/suite/child-module-grandchild-case.xml
@@ -21,7 +21,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
       <datum id="case_id_new_tadpole_0" function="uuid()" />
     </session>
   </entry>
@@ -35,9 +35,9 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short"/>
       <datum id="case_id_new_tadpole_0" function="uuid()" />
-      <datum id="case_id_tadpole" nodeset="instance('casedb')/casedb/case[@case_type='tadpole'][@status='open'][index/parent=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m2_case_short"  detail-confirm="m2_case_long"/>
+      <datum id="case_id_tadpole" nodeset="instance('casedb')/casedb/case[@case_type='tadpole'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m2_case_short"  detail-confirm="m2_case_long"/>
     </session>
   </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/data/suite/child-module-with-parent-select-and-case-list.xml
+++ b/corehq/apps/app_manager/tests/data/suite/child-module-with-parent-select-and-case-list.xml
@@ -20,7 +20,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
-      <datum id="case_id_guppy" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/parent=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
+      <datum id="case_id_guppy" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
     </session>
   </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/data/suite/child-module-with-parent-select-entry-datums-added.xml
+++ b/corehq/apps/app_manager/tests/data/suite/child-module-with-parent-select-entry-datums-added.xml
@@ -20,7 +20,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='gold-fish'][@status='open']" value="./@case_id" detail-select="m0_case_short"/>
-      <datum id="case_id_guppy" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/parent=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
+      <datum id="case_id_guppy" nodeset="instance('casedb')/casedb/case[@case_type='guppy'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/case_id]" value="./@case_id" detail-select="m1_case_short"  detail-confirm="m1_case_long"/>
       <datum function="uuid()" id="case_id_new_pregnancy_0"/>
     </session>
   </entry>

--- a/corehq/apps/app_manager/tests/data/suite/fixture-to-case-selection-parent-child.xml
+++ b/corehq/apps/app_manager/tests/data/suite/fixture-to-case-selection-parent-child.xml
@@ -158,7 +158,7 @@
       <datum id="fixture_value_m0" nodeset="instance('item-list:province')/province_list/province" value="var_name" detail-select="m0_fixture_select"/>
       <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='parent'][@status='open'][province = instance('commcaresession')/session/data/fixture_value_m0]" value="./@case_id" detail-select="m0_case_short"/>
       <datum id="fixture_value_m1" nodeset="instance('item-list:city')/city_list/city" value="var_name" detail-select="m1_fixture_select"/>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id][city = instance('commcaresession')/session/data/fixture_value_m1]" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id][city = instance('commcaresession')/session/data/fixture_value_m1]" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
     </session>
   </entry>
   <menu id="m0">

--- a/corehq/apps/app_manager/tests/data/suite/tiered-select-3.xml
+++ b/corehq/apps/app_manager/tests/data/suite/tiered-select-3.xml
@@ -191,7 +191,7 @@
       <instance id="commcaresession" src="jr://instance/session"></instance>
       <session>
         <datum detail-select="m0_case_short" id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='parent'][@status='open']" value="./@case_id"></datum>
-        <datum detail-confirm="m1_case_long" detail-select="m1_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id"></datum>
+        <datum detail-confirm="m1_case_long" detail-select="m1_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id"></datum>
       </session>
     </entry>
     <entry>
@@ -205,8 +205,8 @@
       <instance id="commcaresession" src="jr://instance/session"></instance>
       <session>
         <datum detail-select="m0_case_short" id="parent_parent_id" nodeset="instance('casedb')/casedb/case[@case_type='parent'][@status='open']" value="./@case_id"></datum>
-        <datum detail-select="m1_case_short" id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_parent_id]" value="./@case_id"></datum>
-        <datum detail-confirm="m2_case_long" detail-select="m2_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='grandchild'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id"></datum>
+        <datum detail-select="m1_case_short" id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_parent_id]" value="./@case_id"></datum>
+        <datum detail-confirm="m2_case_long" detail-select="m2_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='grandchild'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id"></datum>
       </session>
     </entry>
     <menu id="m0">

--- a/corehq/apps/app_manager/tests/data/suite/tiered-select.xml
+++ b/corehq/apps/app_manager/tests/data/suite/tiered-select.xml
@@ -142,7 +142,7 @@
       <instance id="commcaresession" src="jr://instance/session"></instance>
       <session>
         <datum detail-select="m0_case_short" id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='parent'][@status='open']" value="./@case_id"></datum>
-        <datum detail-confirm="m1_case_long" detail-select="m1_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id"></datum>
+        <datum detail-confirm="m1_case_long" detail-select="m1_case_short" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]" value="./@case_id"></datum>
       </session>
     </entry>
     <menu id="m0">

--- a/corehq/apps/app_manager/tests/test_shadow_modules.py
+++ b/corehq/apps/app_manager/tests/test_shadow_modules.py
@@ -413,7 +413,7 @@ class ShadowModuleFormSelectionSuiteTest(SimpleTestCase, TestXmlMixin):
                 <session>
                   <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='parrot'][@status='open']"
                          value="./@case_id" detail-select="m0_case_short"/>
-                  <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='baby_parrot'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]"
+                  <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='baby_parrot'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]"
                          value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
                 </session>
               </entry>
@@ -446,7 +446,7 @@ class ShadowModuleFormSelectionSuiteTest(SimpleTestCase, TestXmlMixin):
                 <session>
                   <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='parrot'][@status='open']"
                          value="./@case_id" detail-select="m4_case_short"/>
-                  <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='baby_parrot'][@status='open'][index/parent=instance('commcaresession')/session/data/parent_id]"
+                  <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='baby_parrot'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]"
                          value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
                 </session>
               </entry>

--- a/corehq/apps/app_manager/tests/test_shadow_modules.py
+++ b/corehq/apps/app_manager/tests/test_shadow_modules.py
@@ -411,9 +411,11 @@ class ShadowModuleFormSelectionSuiteTest(SimpleTestCase, TestXmlMixin):
                 <instance id="casedb" src="jr://instance/casedb"/>
                 <instance id="commcaresession" src="jr://instance/session"/>
                 <session>
-                  <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='parrot'][@status='open']"
+                  <datum id="parent_id"
+                         nodeset="instance('casedb')/casedb/case[@case_type='parrot'][@status='open']"
                          value="./@case_id" detail-select="m0_case_short"/>
-                  <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='baby_parrot'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]"
+                  <datum id="case_id"
+                         nodeset="instance('casedb')/casedb/case[@case_type='baby_parrot'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]"
                          value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
                 </session>
               </entry>
@@ -444,9 +446,11 @@ class ShadowModuleFormSelectionSuiteTest(SimpleTestCase, TestXmlMixin):
                 <instance id="casedb" src="jr://instance/casedb"/>
                 <instance id="commcaresession" src="jr://instance/session"/>
                 <session>
-                  <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='parrot'][@status='open']"
+                  <datum id="parent_id"
+                         nodeset="instance('casedb')/casedb/case[@case_type='parrot'][@status='open']"
                          value="./@case_id" detail-select="m4_case_short"/>
-                  <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='baby_parrot'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]"
+                  <datum id="case_id"
+                         nodeset="instance('casedb')/casedb/case[@case_type='baby_parrot'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]"
                          value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
                 </session>
               </entry>

--- a/corehq/apps/app_manager/tests/test_suite_inline_search.py
+++ b/corehq/apps/app_manager/tests/test_suite_inline_search.py
@@ -462,7 +462,7 @@ class InlineSearchSuiteTest(SimpleTestCase, SuiteMixin):
                 </prompt>
               </query>
               <datum id="case_id"
-                nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())][index/parent=instance('commcaresession')/session/data/parent_id]"
+                nodeset="instance('{RESULTS_INSTANCE_INLINE}')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/parent_id]"
                 value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
             </session>
           </entry>
@@ -655,7 +655,7 @@ class InlineSearchChildModuleTest(SimpleTestCase, SuiteMixin):
                 </prompt>
               </query>
               <datum id="case_id_child_case"
-                nodeset="instance('{self.m1.search_config.get_instance_name()}')/results/case[@case_type='child_case'][@status='open'][not(commcare_is_related_case=true())][index/parent=instance('commcaresession')/session/data/case_id]"
+                nodeset="instance('{self.m1.search_config.get_instance_name()}')/results/case[@case_type='child_case'][@status='open'][not(commcare_is_related_case=true())][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/case_id]"
                 value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
             </session>
           </entry>

--- a/corehq/apps/app_manager/tests/test_suite_usercase.py
+++ b/corehq/apps/app_manager/tests/test_suite_usercase.py
@@ -10,7 +10,6 @@ from corehq.apps.app_manager.models import (
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     SuiteMixin,
-    TestXmlMixin,
     patch_get_xform_resource_overrides,
 )
 

--- a/corehq/apps/app_manager/tests/test_suite_usercase.py
+++ b/corehq/apps/app_manager/tests/test_suite_usercase.py
@@ -75,7 +75,7 @@ class SuiteUsercaseTest(SimpleTestCase, SuiteMixin):
               <datum id="usercase_id"
                 function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/@case_id"/>
               <datum id="case_id_child"
-                nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/parent=instance('commcaresession')/session/data/case_id]"
+                nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][index/*[not(@relationship='extension')]=instance('commcaresession')/session/data/case_id]"
                 value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
             </session>
             <assertions>


### PR DESCRIPTION
## Product Description

<img width="359" height="157" alt="Screenshot 2026-05-29 at 12 03 10 AM" src="https://github.com/user-attachments/assets/b61eb780-45a5-42e4-8ef4-1b000df73e01" />

"Select Parent First" on a child case's module is supposed to ask the user to pick a parent case, then narrow the child list to that parent's children. Today it only works when the child case is indexed under the reference id `parent`. If the parent case was created via Advanced Case Action that named its child-index relationship anything else (e.g. `mother`, `father`), the child never appears in the child menu

After this PR, "Select Parent First" works for any parent case.

## Technical Summary
[SAAS-19755](https://dimagi.atlassian.net/browse/SAAS-19755).

`parent_select.relationship` (which the UI only ever sets to `'parent'` or `None`) was passed to the old `get_parent_filter` ( Now renamed to `get_parent_filter_by_ref_id` to reflect its actual behavior ). Thus the function is always return a filter `[index/parent=…]`, which means the reference id of the relationship is "parent".

The fix is to get all indexes as long as the relationship is not `extension`

Why excludes `extension` rather than positively matching `child`: [the casedb serializer](https://github.com/dimagi/commcare-hq/blob/eeae695bcee1021e13242c82ef457a3311a4e0e1/corehq/ex-submodules/casexml/apps/case/xml/generator.py#L85-L90) only writes the `relationship` attribute when it's `"extension"`. Parent-child relationship is probably the default that doesn't needs a "relationship" attribute.


## Feature Flag
None.

## Safety Assurance

### Safety story
- The change is scoped to one caller `get_datum_meta_module`
- The new filter is more permissive than the old one for parent-child cases, and equally restrictive against host-extension links.
- Apps where the relationship was already `parent` continue to match, because `index/*` still matches `index/parent`.
- Tested locally and on staging.

### Automated test coverage

### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

[SAAS-19755]: https://dimagi.atlassian.net/browse/SAAS-19755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ