### PR TITLE
update setting name to reflect what was already deployed 

### DIFF
--- a/corehq/apps/users/credentials_issuing.py
+++ b/corehq/apps/users/credentials_issuing.py
@@ -144,7 +144,7 @@ def submit_credentials(credentials_to_submit, cred_id_groups):
         json={
             'credentials': credentials_to_submit
         },
-        auth=(settings.CONNECTID_CREDENTIALS_CLIENT_ID, settings.CONNECTID_CREDENTIALS_CLIENT_SECRET),
+        auth=(settings.CONNECTID_CREDENTIALS_CLIENT_ID, settings.CONNECTID_CREDENTIALS_SECRET_KEY),
     )
     response.raise_for_status()
     mark_credentials_as_issued(response, cred_id_groups)

--- a/corehq/apps/users/views/utils.py
+++ b/corehq/apps/users/views/utils.py
@@ -247,6 +247,6 @@ def send_hq_sso_date_metric(link: ConnectIDUserLink):
             },
             auth=(
                 settings.CONNECTID_CREDENTIALS_CLIENT_ID,
-                settings.CONNECTID_CREDENTIALS_CLIENT_SECRET,
+                settings.CONNECTID_CREDENTIALS_SECRET_KEY,
             ),
         )

--- a/settings.py
+++ b/settings.py
@@ -1162,7 +1162,7 @@ CONNECTID_CHANNEL_URL = 'http://localhost:8080/messaging/create_channel/'
 CONNECTID_MESSAGE_URL = 'http://localhost:8080/messaging/send_fcm/'
 CONNECTID_CREDENTIALS_URL = 'http://localhost:8080/users/add_credential/'
 CONNECTID_CREDENTIALS_CLIENT_ID = ''
-CONNECTID_CREDENTIALS_CLIENT_SECRET = ''
+CONNECTID_CREDENTIALS_SECRET_KEY = ''
 CONNECTID_ADD_USER_ANALYTICS_URL = 'http://localhost:8080/users/add_user_analytics/'
 
 MAX_MOBILE_UCR_LIMIT = 300  # used in corehq.apps.cloudcare.util.should_restrict_web_apps_usage


### PR DESCRIPTION



## Product Description

Bug fix https://dimagi.atlassian.net/browse/CI-652

## Technical Summary
The envs have `CONNECTID_CREDENTIALS_SECRET_KEY` populated in place of `CONNECTID_CREDENTIALS_CLIENT_SECRET`, so this updates to use the right setting that's already deployed.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`COMMCARE_CONNECT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Simple setting rename that's been verified that it works.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
