### PR TITLE
Fix errors when get case types updated by save to case

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -527,7 +527,7 @@ def _get_case_types_from_apps_query(domain, is_build=False):
     )
 
 
-def get_case_types_from_apps(domain, include_save_to_case_updates=True):
+def get_case_types_from_apps(domain):
     """
     Get the case types of modules in applications in the domain.
     Also returns case types for SaveToCase properties in the domain, if the toggle is enabled.
@@ -535,7 +535,7 @@ def get_case_types_from_apps(domain, include_save_to_case_updates=True):
     """
     from corehq.apps.accounting.utils import domain_has_privilege
     save_to_case_updates = set()
-    if include_save_to_case_updates and domain_has_privilege(domain, privileges.VELLUM_SAVE_TO_CASE):
+    if domain_has_privilege(domain, privileges.VELLUM_SAVE_TO_CASE):
         save_to_case_updates = _get_save_to_case_updates(domain)
     q = _get_case_types_from_apps_query(domain)
     case_types = set(q.run().aggregations.modules.case_types.keys)

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -505,6 +505,9 @@ def get_version_build_id(domain, app_id, version):
 def _get_save_to_case_updates(domain):
     save_to_case_updates = set()
     for app in get_apps_in_domain(domain):
+        # RemoteApp does not implement get_forms() (would raise AttributeError).
+        if app.is_remote_app():
+            continue
         for form in app.get_forms():
             for update in form.get_save_to_case_updates():
                 save_to_case_updates.add(update)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19824

The traceback shows that `get_case_types_from_apps(domain)` iterates through applications and attempts to call `get_forms()` on a `RemoteApp` object, which does not implement that method: `AttributeError: 'RemoteApp' object has no attribute 'get_forms'`

Call stack:
```
_process_file_and_get_upload()
  -> get_case_types_from_apps(domain)
      -> _get_save_to_case_updates(domain)
          -> app.get_forms()
```
It's [the same logic](https://github.com/dimagi/commcare-hq/blob/bd9499f0bbbdc3dc199b2492b69f6ec73580a125/corehq/apps/app_manager/tasks.py#L99-L102) as how we skip remote app when refresh data dictionary


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
