### PR TITLE
Log per-model timing while dumping a domain

### DIFF
--- a/corehq/apps/dump_reload/couch/dump.py
+++ b/corehq/apps/dump_reload/couch/dump.py
@@ -55,11 +55,13 @@ class CouchDataDumper(DataDumper):
     def _dump_docs(self, doc_class, doc_ids, output_stream):
         model_label = '{}.{}'.format(doc_class._meta.app_label, doc_class.__name__)
         count = 0
-        couch_db = doc_class.get_db()
-        for doc in iter_docs(couch_db, doc_ids, chunksize=500):
-            count += 1
-            output_stream.write(json.dumps(doc))
-            output_stream.write('\n')
+        with self.timer.measure(model_label):
+            couch_db = doc_class.get_db()
+            for doc in iter_docs(couch_db, doc_ids, chunksize=500):
+                count += 1
+                self.timer.tick()
+                output_stream.write(json.dumps(doc))
+                output_stream.write('\n')
         self.stdout.write('Dumped {} {}\n'.format(count, model_label))
         return Counter({model_label: count})
 

--- a/corehq/apps/dump_reload/interface.py
+++ b/corehq/apps/dump_reload/interface.py
@@ -5,6 +5,7 @@ import sys
 import warnings
 from abc import ABCMeta, abstractmethod, abstractproperty
 
+from corehq.apps.dump_reload.timing import DumpTimingLogger
 from corehq.util.log import with_progress_bar
 
 
@@ -25,6 +26,7 @@ class DataDumper(metaclass=ABCMeta):
         self.includes = includes
         self.stdout = stdout or sys.stdout
         self.stderr = stderr or sys.stderr
+        self.timer = DumpTimingLogger()  # read back for the stats report
 
     @abstractmethod
     def dump(self, output_stream):

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -11,6 +11,7 @@ from corehq.apps.dump_reload.const import DATETIME_FORMAT
 from corehq.apps.dump_reload.couch import CouchDataDumper
 from corehq.apps.dump_reload.couch.dump import DomainDumper, ToggleDumper
 from corehq.apps.dump_reload.sql import SqlDataDumper
+from corehq.apps.dump_reload.timing import format_rate
 from corehq.util.timer import TimingContext
 
 logger = logging.getLogger(__name__)
@@ -63,6 +64,7 @@ class Command(BaseCommand):
 
         self.stdout.ending = None
         meta = {}  # {dumper_slug: {model_name: count}}
+        timing_data = {}  # {dumper_slug: {'total': secs, 'models': {label: secs}}}
         # domain dumper should be first since it validates domain exists
         for dumper in [DomainDumper, SqlDataDumper, CouchDataDumper, ToggleDumper]:
             if requested_dumpers and dumper.slug not in requested_dumpers:
@@ -70,9 +72,10 @@ class Command(BaseCommand):
 
             filename = _get_dump_stream_filename(dumper.slug, domain_name, self.utcnow, path=output_dir)
             stream = self.stdout if console else gzip.open(filename, 'wt')
+            dumper_instance = dumper(domain_name, excludes, includes)
             with TimingContext(dumper.slug) as dumper_timer:
                 try:
-                    meta[dumper.slug] = dumper(domain_name, excludes, includes).dump(stream)
+                    meta[dumper.slug] = dumper_instance.dump(stream)
                 except Exception as e:
                     if show_traceback:
                         raise
@@ -82,6 +85,10 @@ class Command(BaseCommand):
                         stream.close()
 
             logger.info(f"[timing] dumper '{dumper.slug}' finished in {dumper_timer.duration:.2f}s")
+            timing_data[dumper.slug] = {
+                'total': dumper_timer.duration,
+                'models': dict(dumper_instance.timer.totals),
+            }
 
             if not console:
                 with zipfile.ZipFile(zipname, mode='a', allowZip64=True) as z:
@@ -93,25 +100,33 @@ class Command(BaseCommand):
             with zipfile.ZipFile(zipname, mode='a', allowZip64=True) as z:
                 z.writestr('meta.json', json.dumps(meta, indent=4))
 
-        self._print_stats(meta)
+        self._print_stats(meta, timing_data)
         self.stdout.write('\nData dumped to file: {}'.format(zipname))
 
-    def _print_stats(self, meta):
+    def _print_stats(self, meta, timing_data):
         self.stdout.ending = '\n'
-        for line in format_dump_stats(meta):
+        for line in format_dump_stats(meta, timing_data):
             self.stdout.write(line)
 
 
-def format_dump_stats(meta):
-    """Lines of the final dump-stats report."""
+def format_dump_stats(meta, timing_data):
+    """Lines of the final dump-stats report: per-model throughput (hours per
+    million rows), and per-dumper and grand-total elapsed time.
+    """
     lines = [f'{"-" * 32} Dump Stats {"-" * 32}']
     for dumper, models in sorted(meta.items()):
-        lines.append(dumper)
+        dumper_timing = timing_data.get(dumper, {})
+        lines.append(f"{dumper}: {dumper_timing.get('total', 0):.2f}s")
+        model_times = dumper_timing.get('models', {})
         for model, count in sorted(models.items()):
-            lines.append(f'  {model:<50}: {count}')
+            model_time = model_times.get(model)
+            suffix = f'  {format_rate(model_time, count)}' if model_time is not None and count else ''
+            lines.append(f'  {model:<50}: {count:>10}{suffix}')
     lines.append('-' * 76)
     total = sum(count for models in meta.values() for count in models.values())
-    lines.append(f'Dumped {total} objects')
+    lines.append(f'Dumped {total} rows')
+    grand_total = sum(d.get('total', 0) for d in timing_data.values())
+    lines.append(f'Total dump time: {grand_total:.2f}s')
     lines.append('-' * 76)
     return lines
 

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -98,16 +98,15 @@ class Command(BaseCommand):
 
     def _print_stats(self, meta):
         self.stdout.ending = '\n'
-        self.stdout.write('{0} Dump Stats {0}'.format('-' * 32))
+        self.stdout.write(f'{"-" * 32} Dump Stats {"-" * 32}')
         for dumper, models in sorted(meta.items()):
             self.stdout.write(dumper)
             for model, count in sorted(models.items()):
-                self.stdout.write("  {:<50}: {}".format(model, count))
-        self.stdout.write('{0}{0}'.format('-' * 38))
-        self.stdout.write('Dumped {} objects'.format(sum(
-            count for model in meta.values() for count in model.values()
-        )))
-        self.stdout.write('{0}{0}'.format('-' * 38))
+                self.stdout.write(f'  {model:<50}: {count}')
+        self.stdout.write('-' * 76)
+        total = sum(count for models in meta.values() for count in models.values())
+        self.stdout.write(f'Dumped {total} objects')
+        self.stdout.write('-' * 76)
 
 
 def _get_dump_stream_filename(slug, domain, utcnow, path=None):

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -1,5 +1,6 @@
 import gzip
 import json
+import logging
 import os
 import zipfile
 from datetime import datetime
@@ -10,6 +11,9 @@ from corehq.apps.dump_reload.const import DATETIME_FORMAT
 from corehq.apps.dump_reload.couch import CouchDataDumper
 from corehq.apps.dump_reload.couch.dump import DomainDumper, ToggleDumper
 from corehq.apps.dump_reload.sql import SqlDataDumper
+from corehq.util.timer import TimingContext
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -66,15 +70,18 @@ class Command(BaseCommand):
 
             filename = _get_dump_stream_filename(dumper.slug, domain_name, self.utcnow, path=output_dir)
             stream = self.stdout if console else gzip.open(filename, 'wt')
-            try:
-                meta[dumper.slug] = dumper(domain_name, excludes, includes).dump(stream)
-            except Exception as e:
-                if show_traceback:
-                    raise
-                raise CommandError("Unable to serialize database: %s" % e)
-            finally:
-                if stream and not console:
-                    stream.close()
+            with TimingContext(dumper.slug) as dumper_timer:
+                try:
+                    meta[dumper.slug] = dumper(domain_name, excludes, includes).dump(stream)
+                except Exception as e:
+                    if show_traceback:
+                        raise
+                    raise CommandError("Unable to serialize database: %s" % e)
+                finally:
+                    if stream and not console:
+                        stream.close()
+
+            logger.info(f"[timing] dumper '{dumper.slug}' finished in {dumper_timer.duration:.2f}s")
 
             if not console:
                 with zipfile.ZipFile(zipname, mode='a', allowZip64=True) as z:

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -98,15 +98,22 @@ class Command(BaseCommand):
 
     def _print_stats(self, meta):
         self.stdout.ending = '\n'
-        self.stdout.write(f'{"-" * 32} Dump Stats {"-" * 32}')
-        for dumper, models in sorted(meta.items()):
-            self.stdout.write(dumper)
-            for model, count in sorted(models.items()):
-                self.stdout.write(f'  {model:<50}: {count}')
-        self.stdout.write('-' * 76)
-        total = sum(count for models in meta.values() for count in models.values())
-        self.stdout.write(f'Dumped {total} objects')
-        self.stdout.write('-' * 76)
+        for line in format_dump_stats(meta):
+            self.stdout.write(line)
+
+
+def format_dump_stats(meta):
+    """Lines of the final dump-stats report."""
+    lines = [f'{"-" * 32} Dump Stats {"-" * 32}']
+    for dumper, models in sorted(meta.items()):
+        lines.append(dumper)
+        for model, count in sorted(models.items()):
+            lines.append(f'  {model:<50}: {count}')
+    lines.append('-' * 76)
+    total = sum(count for models in meta.values() for count in models.values())
+    lines.append(f'Dumped {total} objects')
+    lines.append('-' * 76)
+    return lines
 
 
 def _get_dump_stream_filename(slug, domain, utcnow, path=None):

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -1,4 +1,5 @@
 from collections import Counter, OrderedDict, defaultdict
+from itertools import groupby
 
 from django.apps import apps
 from django.conf import settings
@@ -18,6 +19,7 @@ from corehq.apps.dump_reload.sql.filters import (
     UsernameFilter,
 )
 from corehq.apps.dump_reload.sql.serialization import JsonLinesSerializer
+from corehq.apps.dump_reload.timing import DumpTimingLogger
 from corehq.apps.dump_reload.util import get_model_class, get_model_label
 from corehq.sql_db.config import plproxy_config
 
@@ -285,6 +287,7 @@ class SqlDataDumper(DataDumper):
             self.includes,
             stats_counter=stats,
             stdout=self.stdout,
+            timer=self.timer,
         )
 
         JsonLinesSerializer().serialize(
@@ -296,28 +299,33 @@ class SqlDataDumper(DataDumper):
         return stats
 
 
-def get_objects_to_dump(domain, excludes, includes, stats_counter=None, stdout=None):
+def get_objects_to_dump(domain, excludes, includes, stats_counter=None, stdout=None, timer=None):
     """
     :param domain: domain name to filter with
     :param app_list: List of (app_config, model_class) tuples to dump
     :param excluded_models: List of model_class classes to exclude
+    :param timer: :class:`DumpTimingLogger` to record per-model timing
     :return: generator yielding models objects
     """
     builders = get_model_iterator_builders_to_dump(domain, excludes, includes)
-    yield from get_objects_to_dump_from_builders(builders, stats_counter, stdout)
+    yield from get_objects_to_dump_from_builders(builders, stats_counter, stdout, timer)
 
 
-def get_objects_to_dump_from_builders(builders, stats_counter=None, stdout=None):
+def get_objects_to_dump_from_builders(builders, stats_counter=None, stdout=None, timer=None):
     if stats_counter is None:
         stats_counter = Counter()
-    for model_class, builder in builders:
-        model_label = get_model_label(model_class)
-        for iterator in builder.iterators():
-            for obj in iterator:
-                stats_counter.update([model_label])
-                yield obj
-        if stdout:
-            stdout.write('Dumped {} {}\n'.format(stats_counter[model_label], model_label))
+    timer = timer or DumpTimingLogger()
+    # A model can span several builders (one per shard); group them so the timer brackets it once.
+    for model_label, model_builders in groupby(builders, key=lambda mb: get_model_label(mb[0])):
+        with timer.measure(model_label):
+            for model_class, builder in model_builders:
+                for iterator in builder.iterators():
+                    for obj in iterator:
+                        stats_counter.update([model_label])
+                        timer.tick()
+                        yield obj
+                if stdout:
+                    stdout.write('Dumped {} {}\n'.format(stats_counter[model_label], model_label))
 
 
 def get_model_iterator_builders_to_dump(domain, excludes, includes, limit_to_db=None):

--- a/corehq/apps/dump_reload/tests/test_dump_domain_data.py
+++ b/corehq/apps/dump_reload/tests/test_dump_domain_data.py
@@ -16,18 +16,38 @@ from corehq.apps.dump_reload.management.commands.dump_domain_data import (
 
 
 class TestFormatDumpStats:
-    def test_lists_counts_per_model(self):
-        meta = {'sql': {'app.B': 2, 'app.A': 1}, 'couch': {'x.Y': 3}}
+    def test_with_timing_data_shows_per_model_rate_and_elapsed_totals(self):
+        meta = {'sql': {'app.A': 5}}
+        timing_data = {'sql': {'total': 0.018, 'models': {'app.A': 0.018}}}
 
-        assert format_dump_stats(meta) == [
+        # 0.018s / 5 rows -> 1.000 h/1M; header and grand total stay elapsed
+        assert format_dump_stats(meta, timing_data) == [
             f'{"-" * 32} Dump Stats {"-" * 32}',
-            'couch',
-            f'  {"x.Y":<50}: 3',
-            'sql',
-            f'  {"app.A":<50}: 1',
-            f'  {"app.B":<50}: 2',
+            'sql: 0.02s',
+            f'  {"app.A":<50}: {5:>10}  1.000h /1M rows',
             '-' * 76,
-            'Dumped 6 objects',
+            'Dumped 5 rows',
+            'Total dump time: 0.02s',
+            '-' * 76,
+        ]
+
+    def test_zero_count_with_a_recorded_time_does_not_divide_by_zero(self):
+        meta = {'sql': {'app.Empty': 0}}
+        timing_data = {'sql': {'total': 0.1, 'models': {'app.Empty': 0.1}}}
+
+        assert f'  {"app.Empty":<50}: {0:>10}' in format_dump_stats(meta, timing_data)
+
+    def test_model_without_recorded_time_omits_the_time_column(self):
+        meta = {'domain': {'Domain': 1}}
+        timing_data = {'domain': {'total': 0.5, 'models': {}}}
+
+        assert format_dump_stats(meta, timing_data) == [
+            f'{"-" * 32} Dump Stats {"-" * 32}',
+            'domain: 0.50s',
+            f'  {"Domain":<50}: {1:>10}',
+            '-' * 76,
+            'Dumped 1 rows',
+            'Total dump time: 0.50s',
             '-' * 76,
         ]
 

--- a/corehq/apps/dump_reload/tests/test_dump_domain_data.py
+++ b/corehq/apps/dump_reload/tests/test_dump_domain_data.py
@@ -11,7 +11,25 @@ from django.core.management.base import CommandError
 from corehq.apps.dump_reload.management.commands.dump_domain_data import (
     Command,
     _get_dump_stream_filename,
+    format_dump_stats,
 )
+
+
+class TestFormatDumpStats:
+    def test_lists_counts_per_model(self):
+        meta = {'sql': {'app.B': 2, 'app.A': 1}, 'couch': {'x.Y': 3}}
+
+        assert format_dump_stats(meta) == [
+            f'{"-" * 32} Dump Stats {"-" * 32}',
+            'couch',
+            f'  {"x.Y":<50}: 3',
+            'sql',
+            f'  {"app.A":<50}: 1',
+            f'  {"app.B":<50}: 2',
+            '-' * 76,
+            'Dumped 6 objects',
+            '-' * 76,
+        ]
 
 
 @contextmanager

--- a/corehq/apps/dump_reload/tests/test_timing.py
+++ b/corehq/apps/dump_reload/tests/test_timing.py
@@ -1,5 +1,9 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
+
 import pytest
 
+from corehq.apps.dump_reload.sql.dump import get_objects_to_dump_from_builders
 from corehq.apps.dump_reload.timing import DumpTimingLogger, format_rate
 
 
@@ -67,6 +71,26 @@ def test_a_model_with_no_rows_is_silent():
     assert timer.totals == {}
 
 
+def test_sql_generator_brackets_each_model_with_measure():
+    # Sharded model (two builders) groups under one measure; a zero-row model is still bracketed.
+    builders = [
+        (_model('app', 'A'), _Builder(['a1'])),
+        (_model('app', 'A'), _Builder(['a2'])),
+        (_model('app', 'Empty'), _Builder([])),
+        (_model('app', 'C'), _Builder(['c1'])),
+    ]
+    timer = _RecordingTimer()
+
+    dumped = list(get_objects_to_dump_from_builders(builders, timer=timer))
+
+    assert dumped == ['a1', 'a2', 'c1']
+    assert timer.calls == [
+        ('enter', 'app.A'), ('tick',), ('tick',), ('exit', 'app.A'),
+        ('enter', 'app.Empty'), ('exit', 'app.Empty'),
+        ('enter', 'app.C'), ('tick',), ('exit', 'app.C'),
+    ]
+
+
 @pytest.mark.parametrize("total_seconds, row_count, expected", [
     (3600, 1_000_000, '1.000h /1M rows'),       # 1 hour to dump 1M rows
     (3651.84, 1_000_000, '1.014h /1M rows'),    # rounds to 3 decimals
@@ -89,3 +113,31 @@ class RecordingLogger:
 def fake_clock(times):
     it = iter(times)
     return lambda: next(it)
+
+
+def _model(app_label, name):
+    return type(name, (), {'_meta': SimpleNamespace(app_label=app_label)})
+
+
+class _Builder:
+    def __init__(self, *iterators):
+        self._iterators = iterators
+
+    def iterators(self):
+        return self._iterators
+
+
+class _RecordingTimer:
+    def __init__(self):
+        self.calls = []
+
+    @contextmanager
+    def measure(self, model_label):
+        self.calls.append(('enter', model_label))
+        try:
+            yield
+        finally:
+            self.calls.append(('exit', model_label))
+
+    def tick(self):
+        self.calls.append(('tick',))

--- a/corehq/apps/dump_reload/tests/test_timing.py
+++ b/corehq/apps/dump_reload/tests/test_timing.py
@@ -1,0 +1,91 @@
+import pytest
+
+from corehq.apps.dump_reload.timing import DumpTimingLogger, format_rate
+
+
+def test_logs_a_batch_line_every_batch_size_rows():
+    log = RecordingLogger()
+    timer = DumpTimingLogger(batch_size=3, logger=log, time_func=fake_clock([0, 10, 30]))
+    timer.start('app.Model')
+    for _ in range(6):
+        timer.tick()
+
+    assert log.messages == [
+        '[timing] app.Model: 3 rows in 10.00s (3 total)',
+        '[timing] app.Model: 3 rows in 20.00s (6 total)',
+    ]
+
+
+def test_measure_logs_summary_with_total_and_rate():
+    log = RecordingLogger()
+    timer = DumpTimingLogger(batch_size=10, logger=log, time_func=fake_clock([0, 0.0108]))
+    with timer.measure('app.Model'):
+        for _ in range(3):
+            timer.tick()
+
+    # 0.0108s / 3 rows -> 1.000 h per 1M rows
+    assert log.messages == [
+        '[timing] app.Model: finished 3 rows in 0.01s (1.000h /1M rows)',
+    ]
+
+
+def test_logs_one_summary_per_model():
+    log = RecordingLogger()
+    timer = DumpTimingLogger(
+        batch_size=10, logger=log, time_func=fake_clock([0, 0.0072, 0.0072, 0.0216]),
+    )
+    for label in ['app.First', 'app.Second']:
+        with timer.measure(label):
+            timer.tick()
+            timer.tick()
+
+    # First: 0.0072s/2 -> 1.000h/1M; Second: 0.0144s/2 -> 2.000h/1M
+    assert log.messages == [
+        '[timing] app.First: finished 2 rows in 0.01s (1.000h /1M rows)',
+        '[timing] app.Second: finished 2 rows in 0.01s (2.000h /1M rows)',
+    ]
+
+
+def test_totals_records_total_seconds_per_model():
+    timer = DumpTimingLogger(
+        batch_size=10, logger=RecordingLogger(), time_func=fake_clock([0, 20, 21, 31]),
+    )
+    for label in ['app.First', 'app.Second']:
+        with timer.measure(label):
+            timer.tick()
+
+    assert timer.totals == {'app.First': 20.0, 'app.Second': 10.0}
+
+
+def test_a_model_with_no_rows_is_silent():
+    log = RecordingLogger()
+    timer = DumpTimingLogger(batch_size=10, logger=log, time_func=fake_clock([0]))
+    with timer.measure('app.Empty'):
+        pass
+
+    assert log.messages == []
+    assert timer.totals == {}
+
+
+@pytest.mark.parametrize("total_seconds, row_count, expected", [
+    (3600, 1_000_000, '1.000h /1M rows'),       # 1 hour to dump 1M rows
+    (3651.84, 1_000_000, '1.014h /1M rows'),    # rounds to 3 decimals
+    (7200, 2_000_000, '1.000h /1M rows'),       # scaled by row count
+    (0, 1_000_000, '0.000h /1M rows'),          # zero elapsed, positive rows
+    (5.0, 0, 'n/a /1M rows'),                   # zero rows: no divide by zero
+])
+def test_format_rate(total_seconds, row_count, expected):
+    assert format_rate(total_seconds, row_count) == expected
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, msg):
+        self.messages.append(msg)
+
+
+def fake_clock(times):
+    it = iter(times)
+    return lambda: next(it)

--- a/corehq/apps/dump_reload/timing.py
+++ b/corehq/apps/dump_reload/timing.py
@@ -1,0 +1,64 @@
+import logging
+import time
+from contextlib import contextmanager
+
+logger = logging.getLogger(__name__)
+
+
+class DumpTimingLogger:
+    """Logs per-model export timing during a domain dump. Wrap each model in
+    :meth:`measure` and call :meth:`tick` per row; a model with no rows is silent.
+    """
+
+    def __init__(self, batch_size=10000, logger=logger, time_func=time.monotonic):
+        self.batch_size = batch_size
+        self.logger = logger
+        self.time_func = time_func
+        self.totals = {}  # seconds per model
+        self._label = None
+        self._model_start = None
+        self._batch_start = None
+        self._count = 0
+
+    @contextmanager
+    def measure(self, model_label):
+        self.start(model_label)
+        try:
+            yield
+        finally:
+            self.stop()
+
+    def start(self, model_label):
+        now = self.time_func()
+        self._label = model_label
+        self._model_start = now
+        self._batch_start = now
+        self._count = 0
+
+    def tick(self):
+        self._count += 1
+        if self._count % self.batch_size == 0:
+            now = self.time_func()
+            self.logger.info(
+                f"[timing] {self._label}: {self.batch_size} rows in "
+                f"{now - self._batch_start:.2f}s ({self._count} total)"
+            )
+            self._batch_start = now
+
+    def stop(self):
+        if self._count:
+            total = self.time_func() - self._model_start
+            self.totals[self._label] = self.totals.get(self._label, 0) + total
+            self.logger.info(
+                f"[timing] {self._label}: finished {self._count} rows in "
+                f"{total:.2f}s ({format_rate(total, self._count)})"
+            )
+        self._label = None
+
+
+def format_rate(total_seconds, row_count):
+    """Throughput as hours per million rows, e.g. ``1.014h /1M rows`` (``n/a`` for zero rows)."""
+    if not row_count:
+        return 'n/a /1M rows'
+    hours_per_million = total_seconds / row_count * 1_000_000 / 3600
+    return f'{hours_per_million:.3f}h /1M rows'


### PR DESCRIPTION
Tip: add ?w=1 to the URL (ignore whitespace) on any commit where it looks like there's a lot of churn—in most cases it's just indentation.

## Product Description

There is no user-facing effect. Only affects the dump_domain_data management command.

## Technical Summary

A full domain dump can take hours, with no visibility into which models dominate that time. Benchmarking potential performance improvements is also a challenge.

To address both these pain points, `dump_domain_data` now logs (via `logging.info`) how long each model takes as it runs—a progress line every 10,000 rows of a model, a per-model summary, and a per-dumper total:

```
[timing] form_processor.XFormInstance: 10000 rows in 4.32s (10000 total)
[timing] form_processor.XFormInstance: finished 23814 rows in 10.21s (0.119h /1M rows)
[timing] dumper 'sql' finished in 11.04s
```

The final **Dump Stats** report also gains per-model throughput and per-dumper/grand-total times:

```
-------------------------------- Dump Stats --------------------------------
sql: 11.04s
  form_processor.CommCareCase                       :       1502  0.153h /1M rows
  form_processor.XFormInstance                      :      23814  0.119h /1M rows
--------------------------------------------------------------------------------
Dumped 25316 rows
Total dump time: 11.04s
--------------------------------------------------------------------------------
```

The per-row overhead is negligible next to serializing each row, and it's useful in both testing and real-use contexts, so I did not implement an option to disable timing.

This is quite minor, but just to say explicitly: the way the timings are measured, the dumper's total won't necessarily equal the sum of its models timings (though it'll be close), because the dumper's total is end-to-end wall clock time, which includes some minimal interstitial stuff between individual model runs.

## Feature Flag

N/A

## Safety Assurance

### Safety story

The dumped data is unchanged; this only adds `logging.info` output and enriches the printed Dump Stats report.

### Automated test coverage

There's reasonable coverage for the new functionality, and dump/restore in general has tests that would catch at least the kind of typo-level errors that a relatively orthogonal change like this might introduce.

### QA Plan

Nothing too special. I'll be regularly running test dumps on staging, so on the off chance this breaks something, I will catch it pretty quickly. (I also ran some intermediate versions of this change on staging already, and it worked well.) I've also run it locally on a very small local test domain as a sanity test.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
