### PR TITLE
Use f-strings throughout dump_reload

### DIFF
--- a/corehq/apps/dump_reload/couch/dump.py
+++ b/corehq/apps/dump_reload/couch/dump.py
@@ -53,7 +53,7 @@ class CouchDataDumper(DataDumper):
         return stats
 
     def _dump_docs(self, doc_class, doc_ids, output_stream):
-        model_label = '{}.{}'.format(doc_class._meta.app_label, doc_class.__name__)
+        model_label = f'{doc_class._meta.app_label}.{doc_class.__name__}'
         count = 0
         with self.timer.measure(model_label):
             couch_db = doc_class.get_db()
@@ -62,7 +62,7 @@ class CouchDataDumper(DataDumper):
                 self.timer.tick()
                 output_stream.write(json.dumps(doc))
                 output_stream.write('\n')
-        self.stdout.write('Dumped {} {}\n'.format(count, model_label))
+        self.stdout.write(f'Dumped {count} {model_label}\n')
         return Counter({model_label: count})
 
 
@@ -90,7 +90,7 @@ class ToggleDumper(DataDumper):
             output_stream.write(json.dumps(toggle))
             output_stream.write('\n')
 
-        self.stdout.write('Dumped {} Toggles\n'.format(count))
+        self.stdout.write(f'Dumped {count} Toggles\n')
         return Counter({'Toggle': count})
 
 
@@ -128,10 +128,10 @@ class DomainDumper(DataDumper):
         from corehq.apps.domain.models import Domain
         domain_obj = Domain.get_by_name(self.domain, strict=True)
         if not domain_obj:
-            raise DomainDumpError("Domain not found: {}".format(self.domain))
+            raise DomainDumpError(f"Domain not found: {self.domain}")
 
         json.dump(domain_obj.to_json(), output_stream)
         output_stream.write('\n')
 
-        self.stdout.write('Dumping {} Domain\n'.format(1))
+        self.stdout.write(f'Dumping {1} Domain\n')
         return Counter({'Domain': 1})

--- a/corehq/apps/dump_reload/couch/dump.py
+++ b/corehq/apps/dump_reload/couch/dump.py
@@ -133,5 +133,5 @@ class DomainDumper(DataDumper):
         json.dump(domain_obj.to_json(), output_stream)
         output_stream.write('\n')
 
-        self.stdout.write(f'Dumping {1} Domain\n')
+        self.stdout.write('Dumping 1 Domain\n')
         return Counter({'Domain': 1})

--- a/corehq/apps/dump_reload/couch/load.py
+++ b/corehq/apps/dump_reload/couch/load.py
@@ -58,7 +58,7 @@ class CouchDataLoader(DataLoader):
     def _create_db_for_doc_type(self, doc_type):
         couch_db = get_db_by_doc_type(doc_type)
         if couch_db is None:
-            raise DocumentClassNotFound('No Document class with name "{}" could be found.'.format(doc_type))
+            raise DocumentClassNotFound(f'No Document class with name "{doc_type}" could be found.')
         callback = LoaderCallback(self._success_counter, self.stdout)
         large_doc_types = [Application._doc_type, LinkedApplication._doc_type, RemoteApp._doc_type]
         chunksize = 1 if doc_type in large_doc_types else self.chunksize
@@ -82,14 +82,14 @@ class LoaderCallback(IterDBCallback):
             doc_id = doc['_id']
             doc_type = drop_suffix(doc['doc_type'])
             doc_class = get_document_class_by_doc_type(doc_type)
-            doc_label = '{}.{}'.format(doc_class._meta.app_label, doc_type)
+            doc_label = f'{doc_class._meta.app_label}.{doc_type}'
             if doc_id in success_ids:
                 success_doc_types.append(doc_label)
 
         self._success_counter.update(success_doc_types)
 
         if self.stdout:
-            self.stdout.write('Loaded {} couch docs'.format(sum(self._success_counter.values())))
+            self.stdout.write(f'Loaded {sum(self._success_counter.values())} couch docs')
 
 
 class ToggleLoader(DataLoader):
@@ -118,7 +118,7 @@ class ToggleLoader(DataLoader):
 
             count += 1
 
-        self.stdout.write('Loaded {} Toggles'.format(count))
+        self.stdout.write(f'Loaded {count} Toggles')
         return Counter({'Toggle': count})
 
 
@@ -140,9 +140,9 @@ class DomainLoader(DataLoader):
         else:
             if existing_domain:
                 if force:
-                    self.stderr.write('Loading data for existing domain: {}'.format(domain_name))
+                    self.stderr.write(f'Loading data for existing domain: {domain_name}')
                 else:
-                    raise DataExistsException("Domain: {}".format(domain_name))
+                    raise DataExistsException(f"Domain: {domain_name}")
 
         if not dry_run:
             Domain.get_db().bulk_save([domain_dict], new_edits=False)

--- a/corehq/apps/dump_reload/interface.py
+++ b/corehq/apps/dump_reload/interface.py
@@ -70,7 +70,7 @@ class DataLoader(metaclass=ABCMeta):
 
     def load_from_file(self, file_path, dump_meta, force=False, dry_run=False):
         if not os.path.isfile(file_path):
-            raise Exception("Dump file not found: {}".format(file_path))
+            raise Exception(f"Dump file not found: {file_path}")
 
         self.stdout.write(f"\nLoading {file_path} using '{self.slug}' data loader.")
         meta_slug, _ = os.path.splitext(os.path.basename(file_path))
@@ -82,8 +82,8 @@ class DataLoader(metaclass=ABCMeta):
         # Warn if the file we loaded contains 0 objects.
         if sum(loaded_object_count.values()) == 0:
             warnings.warn(
-                "No data found for '%s'. (File format may be "
-                "invalid.)" % file_path,
+                f"No data found for '{file_path}'. (File format may be "
+                "invalid.)",
                 RuntimeWarning
             )
 

--- a/corehq/apps/dump_reload/management/commands/dump_case_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_case_data.py
@@ -23,17 +23,14 @@ class Command(BaseCommand):
             available_case_types = (CommCareCase.objects.using(for_db_conn).
                                     values_list('type', flat=True).distinct())
             if for_case_type not in available_case_types:
-                raise CommandError("Unexpected case type {for_case_type} passed. "
-                                   "Should be from the following: {case_types}"
-                                   .format(for_case_type=for_case_type, case_types=available_case_types))
+                raise CommandError(f"Unexpected case type {for_case_type} passed. "
+                                   f"Should be from the following: {available_case_types}")
 
         if for_domain:
             available_domains = (CommCareCase.objects.using(for_db_conn).
                                  values_list('domain', flat=True).distinct())
             if for_domain not in available_domains:
-                raise CommandError("Domain name {for_domain} not found for any case in db {for_db_conn}".format(
-                    for_domain=for_domain, for_db_conn=for_db_conn
-                ))
+                raise CommandError(f"Domain name {for_domain} not found for any case in db {for_db_conn}")
 
     def handle(self, *args, **options):
         for_domain = options.get('domain')
@@ -55,40 +52,34 @@ class Command(BaseCommand):
                     available_domains = (CommCareCase.objects.using(db).
                                          values_list('domain', flat=True).distinct())
                     if for_domain not in available_domains:
-                        print("Domain name {for_domain} not found for any case in db {for_db_conn}".format(
-                            for_domain=for_domain,
-                            for_db_conn=db
-                        ))
+                        print(f"Domain name {for_domain} not found for any case in db {db}")
                         continue
-                    where_clause += "domain='{domain}' and ".format(domain=for_domain)
+                    where_clause += f"domain='{for_domain}' and "
 
                 # ensure case type passed present for this db, if not just ignore it with a warning message
                 available_case_types = (CommCareCase.objects.using(db).
                                         values_list('type', flat=True).distinct())
                 if for_case_type and for_case_type not in available_case_types:
-                    print("Ignoring Unexpected case type {for_case_type} passed."
-                          "Should be from the following: {case_types}"
-                          .format(for_case_type=for_case_type, case_types=available_case_types))
+                    print(f"Ignoring Unexpected case type {for_case_type} passed."
+                          f"Should be from the following: {available_case_types}")
                     continue
                 if for_case_type:
                     case_types = [for_case_type]
                 else:
                     case_types = available_case_types
                 for case_type in case_types:
-                    file_name = "{case_type}_{db_name}_{timestamp}.csv".format(
-                        case_type=case_type, db_name=db,
-                        timestamp=datetime.utcnow().strftime(DATETIME_FORMAT))
+                    file_name = f"{case_type}_{db}_{datetime.utcnow().strftime(DATETIME_FORMAT)}.csv"
                     with open(file_name, "w", encoding='utf-8') as output:
                         c = db_conn.cursor()
-                        _where_clause = where_clause + "type='{case_type}' ".format(case_type=case_type)
-                        copy_query = "copy (SELECT * FROM form_processor_commcarecasesql " \
-                                     "{where_clause})".format(where_clause=_where_clause)
+                        _where_clause = where_clause + f"type='{case_type}' "
+                        copy_query = ("copy (SELECT * FROM form_processor_commcarecasesql "
+                                      f"{_where_clause})")
                         print("Query Being Run:")
                         print(copy_query)
                         c.copy_expert(
-                            "{query} TO STDOUT DELIMITER ',' CSV HEADER;".format(query=copy_query), output)
+                            f"{copy_query} TO STDOUT DELIMITER ',' CSV HEADER;", output)
                     with ZipFile(file_name + '.zip', 'w') as zip_file:
                         zip_file.write(file_name, file_name)
                         os.remove(file_name)
             else:
-                print("Ignoring {db}. It does not have the table form_processor_commcarecasesql".format(db=db))
+                print(f"Ignoring {db}. It does not have the table form_processor_commcarecasesql")

--- a/corehq/apps/dump_reload/management/commands/dump_case_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_case_data.py
@@ -68,7 +68,8 @@ class Command(BaseCommand):
                 else:
                     case_types = available_case_types
                 for case_type in case_types:
-                    file_name = f"{case_type}_{db}_{datetime.utcnow().strftime(DATETIME_FORMAT)}.csv"
+                    timestamp = datetime.utcnow().strftime(DATETIME_FORMAT)
+                    file_name = f"{case_type}_{db}_{timestamp}.csv"
                     with open(file_name, "w", encoding='utf-8') as output:
                         c = db_conn.cursor()
                         _where_clause = where_clause + f"type='{case_type}' "

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
             os.makedirs(output_dir, exist_ok=True)
 
         self.utcnow = datetime.utcnow().strftime(DATETIME_FORMAT)
-        zipname = 'data-dump-{}-{}.zip'.format(domain_name, self.utcnow)
+        zipname = f'data-dump-{domain_name}-{self.utcnow}.zip'
         if output_dir:
             zipname = os.path.join(output_dir, zipname)
 
@@ -79,7 +79,7 @@ class Command(BaseCommand):
                 except Exception as e:
                     if show_traceback:
                         raise
-                    raise CommandError("Unable to serialize database: %s" % e)
+                    raise CommandError(f"Unable to serialize database: {e}")
                 finally:
                     if stream and not console:
                         stream.close()
@@ -92,7 +92,7 @@ class Command(BaseCommand):
 
             if not console:
                 with zipfile.ZipFile(zipname, mode='a', allowZip64=True) as z:
-                    z.write(filename, '{}.gz'.format(dumper.slug))
+                    z.write(filename, f'{dumper.slug}.gz')
 
                 os.remove(filename)
 
@@ -101,7 +101,7 @@ class Command(BaseCommand):
                 z.writestr('meta.json', json.dumps(meta, indent=4))
 
         self._print_stats(meta, timing_data)
-        self.stdout.write('\nData dumped to file: {}'.format(zipname))
+        self.stdout.write(f'\nData dumped to file: {zipname}')
 
     def _print_stats(self, meta, timing_data):
         self.stdout.ending = '\n'
@@ -132,7 +132,7 @@ def format_dump_stats(meta, timing_data):
 
 
 def _get_dump_stream_filename(slug, domain, utcnow, path=None):
-    filename = 'dump-{}-{}-{}.gz'.format(slug, domain, utcnow)
+    filename = f'dump-{slug}-{domain}-{utcnow}.gz'
     if path:
         return os.path.join(path, filename)
     return filename

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data_raw.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data_raw.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
             s3_key = settings.S3_ACCESS_KEY
             s3_secret = settings.S3_SECRET_KEY
 
-        self.bucket = options['bucket'] or 'raw-data-{}'.format(domain)
+        self.bucket = options['bucket'] or f'raw-data-{domain}'
         self.client = boto3.client(
             's3',
             region_name=options['region'],
@@ -74,7 +74,7 @@ class Command(BaseCommand):
 
     def _upload(self, type_, path):
         filename = _filename(self.domain, type_, self.timestamp)
-        print("Uploading {} to s3://{}/{}".format(type_, self.bucket, filename))
+        print(f"Uploading {type_} to s3://{self.bucket}/{filename}")
         S3Transfer(self.client).upload_file(
             path, self.bucket, filename,
             extra_args={'ServerSideEncryption': 'AES256'}
@@ -82,26 +82,22 @@ class Command(BaseCommand):
 
 
 def _dump_docs(query, type_):
-    print("Dumping {}".format(type_))
+    print(f"Dumping {type_}")
 
     total_docs = query.count()
     path, file = _get_file(type_)
     with file:
         for doc in with_progress_bar(query.size(500).scroll(), length=total_docs):
-            file.write('{}\n'.format(json.dumps(doc)))
+            file.write(f'{json.dumps(doc)}\n')
     return path
 
 
 def _filename(domain, type_, date):
-    return 'raw_{}_dump_{}_{}.jsonl.gz'.format(
-        type_,
-        domain,
-        date.strftime('%Y%m%d_%H%M%S')
-    )
+    return f"raw_{type_}_dump_{domain}_{date.strftime('%Y%m%d_%H%M%S')}.jsonl.gz"
 
 
 def _get_file(doc_type):
-    with tempfile.NamedTemporaryFile(prefix='domain_dump_raw_{}_'.format(doc_type),
+    with tempfile.NamedTemporaryFile(prefix=f'domain_dump_raw_{doc_type}_',
             mode='wb', delete=False) as fileobj:
         zipped_obj = gzip.GzipFile(filename=fileobj.name, mode='wb')
     return zipped_obj.name, zipped_obj

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data_raw.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data_raw.py
@@ -6,7 +6,7 @@ import tempfile
 from datetime import datetime
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 import boto3
 from botocore.exceptions import ClientError

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -80,9 +80,9 @@ class Command(BaseCommand):
         self.should_throttle = options.get('throttle')
 
         if not os.path.isfile(dump_file_path):
-            raise CommandError("Dump file not found: {}".format(dump_file_path))
+            raise CommandError(f"Dump file not found: {dump_file_path}")
 
-        self.stdout.write("Loading data from %s." % dump_file_path)
+        self.stdout.write(f"Loading data from {dump_file_path}.")
         extracted_dir = self.extract_dump_archive(dump_file_path)
 
         loaded_meta = {}
@@ -103,17 +103,17 @@ class Command(BaseCommand):
             self._print_stats(loaded_meta, dump_meta)
 
     def _print_stats(self, loaded_meta, dump_meta):
-        self.stdout.write('{0} Load Stats {0}'.format('-' * 40))
+        self.stdout.write(f'{"-" * 40} Load Stats {"-" * 40}')
         for loader, models in sorted(loaded_meta.items()):
             self.stdout.write(loader)
             for model, count in sorted(models.items()):
                 expected = dump_meta[loader].get(model, 0)
                 self.stdout.write(f"  {model:<50}: {count} / {expected}")
-        self.stdout.write('{0}{0}'.format('-' * 46))
+        self.stdout.write(f'{"-" * 46}{"-" * 46}')
         loaded_object_count = sum(count for model in loaded_meta.values() for count in model.values())
         total_object_count = sum(count for model in dump_meta.values() for count in model.values())
         self.stdout.write(f'Loaded {loaded_object_count}/{total_object_count} objects')
-        self.stdout.write('{0}{0}'.format('-' * 46))
+        self.stdout.write(f'{"-" * 46}{"-" * 46}')
 
     def extract_dump_archive(self, dump_file_path):
         target_dir = get_tmp_extract_dir(dump_file_path)
@@ -122,7 +122,7 @@ class Command(BaseCommand):
                 archive.extractall(target_dir)
         elif not self.use_extracted:
             raise CommandError(
-                "Extracted dump already exists at {}. Delete it or use --use-extracted".format(target_dir))
+                f"Extracted dump already exists at {target_dir}. Delete it or use --use-extracted")
         return target_dir
 
     def _load_data(self, loader_class, extracted_dump_path, object_filter, dump_meta):
@@ -130,10 +130,10 @@ class Command(BaseCommand):
             loader = loader_class(object_filter, self.stdout, self.stderr, self.chunksize, self.should_throttle)
             return loader.load_from_path(extracted_dump_path, dump_meta, force=self.force, dry_run=self.dry_run)
         except DataExistsException as e:
-            raise CommandError('Some data already exists. Use --force to load anyway: {}'.format(str(e)))
+            raise CommandError(f'Some data already exists. Use --force to load anyway: {str(e)}')
         except Exception as e:
             if not isinstance(e, CommandError):
-                e.args = ("Problem loading data '%s': %s" % (extracted_dump_path, e),)
+                e.args = (f"Problem loading data '{extracted_dump_path}': {e}",)
             raise
 
 

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -109,11 +109,11 @@ class Command(BaseCommand):
             for model, count in sorted(models.items()):
                 expected = dump_meta[loader].get(model, 0)
                 self.stdout.write(f"  {model:<50}: {count} / {expected}")
-        self.stdout.write(f'{"-" * 46}{"-" * 46}')
+        self.stdout.write('-' * 92)
         loaded_object_count = sum(count for model in loaded_meta.values() for count in model.values())
         total_object_count = sum(count for model in dump_meta.values() for count in model.values())
         self.stdout.write(f'Loaded {loaded_object_count}/{total_object_count} objects')
-        self.stdout.write(f'{"-" * 46}{"-" * 46}')
+        self.stdout.write('-' * 92)
 
     def extract_dump_archive(self, dump_file_path):
         target_dir = get_tmp_extract_dir(dump_file_path)
@@ -130,7 +130,7 @@ class Command(BaseCommand):
             loader = loader_class(object_filter, self.stdout, self.stderr, self.chunksize, self.should_throttle)
             return loader.load_from_path(extracted_dump_path, dump_meta, force=self.force, dry_run=self.dry_run)
         except DataExistsException as e:
-            raise CommandError(f'Some data already exists. Use --force to load anyway: {str(e)}')
+            raise CommandError(f'Some data already exists. Use --force to load anyway: {e}')
         except Exception as e:
             if not isinstance(e, CommandError):
                 e.args = (f"Problem loading data '{extracted_dump_path}': {e}",)

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -325,7 +325,7 @@ def get_objects_to_dump_from_builders(builders, stats_counter=None, stdout=None,
                         timer.tick()
                         yield obj
                 if stdout:
-                    stdout.write('Dumped {} {}\n'.format(stats_counter[model_label], model_label))
+                    stdout.write(f'Dumped {stats_counter[model_label]} {model_label}\n')
 
 
 def get_model_iterator_builders_to_dump(domain, excludes, includes, limit_to_db=None):
@@ -362,7 +362,7 @@ def get_all_model_iterators_builders_for_domain(model_class, domain, builders, l
     if limit_to_db:
         if limit_to_db not in using:
             raise DomainDumpError('DB specified is not valide for '
-                                  'model class: {} not in {}'.format(limit_to_db, using))
+                                  f'model class: {limit_to_db} not in {using}')
         using = [limit_to_db]
 
     for db_alias in using:
@@ -389,7 +389,7 @@ def get_apps_and_models(app_or_model_label):
             try:
                 model = apps.get_model(label)
             except LookupError:
-                raise DomainDumpError('Unknown model: %s' % label)
+                raise DomainDumpError(f'Unknown model: {label}')
             specified_models.add(model)
         else:
             try:
@@ -402,7 +402,7 @@ def get_apps_and_models(app_or_model_label):
                 try:
                     get_document_class_by_doc_type(label)
                 except DocumentClassNotFound:
-                    raise DomainDumpError('Unknown app in excludes: %s' % label)
+                    raise DomainDumpError(f'Unknown app in excludes: {label}')
             specified_apps.add(app_config)
     return specified_apps, specified_models
 

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -86,7 +86,7 @@ class IDFilter(DomainFilter):
 
     def get_filters(self, domain_name, db_alias=None):
         for chunk in chunked(self.get_ids(domain_name, db_alias=db_alias), self.chunksize):
-            query_kwarg = '{}__in'.format(self.field)
+            query_kwarg = f'{self.field}__in'
             yield Q(**{query_kwarg: chunk})
 
 

--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -59,7 +59,7 @@ class CouchDumpLoadTest(TestCase):
 
         # make sure that there's no data left in the DB
         objects_remaining = _get_doc_counts_from_db(self.domain_name)
-        self.assertEqual({}, objects_remaining, 'Not all data deleted: {}'.format(objects_remaining))
+        self.assertEqual({}, objects_remaining, f'Not all data deleted: {objects_remaining}')
 
         dump_output = output_stream.getvalue().split('\n')
         dump_lines = [line.strip() for line in dump_output if line.strip()]

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -107,7 +107,7 @@ class BaseDumpLoadTest(TestCase):
         objects_remaining = list(get_objects_to_dump(self.domain_name, [], []))
         object_classes = [obj.__class__.__name__ for obj in objects_remaining]
         counts = Counter(object_classes)
-        self.assertEqual([], objects_remaining, 'Not all data deleted: {}'.format(counts))
+        self.assertEqual([], objects_remaining, f'Not all data deleted: {counts}')
 
         actual_model_counts, dump_lines = self._parse_dump_output(output_stream)
         expected_model_counts = _normalize_object_counter(expected_dump_counts)
@@ -148,9 +148,7 @@ class BaseDumpLoadTest(TestCase):
                 if receiver_path in whitelist_receivers:
                     continue
                 args = inspect.signature(receiver).parameters
-                message = 'Signal handler "{}" for model "{}" missing raw arg'.format(
-                    receiver, model
-                )
+                message = f'Signal handler "{receiver}" for model "{model}" missing raw arg'
                 self.assertIn('raw', args, message)
                 found_models.add(model)
         expected_models = getattr(self, 'raw_post_save_models', set())
@@ -885,7 +883,7 @@ class DefaultDictWithKeyTests(SimpleTestCase):
 def _normalize_object_counter(counter, for_loaded=False):
     """Converts a <Model Class> keyed counter to an model label keyed counter"""
     def _model_class_to_label(model_class):
-        label = '{}.{}'.format(model_class._meta.app_label, model_class.__name__)
+        label = f'{model_class._meta.app_label}.{model_class.__name__}'
         return label if for_loaded else label.lower()
     return Counter({
         _model_class_to_label(model_class): count

--- a/corehq/apps/dump_reload/util.py
+++ b/corehq/apps/dump_reload/util.py
@@ -4,7 +4,7 @@ from corehq.apps.dump_reload.exceptions import DomainDumpError
 
 
 def get_model_label(model_class):
-    return '{}.{}'.format(model_class._meta.app_label, model_class.__name__)
+    return f'{model_class._meta.app_label}.{model_class.__name__}'
 
 
 def get_model_class(model_label):
@@ -12,11 +12,11 @@ def get_model_class(model_label):
     try:
         app_config = apps.get_app_config(app_label)
     except LookupError:
-        raise DomainDumpError("Unknown application: %s" % app_label)
+        raise DomainDumpError(f"Unknown application: {app_label}")
 
     try:
         model = app_config.get_model(model_label)
     except LookupError:
-        raise DomainDumpError("Unknown model: %s.%s" % (app_label, model_label))
+        raise DomainDumpError(f"Unknown model: {app_label}.{model_label}")
 
     return app_config, model


### PR DESCRIPTION
## Product Description
N/A — no user-facing changes.

## Technical Summary
Mechanical cleanup on top of #37780: converts the remaining `%`-interpolation and `.format()` calls under `corehq/apps/dump_reload` to f-strings, continuing the style used in the dump-timing work this branch is based on.

(Also removes a pre-existing unused `CommandError` import that was failing lint and blocking commits in this module in a separate commit.)

## Feature Flag
None

## Safety Assurance

### Safety story
Behavior-preserving conversion. The area is also well-tested, and I'm actively working in this area so on the off chance once of these string conversions causes some error, I'll notice it before the next time we run this for real.

### Automated test coverage
Existing `corehq/apps/dump_reload/tests/` cover the dump/load output paths these strings feed into.

### QA Plan
None — no behavior change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
