### PR TITLE
Raise the SQL dump chunk size to 5000 and make it tunable

### DIFF
--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import zipfile
+from argparse import ArgumentTypeError
 from datetime import datetime
 
 from django.core.management.base import BaseCommand, CommandError
@@ -11,6 +12,7 @@ from corehq.apps.dump_reload.const import DATETIME_FORMAT
 from corehq.apps.dump_reload.couch import CouchDataDumper
 from corehq.apps.dump_reload.couch.dump import DomainDumper, ToggleDumper
 from corehq.apps.dump_reload.sql import SqlDataDumper
+from corehq.apps.dump_reload.sql.filters import DEFAULT_CHUNK_SIZE
 from corehq.apps.dump_reload.timing import format_rate
 from corehq.util.timer import TimingContext
 
@@ -45,6 +47,10 @@ class Command(BaseCommand):
         )
         parser.add_argument('--dumper', dest='dumpers', action='append', default=[],
                             help='Dumper slug to run (use multiple --dumper to run multiple dumpers).')
+        parser.add_argument(
+            '--sql-chunk-size', dest='sql_chunk_size', type=positive_int, default=DEFAULT_CHUNK_SIZE,
+            help=f'Number of rows to fetch per query when dumping SQL data (default: {DEFAULT_CHUNK_SIZE}).'
+        )
 
     def handle(self, domain_name, **options):
         excludes = options.get('exclude')
@@ -53,6 +59,7 @@ class Command(BaseCommand):
         show_traceback = options.get('traceback')
         requested_dumpers = options.get('dumpers')
         output_dir = options.get('dir')
+        sql_chunk_size = options.get('sql_chunk_size', DEFAULT_CHUNK_SIZE)
 
         if output_dir:
             os.makedirs(output_dir, exist_ok=True)
@@ -72,7 +79,10 @@ class Command(BaseCommand):
 
             filename = _get_dump_stream_filename(dumper.slug, domain_name, self.utcnow, path=output_dir)
             stream = self.stdout if console else gzip.open(filename, 'wt')
-            dumper_instance = dumper(domain_name, excludes, includes)
+            if dumper is SqlDataDumper:
+                dumper_instance = dumper(domain_name, excludes, includes, chunk_size=sql_chunk_size)
+            else:
+                dumper_instance = dumper(domain_name, excludes, includes)
             with TimingContext(dumper.slug) as dumper_timer:
                 try:
                     meta[dumper.slug] = dumper_instance.dump(stream)
@@ -107,6 +117,13 @@ class Command(BaseCommand):
         self.stdout.ending = '\n'
         for line in format_dump_stats(meta, timing_data):
             self.stdout.write(line)
+
+
+def positive_int(value):
+    number = int(value)
+    if number <= 0:
+        raise ArgumentTypeError(f'{value!r} is not a positive integer')
+    return number
 
 
 def format_dump_stats(meta, timing_data):

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -9,6 +9,7 @@ from django.db import router
 from corehq.apps.dump_reload.exceptions import DomainDumpError
 from corehq.apps.dump_reload.interface import DataDumper
 from corehq.apps.dump_reload.sql.filters import (
+    DEFAULT_CHUNK_SIZE,
     FilteredModelIteratorBuilder,
     ManyFilters,
     MultimediaBlobMetaFilter,
@@ -265,6 +266,10 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
 class SqlDataDumper(DataDumper):
     slug = 'sql'
 
+    def __init__(self, *args, chunk_size=DEFAULT_CHUNK_SIZE, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.chunk_size = chunk_size
+
     def dump(self, output_stream):
         """
         When serializing data using JsonLinesSerializer().serialize(...), the additional parameters are set for
@@ -288,6 +293,7 @@ class SqlDataDumper(DataDumper):
             stats_counter=stats,
             stdout=self.stdout,
             timer=self.timer,
+            chunk_size=self.chunk_size,
         )
 
         JsonLinesSerializer().serialize(
@@ -299,19 +305,22 @@ class SqlDataDumper(DataDumper):
         return stats
 
 
-def get_objects_to_dump(domain, excludes, includes, stats_counter=None, stdout=None, timer=None):
+def get_objects_to_dump(domain, excludes, includes, stats_counter=None, stdout=None, timer=None,
+                        chunk_size=DEFAULT_CHUNK_SIZE):
     """
     :param domain: domain name to filter with
     :param app_list: List of (app_config, model_class) tuples to dump
     :param excluded_models: List of model_class classes to exclude
     :param timer: :class:`DumpTimingLogger` to record per-model timing
+    :param chunk_size: Number of rows to fetch per query
     :return: generator yielding models objects
     """
     builders = get_model_iterator_builders_to_dump(domain, excludes, includes)
-    yield from get_objects_to_dump_from_builders(builders, stats_counter, stdout, timer)
+    yield from get_objects_to_dump_from_builders(builders, stats_counter, stdout, timer, chunk_size)
 
 
-def get_objects_to_dump_from_builders(builders, stats_counter=None, stdout=None, timer=None):
+def get_objects_to_dump_from_builders(builders, stats_counter=None, stdout=None, timer=None,
+                                      chunk_size=DEFAULT_CHUNK_SIZE):
     if stats_counter is None:
         stats_counter = Counter()
     timer = timer or DumpTimingLogger()
@@ -319,7 +328,7 @@ def get_objects_to_dump_from_builders(builders, stats_counter=None, stdout=None,
     for model_label, model_builders in groupby(builders, key=lambda mb: get_model_label(mb[0])):
         with timer.measure(model_label):
             for model_class, builder in model_builders:
-                for iterator in builder.iterators():
+                for iterator in builder.iterators(chunk_size):
                     for obj in iterator:
                         stats_counter.update([model_label])
                         timer.tick()

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -169,7 +169,7 @@ class UnfilteredModelIteratorBuilder(object):
 
     def iterators(self):
         for queryset in self.querysets():
-            yield queryset_to_iterator(queryset, self.model_class, ignore_ordering=True)
+            yield queryset_to_iterator(queryset, self.model_class, limit=5000, ignore_ordering=True)
 
     def build(self, domain, model_class, db_alias):
         return self.__class__(self.model_label, self.use_all_objects).prepare(domain, model_class, db_alias)

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -14,6 +14,8 @@ from corehq.sql_db.util import (
 )
 from corehq.util.queries import queryset_to_iterator
 
+DEFAULT_CHUNK_SIZE = 5000
+
 
 class DomainFilter(metaclass=ABCMeta):
     @abstractmethod
@@ -167,9 +169,9 @@ class UnfilteredModelIteratorBuilder(object):
     def count(self):
         return sum(q.count() for q in self.querysets())
 
-    def iterators(self):
+    def iterators(self, chunk_size=DEFAULT_CHUNK_SIZE):
         for queryset in self.querysets():
-            yield queryset_to_iterator(queryset, self.model_class, limit=5000, ignore_ordering=True)
+            yield queryset_to_iterator(queryset, self.model_class, limit=chunk_size, ignore_ordering=True)
 
     def build(self, domain, model_class, db_alias):
         return self.__class__(self.model_label, self.use_all_objects).prepare(domain, model_class, db_alias)
@@ -199,7 +201,8 @@ class FilteredModelIteratorBuilder(UnfilteredModelIteratorBuilder):
 
 
 class UniqueFilteredModelIteratorBuilder(FilteredModelIteratorBuilder):
-    def iterators(self):
+    def iterators(self, chunk_size=DEFAULT_CHUNK_SIZE):
+        # chunk_size is unused: deduplication iterates each queryset directly
         def _unique(iterator):
             seen = set()
             for model in iterator:

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -202,7 +202,7 @@ class FilteredModelIteratorBuilder(UnfilteredModelIteratorBuilder):
 
 class UniqueFilteredModelIteratorBuilder(FilteredModelIteratorBuilder):
     def iterators(self, chunk_size=DEFAULT_CHUNK_SIZE):
-        # chunk_size is unused: deduplication iterates each queryset directly
+        # chunk_size is unused, but needed to preserve the base class signature
         def _unique(iterator):
             seen = set()
             for model in iterator:

--- a/corehq/apps/dump_reload/tests/test_dump_domain_data.py
+++ b/corehq/apps/dump_reload/tests/test_dump_domain_data.py
@@ -2,6 +2,8 @@ import os
 import tempfile
 import zipfile
 from contextlib import contextmanager
+from io import StringIO
+from unittest import mock
 
 import pytest
 
@@ -50,6 +52,34 @@ class TestFormatDumpStats:
             'Total dump time: 0.50s',
             '-' * 76,
         ]
+
+
+class TestSqlChunkSizeFlag:
+    @pytest.mark.parametrize('size', ['0', '-500'])
+    def test_rejects_a_non_positive_size(self, size):
+        parser = Command().create_parser('manage.py', 'dump_domain_data')
+        with pytest.raises(CommandError, match='--sql-chunk-size'):
+            parser.parse_args(['mydomain', '--sql-chunk-size', size])
+
+    def test_chunk_size_flows_from_the_command_line_to_queryset_iteration(self):
+        limits = []
+
+        def capture_limit(queryset, model_class, limit, ignore_ordering=False):
+            limits.append(limit)
+            return iter([])
+
+        with mock.patch('corehq.apps.dump_reload.sql.filters.queryset_to_iterator', capture_limit):
+            call_command(
+                'dump_domain_data',
+                'mydomain',
+                '--sql-chunk-size=1234',
+                '--console',
+                dumpers=['sql'],
+                include=['products.SQLProduct'],
+                stdout=StringIO(),
+            )
+
+        assert limits and set(limits) == {1234}
 
 
 @contextmanager

--- a/corehq/apps/dump_reload/tests/test_timing.py
+++ b/corehq/apps/dump_reload/tests/test_timing.py
@@ -123,7 +123,7 @@ class _Builder:
     def __init__(self, *iterators):
         self._iterators = iterators
 
-    def iterators(self):
+    def iterators(self, chunk_size=None):
         return self._iterators
 
 


### PR DESCRIPTION
## Product Description
No user-facing changes — affects the `dump_domain_data` management command only.

## Technical Summary
The SQL side of `dump_domain_data` pulls rows via `queryset_to_iterator`, which it has always used at the generic default of 500 rows per query. Comparing chunk sizes of 500, 5000, and 10000 on staging, 5000 dumped about 10% faster than 500, while 10000 was barely better than 5000, within noise — so 5000 is the new default.

The default should be about right nearly everywhere, but a `--sql-chunk-size` argument lets an operator experiment with other sizes to empirically determine the best default:

```sh
./manage.py dump_domain_data <domain> --sql-chunk-size 10000
```

An invalid value (non-numeric, zero, negative) fails fast, before any data is dumped. `queryset_to_iterator`'s own default of 500 is untouched, so its other callers are unaffected.

## Feature Flag
None

## Safety Assurance

### Safety story
The change only affects how many rows are fetched per query during a dump; the set of rows dumped is identical. Chunking happens by primary-key pagination, the same as before, just with fewer round trips.

### Automated test coverage
New tests in `test_dump_domain_data.py` cover rejection of non-positive sizes (which would otherwise silently dump nothing) and the end-to-end flow from the command line to the `limit` used by `queryset_to_iterator` — guarding against a refactor silently dropping the parameter at a middle hop.

The area is generally well tested otherwise, for catching side effects / typo-like errors.

### QA Plan
None — operator tooling, covered by automated tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)





