### PR TITLE
Force a much faster query plan for `dump_domain_data`'s case/form child models (Update: it was not actually faster :( )

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -33,17 +33,17 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
 
     FilteredModelIteratorBuilder('form_processor.XFormInstance', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.XFormOperation', SimpleFilter('form__domain'),
-                                 pagination_key=(('form_id', 'form__form_id'), 'pk')),
+                                 pagination_key=('form_id', 'pk'), pagination_index='form__form_id'),
 
     FilteredModelIteratorBuilder('form_processor.CommCareCase', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.CommCareCaseIndex', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.CaseAttachment', SimpleFilter('case__domain'),
-                                 pagination_key=(('case_id', 'case__case_id'), 'pk')),
+                                 pagination_key=('case_id', 'pk'), pagination_index='case__case_id'),
     FilteredModelIteratorBuilder('form_processor.CaseTransaction', SimpleFilter('case__domain'),
-                                 pagination_key=(('case_id', 'case__case_id'), 'pk')),
+                                 pagination_key=('case_id', 'pk'), pagination_index='case__case_id'),
     FilteredModelIteratorBuilder('form_processor.LedgerValue', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.LedgerTransaction', SimpleFilter('case__domain'),
-                                 pagination_key=(('case_id', 'case__case_id'), 'pk')),
+                                 pagination_key=('case_id', 'pk'), pagination_index='case__case_id'),
 
     FilteredModelIteratorBuilder('case_search.DomainsNotInCaseSearchIndex', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('case_search.CaseSearchConfig', SimpleFilter('domain')),

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -33,17 +33,17 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
 
     FilteredModelIteratorBuilder('form_processor.XFormInstance', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.XFormOperation', SimpleFilter('form__domain'),
-                                 pagination_key=('form_id', 'pk'), pagination_index='form__form_id'),
+                                 pagination_key=('form_id', 'pk'), use_fk_index_hint=True),
 
     FilteredModelIteratorBuilder('form_processor.CommCareCase', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.CommCareCaseIndex', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.CaseAttachment', SimpleFilter('case__domain'),
-                                 pagination_key=('case_id', 'pk'), pagination_index='case__case_id'),
+                                 pagination_key=('case_id', 'pk'), use_fk_index_hint=True),
     FilteredModelIteratorBuilder('form_processor.CaseTransaction', SimpleFilter('case__domain'),
-                                 pagination_key=('case_id', 'pk'), pagination_index='case__case_id'),
+                                 pagination_key=('case_id', 'pk'), use_fk_index_hint=True),
     FilteredModelIteratorBuilder('form_processor.LedgerValue', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.LedgerTransaction', SimpleFilter('case__domain'),
-                                 pagination_key=('case_id', 'pk'), pagination_index='case__case_id'),
+                                 pagination_key=('case_id', 'pk'), use_fk_index_hint=True),
 
     FilteredModelIteratorBuilder('case_search.DomainsNotInCaseSearchIndex', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('case_search.CaseSearchConfig', SimpleFilter('domain')),

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -33,17 +33,17 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
 
     FilteredModelIteratorBuilder('form_processor.XFormInstance', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.XFormOperation', SimpleFilter('form__domain'),
-                                 pagination_key=('form_id', 'pk')),
+                                 pagination_key=(('form_id', 'form__form_id'), 'pk')),
 
     FilteredModelIteratorBuilder('form_processor.CommCareCase', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.CommCareCaseIndex', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.CaseAttachment', SimpleFilter('case__domain'),
-                                 pagination_key=('case_id', 'pk')),
+                                 pagination_key=(('case_id', 'case__case_id'), 'pk')),
     FilteredModelIteratorBuilder('form_processor.CaseTransaction', SimpleFilter('case__domain'),
-                                 pagination_key=('case_id', 'pk')),
+                                 pagination_key=(('case_id', 'case__case_id'), 'pk')),
     FilteredModelIteratorBuilder('form_processor.LedgerValue', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.LedgerTransaction', SimpleFilter('case__domain'),
-                                 pagination_key=('case_id', 'pk')),
+                                 pagination_key=(('case_id', 'case__case_id'), 'pk')),
 
     FilteredModelIteratorBuilder('case_search.DomainsNotInCaseSearchIndex', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('case_search.CaseSearchConfig', SimpleFilter('domain')),

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -32,14 +32,18 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('blobs.BlobMeta', MultimediaBlobMetaFilter()),
 
     FilteredModelIteratorBuilder('form_processor.XFormInstance', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('form_processor.XFormOperation', SimpleFilter('form__domain')),
+    FilteredModelIteratorBuilder('form_processor.XFormOperation', SimpleFilter('form__domain'),
+                                 pagination_key=('form_id', 'pk')),
 
     FilteredModelIteratorBuilder('form_processor.CommCareCase', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.CommCareCaseIndex', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('form_processor.CaseAttachment', SimpleFilter('case__domain')),
-    FilteredModelIteratorBuilder('form_processor.CaseTransaction', SimpleFilter('case__domain')),
+    FilteredModelIteratorBuilder('form_processor.CaseAttachment', SimpleFilter('case__domain'),
+                                 pagination_key=('case_id', 'pk')),
+    FilteredModelIteratorBuilder('form_processor.CaseTransaction', SimpleFilter('case__domain'),
+                                 pagination_key=('case_id', 'pk')),
     FilteredModelIteratorBuilder('form_processor.LedgerValue', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('form_processor.LedgerTransaction', SimpleFilter('case__domain')),
+    FilteredModelIteratorBuilder('form_processor.LedgerTransaction', SimpleFilter('case__domain'),
+                                 pagination_key=('case_id', 'pk')),
 
     FilteredModelIteratorBuilder('case_search.DomainsNotInCaseSearchIndex', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('case_search.CaseSearchConfig', SimpleFilter('domain')),

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -149,8 +149,9 @@ class UnfilteredModelIteratorBuilder(object):
         self.model_label = model_label
         self.domain = self.model_class = self.db_alias = None
         self.use_all_objects = use_all_objects
-        # exists to make iterators() compatible with subclasses that set pagination_key
+        # defaults so iterators() works for subclasses that set these
         self.pagination_key = ('pk',)
+        self.pagination_index = None
 
     def prepare(self, domain, model_class, db_alias):
         self.domain = domain
@@ -176,6 +177,7 @@ class UnfilteredModelIteratorBuilder(object):
             yield queryset_to_iterator(
                 queryset, self.model_class, limit=chunk_size,
                 ignore_ordering=True, pagination_key=self.pagination_key,
+                pagination_index=self.pagination_index,
             )
 
     def build(self, domain, model_class, db_alias):
@@ -183,14 +185,17 @@ class UnfilteredModelIteratorBuilder(object):
 
 
 class FilteredModelIteratorBuilder(UnfilteredModelIteratorBuilder):
-    def __init__(self, model_label, filter, use_all_objects=False, pagination_key=('pk',)):
+    def __init__(self, model_label, filter, use_all_objects=False, pagination_key=('pk',),
+                 pagination_index=None):
         super(FilteredModelIteratorBuilder, self).__init__(model_label, use_all_objects)
         self.filter = filter
         self.pagination_key = pagination_key
+        self.pagination_index = pagination_index
 
     def build(self, domain, model_class, db_alias):
         return self.__class__(
-            self.model_label, self.filter, self.use_all_objects, self.pagination_key
+            self.model_label, self.filter, self.use_all_objects, self.pagination_key,
+            self.pagination_index,
         ).prepare(domain, model_class, db_alias)
 
     def count(self):

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -151,7 +151,7 @@ class UnfilteredModelIteratorBuilder(object):
         self.use_all_objects = use_all_objects
         # defaults so iterators() works for subclasses that set these
         self.pagination_key = ('pk',)
-        self.pagination_index = None
+        self.use_fk_index_hint = False
 
     def prepare(self, domain, model_class, db_alias):
         self.domain = domain
@@ -177,7 +177,7 @@ class UnfilteredModelIteratorBuilder(object):
             yield queryset_to_iterator(
                 queryset, self.model_class, limit=chunk_size,
                 ignore_ordering=True, pagination_key=self.pagination_key,
-                pagination_index=self.pagination_index,
+                use_fk_index_hint=self.use_fk_index_hint,
             )
 
     def build(self, domain, model_class, db_alias):
@@ -186,16 +186,16 @@ class UnfilteredModelIteratorBuilder(object):
 
 class FilteredModelIteratorBuilder(UnfilteredModelIteratorBuilder):
     def __init__(self, model_label, filter, use_all_objects=False, pagination_key=('pk',),
-                 pagination_index=None):
+                 use_fk_index_hint=False):
         super(FilteredModelIteratorBuilder, self).__init__(model_label, use_all_objects)
         self.filter = filter
         self.pagination_key = pagination_key
-        self.pagination_index = pagination_index
+        self.use_fk_index_hint = use_fk_index_hint
 
     def build(self, domain, model_class, db_alias):
         return self.__class__(
             self.model_label, self.filter, self.use_all_objects, self.pagination_key,
-            self.pagination_index,
+            self.use_fk_index_hint,
         ).prepare(domain, model_class, db_alias)
 
     def count(self):

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -149,6 +149,8 @@ class UnfilteredModelIteratorBuilder(object):
         self.model_label = model_label
         self.domain = self.model_class = self.db_alias = None
         self.use_all_objects = use_all_objects
+        # exists to make iterators() compatible with subclasses that set pagination_key
+        self.pagination_key = ('pk',)
 
     def prepare(self, domain, model_class, db_alias):
         self.domain = domain
@@ -171,21 +173,25 @@ class UnfilteredModelIteratorBuilder(object):
 
     def iterators(self, chunk_size=DEFAULT_CHUNK_SIZE):
         for queryset in self.querysets():
-            yield queryset_to_iterator(queryset, self.model_class, limit=chunk_size, ignore_ordering=True)
+            yield queryset_to_iterator(
+                queryset, self.model_class, limit=chunk_size,
+                ignore_ordering=True, pagination_key=self.pagination_key,
+            )
 
     def build(self, domain, model_class, db_alias):
         return self.__class__(self.model_label, self.use_all_objects).prepare(domain, model_class, db_alias)
 
 
 class FilteredModelIteratorBuilder(UnfilteredModelIteratorBuilder):
-    def __init__(self, model_label, filter, use_all_objects=False):
+    def __init__(self, model_label, filter, use_all_objects=False, pagination_key=('pk',)):
         super(FilteredModelIteratorBuilder, self).__init__(model_label, use_all_objects)
         self.filter = filter
+        self.pagination_key = pagination_key
 
     def build(self, domain, model_class, db_alias):
-        return self.__class__(self.model_label, self.filter, self.use_all_objects).prepare(
-            domain, model_class, db_alias
-        )
+        return self.__class__(
+            self.model_label, self.filter, self.use_all_objects, self.pagination_key
+        ).prepare(domain, model_class, db_alias)
 
     def count(self):
         count = self.filter.count(self.domain)

--- a/corehq/apps/dump_reload/tests/test_dump_domain_data.py
+++ b/corehq/apps/dump_reload/tests/test_dump_domain_data.py
@@ -64,7 +64,7 @@ class TestSqlChunkSizeFlag:
     def test_chunk_size_flows_from_the_command_line_to_queryset_iteration(self):
         limits = []
 
-        def capture_limit(queryset, model_class, limit, ignore_ordering=False):
+        def capture_limit(queryset, model_class, limit, ignore_ordering=False, pagination_key=('pk',)):
             limits.append(limit)
             return iter([])
 

--- a/corehq/apps/dump_reload/tests/test_dump_domain_data.py
+++ b/corehq/apps/dump_reload/tests/test_dump_domain_data.py
@@ -64,7 +64,8 @@ class TestSqlChunkSizeFlag:
     def test_chunk_size_flows_from_the_command_line_to_queryset_iteration(self):
         limits = []
 
-        def capture_limit(queryset, model_class, limit, ignore_ordering=False, pagination_key=('pk',)):
+        def capture_limit(queryset, model_class, limit, ignore_ordering=False,
+                          pagination_key=('pk',), pagination_index=None):
             limits.append(limit)
             return iter([])
 

--- a/corehq/apps/dump_reload/tests/test_dump_domain_data.py
+++ b/corehq/apps/dump_reload/tests/test_dump_domain_data.py
@@ -65,7 +65,7 @@ class TestSqlChunkSizeFlag:
         limits = []
 
         def capture_limit(queryset, model_class, limit, ignore_ordering=False,
-                          pagination_key=('pk',), pagination_index=None):
+                          pagination_key=('pk',), use_fk_index_hint=False):
             limits.append(limit)
             return iter([])
 

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -112,8 +112,8 @@ class TestMultimediaBlobMetaFilter(TestCase):
 @sharded
 class TestPagingChildModelByParentId(TestCase):
     """Page a case child model over the case__domain join with the seek aimed at
-    the parent's case_id (pagination_index='case__case_id'), and check the keyset
-    returns every transaction exactly once across pages and shards."""
+    the parent's case_id (use_fk_index_hint=True), and check the keyset returns
+    every transaction exactly once across pages and shards."""
     domain = 'test-paging-child-by-parent-id'
 
     @classmethod
@@ -127,7 +127,7 @@ class TestPagingChildModelByParentId(TestCase):
             'form_processor.CaseTransaction',
             SimpleFilter('case__domain'),
             pagination_key=('case_id', 'pk'),
-            pagination_index='case__case_id',
+            use_fk_index_hint=True,
         )
         # chunk_size=2 with 3 cases forces paging across the seek boundary
         transactions = [
@@ -142,10 +142,10 @@ class TestPagingChildModelByParentId(TestCase):
         assert len({(txn.case_id, txn.id) for txn in transactions}) == len(transactions)
 
 
-def test_dump_builders_have_valid_pagination_index():
-    """Guard the dump config: every builder that sets pagination_index must name a
-    foreign key traversal value-equivalent to its leading pagination key. A typo
-    would otherwise pass review and silently return no rows at dump time."""
+def test_dump_builders_with_fk_index_hint_have_a_foreign_key_leading_key():
+    """Guard the dump config: every builder that sets use_fk_index_hint must have a
+    leading pagination key backed by a foreign key (so the parent column can be
+    derived). Otherwise it would raise at dump time."""
     from corehq.apps.dump_reload.sql.dump import APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP
     from corehq.apps.dump_reload.util import get_model_class
     from corehq.util.queries import _fk_index_column
@@ -154,10 +154,10 @@ def test_dump_builders_have_valid_pagination_index():
         builder
         for builders in APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP.values()
         for builder in builders
-        if builder.pagination_index
+        if builder.use_fk_index_hint
     ]
-    assert builders, "expected some dump builders to set pagination_index"
+    assert builders, "expected some dump builders to set use_fk_index_hint"
     for builder in builders:
         _, model_cls = get_model_class(builder.model_label)
-        # raises ValueError unless pagination_index is a valid FK traversal of the leading key
-        _fk_index_column(model_cls, builder.pagination_key, builder.pagination_index)
+        # raises ValueError unless pagination_key[0] is a foreign key's column
+        _fk_index_column(model_cls, builder.pagination_key)

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -140,3 +140,24 @@ class TestPagingChildModelByParentId(TestCase):
         assert {txn.case_id for txn in transactions} == {case.case_id for case in self.cases}
         # no dupes; (case_id, id) is the unique key -- id (pk) repeats across shards
         assert len({(txn.case_id, txn.id) for txn in transactions}) == len(transactions)
+
+
+def test_dump_builders_have_valid_pagination_index():
+    """Guard the dump config: every builder that sets pagination_index must name a
+    foreign key traversal value-equivalent to its leading pagination key. A typo
+    would otherwise pass review and silently return no rows at dump time."""
+    from corehq.apps.dump_reload.sql.dump import APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP
+    from corehq.apps.dump_reload.util import get_model_class
+    from corehq.util.queries import _validate_pagination_index
+
+    builders = [
+        builder
+        for builders in APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP.values()
+        for builder in builders
+        if builder.pagination_index
+    ]
+    assert builders, "expected some dump builders to set pagination_index"
+    for builder in builders:
+        _, model_cls = get_model_class(builder.model_label)
+        # raises ValueError unless pagination_index is a valid FK traversal of the leading key
+        _validate_pagination_index(model_cls, builder.pagination_key, builder.pagination_index)

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -148,7 +148,7 @@ def test_dump_builders_have_valid_pagination_index():
     would otherwise pass review and silently return no rows at dump time."""
     from corehq.apps.dump_reload.sql.dump import APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP
     from corehq.apps.dump_reload.util import get_model_class
-    from corehq.util.queries import _validate_pagination_index
+    from corehq.util.queries import _fk_index_column
 
     builders = [
         builder
@@ -160,4 +160,4 @@ def test_dump_builders_have_valid_pagination_index():
     for builder in builders:
         _, model_cls = get_model_class(builder.model_label)
         # raises ValueError unless pagination_index is a valid FK traversal of the leading key
-        _validate_pagination_index(model_cls, builder.pagination_key, builder.pagination_index)
+        _fk_index_column(model_cls, builder.pagination_key, builder.pagination_index)

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -1,10 +1,14 @@
 from django.db import router
 from django.test import TestCase
 
+from casexml.apps.case.mock import CaseFactory
+
 from corehq.apps.dump_reload.sql.filters import MultimediaBlobMetaFilter, FilteredModelIteratorBuilder
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.blobs.models import BlobMeta
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
+from corehq.form_processor.models import CaseTransaction
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 from corehq.motech.repeaters.models import Repeater
 from corehq.motech.models import ConnectionSettings
@@ -103,3 +107,35 @@ class TestMultimediaBlobMetaFilter(TestCase):
         cls.addClassCleanup(cls.db.close)
         cls.domain = 'test-multimedia'
         cls.db_alias = get_db_aliases_for_partitioned_query()[0]
+
+
+@sharded
+class TestPagingChildModelByParentId(TestCase):
+    """Page a case child model over the case__domain join with the seek key on
+    the parent's case_id (case__case_id), and check the keyset returns every
+    transaction exactly once across pages and shards."""
+    domain = 'test-paging-child-by-parent-id'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.cases = [CaseFactory(cls.domain).create_case() for _ in range(3)]
+        cls.addClassCleanup(FormProcessorTestUtils.delete_all_cases_forms_ledgers, cls.domain)
+
+    def test_returns_every_transaction_exactly_once(self):
+        builder = FilteredModelIteratorBuilder(
+            'form_processor.CaseTransaction',
+            SimpleFilter('case__domain'),
+            pagination_key=(('case_id', 'case__case_id'), 'pk'),
+        )
+        # chunk_size=2 with 3 cases forces paging across the seek boundary
+        transactions = [
+            txn
+            for db_alias in get_db_aliases_for_partitioned_query()
+            for iterator in builder.build(self.domain, CaseTransaction, db_alias).iterators(2)
+            for txn in iterator
+        ]
+
+        assert {txn.case_id for txn in transactions} == {case.case_id for case in self.cases}
+        # no dupes; (case_id, id) is the unique key -- id (pk) repeats across shards
+        assert len({(txn.case_id, txn.id) for txn in transactions}) == len(transactions)

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -111,9 +111,9 @@ class TestMultimediaBlobMetaFilter(TestCase):
 
 @sharded
 class TestPagingChildModelByParentId(TestCase):
-    """Page a case child model over the case__domain join with the seek key on
-    the parent's case_id (case__case_id), and check the keyset returns every
-    transaction exactly once across pages and shards."""
+    """Page a case child model over the case__domain join with the seek aimed at
+    the parent's case_id (pagination_index='case__case_id'), and check the keyset
+    returns every transaction exactly once across pages and shards."""
     domain = 'test-paging-child-by-parent-id'
 
     @classmethod
@@ -126,7 +126,8 @@ class TestPagingChildModelByParentId(TestCase):
         builder = FilteredModelIteratorBuilder(
             'form_processor.CaseTransaction',
             SimpleFilter('case__domain'),
-            pagination_key=(('case_id', 'case__case_id'), 'pk'),
+            pagination_key=('case_id', 'pk'),
+            pagination_index='case__case_id',
         )
         # chunk_size=2 with 3 cases forces paging across the seek boundary
         transactions = [

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -151,11 +151,19 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False, 
 def _lexicographic_greater_than(fields, values):
     """Build the tuple comparison ``(a, b, ...) > (va, vb, ...)`` as a Q
     expression, expanding it to ``a > va OR (a = va AND b > vb) OR ...``.
+
+    For a compound key it also ANDs a redundant ``a >= va`` on the leading
+    field. It's implied by the comparison, but Postgres won't derive a bound
+    from inside the OR, so the explicit ``>=`` is what lets it seek ``a``'s
+    index instead of scanning from the start -- a big win when ``a`` is a
+    joined table's indexed column, e.g. ``case__case_id``.
     """
     condition = Q()
     for index, (field, value) in enumerate(zip(fields, values)):
         ties = dict(zip(fields[:index], values[:index]))
         condition |= Q(**ties, **{f"{field}__gt": value})
+    if len(fields) > 1:
+        condition = Q(**{f"{fields[0]}__gte": values[0]}) & condition
     return condition
 
 

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -110,7 +110,7 @@ def paginated_queryset(queryset, chunk_size):
 
 
 def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
-                         pagination_key=('pk',), pagination_index=None):
+                         pagination_key=('pk',), use_fk_index_hint=False):
     """
     Pull from queryset in chunks. This is suitable for deep pagination, but
     cannot be used with ordered querysets (results will be sorted by the
@@ -121,12 +121,11 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
     jointly unique to guarantee that every matching result is returned -- e.g.
     ``('pk',)`` or ``('owner_id', 'pk')`` is okay, but just ``('owner_id',)`` is not.
 
-    ``pagination_index`` is an optional query planner hint that coaxes the
-    planner into using the index on the specified related-table field, which
-    must be value-equivalent to the leading field of pagination_key, working
-    around the fact that Postgres won't carry an inequality in the WHERE clause
-    across a join [1][2]. Example:
-    ``pagination_key=('case_id', 'pk'), pagination_index='case__case_id'``.
+    ``use_fk_index_hint``: when the leading pagination key is a foreign key's
+    stored column (e.g. ``case_id`` backs the ``case`` FK), bound the parent's
+    column each page so Postgres seeks the parent's index -- which it otherwise
+    won't, since it won't carry the keyset's inequality across the join [1][2].
+    Example: ``pagination_key=('case_id', 'pk'), use_fk_index_hint=True``.
 
     Retries on transient database connection failures (bounded at ~31
     minutes total) so long-running iterations survive brief outages.
@@ -139,9 +138,7 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
         raise AssertionError("queryset_to_iterator does not respect ordering.  "
                              "Pass ignore_ordering=True to continue.")
 
-    parent_column = None
-    if pagination_index is not None:
-        parent_column = _fk_index_column(model_cls, pagination_key, pagination_index)
+    parent_column = _fk_index_column(model_cls, pagination_key) if use_fk_index_hint else None
     queryset = queryset.order_by(*pagination_key)
     last_doc_values = None
     while True:
@@ -164,16 +161,15 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
         last_doc_values = tuple(getattr(doc, key) for key in pagination_key)
 
 
-def _fk_index_column(model_cls, pagination_key, pagination_index):
-    """Validate ``pagination_index`` and return the parent column to bound, as a
-    quoted ``"table"."column"`` SQL fragment (see ``queryset_to_iterator``).
+def _fk_index_column(model_cls, pagination_key):
+    """Return the parent column for the foreign key backing the leading pagination
+    key, as a quoted ``"table"."column"`` SQL fragment (see ``queryset_to_iterator``).
 
-    ``pagination_index`` names a foreign key traversal (e.g. ``case__case_id``)
-    whose value equals the leading pagination key on every row -- a foreign key
-    with ``to_field`` guarantees this, since the child's stored ``<fk>_id`` column
-    *is* the parent's ``to_field``. Exactly one such index is allowable for a given
-    leading key, and only when it is a foreign key column. For example, for
-    ``pagination_key[0] = 'case_id'``, only ``pagination_index='case__case_id'``.
+    The leading key must be a foreign key's stored column (e.g. ``case_id`` backs
+    the ``case`` FK). A foreign key with ``to_field`` guarantees the child's stored
+    ``<fk>_id`` column equals the parent's ``to_field`` on every row, so a bound on
+    the parent column is value-equivalent to the keyset's leading bound -- and,
+    unlike the child column, one Postgres can seek the parent's index with.
     """
     leading_key = pagination_key[0]
     foreign_key = next(
@@ -182,15 +178,8 @@ def _fk_index_column(model_cls, pagination_key, pagination_index):
     )
     if foreign_key is None:
         raise ValueError(
-            f"pagination_index can't be used: pagination_key[0]={leading_key!r} is not a "
-            f"foreign key's column on {model_cls.__name__}, so there's no parent index to seek"
-        )
-    allowable = f"{foreign_key.name}__{foreign_key.target_field.name}"
-    if pagination_index != allowable:
-        raise ValueError(
-            f"if set, pagination_index must be {allowable!r} -- the foreign key backing "
-            f"pagination_key[0]={leading_key!r}, traversed to its target column -- "
-            f"not {pagination_index!r}"
+            f"use_fk_index_hint requires pagination_key[0]={leading_key!r} to be a foreign "
+            f"key's column on {model_cls.__name__}, but none is"
         )
     return f'"{foreign_key.related_model._meta.db_table}"."{foreign_key.target_field.column}"'
 

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -139,18 +139,22 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
         raise AssertionError("queryset_to_iterator does not respect ordering.  "
                              "Pass ignore_ordering=True to continue.")
 
-    if pagination_index is None:
-        seek_keys = pagination_key
-    else:
-        _validate_pagination_index(model_cls, pagination_key, pagination_index)
-        seek_keys = (pagination_index, *pagination_key[1:])
+    parent_column = None
+    if pagination_index is not None:
+        parent_column = _fk_index_column(model_cls, pagination_key, pagination_index)
     queryset = queryset.order_by(*pagination_key)
     last_doc_values = None
     while True:
         if last_doc_values is None:
             chunk_qs = queryset
         else:
-            chunk_qs = queryset.filter(_lexicographic_greater_than(seek_keys, last_doc_values))
+            chunk_qs = queryset.filter(_lexicographic_greater_than(pagination_key, last_doc_values))
+            if parent_column is not None:
+                # The parent bound must be raw SQL: the ORM collapses
+                # ``case__case_id`` to the child's own column, which Postgres can't
+                # use to seek the parent. Safe: the column comes from model metadata
+                # and the value is a bound parameter.
+                chunk_qs = chunk_qs.extra(where=[f'{parent_column} >= %s'], params=[last_doc_values[0]])
         chunk = _fetch_chunk_with_retry(chunk_qs, limit, model_cls, last_doc_values)
         if not chunk:
             return
@@ -160,19 +164,16 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
         last_doc_values = tuple(getattr(doc, key) for key in pagination_key)
 
 
-def _validate_pagination_index(model_cls, pagination_key, pagination_index):
-    """Confirm ``pagination_index`` is value-equivalent to the leading
-    pagination key (see ``queryset_to_iterator``).
+def _fk_index_column(model_cls, pagination_key, pagination_index):
+    """Validate ``pagination_index`` and return the parent column to bound, as a
+    quoted ``"table"."column"`` SQL fragment (see ``queryset_to_iterator``).
 
-    The next-page start value is read from ``pagination_key[0]`` but the seek
-    compares ``pagination_index``, so they must hold the same value in every
-    row. A foreign key with ``to_field`` guarantees this: the child's stored
-    ``<fk>_id`` column *is* the parent's ``to_field``.
-
-    So currently exactly one ``pagination_index`` is allowable for a given
-    ``pagination_key[0]``, and only when it is a foreign key column. For example,
-    for ``pagination_key[0] = 'case_id'``, only ``pagination_index='case__case_id'``
-    is allowed.
+    ``pagination_index`` names a foreign key traversal (e.g. ``case__case_id``)
+    whose value equals the leading pagination key on every row -- a foreign key
+    with ``to_field`` guarantees this, since the child's stored ``<fk>_id`` column
+    *is* the parent's ``to_field``. Exactly one such index is allowable for a given
+    leading key, and only when it is a foreign key column. For example, for
+    ``pagination_key[0] = 'case_id'``, only ``pagination_index='case__case_id'``.
     """
     leading_key = pagination_key[0]
     foreign_key = next(
@@ -191,6 +192,7 @@ def _validate_pagination_index(model_cls, pagination_key, pagination_index):
             f"pagination_key[0]={leading_key!r}, traversed to its target column -- "
             f"not {pagination_index!r}"
         )
+    return f'"{foreign_key.related_model._meta.db_table}"."{foreign_key.target_field.column}"'
 
 
 def _lexicographic_greater_than(fields, values):

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -115,6 +115,14 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False, 
     cannot be used with ordered querysets (results will be sorted by the
     ``pagination_key`` fields, by default the pk).
 
+    ``pagination_key`` is the keys to paginate by (the pk by default). Each key
+    is a field name, or a ``(sort_key, seek_key)`` pair: ``sort_key`` is used in
+    ORDER BY and read off each row to resume from; ``seek_key`` is the field
+    compared in the WHERE clause. They differ only to aim the seek at a joined
+    table's column so Postgres seeks that table's index (it won't carry an
+    inequality across a join) -- the two must hold the same value per row, e.g.
+    ``('case_id', 'case__case_id')``.
+
     Retries on transient database connection failures (bounded at ~31
     minutes total) so long-running iterations survive brief outages.
     """
@@ -122,20 +130,22 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False, 
         raise AssertionError("queryset_to_iterator does not respect ordering.  "
                              "Pass ignore_ordering=True to continue.")
 
-    queryset = queryset.order_by(*pagination_key)
+    # normalize bare keys to (sort_key, seek_key) pairs, then split into columns
+    sort_keys, seek_keys = zip(*[key if isinstance(key, tuple) else (key, key) for key in pagination_key])
+    queryset = queryset.order_by(*sort_keys)
     last_doc_values = None
     while True:
         if last_doc_values is None:
             chunk_qs = queryset
         else:
-            chunk_qs = queryset.filter(_lexicographic_greater_than(pagination_key, last_doc_values))
+            chunk_qs = queryset.filter(_lexicographic_greater_than(seek_keys, last_doc_values))
         chunk = _fetch_chunk_with_retry(chunk_qs, limit, model_cls, last_doc_values)
         if not chunk:
             return
         for doc in chunk:
             yield doc
 
-        last_doc_values = tuple(getattr(doc, field) for field in pagination_key)
+        last_doc_values = tuple(getattr(doc, key) for key in sort_keys)
 
 
 def _lexicographic_greater_than(fields, values):

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -5,6 +5,7 @@ import time
 from django.core.paginator import Paginator
 from django.core.paginator import EmptyPage
 from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.models import Q
 from django.db.utils import InterfaceError, OperationalError
 
 logger = logging.getLogger(__name__)
@@ -108,10 +109,11 @@ def paginated_queryset(queryset, chunk_size):
             return
 
 
-def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False):
+def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False, pagination_key=('pk',)):
     """
     Pull from queryset in chunks. This is suitable for deep pagination, but
-    cannot be used with ordered querysets (results will be sorted by pk).
+    cannot be used with ordered querysets (results will be sorted by the
+    ``pagination_key`` fields, by default the pk).
 
     Retries on transient database connection failures (bounded at ~31
     minutes total) so long-running iterations survive brief outages.
@@ -120,21 +122,31 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False):
         raise AssertionError("queryset_to_iterator does not respect ordering.  "
                              "Pass ignore_ordering=True to continue.")
 
-    pk_field = 'pk'
-    queryset = queryset.order_by(pk_field)
-    last_doc_pk = None
+    queryset = queryset.order_by(*pagination_key)
+    last_doc_values = None
     while True:
-        if last_doc_pk is None:
+        if last_doc_values is None:
             chunk_qs = queryset
         else:
-            chunk_qs = queryset.filter(**{pk_field + "__gt": last_doc_pk})
-        chunk = _fetch_chunk_with_retry(chunk_qs, limit, model_cls, last_doc_pk)
+            chunk_qs = queryset.filter(_lexicographic_greater_than(pagination_key, last_doc_values))
+        chunk = _fetch_chunk_with_retry(chunk_qs, limit, model_cls, last_doc_values)
         if not chunk:
             return
         for doc in chunk:
             yield doc
 
-        last_doc_pk = getattr(doc, pk_field)
+        last_doc_values = tuple(getattr(doc, field) for field in pagination_key)
+
+
+def _lexicographic_greater_than(fields, values):
+    """Build the tuple comparison ``(a, b, ...) > (va, vb, ...)`` as a Q
+    expression, expanding it to ``a > va OR (a = va AND b > vb) OR ...``.
+    """
+    condition = Q()
+    for index, (field, value) in enumerate(zip(fields, values)):
+        ties = dict(zip(fields[:index], values[:index]))
+        condition |= Q(**ties, **{f"{field}__gt": value})
+    return condition
 
 
 def _fetch_chunk(queryset, limit):
@@ -142,7 +154,7 @@ def _fetch_chunk(queryset, limit):
     return list(queryset[:limit])
 
 
-def _fetch_chunk_with_retry(queryset, limit, model_cls, last_doc_pk):
+def _fetch_chunk_with_retry(queryset, limit, model_cls, last_doc_values):
     max_attempts = len(_CHUNK_RETRY_DELAYS) + 1
     for attempt in range(max_attempts):
         try:
@@ -152,13 +164,13 @@ def _fetch_chunk_with_retry(queryset, limit, model_cls, last_doc_pk):
                 logger.error(
                     f"queryset_to_iterator: giving up on {model_cls.__name__} "
                     f"after {attempt + 1} attempts "
-                    f"(last_doc_pk={last_doc_pk!r}): {exc}"
+                    f"(last_doc_values={last_doc_values!r}): {exc}"
                 )
                 raise
             delay = _CHUNK_RETRY_DELAYS[attempt]
             logger.warning(
                 f"queryset_to_iterator: {type(exc).__name__} fetching "
-                f"{model_cls.__name__} chunk (last_doc_pk={last_doc_pk!r}, "
+                f"{model_cls.__name__} chunk (last_doc_values={last_doc_values!r}, "
                 f"attempt {attempt + 1}/{max_attempts}); closing connection "
                 f"and retrying in {delay}s: {exc}"
             )

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -188,11 +188,14 @@ def _lexicographic_greater_than(fields, values):
     """Build the tuple comparison ``(a, b, ...) > (va, vb, ...)`` as a Q
     expression, expanding it to ``a > va OR (a = va AND b > vb) OR ...``.
 
-    For a compound key it also ANDs a redundant ``a >= va`` on the leading
-    field. It's implied by the comparison, but Postgres won't derive a bound
-    from inside the OR [1], so the explicit ``>=`` is what lets it seek ``a``'s
-    index instead of scanning from the start. This acts as a query planner hint:
-    it makes a seek on ``a``'s index one of the options the planner can choose.
+    TODO: for a compound key this OR form can't seek the leading field's own
+    index -- Postgres won't derive a bound on ``a`` from inside the OR [1], so it
+    scans from the start. Callers that page a child model by its parent's id avoid
+    this by seeking the parent's index via ``use_fk_index_hint`` instead. A
+    single-table compound-key caller that wanted a leading-index seek would need
+    to AND back a redundant ``a >= va`` (a planner hint), or better, switch to a
+    row-value comparison ``(a, b, ...) > (va, vb, ...)``, which Postgres supports
+    and can seek with [1].
 
     [1] https://use-the-index-luke.com/sql/partial-results/fetch-next-page#sb-equivalent-logic
     """
@@ -200,8 +203,6 @@ def _lexicographic_greater_than(fields, values):
     for index, (field, value) in enumerate(zip(fields, values)):
         ties = dict(zip(fields[:index], values[:index]))
         condition |= Q(**ties, **{f"{field}__gt": value})
-    if len(fields) > 1:
-        condition = Q(**{f"{fields[0]}__gte": values[0]}) & condition
     return condition
 
 

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -120,7 +120,7 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False):
         raise AssertionError("queryset_to_iterator does not respect ordering.  "
                              "Pass ignore_ordering=True to continue.")
 
-    pk_field = model_cls._meta.pk.name
+    pk_field = 'pk'
     queryset = queryset.order_by(pk_field)
     last_doc_pk = None
     while True:

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -199,9 +199,11 @@ def _lexicographic_greater_than(fields, values):
 
     For a compound key it also ANDs a redundant ``a >= va`` on the leading
     field. It's implied by the comparison, but Postgres won't derive a bound
-    from inside the OR, so the explicit ``>=`` is what lets it seek ``a``'s
-    index instead of scanning from the start -- a big win when ``a`` is a
-    joined table's indexed column, e.g. ``case__case_id``.
+    from inside the OR [1], so the explicit ``>=`` is what lets it seek ``a``'s
+    index instead of scanning from the start. This acts as a query planner hint:
+    it makes a seek on ``a``'s index one of the options the planner can choose.
+
+    [1] https://use-the-index-luke.com/sql/partial-results/fetch-next-page#sb-equivalent-logic
     """
     condition = Q()
     for index, (field, value) in enumerate(zip(fields, values)):

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -119,7 +119,8 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
     ``pagination_key`` is the tuple of field names to paginate by (the pk by
     default), and the order in which results will be yielded. Its fields must be
     jointly unique to guarantee that every matching result is returned -- e.g.
-    ``('pk',)`` or ``('owner_id', 'pk')`` is okay, but just ``('owner_id',)`` is not.
+    ``('pk',)`` or ``('owner_id', 'pk')`` is okay, but ``('owner_id',)`` is not,
+    assuming multiple rows can share an ``owner_id``.
 
     ``use_fk_index_hint``: when the leading pagination key is a foreign key's
     stored column (e.g. ``case_id`` backs the ``case`` FK), bound the parent's

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -109,30 +109,41 @@ def paginated_queryset(queryset, chunk_size):
             return
 
 
-def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False, pagination_key=('pk',)):
+def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
+                         pagination_key=('pk',), pagination_index=None):
     """
     Pull from queryset in chunks. This is suitable for deep pagination, but
     cannot be used with ordered querysets (results will be sorted by the
     ``pagination_key`` fields, by default the pk).
 
-    ``pagination_key`` is the keys to paginate by (the pk by default). Each key
-    is a field name, or a ``(sort_key, seek_key)`` pair: ``sort_key`` is used in
-    ORDER BY and read off each row to resume from; ``seek_key`` is the field
-    compared in the WHERE clause. They differ only to aim the seek at a joined
-    table's column so Postgres seeks that table's index (it won't carry an
-    inequality across a join) -- the two must hold the same value per row, e.g.
-    ``('case_id', 'case__case_id')``.
+    ``pagination_key`` is the tuple of field names to paginate by (the pk by
+    default), and the order in which results will be yielded. Its fields must be
+    jointly unique to guarantee that every matching result is returned -- e.g.
+    ``('pk',)`` or ``('owner_id', 'pk')`` is okay, but just ``('owner_id',)`` is not.
+
+    ``pagination_index`` is an optional query planner hint that coaxes the
+    planner into using the index on the specified related-table field, which
+    must be value-equivalent to the leading field of pagination_key, working
+    around the fact that Postgres won't carry an inequality in the WHERE clause
+    across a join [1][2]. Example:
+    ``pagination_key=('case_id', 'pk'), pagination_index='case__case_id'``.
 
     Retries on transient database connection failures (bounded at ~31
     minutes total) so long-running iterations survive brief outages.
+
+    [1] https://postgrespro.com/list/thread-id/2550799
+    [2] https://github.com/postgres/postgres/blob/REL_18_4/src/backend/optimizer/README
+        (the EquivalenceClasses section, on how the planner propagates equalities across joins)
     """
     if queryset.ordered and not ignore_ordering:
         raise AssertionError("queryset_to_iterator does not respect ordering.  "
                              "Pass ignore_ordering=True to continue.")
 
-    # normalize bare keys to (sort_key, seek_key) pairs, then split into columns
-    sort_keys, seek_keys = zip(*[key if isinstance(key, tuple) else (key, key) for key in pagination_key])
-    queryset = queryset.order_by(*sort_keys)
+    if pagination_index is None:
+        seek_keys = pagination_key
+    else:
+        seek_keys = (pagination_index, *pagination_key[1:])
+    queryset = queryset.order_by(*pagination_key)
     last_doc_values = None
     while True:
         if last_doc_values is None:
@@ -145,7 +156,7 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False, 
         for doc in chunk:
             yield doc
 
-        last_doc_values = tuple(getattr(doc, key) for key in sort_keys)
+        last_doc_values = tuple(getattr(doc, key) for key in pagination_key)
 
 
 def _lexicographic_greater_than(fields, values):

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -142,6 +142,7 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
     if pagination_index is None:
         seek_keys = pagination_key
     else:
+        _validate_pagination_index(model_cls, pagination_key, pagination_index)
         seek_keys = (pagination_index, *pagination_key[1:])
     queryset = queryset.order_by(*pagination_key)
     last_doc_values = None
@@ -157,6 +158,39 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
             yield doc
 
         last_doc_values = tuple(getattr(doc, key) for key in pagination_key)
+
+
+def _validate_pagination_index(model_cls, pagination_key, pagination_index):
+    """Confirm ``pagination_index`` is value-equivalent to the leading
+    pagination key (see ``queryset_to_iterator``).
+
+    The next-page start value is read from ``pagination_key[0]`` but the seek
+    compares ``pagination_index``, so they must hold the same value in every
+    row. A foreign key with ``to_field`` guarantees this: the child's stored
+    ``<fk>_id`` column *is* the parent's ``to_field``.
+
+    So currently exactly one ``pagination_index`` is allowable for a given
+    ``pagination_key[0]``, and only when it is a foreign key column. For example,
+    for ``pagination_key[0] = 'case_id'``, only ``pagination_index='case__case_id'``
+    is allowed.
+    """
+    leading_key = pagination_key[0]
+    foreign_key = next(
+        (f for f in model_cls._meta.fields if f.many_to_one and f.get_attname() == leading_key),
+        None,
+    )
+    if foreign_key is None:
+        raise ValueError(
+            f"pagination_index can't be used: pagination_key[0]={leading_key!r} is not a "
+            f"foreign key's column on {model_cls.__name__}, so there's no parent index to seek"
+        )
+    allowable = f"{foreign_key.name}__{foreign_key.target_field.name}"
+    if pagination_index != allowable:
+        raise ValueError(
+            f"if set, pagination_index must be {allowable!r} -- the foreign key backing "
+            f"pagination_key[0]={leading_key!r}, traversed to its target column -- "
+            f"not {pagination_index!r}"
+        )
 
 
 def _lexicographic_greater_than(fields, values):

--- a/corehq/util/tests/test_queries.py
+++ b/corehq/util/tests/test_queries.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
@@ -32,6 +33,26 @@ def test_lexicographic_greater_than_relation_path():
         _lexicographic_greater_than(('case__case_id', 'id'), ('abc', 5))
         == Q(case__case_id__gte='abc') & (Q(case__case_id__gt='abc') | Q(case__case_id='abc', id__gt=5))
     )
+
+
+def test_pagination_index_seeks_on_the_index_not_the_cursor_key():
+    # The cursor is read from pagination_key ('case_id'/'pk'), but the WHERE seek
+    # is built from pagination_index ('case__case_id') -- the parent's column.
+    from corehq.form_processor.models import CaseTransaction
+    # _fetch_chunk is patched, so the queryset is never executed against the db
+    queryset = CaseTransaction.objects.using('default')
+    chunks = [[SimpleNamespace(case_id='abc', pk=5)], []]
+    with patch.object(queries, '_fetch_chunk', side_effect=chunks), \
+            patch.object(queries, '_lexicographic_greater_than',
+                         wraps=queries._lexicographic_greater_than) as build_seek:
+        list(queryset_to_iterator(
+            queryset, CaseTransaction, limit=1, ignore_ordering=True,
+            pagination_key=('case_id', 'pk'), pagination_index='case__case_id',
+        ))
+
+    assert build_seek.call_args_list  # paged past the first chunk
+    assert all(call.args[0] == ('case__case_id', 'pk') for call in build_seek.call_args_list)
+    assert all(call.args[1] == ('abc', 5) for call in build_seek.call_args_list)
 
 
 class TestQuerysetToIterator(TestCase):
@@ -78,24 +99,6 @@ class TestQuerysetToIterator(TestCase):
             [u.username for u in all_users],
             [u.username for u in self.users],
         )
-
-    def test_seek_key_builds_the_cursor_not_the_sort_key(self):
-        # pk and id are the same column on User, so this divergent
-        # (sort_key, seek_key) still pages correctly -- and lets us confirm the
-        # cursor is built from the seek key ('id'), not the sort key ('pk')
-        query = User.objects.filter(last_name="Tenenbaum")
-        with patch.object(queries, '_lexicographic_greater_than',
-                          wraps=queries._lexicographic_greater_than) as build_cursor:
-            all_users = list(
-                queryset_to_iterator(query, User, limit=4, pagination_key=(('pk', 'id'),))
-            )
-
-        self.assertEqual(
-            [u.username for u in all_users],
-            [u.username for u in self.users],
-        )
-        assert build_cursor.call_args_list  # paged past the first chunk
-        assert all(call.args[0] == ('id',) for call in build_cursor.call_args_list)
 
     def test_pagination_key_pk_first(self):
         query = User.objects.filter(last_name="Tenenbaum")

--- a/corehq/util/tests/test_queries.py
+++ b/corehq/util/tests/test_queries.py
@@ -15,10 +15,22 @@ def test_lexicographic_greater_than_single_field():
 
 
 def test_lexicographic_greater_than_multiple_fields():
-    assert _lexicographic_greater_than(('a', 'b'), (1, 2)) == Q(a__gt=1) | Q(a=1, b__gt=2)
+    # the leading a >= va is redundant but lets Postgres seek a's index
+    assert (
+        _lexicographic_greater_than(('a', 'b'), (1, 2))
+        == Q(a__gte=1) & (Q(a__gt=1) | Q(a=1, b__gt=2))
+    )
     assert (
         _lexicographic_greater_than(('a', 'b', 'c'), (1, 2, 3))
-        == Q(a__gt=1) | Q(a=1, b__gt=2) | Q(a=1, b=2, c__gt=3)
+        == Q(a__gte=1) & (Q(a__gt=1) | Q(a=1, b__gt=2) | Q(a=1, b=2, c__gt=3))
+    )
+
+
+def test_lexicographic_greater_than_relation_path():
+    # the seek key can point at a joined table's column (e.g. case__case_id)
+    assert (
+        _lexicographic_greater_than(('case__case_id', 'id'), ('abc', 5))
+        == Q(case__case_id__gte='abc') & (Q(case__case_id__gt='abc') | Q(case__case_id='abc', id__gt=5))
     )
 
 

--- a/corehq/util/tests/test_queries.py
+++ b/corehq/util/tests/test_queries.py
@@ -67,6 +67,24 @@ class TestQuerysetToIterator(TestCase):
             [u.username for u in self.users],
         )
 
+    def test_seek_key_builds_the_cursor_not_the_sort_key(self):
+        # pk and id are the same column on User, so this divergent
+        # (sort_key, seek_key) still pages correctly -- and lets us confirm the
+        # cursor is built from the seek key ('id'), not the sort key ('pk')
+        query = User.objects.filter(last_name="Tenenbaum")
+        with patch.object(queries, '_lexicographic_greater_than',
+                          wraps=queries._lexicographic_greater_than) as build_cursor:
+            all_users = list(
+                queryset_to_iterator(query, User, limit=4, pagination_key=(('pk', 'id'),))
+            )
+
+        self.assertEqual(
+            [u.username for u in all_users],
+            [u.username for u in self.users],
+        )
+        assert build_cursor.call_args_list  # paged past the first chunk
+        assert all(call.args[0] == ('id',) for call in build_cursor.call_args_list)
+
     def test_pagination_key_pk_first(self):
         query = User.objects.filter(last_name="Tenenbaum")
 

--- a/corehq/util/tests/test_queries.py
+++ b/corehq/util/tests/test_queries.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from django.contrib.auth.models import User
 from django.db import connections
 from django.db.models import Q
@@ -8,7 +9,11 @@ from django.db.utils import InterfaceError, OperationalError
 from django.test.testcases import TestCase
 
 from corehq.util import queries
-from corehq.util.queries import _lexicographic_greater_than, queryset_to_iterator
+from corehq.util.queries import (
+    _lexicographic_greater_than,
+    _validate_pagination_index,
+    queryset_to_iterator,
+)
 
 
 def test_lexicographic_greater_than_single_field():
@@ -33,6 +38,23 @@ def test_lexicographic_greater_than_relation_path():
         _lexicographic_greater_than(('case__case_id', 'id'), ('abc', 5))
         == Q(case__case_id__gte='abc') & (Q(case__case_id__gt='abc') | Q(case__case_id='abc', id__gt=5))
     )
+
+
+def test_validate_pagination_index_accepts_a_real_fk_traversal():
+    from corehq.form_processor.models import CaseTransaction
+    # case_id is the stored column of CaseTransaction.case; case__case_id is its target
+    _validate_pagination_index(CaseTransaction, ('case_id', 'pk'), 'case__case_id')  # no raise
+
+
+@pytest.mark.parametrize("pagination_key, pagination_index", [
+    (('pk', 'case_id'), 'case__case_id'),  # leading key isn't backed by a foreign key
+    (('case_id', 'pk'), 'case_id'),        # missing the foreign key traversal
+    (('case_id', 'pk'), 'case__domain'),   # right foreign key, wrong target column
+])
+def test_validate_pagination_index_rejects_value_inequivalent_paths(pagination_key, pagination_index):
+    from corehq.form_processor.models import CaseTransaction
+    with pytest.raises(ValueError):
+        _validate_pagination_index(CaseTransaction, pagination_key, pagination_index)
 
 
 def test_pagination_index_seeks_on_the_index_not_the_cursor_key():

--- a/corehq/util/tests/test_queries.py
+++ b/corehq/util/tests/test_queries.py
@@ -21,22 +21,13 @@ def test_lexicographic_greater_than_single_field():
 
 
 def test_lexicographic_greater_than_multiple_fields():
-    # the leading a >= va is redundant but lets Postgres seek a's index
     assert (
         _lexicographic_greater_than(('a', 'b'), (1, 2))
-        == Q(a__gte=1) & (Q(a__gt=1) | Q(a=1, b__gt=2))
+        == (Q(a__gt=1) | Q(a=1, b__gt=2))
     )
     assert (
         _lexicographic_greater_than(('a', 'b', 'c'), (1, 2, 3))
-        == Q(a__gte=1) & (Q(a__gt=1) | Q(a=1, b__gt=2) | Q(a=1, b=2, c__gt=3))
-    )
-
-
-def test_lexicographic_greater_than_relation_path():
-    # the seek key can point at a joined table's column (e.g. case__case_id)
-    assert (
-        _lexicographic_greater_than(('case__case_id', 'id'), ('abc', 5))
-        == Q(case__case_id__gte='abc') & (Q(case__case_id__gt='abc') | Q(case__case_id='abc', id__gt=5))
+        == (Q(a__gt=1) | Q(a=1, b__gt=2) | Q(a=1, b=2, c__gt=3))
     )
 
 

--- a/corehq/util/tests/test_queries.py
+++ b/corehq/util/tests/test_queries.py
@@ -11,7 +11,7 @@ from django.test.testcases import TestCase
 from corehq.util import queries
 from corehq.util.queries import (
     _lexicographic_greater_than,
-    _validate_pagination_index,
+    _fk_index_column,
     queryset_to_iterator,
 )
 
@@ -40,10 +40,11 @@ def test_lexicographic_greater_than_relation_path():
     )
 
 
-def test_validate_pagination_index_accepts_a_real_fk_traversal():
+def test_fk_index_column_returns_the_parent_column():
     from corehq.form_processor.models import CaseTransaction
     # case_id is the stored column of CaseTransaction.case; case__case_id is its target
-    _validate_pagination_index(CaseTransaction, ('case_id', 'pk'), 'case__case_id')  # no raise
+    assert (_fk_index_column(CaseTransaction, ('case_id', 'pk'), 'case__case_id')
+            == '"form_processor_commcarecasesql"."case_id"')
 
 
 @pytest.mark.parametrize("pagination_key, pagination_index", [
@@ -51,30 +52,35 @@ def test_validate_pagination_index_accepts_a_real_fk_traversal():
     (('case_id', 'pk'), 'case_id'),        # missing the foreign key traversal
     (('case_id', 'pk'), 'case__domain'),   # right foreign key, wrong target column
 ])
-def test_validate_pagination_index_rejects_value_inequivalent_paths(pagination_key, pagination_index):
+def test_fk_index_column_rejects_value_inequivalent_paths(pagination_key, pagination_index):
     from corehq.form_processor.models import CaseTransaction
     with pytest.raises(ValueError):
-        _validate_pagination_index(CaseTransaction, pagination_key, pagination_index)
+        _fk_index_column(CaseTransaction, pagination_key, pagination_index)
 
 
-def test_pagination_index_seeks_on_the_index_not_the_cursor_key():
-    # The cursor is read from pagination_key ('case_id'/'pk'), but the WHERE seek
-    # is built from pagination_index ('case__case_id') -- the parent's column.
+def test_pagination_index_seeks_the_parent_column_while_keyset_stays_on_the_child():
+    # The keyset is built on the child's own column (pagination_key); pagination_index
+    # adds a raw bound on the parent column so Postgres can seek the parent's index.
     from corehq.form_processor.models import CaseTransaction
-    # _fetch_chunk is patched, so the queryset is never executed against the db
-    queryset = CaseTransaction.objects.using('default')
-    chunks = [[SimpleNamespace(case_id='abc', pk=5)], []]
-    with patch.object(queries, '_fetch_chunk', side_effect=chunks), \
-            patch.object(queries, '_lexicographic_greater_than',
-                         wraps=queries._lexicographic_greater_than) as build_seek:
+    pages = []
+
+    def capture(queryset, limit):
+        pages.append(str(queryset.query))   # compiles SQL; no db access
+        return [SimpleNamespace(case_id='abc', pk=5)] if len(pages) == 1 else []
+
+    with patch.object(queries, '_fetch_chunk', side_effect=capture):
         list(queryset_to_iterator(
-            queryset, CaseTransaction, limit=1, ignore_ordering=True,
-            pagination_key=('case_id', 'pk'), pagination_index='case__case_id',
+            CaseTransaction.objects.using('default'), CaseTransaction, limit=1,
+            ignore_ordering=True, pagination_key=('case_id', 'pk'),
+            pagination_index='case__case_id',
         ))
 
-    assert build_seek.call_args_list  # paged past the first chunk
-    assert all(call.args[0] == ('case__case_id', 'pk') for call in build_seek.call_args_list)
-    assert all(call.args[1] == ('abc', 5) for call in build_seek.call_args_list)
+    assert len(pages) == 2  # first page, then the seeked page
+    seeked_page = pages[1]
+    # raw bound on the parent column -- the planner hint
+    assert '"form_processor_commcarecasesql"."case_id" >= ' in seeked_page
+    # keyset still on the child's own column
+    assert '"form_processor_casetransaction"."case_id"' in seeked_page
 
 
 class TestQuerysetToIterator(TestCase):

--- a/corehq/util/tests/test_queries.py
+++ b/corehq/util/tests/test_queries.py
@@ -10,8 +10,8 @@ from django.test.testcases import TestCase
 
 from corehq.util import queries
 from corehq.util.queries import (
-    _lexicographic_greater_than,
     _fk_index_column,
+    _lexicographic_greater_than,
     queryset_to_iterator,
 )
 
@@ -43,24 +43,23 @@ def test_lexicographic_greater_than_relation_path():
 def test_fk_index_column_returns_the_parent_column():
     from corehq.form_processor.models import CaseTransaction
     # case_id is the stored column of CaseTransaction.case; case__case_id is its target
-    assert (_fk_index_column(CaseTransaction, ('case_id', 'pk'), 'case__case_id')
+    assert (_fk_index_column(CaseTransaction, ('case_id', 'pk'))
             == '"form_processor_commcarecasesql"."case_id"')
 
 
-@pytest.mark.parametrize("pagination_key, pagination_index", [
-    (('pk', 'case_id'), 'case__case_id'),  # leading key isn't backed by a foreign key
-    (('case_id', 'pk'), 'case_id'),        # missing the foreign key traversal
-    (('case_id', 'pk'), 'case__domain'),   # right foreign key, wrong target column
+@pytest.mark.parametrize("pagination_key", [
+    ('pk', 'case_id'),       # pk is not a foreign key's column
+    ('server_date', 'pk'),   # nor is a plain field
 ])
-def test_fk_index_column_rejects_value_inequivalent_paths(pagination_key, pagination_index):
+def test_fk_index_column_rejects_a_leading_key_with_no_foreign_key(pagination_key):
     from corehq.form_processor.models import CaseTransaction
     with pytest.raises(ValueError):
-        _fk_index_column(CaseTransaction, pagination_key, pagination_index)
+        _fk_index_column(CaseTransaction, pagination_key)
 
 
-def test_pagination_index_seeks_the_parent_column_while_keyset_stays_on_the_child():
-    # The keyset is built on the child's own column (pagination_key); pagination_index
-    # adds a raw bound on the parent column so Postgres can seek the parent's index.
+def test_use_fk_index_hint_seeks_the_parent_column_while_keyset_stays_on_the_child():
+    # The keyset is built on the child's own column (pagination_key); the hint adds
+    # a raw bound on the parent column so Postgres can seek the parent's index.
     from corehq.form_processor.models import CaseTransaction
     pages = []
 
@@ -72,7 +71,7 @@ def test_pagination_index_seeks_the_parent_column_while_keyset_stays_on_the_chil
         list(queryset_to_iterator(
             CaseTransaction.objects.using('default'), CaseTransaction, limit=1,
             ignore_ordering=True, pagination_key=('case_id', 'pk'),
-            pagination_index='case__case_id',
+            use_fk_index_hint=True,
         ))
 
     assert len(pages) == 2  # first page, then the seeked page

--- a/corehq/util/tests/test_queries.py
+++ b/corehq/util/tests/test_queries.py
@@ -2,11 +2,24 @@ from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.db import connections
+from django.db.models import Q
 from django.db.utils import InterfaceError, OperationalError
 from django.test.testcases import TestCase
 
 from corehq.util import queries
-from corehq.util.queries import queryset_to_iterator
+from corehq.util.queries import _lexicographic_greater_than, queryset_to_iterator
+
+
+def test_lexicographic_greater_than_single_field():
+    assert _lexicographic_greater_than(('id',), (5,)) == Q(id__gt=5)
+
+
+def test_lexicographic_greater_than_multiple_fields():
+    assert _lexicographic_greater_than(('a', 'b'), (1, 2)) == Q(a__gt=1) | Q(a=1, b__gt=2)
+    assert (
+        _lexicographic_greater_than(('a', 'b', 'c'), (1, 2, 3))
+        == Q(a__gt=1) | Q(a=1, b__gt=2) | Q(a=1, b=2, c__gt=3)
+    )
 
 
 class TestQuerysetToIterator(TestCase):
@@ -34,6 +47,33 @@ class TestQuerysetToIterator(TestCase):
             # query 3: Users 9, 10
             # query 4: Check that there are no users past #10
             all_users = list(queryset_to_iterator(query, User, limit=4))
+
+        self.assertEqual(
+            [u.username for u in all_users],
+            [u.username for u in self.users],
+        )
+
+    def test_pagination_key_multiple_fields(self):
+        query = User.objects.filter(last_name="Tenenbaum")
+
+        # All users share a last_name, so paging hinges on the pk tie-breaker
+        with self.assertNumQueries(4):
+            all_users = list(
+                queryset_to_iterator(query, User, limit=4, pagination_key=('last_name', 'pk'))
+            )
+
+        self.assertEqual(
+            [u.username for u in all_users],
+            [u.username for u in self.users],
+        )
+
+    def test_pagination_key_pk_first(self):
+        query = User.objects.filter(last_name="Tenenbaum")
+
+        with self.assertNumQueries(4):
+            all_users = list(
+                queryset_to_iterator(query, User, limit=4, pagination_key=('pk', 'username'))
+            )
 
         self.assertEqual(
             [u.username for u in all_users],


### PR DESCRIPTION
## Product Description
No user-facing change. Speeds up the `dump_domain_data` management command for domains with many cases/forms.

## Technical Summary

One output-facing change: the case/form child models are now dumped sorted by (`case_id`/`form_id`, `pk`) instead of `pk`.

The case/form child models (`XFormOperation`, `CaseAttachment`, `CaseTransaction`, `LedgerTransaction`) filter by their parent case/form's `domain` (they have no `domain` of their own). That join *can* be done efficiently on the existing indices, but with our `pk` pagination Postgres defaults to a wildly inefficient plan: scan the child table by `pk` from the cursor, look up each child's parent by `case_id`, discard the ~99% whose parent isn't in the domain, and accumulate until 5,000 survive. One page can take minutes.

<details>
<summary>Here is the original query plan if you're interested.</summary>

(The domain and id have been altered to fake/arbitrary values.)

```
                                                                                                      QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1001.17..2952951.70 rows=5000 width=202) (actual time=613.302..99840.896 rows=5000 loops=1)
   ->  Gather Merge  (cost=1001.17..177263268.88 rows=300246 width=202) (actual time=613.301..99840.067 rows=5000 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Nested Loop  (cost=1.15..177227613.02 rows=125102 width=202) (actual time=545.580..80371.096 rows=1669 loops=3)
               ->  Parallel Index Scan using form_processor_casetransaction_pkey on form_processor_casetransaction  (cost=0.57..9488472.95 rows=20508617 width=202) (actual time=2.283..1056.167 rows=165608 loops=3)
                     Index Cond: (id > 531842906)
               ->  Index Scan using form_processor_commcarecasesql_case_id_key on form_processor_commcarecasesql  (cost=0.57..8.18 rows=1 width=36) (actual time=0.478..0.478 rows=0 loops=496824)
                     Index Cond: ((case_id)::text = (form_processor_casetransaction.case_id)::text)
                     Filter: ((domain)::text = 'my-domain'::text)
                     Rows Removed by Filter: 1
 Planning Time: 4.338 ms
 Execution Time: 99841.598 ms
(13 rows)
```
</details>

Two changes combine to get the efficient plan — pagination alone won't trigger it. Representative raw queries tested on production go from ~1–2 min to ~1s per 5,000 rows (~100x). Using case transactions as the example:

1. **Paginate by `(case_id, pk)`, not just `pk`.** This lets the planner filter the parent table to the domain's case_ids first, then for each case_id fetch its handful of transactions and sort them by `pk` in memory (cheap) — one stream until 5,000 accumulate. Postgres won't pick this from the keyset alone: it can't derive a usable bound from inside the `OR` that a `(case_id, pk)` keyset expands to.
2. **Add a redundant top-level `where case.case_id >= last_id` on the _parent_ table.** It's value-equivalent to the keyset's leading condition, so it changes no results — but it's the hint Postgres needs to seek the `case` table's index and prune by domain first. It has to be raw SQL: the ORM collapses the equivalent `case__case_id` lookup to the child's own column, and Postgres won't carry the keyset's inequality across the join — so otherwise the bound lands on the child and the plan never flips.

<details>
<summary>Here's the new query plan if you're interested.</summary>

The key change: the `commcarecasesql` scan now **seeks** via `Index Cond: case_id >= …` instead of scanning the child table, and the whole thing finishes in ~1.2s (instead of the ~1.5m above).

(Domain, id, and case_id altered to the same fake/arbitrary values.)

```
                                                                                                       QUERY PLAN
  -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   Limit  (cost=2900.74..3735700.45 rows=5000 width=202) (actual time=9.099..1241.896 rows=5000 loops=1)
     ->  Incremental Sort  (cost=2900.74..2795645162.30 rows=3744699 width=202) (actual time=9.098..1241.427 rows=5000 loops=1)
           Sort Key: form_processor_casetransaction.case_id, form_processor_casetransaction.id
           Presorted Key: form_processor_casetransaction.case_id
           ->  Nested Loop  (cost=1.27..2795502983.80 rows=3744699 width=202) (actual time=0.062..1234.911 rows=8341 loops=1)
                 ->  Index Scan using form_processor_commcarecasesql_case_id_key on form_processor_commcarecasesql  (cost=0.57..555483313.85 rows=879109 width=36) (actual time=0.032..1045.104 rows=1148 loops=1)
                       Index Cond: ((case_id)::text >= '11111111-1111-1111-1111-111111111111'::text)
                       Filter: ((domain)::text = 'my-domain'::text)
                       Rows Removed by Filter: 185334
                 ->  Index Scan using form_processor_casetransaction_case_id_5c2e4cc3f690d7bb_uniq on form_processor_casetransaction  (cost=0.70..2545.89 rows=217 width=202) (actual time=0.026..0.162 rows=7 loops=1148)
                       Index Cond: ((case_id)::text = (form_processor_commcarecasesql.case_id)::text)
                       Filter: (((form_processor_commcarecasesql.case_id)::text > '11111111-1111-1111-1111-111111111111'::text) OR (((form_processor_commcarecasesql.case_id)::text = '11111111-1111-1111-1111-111111111111'::text) AND (id > 531842906)))
                       Rows Removed by Filter: 0
   Planning Time: 0.474 ms
   Execution Time: 1242.179 ms
  (15 rows)
```

</details>

**No new indices.** This stays within the existing indices. A `(domain, case_id)` index on the case table would likely help, but an index isn't free to maintain on such a large, high-volume table — a real steady-state cost for a workflow run only occasionally. The tradeoff is the planner "contortions" above; they're deliberately isolated and documented (here and in the code) because a Postgres upgrade or an unrelated change to the dump code could flip the plan back — or make the contortions unnecessary.

**Update June 10, 2026**
I did an isolated run on a medium-large test domain on production, and the before and after for just the CaseTransaction model. It went from ~1500s to ~50s for about 17.5k rows—about a 30x improvement. (It's worth noting that for this particular example, CaseTransaction and other case/form child models were not the main bottleneck, so the improvement isn't as obvious in the total number as it is in the number for the individual model. I hope, and believe, that for a larger project space, this optimization will be proportionally more impactful on the total.)

## Feature Flag
None

## Safety Assurance

### Safety story
- **Same rows, new order.** These models now sort by `(case_id, pk)` instead of `pk`, so their dump order changes — but the *set* of rows does not (the extra `case.case_id >= …` bound is value-equivalent to the keyset's leading condition on every joined row). Load is order-independent (rows load by natural key), so the reorder is safe. Other callers (the default `('pk',)`) are untouched.
- **The parent-index hint can't be misconfigured silently.** It's opt-in per model and derives the parent column from the foreign key backing the leading pagination key; if that key isn't a foreign key's column it raises at iteration start. A test over the dump config catches a bad entry in CI.
- **Production testing was query-plan only.** The only thing run against production was a handful of representative `EXPLAIN ANALYZE` queries — to understand the planner, find the fix, and vet it (~1–2 min → ~1s per 5,000 rows, ~100x). **No full dump has been run on production**; that end-to-end run is intentionally deferred until after this review.
- **End-to-end testing on staging**. Because the staging tables are so small already, there was no obvious speed improvement; importantly, though, there was also no speed regression, showing that this new query plan is just as good on small tables. So it's a more-or-less strict improvement, not a speedup of large tables / large domains at the expense of smaller ones.
- Operator tooling, run on demand; no live request paths are affected.

### Automated test coverage
- Unit tests for the keyset condition (`_lexicographic_greater_than`): the single- and multi-field `OR` expansion.
- `queryset_to_iterator` paging tests, including that the parent-index hint adds a raw `case.case_id >= …` bound while the keyset stays on the child's own column.
- Validation that the parent column is derived from the foreign key backing the leading pagination key, and that a leading key with no such foreign key is rejected.
- A guard test over the dump config asserts every model using the parent-index hint has a foreign-key-backed leading key, so a misconfiguration fails in CI rather than at dump time.
- A sharded test that pages `CaseTransaction` over the join with the parent-index hint at a small chunk size, asserting every transaction is returned exactly once across page boundaries.
- Existing `dump_reload` tests exercise the iterator builders end to end.

### QA Plan
None — covered by automated tests, the staging run, and the production `EXPLAIN ANALYZE`.

### Migrations
None.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change



