### PR TITLE
Fix variable shadowing typo in UniqueFilteredModelIteratorBuilder.iterators

### DIFF
--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -207,6 +207,5 @@ class UniqueFilteredModelIteratorBuilder(FilteredModelIteratorBuilder):
                     seen.add(model.pk)
                     yield model
 
-        querysets = self.querysets()
-        for querysets in querysets:
-            yield _unique(querysets)
+        for queryset in self.querysets():
+            yield _unique(queryset)


### PR DESCRIPTION
## Product Description
None — internal readability cleanup with no user-facing effect.

## Technical Summary
Noticed while reviewing [#37786](https://github.com/dimagi/commcare-hq/pull/37786#discussion_r3348779163).

`UniqueFilteredModelIteratorBuilder.iterators()` reused the name `querysets`
for both the generator returned by `self.querysets()` and the loop variable:

```python
querysets = self.querysets()
for querysets in querysets:
    yield _unique(querysets)
```

This is almost certainly an unintentional typo. To be clear, it's not a
functional bug — it's technically functionally valid: Python evaluates a
`for` loop's iterable expression exactly once at loop setup and iterates the
captured iterator, so rebinding the `querysets` name on each pass has no
effect on iteration. But the shadowing is an anti-pattern and confusing to
read. The fix iterates over `self.querysets()` directly
with a singular `queryset` loop variable. Behavior is identical.

## Feature Flag
None.

## Safety Assurance

### Safety story
Strictly a readability change: a local loop-variable rename plus dropping the
redundant intermediate assignment. The iteration logic is provably identical
(the `for` iterable is evaluated once regardless of the name reuse), so the
change is inherently safe.

### Automated test coverage
Covered by the existing `dump_reload` test suite, which exercises the
filtered/unique iterator builders during domain dump/restore.

### QA Plan
Not required — no behavioral change.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
