### PR TITLE
Fix 500; Set var before using

### DIFF
--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -2060,6 +2060,7 @@ def create_channels(request, domain, *args, **kwargs):
     user_links = ConnectIDUserLink.objects.filter(domain=domain, channel_id__isnull=True)
     backend = ConnectBackend()
     channel_users = []
+    success = False
     for link in user_links:
         success = backend.create_channel(link)
         if success:


### PR DESCRIPTION
## Product Description

This is a bug fix for a 500

https://dimagi.atlassian.net/browse/CI-699
[Sentry](https://dimagi.sentry.io/issues/7523999731/?environment=staging&project=136860&query=is%3Aunresolved&referrer=issue-stream)

## Technical Summary
Var was not set before getting used. So this just sets initial value.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
COMMCARE_CONNECT

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

Tested locally

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
