### PR TITLE
Speed up domain dumps by avoiding a per-row fetch during natural-key serialization

### DIFF
--- a/corehq/apps/dump_reload/sql/serialization.py
+++ b/corehq/apps/dump_reload/sql/serialization.py
@@ -2,8 +2,32 @@ import json
 from copy import copy
 
 from django.core.serializers.json import Serializer as JsonSerializer
+from memoized import memoized
 
 from corehq.util.json import CommCareJSONEncoder
+
+
+@memoized
+def _fk_value_is_natural_key(fk_field):
+    """Answers the question "Is fk_field's value already the natural_key of the foreign object?"
+
+    For example, case_transaction.case_id is already the natural_key of case_transaction.case.
+    Knowing this allows the caller to skip an unnecessary db query to look up the foreign object.
+    """
+    # e.g. related_model = CommCareCase
+    related_model = fk_field.remote_field.model
+    # e.g. to_field = 'case_id'
+    to_field = fk_field.remote_field.field_name
+    if not hasattr(related_model, 'natural_key'):
+        return False
+    try:
+        # natural_key() is an arbitrary instance method, not a field name, so we can only tell
+        # whether it returns the to_field value by trying it: set to_field to a challenge value
+        # and check natural_key() gives it back. e.g. CommCareCase(case_id=X).natural_key() == X
+        challenge = '68bbc985c27d9fd693d72fbeaecd862b90827f64'
+        return related_model(**{to_field: challenge}).natural_key() == challenge
+    except Exception:
+        return False
 
 
 class JsonLinesSerializer(JsonSerializer):
@@ -16,6 +40,17 @@ class JsonLinesSerializer(JsonSerializer):
 
     def end_serialization(self):
         pass
+
+    def handle_fk_field(self, obj, field):
+        """Avoid fetching the foreign object when the FK value is already its natural key.
+        e.g. use `case_transaction.case_id` instead of `case_transaction.case.natural_key()`:
+        they're identical, and accessing `case_transaction.case` runs an unnecessary db query.
+        """
+        if self.use_natural_foreign_keys and _fk_value_is_natural_key(field):
+            # e.g. self._current['case'] = case_transaction.case_id
+            self._current[field.name] = getattr(obj, field.get_attname())
+        else:
+            super().handle_fk_field(obj, field)
 
     def get_dump_object(self, obj):
         dumped_obj = super().get_dump_object(obj)

--- a/corehq/apps/dump_reload/tests/test_serialization.py
+++ b/corehq/apps/dump_reload/tests/test_serialization.py
@@ -113,6 +113,29 @@ class TestForeignKeyFieldSerialization(SimpleTestCase):
         fk_field = deserialized_model['fields']['form']
         self.assertEqual(fk_field, 'abc123')
 
+    def test_natural_foreign_key_for_CommCareCase_does_not_load_the_parent(self):
+        # Only the FK value is set (no related object). Loading the parent here
+        # would hit the DB -- forbidden in SimpleTestCase -- so this fails if the
+        # serializer doesn't take the natural-key-from-fk-value shortcut.
+        transaction = CaseTransaction(case_id='abc123')
+
+        output_stream = StringIO()
+        with patch('corehq.apps.dump_reload.sql.dump.get_objects_to_dump', return_value=[transaction]):
+            SqlDataDumper('test', [], []).dump(output_stream)
+
+        deserialized_model = json.loads(output_stream.getvalue())
+        self.assertEqual(deserialized_model['fields']['case'], 'abc123')
+
+    def test_natural_foreign_key_for_XFormInstance_does_not_load_the_parent(self):
+        operation = XFormOperation(form_id='abc123')
+
+        output_stream = StringIO()
+        with patch('corehq.apps.dump_reload.sql.dump.get_objects_to_dump', return_value=[operation]):
+            SqlDataDumper('test', [], []).dump(output_stream)
+
+        deserialized_model = json.loads(output_stream.getvalue())
+        self.assertEqual(deserialized_model['fields']['form'], 'abc123')
+
 
 class TestEncryptedFieldSerialization(SimpleTestCase):
 


### PR DESCRIPTION
## Product Description
No user-facing change. Speeds up the `dump_domain_data` management command — on staging a large domain dumped roughly twice as fast (details under Safety story).

## Technical Summary
The SQL dumper serializes with `use_natural_foreign_keys=True`. For a foreign key, Django's serializer loads the **related object** so it can call `natural_key()` on it:

```python
# django/core/serializers/python.py — Serializer.handle_fk_field
related = getattr(obj, field.name)   # e.g. transaction.case  → a DB query
value = related.natural_key()
```

The form-processor child models point at their parent via `case_id` / `form_id` (using `to_field`) rather than the default `pk`, and those are the parent's `natural_key()`. So `CaseTransaction`, `CaseAttachment`, `LedgerTransaction`, `CommCareCaseIndex` (→ `CommCareCase`) and `XFormOperation` (→ `XFormInstance`) each do **one full parent fetch per child row** only to recover a value the child already stores:

```sql
SELECT id, case_id, domain, ..., case_json FROM form_processor_commcarecasesql
WHERE case_id = '…' LIMIT 21;       -- once per CaseTransaction (×438k for the staging domain)
```

`transaction.case_id` already equals `transaction.case.natural_key()`, so that fetch is pure waste.

**The fix:** override `handle_fk_field` so that when the FK's `to_field` is the related model's natural key, it serializes the local FK value directly with no fetch. The output is byte-for-byte identical.

## Safety Assurance

### Safety story
- **Output-identical.** The serialized value is unchanged: we only use the shortcut when we can show it will be identical.
- **Self-limiting.** Anything our method can't prove falls back to Django's existing behavior, so the worst case is "no speedup," never "wrong output."
- **Measured on staging (`qateam`):** total dump **3487s → 1628s (−53%)**, SQL portion **3333s → 1478s (−56%)**. `CaseTransaction` dropped from **1.305 → 0.135 h/1M rows** (≈10×) and `CommCareCaseIndex` similarly, while `CommCareCase` — which has no natural-FK-to-natural-key — was unchanged, validating our theory of this per-row fetch as the cost.

### Automated test coverage
- Existing `TestForeignKeyFieldSerialization` already pins the serialized output for the natural-key FKs (`CommCareCase`, `XFormInstance`), the tuple-key fallbacks (`Permission`, `User`), and plain pk FKs — all still pass, so the fallback path is provably preserved.
- Two new tests serialize a child with only its FK id set (no related object) under `SimpleTestCase`: the old path would query the DB (forbidden there), so they fail unless the fetch is skipped — locking in both the no-fetch behavior and the emitted value.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
