### PR TITLE
Add URL, Domain, Page Title context for OCS bot

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/commcarehq.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/commcarehq.js
@@ -8,3 +8,4 @@ import 'bootstrap';
 import 'hqwebapp/js/bootstrap3/common';
 import 'hqwebapp/js/bootstrap3/base_main';
 import 'open-chat-studio-widget';
+import 'hqwebapp/js/ocs_widget_global_context';

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/commcarehq.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/commcarehq.js
@@ -8,3 +8,4 @@ import 'bootstrap5';
 import 'hqwebapp/js/bootstrap5/common';
 import 'hqwebapp/js/bootstrap5/base_main';
 import 'open-chat-studio-widget';
+import 'hqwebapp/js/ocs_widget_global_context';

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
@@ -1,0 +1,39 @@
+/*
+*  Setters for the OCS chat widget's page context object.
+*
+*  One setter per supported field so the context shape stays fixed —
+*  adding a new field is a deliberate change here.
+*
+*  Widget API: https://docs.openchatstudio.com/chat_widget/reference/#page-context
+*/
+
+const WIDGET_SELECTOR = 'open-chat-studio-widget';
+let _currentContext = {};
+
+function _publish() {
+    const widget = document.querySelector(WIDGET_SELECTOR);
+    if (widget) {
+        widget.pageContext = _currentContext;
+    }
+}
+
+function setUrl(url) {
+    _currentContext.url = url;
+    _publish();
+}
+
+function setPageTitle(page_title) {
+    _currentContext.page_title = page_title;
+    _publish();
+}
+
+function setDomain(domain) {
+    _currentContext.domain = domain;
+    _publish();
+}
+
+export default {
+    setUrl: setUrl,
+    setPageTitle: setPageTitle,
+    setDomain: setDomain,
+};

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_global_context.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_global_context.js
@@ -1,0 +1,41 @@
+import ocs_context from "hqwebapp/js/ocs_widget_context_setter";
+
+function _domainFromUrl() {
+    var match = window.location.pathname.match(/^\/a\/([^/]+)\//);
+    return match ? match[1] : null;
+}
+
+function _setInitialContext() {
+    ocs_context.setUrl(window.location.href);
+    ocs_context.setPageTitle(document.title);
+    ocs_context.setDomain(_domainFromUrl());
+}
+
+function _observePageTitleChanges() {
+    var titleEl = document.querySelector('title');
+    if (!titleEl) {
+        return;
+    }
+    var observer = new MutationObserver(function () {
+        ocs_context.setPageTitle(document.title);
+    });
+    observer.observe(titleEl, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+    });
+}
+
+function _observeUrlChanges() {
+    window.addEventListener('hashchange', ocs_context.setUrl(window.location.href));
+    window.addEventListener('popstate', ocs_context.setUrl(window.location.href));
+}
+
+// Only listen to top window to ignore App Preview iframe
+if (window === window.top) {
+    document.addEventListener('DOMContentLoaded', function () {
+        _setInitialContext();
+        _observePageTitleChanges();
+        _observeUrlChanges();
+    });
+}


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
OCS Bot now know the url, the page title and the domain when user send a new message to ocs bot.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19845

First step of an incremental rollout sketched in the [App Builder Page Context spec](https://docs.google.com/document/d/10ew68kDMgaHNeDwOdeKrA4P1R31jNQaVDVryqCBGZso/edit?tab=t.0). This PR just send url, domain name and page title.

Per the [OCS doc](https://docs.openchatstudio.com/chat_widget/reference/#page-context), the widget attaches pageContext only when the user sends a message and clears it afterward. So even though our setters run frequently, no traffic is generated unless the user actually asks the bot something.

The global context is gated on `window === window.top` so the App Preview iframe inside the form designer doesn't double-publish context with its own (empty) title and (null) domain.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`OCS_CHATBOT` feature preview

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Only add stuff to the page context that will be sent along to ocs bot

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
