### PR TITLE
Declare calculated_property variable on enum-image alt text

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -136,6 +136,17 @@ class FormattedDetailColumn(object):
             variables['lang'] = self.id_strings.current_language()
         return variables
 
+    def _calculated_property(self):
+        xpath = sx.CalculatedPropertyXPath(function=self.xpath)
+        if re.search(r'\$lang', self.xpath):
+            xpath.variables.node.append(
+                sx.CalculatedPropertyXPathVariable(
+                    name='lang',
+                    locale_id=self.id_strings.current_language()
+                ).node
+            )
+        return sx.XPathVariable(name='calculated_property', xpath=xpath).node
+
     @property
     def template(self):
         template = sx.Template(
@@ -144,16 +155,7 @@ class FormattedDetailColumn(object):
             width=self.template_width,
         )
         if self.column.useXpathExpression and self.column.format != 'translatable-enum':
-            xpath = sx.CalculatedPropertyXPath(function=self.xpath)
-            if re.search(r'\$lang', self.xpath):
-                xpath.variables.node.append(
-                    sx.CalculatedPropertyXPathVariable(
-                        name='lang',
-                        locale_id=self.id_strings.current_language()
-                    ).node
-                )
-            xpath_variable = sx.XPathVariable(name='calculated_property', xpath=xpath)
-            template.text.xpath.variables.node.append(xpath_variable.node)
+            template.text.xpath.variables.node.append(self._calculated_property())
 
         if self.variables:
             for key, value in sorted(self.variables.items()):
@@ -183,18 +185,8 @@ class FormattedDetailColumn(object):
                 type=sort_type,
             )
 
-            if self.column.useXpathExpression:
-                xpath = sx.CalculatedPropertyXPath(function=self.xpath)
-                if re.search(r'\$lang', self.xpath):
-                    xpath.variables.node.append(
-                        sx.CalculatedPropertyXPathVariable(
-                            name='lang',
-                            locale_id=self.id_strings.current_language()
-                        ).node
-                    )
-                if self.column.format != 'translatable-enum':
-                    xpath_variable = sx.XPathVariable(name='calculated_property', xpath=xpath)
-                    sort.text.xpath.variables.node.append(xpath_variable.node)
+            if self.column.useXpathExpression and self.column.format != 'translatable-enum':
+                sort.text.xpath.variables.node.append(self._calculated_property())
 
         if self.sort_element:
             if not sort:
@@ -215,15 +207,7 @@ class FormattedDetailColumn(object):
                     type=sort_type,
                 )
                 if not sort_calculation and self.column.useXpathExpression:
-                    xpath = sx.CalculatedPropertyXPath(function=self.xpath)
-                    if re.search(r'\$lang', self.xpath):
-                        xpath.variables.node.append(
-                            sx.CalculatedPropertyXPathVariable(
-                                name='lang', locale_id=self.id_strings.current_language()
-                            ).node
-                        )
-                    xpath_variable = sx.XPathVariable(name='calculated_property', xpath=xpath)
-                    sort.text.xpath.variables.node.append(xpath_variable.node)
+                    sort.text.xpath.variables.node.append(self._calculated_property())
 
             if self.sort_element.type == 'distance':
                 sort.text.xpath_function = self.evaluate_template(Distance.SORT_XPATH_FUNCTION)

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -506,9 +506,13 @@ class EnumImage(Enum):
     @property
     def alt_text(self):
         if self.app.supports_alt_text:
-            return sx.AltText(
+            alt_text = sx.AltText(
                 text=sx.Text(xpath=self.alt_text_xpath)
             )
+            if (self.column.useXpathExpression
+                    and toggles.ENUM_CALC_VARIABLES.enabled(self.app.domain)):
+                alt_text.text.xpath.variables.node.append(self._calculated_property())
+            return alt_text
 
     def _xpath_template(self, type):
         return "if({key_as_condition}, {key_as_var_name}"

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -492,19 +492,16 @@ class EnumImage(Enum):
         if self.column.endpoint_action_id and self.app.supports_detail_field_action:
             return sx.EndpointAction(endpoint_id=self.column.endpoint_action_id, background="true")
 
-    def _make_alt_text(self, type):
+    @property
+    def alt_text_xpath(self):
         return sx.XPathEnum.build(
             enum=self.column.enum,
             format=self.column.format,
-            type=type,
-            template=self._xpath_template(type),
-            get_template_context=self._xpath_template_context(type),
+            type='display',
+            template=self._xpath_template('display'),
+            get_template_context=self._xpath_template_context('display'),
             get_value=lambda key: self.id_strings.detail_column_alt_text_variable(self.module, self.detail_type,
                                                                                   self.column, key))
-
-    @property
-    def alt_text_xpath(self):
-        return self._make_alt_text('display')
 
     @property
     def alt_text(self):

--- a/corehq/apps/app_manager/tests/test_suite_formats.py
+++ b/corehq/apps/app_manager/tests/test_suite_formats.py
@@ -7,6 +7,7 @@ from django.test import SimpleTestCase
 from corehq import privileges
 from corehq.apps.app_manager.models import (
     Application,
+    BuildSpec,
     DetailColumn,
     MappingItem,
     Module,
@@ -319,6 +320,7 @@ class SuiteFormatsTest(SimpleTestCase, TestXmlMixin):
 
     def _build_calculated_enum_image_app(self):
         app = Application.new_app('domain', 'Untitled Application')
+        app.build_spec = BuildSpec(version='2.54.0', build_number=1)
         module = app.add_module(Module.new_module('Untitled Module', None))
         module.case_type = 'patient'
 
@@ -400,6 +402,35 @@ class SuiteFormatsTest(SimpleTestCase, TestXmlMixin):
             expected,
             app.create_suite(),
             './detail/field/template[@form="image"]',
+        )
+
+    @flag_enabled('ENUM_CALC_VARIABLES')
+    def test_enum_calc_alt_text_defines_variable(self, *args):
+        app = self._build_calculated_enum_image_app()
+
+        expected = """
+        <partial>
+          <alt_text>
+            <text>
+              <xpath function="if($calculated_property = 'high', $khigh, if($calculated_property = 'low', $klow, ''))">
+                <variable name="khigh">
+                  <locale id="m0.case_short.case_if(stars &gt; 4, 'high', 'low')_1.alt_text.khigh"/>
+                </variable>
+                <variable name="klow">
+                  <locale id="m0.case_short.case_if(stars &gt; 4, 'high', 'low')_1.alt_text.klow"/>
+                </variable>
+                <variable name="calculated_property">
+                  <xpath function="if(stars &gt; 4, 'high', 'low')"/>
+                </variable>
+              </xpath>
+            </text>
+          </alt_text>
+        </partial>
+        """  # noqa: #501
+        self.assertXmlPartialEqual(
+            expected,
+            app.create_suite(),
+            './detail/field/alt_text',
         )
 
     def test_case_detail_alt_text_mapping(self, *args):


### PR DESCRIPTION
## Product Description

With the ENUM_CALC_VARIABLES feature flag enabled, a case list containing an enum-image (or clickable-icon) column whose field is a calculated xpath expression fails to load entirely in formplayer/web apps:

> The problem was located in if($calculated_property = '...', $h..., ...): attempt to cast null value to string

This PR fixes that crash. No behavior changes with the flag off.

## Technical Summary

Follow-up to #37722, which made enum conditions reference a `$calculated_property` variable instead of repeating the (potentially expensive) source expression once per mapping.

The problem with that was that the enum conditions are repeated in 3 contexts, one of which (alt text) didn't have the calculated property variable present.

The first two commits are output-identical refactors (extracting the variable construction into a helper, inlining a single-use method); the behavior change is the last commit.

## Feature Flag

ENUM_CALC_VARIABLES

## Safety Assurance

### Safety story

- The fix is gated on the ENUM_CALC_VARIABLES flag (a temporary testing flag) plus `useXpathExpression`, so flag-off suite generation is unchanged.
- The two refactor commits produce byte-identical suite XML; the only evaluation-order difference is no longer constructing a discarded object in one sort_node branch.
- Confirmed empirically against a real app that adding the variable declaration to the alt text resolves the formplayer error.

### Automated test coverage

`test_enum_calc_alt_text_defines_variable` checks this situation

### QA Plan

No QA ticket; flag is enabled on limited test domains. Verification is manual: load a case list with a calculated-property enum-image column on a flagged domain.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change