### PR TITLE
Add space in 'CommCare HQ' in SMS verification welcome message

### DIFF
--- a/corehq/apps/sms/messages.py
+++ b/corehq/apps/sms/messages.py
@@ -73,9 +73,9 @@ _MESSAGES = {
         " messages from CommCareHQ. To opt-in, reply to this number with {0}"),
     MSG_DUPLICATE_USERNAME: gettext_noop("CommCare user {0} already exists"),
     MSG_USERNAME_TOO_LONG: gettext_noop("Username {0} is too long.  Must be under {1} characters."),
-    MSG_VERIFICATION_START_WITH_REPLY: gettext_noop("Welcome to CommCareHQ! Is this phone used by {0}? "
+    MSG_VERIFICATION_START_WITH_REPLY: gettext_noop("Welcome to CommCare HQ! Is this phone used by {0}? "
         "If yes, reply '123' to {1} to start using SMS with CommCareHQ."),
-    MSG_VERIFICATION_START_WITHOUT_REPLY: gettext_noop("Welcome to CommCareHQ! Is this phone used by {0}? "
+    MSG_VERIFICATION_START_WITHOUT_REPLY: gettext_noop("Welcome to CommCare HQ! Is this phone used by {0}? "
         "If yes, reply '123' to start using SMS with CommCareHQ."),
     MSG_VERIFICATION_SUCCESSFUL: gettext_noop("Thank you. This phone has been verified for "
         "using SMS with CommCareHQ"),

--- a/corehq/apps/sms/messages.py
+++ b/corehq/apps/sms/messages.py
@@ -112,7 +112,7 @@ def get_message(msg_id, verified_number=None, context=None, domain=None, languag
     else:
         try:
             user_lang = verified_number.owner.get_language_code()
-        except:
+        except Exception:
             user_lang = None
 
     def get_translation(lang):


### PR DESCRIPTION
## Product Description
Fixes a small branding inconsistency in the SMS verification welcome message: "CommCareHQ" → "CommCare HQ".

## Technical Summary
Two strings in `corehq/apps/sms/messages.py` had "CommCareHQ" without the space. Also tightened a bare `except:` in the same file to `except Exception:` to satisfy the linter (the bare clause was already in the file; this was the minimal fix to keep ruff happy while touching neighboring lines).

## Feature Flag
N/A

## Safety Assurance

### Safety story
User-facing string change in two SMS messages plus a no-op lint cleanup on an adjacent `except` clause. Inherently safe.

### Automated test coverage
No new tests — copy change.

### QA Plan
N/A

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change