### PR TITLE
Remove defaultchangefeedpillow related code from HQ

### DIFF
--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -48,10 +48,6 @@ class KafkaProcessor(PillowProcessor):
                 _create_deleted_couch_doc(change.id, doc_type, deleted_on)
 
 
-def get_default_couch_db_change_feed_pillow(pillow_id, **kwargs):
-    return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db(None))
-
-
 def get_user_groups_db_kafka_pillow(pillow_id, **kwargs):
     return get_change_feed_pillow_for_db(
         pillow_id, couch_config.get_db_for_class(CommCareUser), topics.COMMCARE_USER

--- a/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
+++ b/corehq/apps/es/tests/test_elastic_sync_multiplexed_command.py
@@ -361,8 +361,7 @@ class TestCopyCheckpointsBeforeIndexSwap(TestCase):
 
             # Save a case and propogate the changes to the pillow
             with process_pillow_changes(case_pillow):
-                with process_pillow_changes('DefaultChangeFeedPillow'):
-                    create_and_save_a_case(domain, case_id=uuid.uuid4().hex, case_name='test case')
+                create_and_save_a_case(domain, case_id=uuid.uuid4().hex, case_name='test case')
 
             # Save the checkpoints after case is processed
             updated_checkpoints = case_pillow.checkpoint.get_current_sequence_as_dict()

--- a/corehq/apps/hqcase/tests/test_dbaccessors.py
+++ b/corehq/apps/hqcase/tests/test_dbaccessors.py
@@ -32,7 +32,6 @@ class ESAccessorsTest(TestCase):
         case_id = uuid.uuid4().hex
         case_name = 'case-name-{}'.format(uuid.uuid4().hex)
         with process_pillow_changes('case-pillow', {'skip_ucr': True}):
-            with process_pillow_changes('DefaultChangeFeedPillow'):
-                create_and_save_a_case(self.domain, case_id, case_name)
+            create_and_save_a_case(self.domain, case_id, case_name)
         manager.index_refresh(case_adapter.index_name)
         return case_id, case_name

--- a/corehq/apps/sms/tests/opt_tests.py
+++ b/corehq/apps/sms/tests/opt_tests.py
@@ -42,8 +42,7 @@ class OptTestCase(DomainSubscriptionMixin, TestCase):
             prefix='1',
             backend=cls.custom_backend,
         )
-        cls.process_pillow_changes = process_pillow_changes('DefaultChangeFeedPillow')
-        cls.process_pillow_changes.add_pillow(get_case_messaging_sync_pillow())
+        cls.process_pillow_changes = process_pillow_changes(get_case_messaging_sync_pillow())
 
     @classmethod
     def tearDownClass(cls):

--- a/corehq/ex-submodules/couchforms/tests/test_analytics.py
+++ b/corehq/ex-submodules/couchforms/tests/test_analytics.py
@@ -193,10 +193,9 @@ class CouchformsESAnalyticsTest(TestCase):
         def create_forms_and_sync_to_es():
             forms = []
             with process_pillow_changes('xform-pillow', {'skip_ucr': True}):
-                with process_pillow_changes('DefaultChangeFeedPillow'):
-                    for received_on in [cls.now, cls.now - cls._60_days]:
-                        forms.append(create_form(received_on))
-                    forms.append(create_form(cls.now, app_id=None, xmlns="system"))
+                for received_on in [cls.now, cls.now - cls._60_days]:
+                    forms.append(create_form(received_on))
+                forms.append(create_form(cls.now, app_id=None, xmlns="system"))
             return forms
 
         from casexml.apps.case.tests.util import delete_all_xforms

--- a/corehq/form_processor/tests/test_kafka.py
+++ b/corehq/form_processor/tests/test_kafka.py
@@ -38,11 +38,9 @@ class KafkaPublishingTest(TestCase):
             change_feed=KafkaChangeFeed(topics=[topics.CASE_SQL], client_id='test-kafka-case-feed'),
             processor=cls.processor
         )
-        cls.process_form_changes = process_pillow_changes('DefaultChangeFeedPillow')
-        cls.process_form_changes.add_pillow(cls.form_pillow)
+        cls.process_form_changes = process_pillow_changes(cls.form_pillow)
 
-        cls.process_case_changes = process_pillow_changes('DefaultChangeFeedPillow')
-        cls.process_case_changes.add_pillow(cls.case_pillow)
+        cls.process_case_changes = process_pillow_changes(cls.case_pillow)
 
     def tearDown(self):
         FormProcessorTestUtils.delete_all_cases_forms_ledgers()

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -253,8 +253,7 @@ class SchedulingRecipientTest(TestCase):
         cls.case_group = CommCareCaseGroup(domain=cls.domain)
         cls.case_group.save()
 
-        cls.process_pillow_changes = process_pillow_changes('DefaultChangeFeedPillow')
-        cls.process_pillow_changes.add_pillow(get_case_messaging_sync_pillow())
+        cls.process_pillow_changes = process_pillow_changes(get_case_messaging_sync_pillow())
 
     @classmethod
     def tearDownClass(cls):

--- a/settings.py
+++ b/settings.py
@@ -1885,11 +1885,6 @@ PILLOWTOPS = {
             'instance': 'corehq.apps.change_feed.pillow.get_application_db_kafka_pillow',
         },
         {
-            'name': 'DefaultChangeFeedPillow',
-            'class': 'pillowtop.pillow.interface.ConstructedPillow',
-            'instance': 'corehq.apps.change_feed.pillow.get_default_couch_db_change_feed_pillow',
-        },
-        {
             'name': 'DomainDbKafkaPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.apps.change_feed.pillow.get_domain_db_kafka_pillow',

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -34,13 +34,6 @@
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "CaseSearchToElasticsearchPillow"
     },
-    "DefaultChangeFeedPillow": {
-        "advertised_name": "DefaultChangeFeedPillow",
-        "change_feed_type": "CouchChangeFeed",
-        "checkpoint_id": "DefaultChangeFeedPillow",
-        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
-        "name": "DefaultChangeFeedPillow"
-    },
     "DomainDbKafkaPillow": {
         "advertised_name": "DomainDbKafkaPillow",
         "change_feed_type": "CouchChangeFeed",

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -31,8 +31,7 @@ class CasePillowTest(TestCase):
 
     def setUp(self):
         super(CasePillowTest, self).setUp()
-        self.process_case_changes = process_pillow_changes('DefaultChangeFeedPillow')
-        self.process_case_changes.add_pillow('case-pillow', {'skip_ucr': True})
+        self.process_case_changes = process_pillow_changes('case-pillow', {'skip_ucr': True})
         FormProcessorTestUtils.delete_all_cases()
 
     def tearDown(self):

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -33,8 +33,7 @@ class XFormPillowTest(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.process_form_changes = process_pillow_changes('DefaultChangeFeedPillow')
-        cls.process_form_changes.add_pillow(cls.pillow_id, {'skip_ucr': True})
+        cls.process_form_changes = process_pillow_changes(cls.pillow_id, {'skip_ucr': True})
         cls.user = CommCareUser.create(
             cls.domain,
             cls.username,


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
We have removed DefaultChangeFeedPillow back in January and a [changelog](https://forum.dimagi.com/t/commcare-cloud-release-notes-2026-04-06/12275) has been already added 2 months back. 

This is the final cleanup where we are removing the code that mentions `DefaultChangeFeedPIllow`
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19099

## Safety Assurance
Pretty safe change, the pillow has already been removed from all Dimagi HQ environmentsl
### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
NA
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
NA

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
