### PR TITLE
Add `FACE_CAPTURE` feature release flag

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -359,7 +359,6 @@ def _get_vellum_features(request, domain, app):
         'markdown_tables': app.enable_markdown_tables,
         'use_custom_repeat_button_text': app.build_version >= LooseVersion('2.55'),
         'support_document_upload': app.support_document_upload,
-        'face_capture': toggles.FACE_CAPTURE.enabled(domain),
         'edit_locked_questions': request.couch_user.can_edit_locked_questions_in_apps(),
     })
     return vellum_features

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -359,6 +359,7 @@ def _get_vellum_features(request, domain, app):
         'markdown_tables': app.enable_markdown_tables,
         'use_custom_repeat_button_text': app.build_version >= LooseVersion('2.55'),
         'support_document_upload': app.support_document_upload,
+        'face_capture': toggles.FACE_CAPTURE.enabled(domain),
         'edit_locked_questions': request.couch_user.can_edit_locked_questions_in_apps(),
     })
     return vellum_features

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2145,6 +2145,14 @@ ENTERPRISE_ADMIN_SELF_SERVICE = FeatureRelease(
     ),
 )
 
+FACE_CAPTURE = FeatureRelease(
+    'face_capture',
+    'Form Builder includes a "Face Capture" question type',
+    TAG_RELEASE,
+    namespaces=[NAMESPACE_USER, NAMESPACE_DOMAIN],
+    owner='Norman Hooper',
+)
+
 APPLICATION_RELEASE_LOGS = StaticToggle(
     'application_release_logs',
     'Show Application release logs',


### PR DESCRIPTION
## Technical Summary

Adds a `FACE_CAPTURE` feature release flag for the new **Face Capture** question type in Vellum.

See corresponding PR https://github.com/dimagi/Vellum/pull/1257

## Feature Flag

`FACE_CAPTURE`

## Safety Assurance

### Safety story

No change to HQ behavior.

### Automated test coverage

Not applicable

### QA Plan

Not applicable

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
