### PR TITLE
Print export file path at end of run_blob_export

### DIFF
--- a/corehq/blobs/management/commands/run_blob_export.py
+++ b/corehq/blobs/management/commands/run_blob_export.py
@@ -79,6 +79,7 @@ class Command(BaseCommand):
             limit_to_db=limit_to_db,
             already_exported=already_exported,
         )
+        self.stdout.write(f'\nData dumped to file: {export_filename}')
         if skips:
             sys.exit(skips)
 

--- a/corehq/blobs/management/commands/run_blob_export.py
+++ b/corehq/blobs/management/commands/run_blob_export.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
         **options,
     ):
         already_exported = get_lines_from_file(options['already_exported'])
-        print("Found {} existing blobs, these will be skipped".format(len(already_exported)))
+        print(f"Found {len(already_exported)} existing blobs, these will be skipped")
 
         if not domain:
             raise CommandError(USAGE)
@@ -63,7 +63,7 @@ class Command(BaseCommand):
         if dir:
             os.makedirs(dir, exist_ok=True)
 
-        self.stdout.write("\nRunning blob exporter\n{}".format('-' * 50))
+        self.stdout.write(f"\nRunning blob exporter\n{'-' * 50}")
         export_filename = _get_export_filename(
             domain, already_exported, path=dir, limited_to_db=limit_to_db
         )


### PR DESCRIPTION
## Product Description
N/A — operator-facing CLI output only.

## Technical Summary
Two small changes to the `run_blob_export` management command:

1. Print the export file path when the command finishes, modeled after the
   equivalent line in `dump_domain_data`. Previously the operator had to derive
   the generated filename (timestamp + domain + db) themselves to find the dump.
2. Convert the two remaining `.format()` calls in the file to f-strings for
   consistency. (The `strftime` format string is unrelated and left as-is.)

These are split into two commits: the behavior change, then the f-string cleanup.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Inherently safe: the only behavior change is an additional `stdout.write` line.
The f-string conversion is a no-op refactor verified by `ruff`. No data paths,
no migrations.

### Automated test coverage
Existing tests in `corehq/blobs/tests/test_run_blob_export.py` exercise the
command. The added output line is not asserted on (it's informational).

### QA Plan
N/A — covered by the safety story above.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
