### PR TITLE
Send user role and permissions to OCS chat widget

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
@@ -32,8 +32,38 @@ function setDomain(domain) {
     _publish();
 }
 
+function setRole(role) {
+    _currentContext.role = role;
+    _publish();
+}
+
+function setIsDimagiAdmin(isDimagiAdmin) {
+    _currentContext.is_dimagi_admin = isDimagiAdmin;
+    _publish();
+}
+
+function setIsDomainAdmin(isDomainAdmin) {
+    _currentContext.is_domain_admin = isDomainAdmin;
+    _publish();
+}
+
+function setIsEnterpriseAdmin(isEnterpriseAdmin) {
+    _currentContext.is_enterprise_admin = isEnterpriseAdmin;
+    _publish();
+}
+
+function setPermissions(permissions) {
+    _currentContext.permissions = permissions;
+    _publish();
+}
+
 export default {
     setUrl: setUrl,
     setPageTitle: setPageTitle,
     setDomain: setDomain,
+    setRole: setRole,
+    setIsDimagiAdmin: setIsDimagiAdmin,
+    setIsDomainAdmin: setIsDomainAdmin,
+    setIsEnterpriseAdmin: setIsEnterpriseAdmin,
+    setPermissions: setPermissions,
 };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_global_context.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_global_context.js
@@ -1,8 +1,40 @@
+import $ from "jquery";
+import initialPageData from "hqwebapp/js/initial_page_data";
 import ocsContext from "hqwebapp/js/ocs_widget_context_setter";
+
+var WIDGET_SELECTOR = 'open-chat-studio-widget';
 
 function _domainFromUrl() {
     var match = window.location.pathname.match(/^\/a\/([^/]+)\//);
     return match ? match[1] : null;
+}
+
+function _fetchMyRole() {
+    var url;
+    try {
+        url = initialPageData.reverse('my_role');
+    } catch {
+        // URL only registered on domain-scoped pages — nothing to fetch elsewhere.
+        return;
+    }
+    $.getJSON(url)
+        .done(function (data) {
+            if (data.role !== undefined) {
+                ocsContext.setRole(data.role);
+            }
+            if (data.is_dimagi_admin !== undefined) {
+                ocsContext.setIsDimagiAdmin(data.is_dimagi_admin);
+            }
+            if (data.is_domain_admin !== undefined) {
+                ocsContext.setIsDomainAdmin(data.is_domain_admin);
+            }
+            if (data.is_enterprise_admin !== undefined) {
+                ocsContext.setIsEnterpriseAdmin(data.is_enterprise_admin);
+            }
+            if (data.permissions !== undefined) {
+                ocsContext.setPermissions(data.permissions);
+            }
+        })
 }
 
 function _setInitialContext() {
@@ -34,8 +66,12 @@ function _observeUrlChanges() {
 // Only listen to top window to ignore App Preview iframe
 if (window === window.top) {
     document.addEventListener('DOMContentLoaded', function () {
+        if (!document.querySelector(WIDGET_SELECTOR)) {
+            return;
+        }
         _setInitialContext();
         _observePageTitleChanges();
         _observeUrlChanges();
+        _fetchMyRole();
     });
 }

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -182,6 +182,7 @@
     {% registerurl 'send_mobile_reminder' %}  {# used by mobile reminder popup below #}
     {% if domain %}
       {% registerurl 'submit_feedback' domain %}   {# used by feedback knockout widget #}
+      {% registerurl 'my_role' domain %}   {# used by hqwebapp/js/ocs_widget_global_context.js #}
     {% endif %}
 
     <div class="commcarehq-urls hide">

--- a/corehq/apps/users/tests/test_my_role_view.py
+++ b/corehq/apps/users/tests/test_my_role_view.py
@@ -1,0 +1,124 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from corehq.apps.accounting.models import (
+    BillingAccount,
+    BillingAccountType,
+    Currency,
+)
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import HqPermissions, WebUser
+from corehq.apps.users.models_role import UserRole
+from corehq.apps.users.views.my_role import _build_my_role
+
+
+class TestBuildMyRole(TestCase):
+    domain = 'test-my-role'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+
+    def _make_user(self, username, role=None, is_admin=False, is_superuser=False):
+        user = WebUser.create(self.domain, username, 'password', None, None)
+        user.is_superuser = is_superuser
+        if role:
+            user.set_role(self.domain, role.get_qualified_id())
+        elif is_admin:
+            user.set_role(self.domain, 'admin')
+        user.save()
+        self.addCleanup(user.delete, self.domain, deleted_by=None)
+        return user
+
+    def test_regular_user_with_role_gets_role_label(self):
+        role = UserRole.create(self.domain, 'App Editor')
+        user = self._make_user('regular@test.com', role=role)
+
+        result = _build_my_role(user, self.domain)
+
+        assert result['role'] == 'App Editor'
+
+    def test_regular_user_permissions_match_role(self):
+        permissions = HqPermissions(edit_apps=True, view_apps=True)
+        role = UserRole.create(self.domain, 'editor', permissions=permissions)
+        user = self._make_user('editor@test.com', role=role)
+
+        result = _build_my_role(user, self.domain)
+
+        assert result['permissions']['edit_apps'] is True
+        assert result['permissions']['view_apps'] is True
+        assert result['permissions']['edit_web_users'] is False
+
+    def test_permissions_dict_covers_every_known_permission(self):
+        role = UserRole.create(self.domain, 'minimal')
+        user = self._make_user('minimal@test.com', role=role)
+
+        result = _build_my_role(user, self.domain)
+
+        assert set(result['permissions'].keys()) == HqPermissions.permission_names()
+
+    def test_parameterized_permission_with_partial_access_returns_object(self):
+        permissions = HqPermissions(
+            view_report_list=['report-id-1'],
+            web_apps_list=['app-id-1', 'app-id-2'],
+        )
+        role = UserRole.create(self.domain, 'restricted', permissions=permissions)
+        user = self._make_user('restricted@test.com', role=role)
+
+        result = _build_my_role(user, self.domain)
+
+        assert result['permissions']['view_reports'] == {
+            'scope': 'limited', 'items': ['report-id-1'],
+        }
+        assert result['permissions']['access_web_apps'] == {
+            'scope': 'limited', 'items': ['app-id-1', 'app-id-2'],
+        }
+        assert result['permissions']['view_tableau'] is False
+
+    def test_parameterized_permission_with_no_access_returns_false(self):
+        user = self._make_user('lurker-lists@test.com')
+
+        result = _build_my_role(user, self.domain)
+
+        assert result['permissions']['view_reports'] is False
+        assert result['permissions']['view_tableau'] is False
+        assert result['permissions']['access_web_apps'] is False
+        assert result['permissions']['manage_data_registry'] is False
+        assert result['permissions']['view_data_registry_contents'] is False
+        assert result['permissions']['commcare_analytics_roles'] is False
+
+    def test_domain_admin_flag_true_for_domain_admin(self):
+        user = self._make_user('admin@test.com', is_admin=True)
+
+        result = _build_my_role(user, self.domain)
+
+        assert result['is_domain_admin'] is True
+        for name in HqPermissions.permission_names():
+            assert result['permissions'][name] is True
+
+    def test_dimagi_admin_payload_is_only_the_flag(self):
+        user = self._make_user('dimagi@test.com', is_superuser=True)
+
+        result = _build_my_role(user, self.domain)
+
+        assert result == {'is_dimagi_admin': True}
+
+    def test_enterprise_admin_flag_true_when_email_listed(self):
+        user = self._make_user('ent-admin@test.com')
+
+        currency, _ = Currency.objects.get_or_create(code='USD')
+        account = BillingAccount.objects.create(
+            name='test-acct',
+            currency=currency,
+            account_type=BillingAccountType.GLOBAL_SERVICES,
+            is_customer_billing_account=True,
+            enterprise_admin_emails=[user.username],
+        )
+        self.addCleanup(account.delete)
+        with patch.object(BillingAccount, 'get_account_by_domain', return_value=account):
+            result = _build_my_role(user, self.domain)
+
+        assert result['is_enterprise_admin'] is True

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -75,6 +75,7 @@ from .views.mobile.users import (
     update_user_groups,
     web_user_download_job_poll,
 )
+from .views.my_role import my_role
 from .views.role import (
     EditRoleView,
     ListRolesView,
@@ -152,6 +153,7 @@ urlpatterns = [
     ),
     url(r'^enterprise/json/$', paginate_enterprise_users, name='paginate_enterprise_users'),
     url(r'^join/(?P<uuid>[ \w-]+)/$', accept_invitation, name='domain_accept_invitation'),
+    url(r'^my_role/$', my_role, name='my_role'),
     url(r'^roles/$', ListRolesView.as_view(), name=ListRolesView.urlname),
     url(r'^roles/create/$', create_user_role, name='create_user_role'),
     url(r'^roles/update/(?P<role_id>[ \w-]+)/$', update_user_role, name='update_user_role'),

--- a/corehq/apps/users/views/my_role.py
+++ b/corehq/apps/users/views/my_role.py
@@ -64,30 +64,48 @@ def _resolve_item_names(domain, list_field, raw_items):
     return [name_map.get(item, item) for item in raw_items]
 
 
+def _report_name_map(domain):
+    return {r['path']: r['name'] for r in get_possible_reports(domain)}
+
+
+def _tableau_name_map(domain):
+    return {
+        str(viz.id): viz.name
+        for viz in TableauVisualization.objects.filter(domain=domain)
+    }
+
+
+def _web_apps_name_map(domain):
+    return {app._id: app.name for app in get_cloudcare_apps(domain)}
+
+
+def _data_registry_name_map(domain):
+    return {r['slug']: r['name'] for r in get_data_registry_dropdown_options(domain)}
+
+
+def _analytics_roles_name_map(domain):
+    return {r['slug']: r['name'] for r in _commcare_analytics_roles_options()}
+
+
+def _user_profile_name_map(domain):
+    definition = CustomDataFieldsDefinition.get(domain, CUSTOM_USER_DATA_FIELD_TYPE)
+    if definition is None:
+        return {}
+    return {str(profile.id): profile.name for profile in definition.get_profiles()}
+
+
+_NAME_MAP_BUILDERS = {
+    'view_report_list': _report_name_map,
+    'view_tableau_list': _tableau_name_map,
+    'web_apps_list': _web_apps_name_map,
+    'manage_data_registry_list': _data_registry_name_map,
+    'view_data_registry_contents_list': _data_registry_name_map,
+    'commcare_analytics_roles_list': _analytics_roles_name_map,
+    'edit_user_profile_list': _user_profile_name_map,
+}
+
+
 def _name_map_for(domain, list_field):
     """Build the {raw_id: friendly_name} map for one parameterized list."""
-    if list_field == 'view_report_list':
-        return {r['path']: r['name'] for r in get_possible_reports(domain)}
-
-    if list_field == 'view_tableau_list':
-        return {
-            str(viz.id): viz.name
-            for viz in TableauVisualization.objects.filter(domain=domain)
-        }
-
-    if list_field == 'web_apps_list':
-        return {app._id: app.name for app in get_cloudcare_apps(domain)}
-
-    if list_field in ('manage_data_registry_list', 'view_data_registry_contents_list'):
-        return {r['slug']: r['name'] for r in get_data_registry_dropdown_options(domain)}
-
-    if list_field == 'commcare_analytics_roles_list':
-        return {r['slug']: r['name'] for r in _commcare_analytics_roles_options()}
-
-    if list_field == 'edit_user_profile_list':
-        definition = CustomDataFieldsDefinition.get(domain, CUSTOM_USER_DATA_FIELD_TYPE)
-        if definition is None:
-            return {}
-        return {str(profile.id): profile.name for profile in definition.get_profiles()}
-
-    return {}
+    builder = _NAME_MAP_BUILDERS.get(list_field)
+    return builder(domain) if builder else {}

--- a/corehq/apps/users/views/my_role.py
+++ b/corehq/apps/users/views/my_role.py
@@ -4,6 +4,7 @@ from django.views.decorators.http import require_GET
 from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.users.models import PARAMETERIZED_PERMISSIONS, HqPermissions
+from corehq.util.quickcache import quickcache
 
 
 @require_GET
@@ -13,6 +14,7 @@ def my_role(request, domain):
     return JsonResponse(_build_my_role(request.couch_user, domain))
 
 
+@quickcache(['couch_user.user_id', 'domain'], timeout=30 * 60)
 def _build_my_role(couch_user, domain):
     if couch_user.is_global_admin():
         return {'is_dimagi_admin': True}

--- a/corehq/apps/users/views/my_role.py
+++ b/corehq/apps/users/views/my_role.py
@@ -1,0 +1,45 @@
+from django.http import JsonResponse
+from django.views.decorators.http import require_GET
+
+from corehq.apps.accounting.models import BillingAccount
+from corehq.apps.domain.decorators import login_and_domain_required
+from corehq.apps.users.models import PARAMETERIZED_PERMISSIONS, HqPermissions
+
+
+@require_GET
+@login_and_domain_required
+def my_role(request, domain):
+    """Return the requesting user's role label, admin flags, and permission booleans."""
+    return JsonResponse(_build_my_role(request.couch_user, domain))
+
+
+def _build_my_role(couch_user, domain):
+    if couch_user.is_global_admin():
+        return {'is_dimagi_admin': True}
+
+    dm = couch_user.get_domain_membership(domain, allow_enterprise=True)
+    account = BillingAccount.get_account_by_domain(domain)
+    role_permissions = dm.role.permissions if dm.role else HqPermissions()
+
+    permissions = {}
+    for name in HqPermissions.permission_names():
+        granted = couch_user.has_permission(domain, name)
+        if name in PARAMETERIZED_PERMISSIONS:
+            items = list(getattr(role_permissions, PARAMETERIZED_PERMISSIONS[name]))
+            if granted:
+                permissions[name] = True
+            elif items:
+                permissions[name] = {'scope': 'limited', 'items': items}
+            else:
+                permissions[name] = False
+        else:
+            permissions[name] = granted
+
+    return {
+        'role': couch_user.role_label(domain),
+        'is_domain_admin': bool(dm.is_admin),
+        'is_enterprise_admin': bool(
+            account and account.has_enterprise_admin(couch_user.username)
+        ),
+        'permissions': permissions,
+    }

--- a/corehq/apps/users/views/my_role.py
+++ b/corehq/apps/users/views/my_role.py
@@ -61,13 +61,11 @@ def _build_my_role(couch_user, domain):
 def _resolve_item_names(domain, list_field, raw_items):
     """Map raw IDs to user-facing names; unknown IDs fall through unchanged."""
     name_map = _name_map_for(domain, list_field)
-    if name_map is None:
-        return raw_items
     return [name_map.get(item, item) for item in raw_items]
 
 
 def _name_map_for(domain, list_field):
-    """Build the {raw_id: friendly_name} map for one parameterized list, or None."""
+    """Build the {raw_id: friendly_name} map for one parameterized list."""
     if list_field == 'view_report_list':
         return {r['path']: r['name'] for r in get_possible_reports(domain)}
 
@@ -92,4 +90,4 @@ def _name_map_for(domain, list_field):
             return {}
         return {str(profile.id): profile.name for profile in definition.get_profiles()}
 
-    return None
+    return {}

--- a/corehq/apps/users/views/my_role.py
+++ b/corehq/apps/users/views/my_role.py
@@ -2,8 +2,15 @@ from django.http import JsonResponse
 from django.views.decorators.http import require_GET
 
 from corehq.apps.accounting.models import BillingAccount
+from corehq.apps.cloudcare.dbaccessors import get_cloudcare_apps
+from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
 from corehq.apps.domain.decorators import login_and_domain_required
+from corehq.apps.registry.utils import get_data_registry_dropdown_options
+from corehq.apps.reports.models import TableauVisualization
+from corehq.apps.reports.util import get_possible_reports
 from corehq.apps.users.models import PARAMETERIZED_PERMISSIONS, HqPermissions
+from corehq.apps.users.views import _commcare_analytics_roles_options
+from corehq.apps.users.views.mobile.custom_data_fields import CUSTOM_USER_DATA_FIELD_TYPE
 from corehq.util.quickcache import quickcache
 
 
@@ -62,33 +69,24 @@ def _resolve_item_names(domain, list_field, raw_items):
 def _name_map_for(domain, list_field):
     """Build the {raw_id: friendly_name} map for one parameterized list, or None."""
     if list_field == 'view_report_list':
-        from corehq.apps.reports.util import get_possible_reports
         return {r['path']: r['name'] for r in get_possible_reports(domain)}
 
     if list_field == 'view_tableau_list':
-        from corehq.apps.reports.models import TableauVisualization
         return {
             str(viz.id): viz.name
             for viz in TableauVisualization.objects.filter(domain=domain)
         }
 
     if list_field == 'web_apps_list':
-        from corehq.apps.cloudcare.dbaccessors import get_cloudcare_apps
         return {app._id: app.name for app in get_cloudcare_apps(domain)}
 
     if list_field in ('manage_data_registry_list', 'view_data_registry_contents_list'):
-        from corehq.apps.registry.utils import get_data_registry_dropdown_options
         return {r['slug']: r['name'] for r in get_data_registry_dropdown_options(domain)}
 
     if list_field == 'commcare_analytics_roles_list':
-        from corehq.apps.users.views import _commcare_analytics_roles_options
         return {r['slug']: r['name'] for r in _commcare_analytics_roles_options()}
 
     if list_field == 'edit_user_profile_list':
-        from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
-        from corehq.apps.users.views.mobile.custom_data_fields import (
-            CUSTOM_USER_DATA_FIELD_TYPE,
-        )
         definition = CustomDataFieldsDefinition.get(domain, CUSTOM_USER_DATA_FIELD_TYPE)
         if definition is None:
             return {}

--- a/corehq/apps/users/views/my_role.py
+++ b/corehq/apps/users/views/my_role.py
@@ -25,11 +25,15 @@ def _build_my_role(couch_user, domain):
     for name in HqPermissions.permission_names():
         granted = couch_user.has_permission(domain, name)
         if name in PARAMETERIZED_PERMISSIONS:
-            items = list(getattr(role_permissions, PARAMETERIZED_PERMISSIONS[name]))
+            list_field = PARAMETERIZED_PERMISSIONS[name]
+            raw_items = list(getattr(role_permissions, list_field))
             if granted:
                 permissions[name] = True
-            elif items:
-                permissions[name] = {'scope': 'limited', 'items': items}
+            elif raw_items:
+                permissions[name] = {
+                    'scope': 'limited',
+                    'items': _resolve_item_names(domain, list_field, raw_items),
+                }
             else:
                 permissions[name] = False
         else:
@@ -43,3 +47,49 @@ def _build_my_role(couch_user, domain):
         ),
         'permissions': permissions,
     }
+
+
+def _resolve_item_names(domain, list_field, raw_items):
+    """Map raw IDs to user-facing names; unknown IDs fall through unchanged."""
+    name_map = _name_map_for(domain, list_field)
+    if name_map is None:
+        return raw_items
+    return [name_map.get(item, item) for item in raw_items]
+
+
+def _name_map_for(domain, list_field):
+    """Build the {raw_id: friendly_name} map for one parameterized list, or None."""
+    if list_field == 'view_report_list':
+        from corehq.apps.reports.util import get_possible_reports
+        return {r['path']: r['name'] for r in get_possible_reports(domain)}
+
+    if list_field == 'view_tableau_list':
+        from corehq.apps.reports.models import TableauVisualization
+        return {
+            str(viz.id): viz.name
+            for viz in TableauVisualization.objects.filter(domain=domain)
+        }
+
+    if list_field == 'web_apps_list':
+        from corehq.apps.cloudcare.dbaccessors import get_cloudcare_apps
+        return {app._id: app.name for app in get_cloudcare_apps(domain)}
+
+    if list_field in ('manage_data_registry_list', 'view_data_registry_contents_list'):
+        from corehq.apps.registry.utils import get_data_registry_dropdown_options
+        return {r['slug']: r['name'] for r in get_data_registry_dropdown_options(domain)}
+
+    if list_field == 'commcare_analytics_roles_list':
+        from corehq.apps.users.views import _commcare_analytics_roles_options
+        return {r['slug']: r['name'] for r in _commcare_analytics_roles_options()}
+
+    if list_field == 'edit_user_profile_list':
+        from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
+        from corehq.apps.users.views.mobile.custom_data_fields import (
+            CUSTOM_USER_DATA_FIELD_TYPE,
+        )
+        definition = CustomDataFieldsDefinition.get(domain, CUSTOM_USER_DATA_FIELD_TYPE)
+        if definition is None:
+            return {}
+        return {str(profile.id): profile.name for profile in definition.get_profiles()}
+
+    return None


### PR DESCRIPTION
## Product Description

No user-visible change. Builds on the existing OCS chat widget, adds the requesting user's role label and permission set so the bot can avoid suggesting actions the user can't actually perform on this domain.

The shape of permissions:
either
```
is_dimagi_admin: true
```
or
```
is_domain_admin: false
is_enterprise_admin: false
role: "App Editor"
permissions:{ 
        access_all_locations: true
        access_api: false
        access_default_login_as_user: false
        access_mobile_endpoints: false
        access_release_management: false
        access_web_apps: false
        commcare_analytics_roles: false
        download_reports: true
        edit_apps: true
        edit_billing: false
        edit_commcare_analytics: false
        edit_commcare_users: false
        edit_data: false
        edit_data_dict: false
        edit_file_dropzone: false
        edit_groups: false
        edit_linked_configurations: false
        edit_locations: false
        edit_locked_questions_in_apps: false
        edit_messaging: false
        edit_motech: false
        edit_reports: false
        edit_shared_exports: false
        edit_ucrs: false
        edit_user_profile: false
        edit_user_tableau_config: false
        edit_users_in_groups: false
        edit_users_in_locations: false
        edit_web_users: false
        limited_login_as: false
        login_as_all_users: false
        manage_attendance_tracking: false
        manage_data_registry: false
        manage_domain_alerts: false
        report_an_issue: true
        view_apps: true
        view_commcare_analytics: false
        view_commcare_users: false
        view_data_dict: false
        view_data_registry_contents: false
        view_file_dropzone: false
        view_groups: false
        view_locations: false
        view_reports: {scope: 'limited', items: [UserActivity]}
        view_roles: false
        view_tableau: false
        view_user_tableau_config: false
        view_web_users: false
 }
```

## Technical Summary
Ticket: https://dimagi.atlassian.net/browse/SAAS-19846
Developer spec: https://docs.google.com/document/d/10ew68kDMgaHNeDwOdeKrA4P1R31jNQaVDVryqCBGZso/edit?tab=t.0#bookmark=id.9x7lc6ptl059

Three pieces:

1. **`GET /a/<domain>/settings/users/my_role/`** (`corehq/apps/users/views/my_role.py`) returns the requesting user's role label, admin flags (`is_dimagi_admin`, `is_domain_admin`, `is_enterprise_admin`), and a `permissions` dict. Permissions are resolved via `couch_user.has_permission()` so global-admin and enterprise-inheritance paths work correctly.

2. **JS setters** (`hqwebapp/js/ocs_widget_context_setter.js`) gain five new explicit per-field functions (`setRole`, `setIsDimagiAdmin`, etc.). 

3. **Page-load fetch** (`hqwebapp/js/ocs_widget_global_context.js`) calls the endpoint on every page load.

Tests triggered manually in https://github.com/dimagi/commcare-hq/actions/runs/27292562100

## Feature Flag

`OCS_CHATBOT` feature preview

## Safety Assurance

### Safety story

- Pure additions: new view, new URL route, new JS module wiring.
- Endpoint requires `@login_and_domain_required`. Anonymous → 302 to login.
- Returns only the requesting user's own permissions. No new exposure of other users' data.

### Automated test coverage

`corehq/apps/users/tests/test_my_role_view.py` 

### QA Plan

Not planning on putting this through QA. 

But for my own reference, I go through the following steps:

Enable `OCS_CHATBOT` feature preview on a dev domain, open DevTools console (with `commcarehq.js` rebuilt), then:

1. **App Builder page as domain admin** → log shows `pageContext.permissions.edit_apps === true`, `is_domain_admin === true`.
2. **App Builder page as Dimagi superuser** → `pageContext === {url, page_title, domain, is_dimagi_admin: true}` (no role/permissions block).
4. **Custom role with `view_report_list=['some-id']` and `view_reports=false`** → `permissions.view_reports === {scope: 'limited', items: ['some-id']}`.
5. **Custom role with no `view_reports` access at all** → `permissions.view_reports === false`.
6. **Non-domain page (e.g. /home/)** → no fetch attempted; pageContext has only url/title.
7. **Page where the widget isn't rendered** (preview off, or `CHATBOT_ID`/`CHATBOT_TOKEN` missing) → no setters fire; no console activity.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review

- [x] Risk label is set correctly (low — additions only, behind feature preview)
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change