### PR TITLE
Let uv manage Python in CI workflows

### DIFF
--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-        with:
-          version: '0.7.2'
 
       - name: Install Python Dependencies
         run: |

--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -11,11 +11,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.9'
-
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -25,7 +20,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Install Python Dependencies
+      - name: Install Python and Dependencies
         run: |
           uv sync --locked --compile-bytecode --no-progress
 

--- a/.github/workflows/dependency-metrics.yml
+++ b/.github/workflows/dependency-metrics.yml
@@ -13,12 +13,9 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.9'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-      - name: install dev-requirements
+      - name: Install python and dev-requirements
         run: uv sync --all-groups --locked --compile-bytecode --no-progress
       - name: run metrics for pip
         run: uv run --no-sync metrics pip --send

--- a/.github/workflows/dependency-metrics.yml
+++ b/.github/workflows/dependency-metrics.yml
@@ -18,8 +18,6 @@ jobs:
           python-version: '3.9'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-        with:
-          version: '0.7.2'
       - name: install dev-requirements
         run: uv sync --all-groups --locked --compile-bytecode --no-progress
       - name: run metrics for pip

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -12,8 +12,6 @@ jobs:
         with:
           submodules: recursive
       - uses: astral-sh/setup-uv@v7
-        with:
-          version: '0.7.2'
       - name: Install docs requirements
         run: uv sync --group=docs --no-group=sso --locked --compile-bytecode --no-progress
       - name: Test docs build

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -16,8 +16,6 @@ jobs:
           ref: master
           submodules: recursive
       - uses: astral-sh/setup-uv@v7
-        with:
-          version: '0.7.2'
       - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         id: generate-token
         with:


### PR DESCRIPTION
## Product Description
No user-facing changes.

## Technical Summary
Removes `actions/setup-python` from the workflows that use uv. Since `uv sync` resolves and installs the correct Python version itself, the separate setup-python step was redundant — and was pinning an outdated Python 3.9 in the build-static workflow while the project has since moved to 3.13.

Also unpins the `astral-sh/setup-uv` version across all workflows so they pick up the latest uv release rather than staying on 0.7.2.

## Feature Flag
N/A

## Safety Assurance

### Safety story
CI-only change. No application code is affected.

### Automated test coverage
N/A — workflow-only change.

### QA Plan
The workflows will run on the next push to `autostaging` / relevant triggers. No regression risk to application behavior.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations