### PR TITLE
Detect locked Advanced Case Actions questions for validation

### DIFF
--- a/corehq/apps/app_manager/tests/data/locked_questions.xml
+++ b/corehq/apps/app_manager/tests/data/locked_questions.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Locked Questions</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/LOCKED-QUESTIONS" uiVersion="1" version="1" name="Locked Questions">
+					<child_name />
+					<visit>
+						<register_child vellum:case_type="child" vellum:lock="all" vellum:role="SaveToCase">
+							<case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id="">
+								<create>
+									<case_type />
+									<case_name />
+								</create>
+							</case>
+						</register_child>
+					</visit>
+					<household vellum:lock="all">
+						<household_size />
+					</household>
+				</data>
+			</instance>
+			<instance src="jr://instance/session" id="commcaresession" />
+			<bind nodeset="/data/child_name" type="xsd:string" />
+			<bind nodeset="/data/visit" />
+			<bind nodeset="/data/visit/register_child/case" relevant="true()" />
+			<bind nodeset="/data/visit/register_child/case/create/case_type" calculate="'child'" />
+			<bind nodeset="/data/visit/register_child/case/create/case_name" calculate="/data/child_name" />
+			<bind nodeset="/data/visit/register_child/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
+			<bind nodeset="/data/visit/register_child/case/@user_id" calculate="instance('commcaresession')/session/context/userid" />
+			<bind nodeset="/data/household" />
+			<bind nodeset="/data/household/household_size" type="xsd:int" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="child_name-label">
+						<value>Child name</value>
+					</text>
+					<text id="visit-label">
+						<value>Visit</value>
+					</text>
+					<text id="household-label">
+						<value>Household</value>
+					</text>
+					<text id="household_size-label">
+						<value>Household size</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/child_name">
+			<label ref="jr:itext('child_name-label')" />
+		</input>
+		<group ref="/data/visit">
+			<label ref="jr:itext('visit-label')" />
+		</group>
+		<group ref="/data/household">
+			<label ref="jr:itext('household-label')" />
+			<input ref="/data/household/household_size">
+				<label ref="jr:itext('household_size-label')" />
+			</input>
+		</group>
+	</h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -360,6 +360,37 @@ class LockedQuestionsTest(AppFormTestCase):
         form = self.app.get_form(self.form_with_repeats_unique_id)
         assert form.wrapped_xform().locked_question_paths == set()
 
+    def test_locked_question_paths_includes_locked_data_node(self):
+        # A lock declared directly on a data-instance node is found alongside
+        # binds locked via ``nodeset``.
+        form = self.app.get_form(self.form_unique_id)
+        modified_source = form.source.replace(
+            '<question3 />', '<question3 vellum:lock="all" />')
+        assert modified_source != form.source
+        paths = XForm(modified_source).locked_question_paths
+        assert paths == {'/data/question2', '/data/question3'}
+
+    def test_locked_question_paths_includes_nested_locked_data_node(self):
+        # A locked data node can be nested inside a group; the lock is found at
+        # any depth, with a full path.
+        form = self.app.get_form(self.form_unique_id)
+        modified_source = form.source.replace(
+            '<question16 />', '<question16 vellum:lock="all" />')
+        assert modified_source != form.source
+        paths = XForm(modified_source).locked_question_paths
+        assert '/data/question15/question16' in paths
+
+    def test_has_locked_questions_true_for_data_node_lock_only(self):
+        # The lock lives on a data node, not on any bind.
+        form = self.app.get_form(self.form_unique_id)
+        modified_source = form.source.replace(
+            '<bind nodeset="/data/question2" type="xsd:string" vellum:lock="all" />',
+            '<bind nodeset="/data/question2" type="xsd:string" />',
+        ).replace('<question3 />', '<question3 vellum:lock="all" />')
+        xform = XForm(modified_source)
+        assert xform.has_locked_questions
+        assert xform.locked_question_paths == {'/data/question3'}
+
 
 class QuestionSignatureTest(AppFormTestCase):
 

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -183,7 +183,10 @@ QUESTIONS = [
 ]
 
 
-class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
+class AppFormTestCase(SimpleTestCase, TestFileMixin):
+    """Base for tests that build an app with one module and add forms to it
+    from XML data files."""
+
     domain = 'test-domain'
 
     file_path = ('data',)
@@ -194,25 +197,25 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
     def setUp(self):
         self.app = Application.new_app(self.domain, "Test")
         self.app.add_module(Module.new_module("Module", 'en'))
-        module = self.app.get_module(0)
-        module.case_type = 'test'
+        self.module = self.app.get_module(0)
+        self.module.case_type = 'test'
 
-        form = self.app.new_form(
-            module.id,
-            name="Form",
+    def add_form(self, data_file, name=None):
+        return self.app.new_form(
+            self.module.id,
+            name=name or data_file,
             lang='en',
-            attachment=self.get_xml('case_in_form').decode('utf-8')
+            attachment=self.get_xml(data_file).decode('utf-8'),
         )
 
-        form_with_repeats = self.app.new_form(
-            module.id,
-            name="Form with repeats",
-            lang='en',
-            attachment=self.get_xml('form_with_repeats').decode('utf-8')
-        )
 
-        self.form_unique_id = form.unique_id
-        self.form_with_repeats_unique_id = form_with_repeats.unique_id
+class GetFormQuestionsTest(AppFormTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.form_unique_id = self.add_form('case_in_form', "Form").unique_id
+        self.form_with_repeats_unique_id = self.add_form(
+            'form_with_repeats', "Form with repeats").unique_id
 
     def test_get_questions(self):
         form = self.app.get_form(self.form_unique_id)
@@ -229,106 +232,6 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
             ['en', 'es'], include_triggers=True, include_translations=True)
 
         self.assertEqual(questions, QUESTIONS)
-
-    def test_has_locked_questions_true(self):
-        form = self.app.get_form(self.form_unique_id)
-        assert form.wrapped_xform().has_locked_questions
-
-    def test_has_locked_questions_false(self):
-        form = self.app.get_form(self.form_with_repeats_unique_id)
-        assert not form.wrapped_xform().has_locked_questions
-
-    def test_locked_question_paths(self):
-        form = self.app.get_form(self.form_unique_id)
-        assert form.wrapped_xform().locked_question_paths == {'/data/question2'}
-
-    def test_locked_question_paths_empty_when_none_locked(self):
-        form = self.app.get_form(self.form_with_repeats_unique_id)
-        assert form.wrapped_xform().locked_question_paths == set()
-
-    def test_question_signature_stable_for_unchanged_form(self):
-        form_a = self.app.get_form(self.form_unique_id)
-        form_b = self.app.get_form(self.form_unique_id)
-        sig_a = form_a.wrapped_xform().get_question_signature('/data/question2')
-        sig_b = form_b.wrapped_xform().get_question_signature('/data/question2')
-        assert sig_a == sig_b
-        assert sig_a  # non-empty for an existing question
-
-    def test_question_signature_empty_for_unknown_path(self):
-        form = self.app.get_form(self.form_unique_id)
-        assert form.wrapped_xform().get_question_signature('/data/does_not_exist') == frozenset()
-
-    def test_question_signature_changes_when_bind_changes(self):
-        # Mutate the bind type for /data/question2 and confirm signature differs.
-        form = self.app.get_form(self.form_unique_id)
-        original = form.wrapped_xform().get_question_signature('/data/question2')
-        modified_source = form.source.replace(
-            '<bind nodeset="/data/question2" type="xsd:string" vellum:lock="all" />',
-            '<bind nodeset="/data/question2" type="xsd:int" vellum:lock="all" />',
-        )
-        assert modified_source != form.source  # sanity: replacement happened
-        modified = XForm(modified_source).get_question_signature('/data/question2')
-        assert original != modified
-
-    def test_question_signature_changes_when_label_changes(self):
-        # Modifying the itext entry for /data/question2 should change the signature.
-        form = self.app.get_form(self.form_unique_id)
-        original = form.wrapped_xform().get_question_signature('/data/question2')
-        modified_source = form.source.replace(
-            '<text id="question2-label">',
-            '<text id="question2-label" data-changed="true">',
-        )
-        assert modified_source != form.source
-        modified = XForm(modified_source).get_question_signature('/data/question2')
-        assert original != modified
-
-    def test_question_signature_changes_when_constraint_added(self):
-        # Adding a constraint attribute to the bind should change the signature.
-        form = self.app.get_form(self.form_unique_id)
-        original = form.wrapped_xform().get_question_signature('/data/question2')
-        modified_source = form.source.replace(
-            '<bind nodeset="/data/question2" type="xsd:string" vellum:lock="all" />',
-            '<bind nodeset="/data/question2" type="xsd:string" '
-            'constraint=". &gt; 0" vellum:lock="all" />',
-        )
-        assert modified_source != form.source
-        modified = XForm(modified_source).get_question_signature('/data/question2')
-        assert original != modified
-
-    def test_question_signature_changes_when_hint_text_changes(self):
-        # Hint label refs are pulled in via itext; changing the hint text
-        # should flow through the signature.
-        form = self.app.get_form(self.form_unique_id)
-        original = form.wrapped_xform().get_question_signature('/data/question1')
-        modified_source = form.source.replace(
-            '<text id="question1-hint">',
-            '<text id="question1-hint" data-changed="true">',
-        )
-        assert modified_source != form.source
-        modified = XForm(modified_source).get_question_signature('/data/question1')
-        assert original != modified
-
-    def test_question_signature_changes_when_select_option_value_changes(self):
-        # Item value changes inside a select1 are part of the control subtree.
-        form = self.app.get_form(self.form_unique_id)
-        original = form.wrapped_xform().get_question_signature('/data/question15/question21')
-        modified_source = form.source.replace('<value>item22</value>', '<value>item99</value>')
-        assert modified_source != form.source
-        modified = XForm(modified_source).get_question_signature('/data/question15/question21')
-        assert original != modified
-
-    def test_question_signature_changes_when_data_instance_attr_changes(self):
-        # The data-instance node is part of the signature; the vellum:comment
-        # on /data/question2 lives there.
-        form = self.app.get_form(self.form_unique_id)
-        original = form.wrapped_xform().get_question_signature('/data/question2')
-        modified_source = form.source.replace(
-            '<question2 vellum:comment="This is a comment" />',
-            '<question2 vellum:comment="Edited comment" />',
-        )
-        assert modified_source != form.source
-        modified = XForm(modified_source).get_question_signature('/data/question2')
-        assert original != modified
 
     def test_get_questions_with_locked_status(self):
         form = self.app.get_form(self.form_unique_id)
@@ -431,3 +334,119 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
             "type": "Select",
             "value": "/data/lookup-table"
         })
+
+
+class LockedQuestionsTest(AppFormTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.form_unique_id = self.add_form('case_in_form', "Form").unique_id
+        self.form_with_repeats_unique_id = self.add_form(
+            'form_with_repeats', "Form with repeats").unique_id
+
+    def test_has_locked_questions_true(self):
+        form = self.app.get_form(self.form_unique_id)
+        assert form.wrapped_xform().has_locked_questions
+
+    def test_has_locked_questions_false(self):
+        form = self.app.get_form(self.form_with_repeats_unique_id)
+        assert not form.wrapped_xform().has_locked_questions
+
+    def test_locked_question_paths(self):
+        form = self.app.get_form(self.form_unique_id)
+        assert form.wrapped_xform().locked_question_paths == {'/data/question2'}
+
+    def test_locked_question_paths_empty_when_none_locked(self):
+        form = self.app.get_form(self.form_with_repeats_unique_id)
+        assert form.wrapped_xform().locked_question_paths == set()
+
+
+class QuestionSignatureTest(AppFormTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.form_unique_id = self.add_form('case_in_form', "Form").unique_id
+
+    def test_question_signature_stable_for_unchanged_form(self):
+        form_a = self.app.get_form(self.form_unique_id)
+        form_b = self.app.get_form(self.form_unique_id)
+        sig_a = form_a.wrapped_xform().get_question_signature('/data/question2')
+        sig_b = form_b.wrapped_xform().get_question_signature('/data/question2')
+        assert sig_a == sig_b
+        assert sig_a  # non-empty for an existing question
+
+    def test_question_signature_empty_for_unknown_path(self):
+        form = self.app.get_form(self.form_unique_id)
+        assert form.wrapped_xform().get_question_signature('/data/does_not_exist') == frozenset()
+
+    def test_question_signature_changes_when_bind_changes(self):
+        # Mutate the bind type for /data/question2 and confirm signature differs.
+        form = self.app.get_form(self.form_unique_id)
+        original = form.wrapped_xform().get_question_signature('/data/question2')
+        modified_source = form.source.replace(
+            '<bind nodeset="/data/question2" type="xsd:string" vellum:lock="all" />',
+            '<bind nodeset="/data/question2" type="xsd:int" vellum:lock="all" />',
+        )
+        assert modified_source != form.source  # sanity: replacement happened
+        modified = XForm(modified_source).get_question_signature('/data/question2')
+        assert original != modified
+
+    def test_question_signature_changes_when_label_changes(self):
+        # Modifying the itext entry for /data/question2 should change the signature.
+        form = self.app.get_form(self.form_unique_id)
+        original = form.wrapped_xform().get_question_signature('/data/question2')
+        modified_source = form.source.replace(
+            '<text id="question2-label">',
+            '<text id="question2-label" data-changed="true">',
+        )
+        assert modified_source != form.source
+        modified = XForm(modified_source).get_question_signature('/data/question2')
+        assert original != modified
+
+    def test_question_signature_changes_when_constraint_added(self):
+        # Adding a constraint attribute to the bind should change the signature.
+        form = self.app.get_form(self.form_unique_id)
+        original = form.wrapped_xform().get_question_signature('/data/question2')
+        modified_source = form.source.replace(
+            '<bind nodeset="/data/question2" type="xsd:string" vellum:lock="all" />',
+            '<bind nodeset="/data/question2" type="xsd:string" '
+            'constraint=". &gt; 0" vellum:lock="all" />',
+        )
+        assert modified_source != form.source
+        modified = XForm(modified_source).get_question_signature('/data/question2')
+        assert original != modified
+
+    def test_question_signature_changes_when_hint_text_changes(self):
+        # Hint label refs are pulled in via itext; changing the hint text
+        # should flow through the signature.
+        form = self.app.get_form(self.form_unique_id)
+        original = form.wrapped_xform().get_question_signature('/data/question1')
+        modified_source = form.source.replace(
+            '<text id="question1-hint">',
+            '<text id="question1-hint" data-changed="true">',
+        )
+        assert modified_source != form.source
+        modified = XForm(modified_source).get_question_signature('/data/question1')
+        assert original != modified
+
+    def test_question_signature_changes_when_select_option_value_changes(self):
+        # Item value changes inside a select1 are part of the control subtree.
+        form = self.app.get_form(self.form_unique_id)
+        original = form.wrapped_xform().get_question_signature('/data/question15/question21')
+        modified_source = form.source.replace('<value>item22</value>', '<value>item99</value>')
+        assert modified_source != form.source
+        modified = XForm(modified_source).get_question_signature('/data/question15/question21')
+        assert original != modified
+
+    def test_question_signature_changes_when_data_instance_attr_changes(self):
+        # The data-instance node is part of the signature; the vellum:comment
+        # on /data/question2 lives there.
+        form = self.app.get_form(self.form_unique_id)
+        original = form.wrapped_xform().get_question_signature('/data/question2')
+        modified_source = form.source.replace(
+            '<question2 vellum:comment="This is a comment" />',
+            '<question2 vellum:comment="Edited comment" />',
+        )
+        assert modified_source != form.source
+        modified = XForm(modified_source).get_question_signature('/data/question2')
+        assert original != modified

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -459,6 +459,21 @@ class QuestionSignatureTest(AppFormTestCase):
             assert modified_source != form.source, old
             assert XForm(modified_source).get_question_signature(path) == original, old
 
+    def test_locked_group_signature_stable_when_emptied(self):
+        # Deleting the last child of a locked group leaves the group present
+        # but empty. Its signature must not change just because the leftover
+        # layout whitespace shifted.
+        form = self.app.get_form(self.locked_form_unique_id)
+        path = '/data/household'
+        original = form.wrapped_xform().get_question_signature(path)
+        modified_source = (
+            form.source
+            .replace('<household_size />', '')
+            .replace('<bind nodeset="/data/household/household_size" type="xsd:int" />', '')
+        )
+        assert modified_source != form.source
+        assert XForm(modified_source).get_question_signature(path) == original
+
     def test_locked_group_signature_detects_group_own_edits(self):
         # Changes to the group's own bind or label must still be caught.
         form = self.app.get_form(self.locked_form_unique_id)

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -397,6 +397,82 @@ class QuestionSignatureTest(AppFormTestCase):
     def setUp(self):
         super().setUp()
         self.form_unique_id = self.add_form('case_in_form', "Form").unique_id
+        self.locked_form_unique_id = self.add_form('locked_questions').unique_id
+
+    def test_binds_for_path_save_to_case_includes_case_subtree(self):
+        xform = self.app.get_form(self.locked_form_unique_id).wrapped_xform()
+        nodesets = {
+            bind.attrib['nodeset']
+            for bind in xform._binds_for_path('/data/visit/register_child', include_descendants=True)
+        }
+        assert nodesets == {
+            '/data/visit/register_child/case',
+            '/data/visit/register_child/case/create/case_type',
+            '/data/visit/register_child/case/create/case_name',
+            '/data/visit/register_child/case/@date_modified',
+            '/data/visit/register_child/case/@user_id',
+        }
+
+    def test_binds_for_path_prefix_boundary(self):
+        # The trailing ``/`` must keep a prefix-sharing sibling out: a path of
+        # ``/data/visit/register_chi`` must not sweep in ``register_child``.
+        xform = self.app.get_form(self.locked_form_unique_id).wrapped_xform()
+        assert xform._binds_for_path('/data/visit/register_chi', include_descendants=True) == []
+
+    def test_save_to_case_signature_changes_when_descendant_bind_changes(self):
+        # The case-name calculate lives on a descendant bind, not the data
+        # node; changing it must change the locked question's signature.
+        form = self.app.get_form(self.locked_form_unique_id)
+        path = '/data/visit/register_child'
+        original = form.wrapped_xform().get_question_signature(path)
+        modified_source = form.source.replace(
+            'calculate="/data/child_name"', 'calculate="\'static name\'"')
+        assert modified_source != form.source
+        assert XForm(modified_source).get_question_signature(path) != original
+
+    def test_save_to_case_signature_changes_when_case_subtree_changes(self):
+        # The <case> subtree (which properties are written) is part of the
+        # question and lives in the data instance.
+        form = self.app.get_form(self.locked_form_unique_id)
+        path = '/data/visit/register_child'
+        original = form.wrapped_xform().get_question_signature(path)
+        modified_source = form.source.replace(
+            '<case_name />', '<case_name />\n<external_id />')
+        assert modified_source != form.source
+        assert XForm(modified_source).get_question_signature(path) != original
+
+    def test_locked_group_signature_ignores_child_question_edits(self):
+        # A locked group must leave its children independently editable: edits
+        # to the child's bind, label, or data node must not change the group's
+        # signature.
+        form = self.app.get_form(self.locked_form_unique_id)
+        path = '/data/household'
+        original = form.wrapped_xform().get_question_signature(path)
+        edits = [
+            ('<bind nodeset="/data/household/household_size" type="xsd:int" />',
+             '<bind nodeset="/data/household/household_size" type="xsd:string" />'),
+            ('<value>Household size</value>', '<value>Number of people</value>'),
+            ('<household_size />', '<household_size vellum:comment="added" />'),
+        ]
+        for old, new in edits:
+            modified_source = form.source.replace(old, new)
+            assert modified_source != form.source, old
+            assert XForm(modified_source).get_question_signature(path) == original, old
+
+    def test_locked_group_signature_detects_group_own_edits(self):
+        # Changes to the group's own bind or label must still be caught.
+        form = self.app.get_form(self.locked_form_unique_id)
+        path = '/data/household'
+        original = form.wrapped_xform().get_question_signature(path)
+        edits = [
+            ('<bind nodeset="/data/household" />',
+             '<bind nodeset="/data/household" relevant="false()" />'),
+            ('<value>Household</value>', '<value>Family</value>'),
+        ]
+        for old, new in edits:
+            modified_source = form.source.replace(old, new)
+            assert modified_source != form.source, old
+            assert XForm(modified_source).get_question_signature(path) != original, old
 
     def test_question_signature_stable_for_unchanged_form(self):
         form_a = self.app.get_form(self.form_unique_id)

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -774,21 +774,26 @@ class XForm(WrappedNode):
         include_descendants = self._is_save_to_case(path)
         parts = set()
 
+        # Remove leading and trailing whitespace in XML elements; it's not relevant here
+        parser = ET.XMLParser(remove_blank_text=True)
+        def reparse_to_string(xml):
+            return ET.tostring(ET.XML(ET.tostring(xml), parser))
+
         for bind in self._binds_for_path(path, include_descendants):
-            parts.add(ET.tostring(bind.xml))
+            parts.add(reparse_to_string(bind.xml))
 
         for control in self._controls_for_path(path):
             if not include_descendants:
                 control = self._without_descendant_questions(control, path)
-            parts.add(ET.tostring(control))
+            parts.add(reparse_to_string(control))
             for itext_id in _itext_refs_in(control):
                 for text_node in self._itext_text_nodes(itext_id):
-                    parts.add(ET.tostring(text_node))
+                    parts.add(reparse_to_string(text_node))
 
         for data_node in self._data_instance_nodes_for_path(path):
             if not include_descendants:
                 data_node = self._without_child_elements(data_node)
-            parts.add(ET.tostring(data_node))
+            parts.add(reparse_to_string(data_node))
 
         return parts
 
@@ -837,6 +842,10 @@ class XForm(WrappedNode):
         shallow = copy.deepcopy(node)
         for child in list(shallow):
             shallow.remove(child)
+        # Drop the indentation left where the children were: an emptied node
+        # would otherwise carry whitespace-only text.
+        if shallow.text is not None and not shallow.text.strip():
+            shallow.text = None
         return shallow
 
     def _controls_for_path(self, path):

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -715,20 +715,25 @@ class XForm(WrappedNode):
 
     @property
     def has_locked_questions(self):
-        """Whether any binds in this form's XML are locked (``vellum:lock="all"``)."""
-        if not self.exists():
-            return False
-        try:
-            binds = self.bind_nodes
-        except XFormException:
-            return False
-        return any(bind.attrib.get('{v}lock') == 'all' for bind in binds)
+        """Whether any questions in this form are locked (``vellum:lock="all"``).
+
+        A lock may be declared on a ``<bind>`` or directly on a data node.
+        """
+        return bool(self.locked_question_paths)
 
     @property
     def locked_question_paths(self):
-        """Set of ``nodeset`` paths for binds with ``vellum:lock="all"``."""
+        """Set of paths for questions locked with ``vellum:lock="all"``.
+
+        Locks may be declared on a ``<bind>`` (via its ``nodeset``) or directly
+        on a data-instance node.
+        """
         if not self.exists():
             return set()
+        return self._locked_bind_paths() | self._locked_data_node_paths()
+
+    def _locked_bind_paths(self):
+        """``nodeset`` paths for binds with ``vellum:lock="all"``."""
         try:
             binds = self.bind_nodes
         except XFormException:
@@ -737,6 +742,14 @@ class XForm(WrappedNode):
             bind.attrib['nodeset']
             for bind in binds
             if bind.attrib.get('{v}lock') == 'all' and bind.attrib.get('nodeset')
+        }
+
+    def _locked_data_node_paths(self):
+        """Paths for data-instance nodes with ``vellum:lock="all"``."""
+        return {
+            path
+            for path, node in self._get_flattened_data_nodes().items()
+            if node.attrib.get('{v}lock') == 'all'
         }
 
     def get_question_signature(self, path):

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 import itertools
 import logging
 import re
@@ -755,32 +756,88 @@ class XForm(WrappedNode):
     def get_question_signature(self, path):
         """Representation of the question at ``path`` for equality comparison.
 
-        Includes the bind element, the control element + descendants, the
-        data instance node, and any itext entries referenced from the
-        control's labels/hints/help/items. Callers should not rely on the
-        absence or presence of any particular item within this set.
+        Includes the bind element(s), the control element, the data instance
+        node, and any itext entries referenced from the control's
+        labels/hints/help/items. Callers should not rely on the absence or
+        presence of any particular item within this set.
+
+        SaveToCase question are handled specially: all path descendants are
+        included. For any other node with children, notably a group or repeat,
+        the descendants under ``path`` are separate, independently editable
+        questions, so they are excluded.
 
         Returns an empty ``set`` if the path isn't present in the form.
         """
         if not self.exists():
             return set()
 
+        include_descendants = self._is_save_to_case(path)
         parts = set()
 
-        for bind in self.bind_nodes:
-            if bind.attrib.get('nodeset') == path:
-                parts.add(ET.tostring(bind.xml))
+        for bind in self._binds_for_path(path, include_descendants):
+            parts.add(ET.tostring(bind.xml))
 
         for control in self._controls_for_path(path):
+            if not include_descendants:
+                control = self._without_descendant_questions(control, path)
             parts.add(ET.tostring(control))
             for itext_id in _itext_refs_in(control):
                 for text_node in self._itext_text_nodes(itext_id):
                     parts.add(ET.tostring(text_node))
 
         for data_node in self._data_instance_nodes_for_path(path):
+            if not include_descendants:
+                data_node = self._without_child_elements(data_node)
             parts.add(ET.tostring(data_node))
 
         return parts
+
+    def _is_save_to_case(self, path):
+        role_attr = '{v}role'.format(**self.namespaces)
+        return any(
+            node.attrib.get(role_attr) == 'SaveToCase'
+            for node in self._data_instance_nodes_for_path(path)
+        )
+
+    def _binds_for_path(self, path, include_descendants):
+        """Binds that define the question at ``path``.
+
+        The exact ``nodeset == path`` bind is always included. When
+        ``include_descendants`` is true, binds on the subtree are also included.
+        The trailing ``/`` in the prefix avoids matching siblings that merely
+        share a prefix (e.g. ``/data/q1`` must not match ``/data/q123``).
+        """
+        prefix = path + '/'
+        return [
+            bind for bind in self.bind_nodes
+            if (nodeset := bind.attrib.get('nodeset'))
+            and (nodeset == path or (include_descendants and nodeset.startswith(prefix)))
+        ]
+
+    def _without_descendant_questions(self, control, path):
+        """Copy of a control with the controls of child questions removed.
+
+        A group/repeat control nests the controls of its child questions,
+        whose ``ref``/``nodeset`` is a descendant of ``path``. Those belong to
+        other questions, so they are dropped, leaving the node's own
+        label/hint/etc.
+        """
+        pruned = copy.deepcopy(control)
+        prefix = path + '/'
+        for node in pruned.xpath('.//*[@ref or @nodeset]'):
+            ref = node.get('ref') or node.get('nodeset') or ''
+            if ref.startswith(prefix):
+                parent = node.getparent()
+                if parent is not None:
+                    parent.remove(node)
+        return pruned
+
+    def _without_child_elements(self, node):
+        """Copy of a data node with element children removed (attributes kept)."""
+        shallow = copy.deepcopy(node)
+        for child in list(shallow):
+            shallow.remove(child)
+        return shallow
 
     def _controls_for_path(self, path):
         """Body elements with ``ref`` or ``nodeset`` matching ``path``."""


### PR DESCRIPTION
## Product Description
No UI changes. Validates against changes to locked Advanced Case Actions questions.

## Technical Summary
HQ side of https://dimagi.atlassian.net/browse/SAAS-19855
Vellum PR: https://github.com/dimagi/Vellum/pull/1258

Allows locked Advanced Case Actions (`SaveToCase`) questions to be correctly detected as locked via the `vellum:lock` attribute on their data nodes. All other questions would expect to have this attribute on their `<bind>` node.

In implementing logic to correctly identify `<bind>` nodes related to a given `SaveToCase` question, also fixes a preexisting bug with locked groups: a group would have had its question signature changed when a child question was edited, which is not the intended behavior.


## Safety Assurance

### Safety story
Low-risk: the change is confined to XForm read-only helpers (has_locked_questions, locked_question_paths, get_question_signature) and their tests. The public API/signatures are unchanged, so the call site in views/forms.py is unaffected. No data is read or written; nothing is migrated. 

Tested locally and on staging that:
- Upload XForm is disabled for a user without permission when a form contains a locked `SaveToCase` question
- Individual edits to a locked `SaveToCase` by manipulating Vellum UI are rejected for users without permission
- Edits to unlocked questions in a locked group are always allowed

### Automated test coverage
`LockedQuestionsTest`: bind locks, data-node locks (including nested), and has_locked_questions driven by a data-node lock alone.
`QuestionSignatureTest`: `_binds_for_path` descendant matching + prefix-boundary; SaveToCase signature changes when a descendant bind's calculate or the <case> subtree changes; locked-group signature ignores child-question edits (bind/label/data) but still detects edits to the group's own bind/label; plus pre-existing question signature cases.

### QA Plan
Not planning formal QA.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
