### PR TITLE
Return date_joined as UTC string not datetime obj

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -167,7 +167,7 @@
     {% if request.couch_user and USERFLOW_TOKEN %}
       {% initial_page_data 'userflow_token' USERFLOW_TOKEN %}
       {% initial_page_data 'userflow_user_id' request.couch_user.user_id %}
-      {% initial_page_data 'userflow_signed_up_at' request.couch_user.date_joined %}
+      {% initial_page_data 'userflow_signed_up_at' request.couch_user.date_joined_iso_utc %}
       {% initial_page_data 'userflow_server_env' server_environment %}
       {% initial_page_data 'userflow_domain' domain %}
       {% if request.subscription %}

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -824,6 +824,12 @@ class DjangoUserMixin(DocumentSchema):
         """ Currently just for debugging"""
         return check_password(password, self.password)
 
+    @property
+    def date_joined_iso_utc(self):
+        if self.date_joined.tzinfo is None:
+            return self.date_joined.replace(tzinfo=tz.utc).isoformat()
+        return self.date_joined.astimezone(tz.utc).isoformat()
+
 
 class EulaMixin(DocumentSchema):
     CURRENT_VERSION = EULA_CURRENT_VERSION


### PR DESCRIPTION
## Technical Summary

Curently Userflow is getting a string of a string of a datetime, without a timezone. What it needs is an ISO-formatted datetime in UTC. This change fixes that.

For context, see PR https://github.com/dimagi/commcare-hq/pull/37810

🦖 Jira: [SAAS-19873](https://dimagi.atlassian.net/browse/SAAS-19873)

## Safety Assurance

### Safety story

Tested locally.

### Automated test coverage

No

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19873]: https://dimagi.atlassian.net/browse/SAAS-19873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ