### PR TITLE
Support a sentinel object in hard_delete_forms

### DIFF
--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -21,6 +21,10 @@ UNDEFINED_XMLNS_LOG_DIR = settings.LOG_HOME
 
 logger = logging.getLogger(__name__)
 
+# special class used to bypass domain filter in hard_delete_forms
+# should only ever be used by permanently_delete_eligible_data
+SENTINEL_DOMAIN = object()
+
 
 # @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def permanently_delete_eligible_data(dry_run=True):

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -21,7 +21,7 @@ UNDEFINED_XMLNS_LOG_DIR = settings.LOG_HOME
 
 logger = logging.getLogger(__name__)
 
-# special class used to bypass domain filter in hard_delete_forms
+# special object used to bypass domain filter in hard_delete_forms
 # should only ever be used by permanently_delete_eligible_data
 SENTINEL_DOMAIN = object()
 

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -436,18 +436,14 @@ class XFormInstanceManager(RequireDBManager):
                         .filter(domain=domain, form_id__in=form_ids_to_delete)
                         .delete()
                     )
+                if batch_count:
+                    count_mismatch = batch_count != len(form_ids_to_delete)
+                    self.hard_delete_blobs(form_ids_to_delete, verify_deleted=count_mismatch)
+                if publish_changes:
+                    self.publish_deleted_forms(domain, form_ids_to_delete)
 
                 shard_count += batch_count.get(self.model._meta.label, 0)
-
             deleted_count += shard_count
-
-        if deleted_count:
-            count_mismatch = deleted_count != len(form_ids)
-            self.hard_delete_blobs(form_ids, verify_deleted=count_mismatch)
-
-        if publish_changes:
-            self.publish_deleted_forms(domain, form_ids)
-
         return deleted_count
 
     def hard_delete_blobs(self, form_ids, verify_deleted=False):

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -442,7 +442,7 @@ class XFormInstanceManager(RequireDBManager):
                         .filter(domain_filter, form_id__in=form_ids_to_delete)
                         .delete()
                     )
-                if batch_count:
+                if form_ids_to_delete:
                     metas = BlobMeta.objects.using(db_name).filter(
                         domain_filter, parent_id__in=form_ids_to_delete
                     )

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -195,25 +195,6 @@ class XFormInstanceManager(RequireDBManager):
             )
         return result
 
-    def hard_delete_expired_forms(self, commit=False):
-        """
-        Permanently deletes forms that were soft deleted outside of
-        the DATA_RETENTION_WINDOW, meaning the ``deleted_on`` field is
-        older than the current time - the DATA_RETENTION_WINDOW.
-        :param commit: defaults to False. If True, will delete expired forms
-        :return: dictionary of count of deleted forms
-        """
-        expiration_date = get_cutoff_date_for_data_deletion()
-        total_count = {}
-        for db_name in get_db_aliases_for_partitioned_query():
-            queryset = self.using(db_name).filter(deleted_on__lt=expiration_date)
-            if commit:
-                deleted_counts = queryset.delete()[1]
-            else:
-                deleted_counts = {'form_processor.XFormInstance': queryset.count()}
-            total_count = Counter(total_count) + Counter(deleted_counts)
-        return total_count
-
     def iter_form_ids_by_xmlns(self, domain, xmlns=None):
         q_expr = Q(domain=domain) & Q(state=self.model.NORMAL)
         if xmlns:
@@ -390,6 +371,25 @@ class XFormInstanceManager(RequireDBManager):
                 publish_form_saved(form)
 
         return count
+
+    def hard_delete_expired_forms(self, commit=False):
+        """
+        Permanently deletes forms that were soft deleted outside of
+        the DATA_RETENTION_WINDOW, meaning the ``deleted_on`` field is
+        older than the current time - the DATA_RETENTION_WINDOW.
+        :param commit: defaults to False. If True, will delete expired forms
+        :return: dictionary of count of deleted forms
+        """
+        expiration_date = get_cutoff_date_for_data_deletion()
+        total_count = Counter({})
+        for db_name in get_db_aliases_for_partitioned_query():
+            queryset = self.using(db_name).filter(deleted_on__lt=expiration_date)
+            if commit:
+                deleted_counts = queryset.delete()[1]
+            else:
+                deleted_counts = {'form_processor.XFormInstance': queryset.count()}
+            total_count += Counter(deleted_counts)
+        return total_count
 
     def hard_delete_forms(self, domain, form_ids, *, publish_changes=True, leave_tombstones=True):
         """Delete forms permanently

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -1,5 +1,5 @@
 import logging
-from collections import Counter
+from collections import Counter, defaultdict
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from io import BytesIO
@@ -394,34 +394,40 @@ class XFormInstanceManager(RequireDBManager):
     def hard_delete_forms(self, domain, form_ids, *, publish_changes=True, leave_tombstones=True):
         """Delete forms permanently
 
+        :param domain: only delete forms in the specified domain.
         :param publish_changes: Flag for change feed publication.
             Documents in Elasticsearch will not be deleted if this is false.
         :param leave_tombstones: If adding a new usage, DO NOT SET THIS TO FALSE.
             The user location mapping case and domain deletion are the only valid
             use cases for not leaving tombstones.
         """
+        from corehq.apps.cleanup.tasks import SENTINEL_DOMAIN
         assert isinstance(form_ids, list)
+
+        domain_filter = Q() if domain == SENTINEL_DOMAIN else Q(domain=domain)
 
         deleted_count = 0
         for db_name, split_form_ids in split_list_by_db_partition(form_ids):
             queryset = (
                 self.using(db_name)
-                .filter(domain=domain, form_id__in=split_form_ids)
-                .values_list('form_id', 'deleted_on')
+                .filter(domain_filter, form_id__in=split_form_ids)
+                .values_list('form_id', 'deleted_on', 'domain')
             )
             shard_count = 0
             while results := queryset[:BATCH_SIZE]:
                 hard_deletion_date = datetime.now(tz=UTC)
                 form_ids_to_delete = []
+                form_ids_by_domain = defaultdict(list)
                 tombstones = []
-                for form_id, soft_deleted_on in results:
+                for form_id, soft_deleted_on, form_domain in results:
+                    form_ids_by_domain[form_domain].append(form_id)
                     form_ids_to_delete.append(form_id)
                     if leave_tombstones:
                         tombstones.append(
                             build_tombstone(
                                 XFormInstance,
                                 form_id,
-                                domain,
+                                form_domain,
                                 soft_deleted_on,
                                 hard_deletion_date,
                             )
@@ -433,16 +439,17 @@ class XFormInstanceManager(RequireDBManager):
                     )
                     _, batch_count = (
                         self.using(db_name)
-                        .filter(domain=domain, form_id__in=form_ids_to_delete)
+                        .filter(domain_filter, form_id__in=form_ids_to_delete)
                         .delete()
                     )
                 if batch_count:
                     metas = BlobMeta.objects.using(db_name).filter(
-                        domain=domain, parent_id__in=form_ids_to_delete
+                        domain_filter, parent_id__in=form_ids_to_delete
                     )
                     get_blob_db().bulk_delete(metas=metas)
                 if publish_changes:
-                    self.publish_deleted_forms(domain, form_ids_to_delete)
+                    for _domain, form_ids_in_domain in form_ids_by_domain.items():
+                        self.publish_deleted_forms(_domain, form_ids_in_domain)
 
                 shard_count += batch_count.get(self.model._meta.label, 0)
             deleted_count += shard_count

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -437,22 +437,16 @@ class XFormInstanceManager(RequireDBManager):
                         .delete()
                     )
                 if batch_count:
-                    count_mismatch = batch_count != len(form_ids_to_delete)
-                    self.hard_delete_blobs(form_ids_to_delete, verify_deleted=count_mismatch)
+                    metas = BlobMeta.objects.using(db_name).filter(
+                        domain=domain, parent_id__in=form_ids_to_delete
+                    )
+                    get_blob_db().bulk_delete(metas=metas)
                 if publish_changes:
                     self.publish_deleted_forms(domain, form_ids_to_delete)
 
                 shard_count += batch_count.get(self.model._meta.label, 0)
             deleted_count += shard_count
         return deleted_count
-
-    def hard_delete_blobs(self, form_ids, verify_deleted=False):
-        if verify_deleted:
-            deleted_forms = [f for f in form_ids if not self.form_exists(f)]
-        else:
-            deleted_forms = form_ids
-        metas = get_blob_db().metadb.get_for_parents(deleted_forms)
-        get_blob_db().bulk_delete(metas=metas)
 
     @staticmethod
     def publish_deleted_forms(domain, form_ids):

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -451,6 +451,7 @@ class TestHardDeleteForms(TestCase):
         XFormInstance.objects.hard_delete_forms(DOMAIN, [form.form_id], leave_tombstones=True)
         tombstone = Tombstone.objects.partitioned_get(form.form_id)
         assert tombstone.doc_id == form.form_id
+        assert tombstone.domain == DOMAIN
 
     def test_tombstones_are_not_created(self):
         form = create_form_for_test(DOMAIN)
@@ -476,6 +477,18 @@ class TestHardDeleteForms(TestCase):
         count = XFormInstance.objects.hard_delete_forms(DOMAIN, [form.form_id])
 
         assert count == 1
+
+    def test_sentinel_value_deletes_across_domains_and_creates_tombstones(self):
+        from corehq.apps.cleanup.tasks import SENTINEL_DOMAIN
+        form = create_form_for_test(DOMAIN)
+        other_form = create_form_for_test('other_domain')
+        deleted = XFormInstance.objects.hard_delete_forms(SENTINEL_DOMAIN, [form.form_id, other_form.form_id])
+        assert deleted == 2
+        for f in [form, other_form]:
+            # should not raise errors
+            Tombstone.objects.partitioned_query(f.form_id).get(
+                doc_id=f.form_id, domain=f.domain, model=XFormInstance
+            )
 
 
 class DeleteAttachmentsFSDBTests(TestCase):


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19878

While this [sentinel object](https://peps.python.org/pep-0661/) is not available in 3.13, it is worth reading through for context on sentinel objects.

The idea here is to support a way to call `hard_delete_forms` with no domain argument in the case where we want to periodically clean up soft deleted forms from various domains. Currently, we'd have to go through the cumbersome process of gather soft deleted/eligible forms for hard deletion, split by domain, and call `hard_delete_forms` for each domain that has forms to delete.

The initial option was to make `domain` an optional argument, but this makes it too easy to call `hard_delete_forms` without a domain, which is generally not safe. In reality, we only want to support bypassing this domain requirement where we _need_ this behavior, which is cleaning up soft deleted forms across various domains.

In addition to supporting a sentinel object to bypass the domain requirements, this PR reworks the blob deletion logic to avoid the expensive "verify" step, which to me seemed like a roundabout way of just doing a domain check.

There are likely more improvements coming to this function to make the whole chain of create tombstones -> delete forms -> delete blobs more robust, but leaving this PR scoped to sentinel object support for now.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Automated tests ensure this still works as expected, and there is only one place in production that uses this function which is the user location case mapping code.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Automated tests ensure hard delete forms logic continues to work as expected.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
