### PR TITLE
Automatically rebuild vellum-staging when it conflicts with master

### DIFF
--- a/.github/workflows/rebuild-staging.yml
+++ b/.github/workflows/rebuild-staging.yml
@@ -128,11 +128,7 @@ jobs:
         fi
     - name: Check out Vellum
       if: steps.vellum-check.outputs.needs-rebuild == 'true'
-      uses: actions/checkout@v6
-      with:
-        repository: dimagi/Vellum
-        ref: staging
-        path: vellum-repo
+      run: git clone --depth 1 --branch staging https://github.com/dimagi/Vellum.git ../Vellum
     - uses: actions/setup-node@v6
       if: steps.vellum-check.outputs.needs-rebuild == 'true'
       with:
@@ -141,6 +137,6 @@ jobs:
       if: steps.vellum-check.outputs.needs-rebuild == 'true'
       env:
         GIT_EDITOR: 'true'  # bypass "git commit --edit" in vellum-to-hq
-      run: uv run --with sh scripts/vellum-to-hq staging --no-test --push --vellum-dir=./vellum-repo
+      run: uv run --with sh scripts/vellum-to-hq staging --no-test --push --vellum-dir=../Vellum
     - name: Rebuild staging
       run: ./scripts/rebuildstaging

--- a/.github/workflows/rebuild-staging.yml
+++ b/.github/workflows/rebuild-staging.yml
@@ -140,7 +140,7 @@ jobs:
     - name: Rebuild vellum-staging
       if: steps.vellum-check.outputs.needs-rebuild == 'true'
       env:
-        GIT_EDITOR: 'true'
+        GIT_EDITOR: 'true'  # bypass "git commit --edit" in vellum-to-hq
       run: uv run --with sh scripts/vellum-to-hq staging --no-test --push --vellum-dir=./vellum-repo
     - name: Rebuild staging
       run: ./scripts/rebuildstaging

--- a/.github/workflows/rebuild-staging.yml
+++ b/.github/workflows/rebuild-staging.yml
@@ -109,5 +109,38 @@ jobs:
       run: |
         git config user.name "GitHub Actions"
         git config user.email "actions@github.com"
+    - name: Check if vellum-staging needs rebuild
+      id: vellum-check
+      run: |
+        if ! git fetch origin vellum-staging 2>/dev/null; then
+          echo "vellum-staging branch not found, skipping"
+          echo "needs-rebuild=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if git merge --no-commit --no-ff origin/vellum-staging; then
+          echo "vellum-staging merges cleanly, no rebuild needed"
+          git merge --abort
+          echo "needs-rebuild=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "vellum-staging conflicts with master, rebuild needed"
+          git merge --abort
+          echo "needs-rebuild=true" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Check out Vellum
+      if: steps.vellum-check.outputs.needs-rebuild == 'true'
+      uses: actions/checkout@v6
+      with:
+        repository: dimagi/Vellum
+        ref: staging
+        path: vellum-repo
+    - uses: actions/setup-node@v6
+      if: steps.vellum-check.outputs.needs-rebuild == 'true'
+      with:
+        node-version: '24'
+    - name: Rebuild vellum-staging
+      if: steps.vellum-check.outputs.needs-rebuild == 'true'
+      env:
+        GIT_EDITOR: 'true'
+      run: uv run --with sh scripts/vellum-to-hq staging --no-test --push --vellum-dir=./vellum-repo
     - name: Rebuild staging
       run: ./scripts/rebuildstaging


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19904

Sample output from the test run after Evan merged his branch into master on vellum but intentionally did not fix staging:
```
4cfa9bd223edd65bda0cf26d128375e23f08f49c (HEAD -> staging, origin/staging) Merge branch 'dependabot/npm_and_yarn/underscore-1.13.8' into staging
0f14a28774b0b739221b89639dc2e91ecf0cd482 (origin/ejp/locked-questions-savetocase, ejp/locked-questions-savetocase) Make fd-mode-toggle-link a disable-able button
bd836796b51d1d4f38fd2858ab7da49a28077cbb Set Case Management dropdown disabled state from widget.isDisabled()
d24bcc906072ceae1158c8892f5556f1f2697fe3 Don't disable option, optgroups
2d7165ce8622a53441cbb0e08479d5fde4424d26 Use <button> not <a> for fd-add-property so disabled attr gets applied correctly
98be621dd2b9fc33aebeccc091d254113d04b629 Remove outdated top-level comment
64c89f6bb8424854781c48d1d7795f82cfbaddce Remove exceptions for advanced case actions from group lock actions
a244b49c1c8f8313dedbdb1d6d255413194b2fd1 Add tests for lock plugin compatibility with Advanced Case Actions
8f9ef4c650b178ea3e06d185918c92cb7a64e75f Read or set locked xml attribute from bind or data node as needed
63393f2bb16e003ea873bb526ab1e2ffc44dee90 Rename LOCKED_BIND_ATTR -> LOCKED_XML_ATTR
69f24b5c533af5191cb4e70f17791ba3e6ec86ec Allow locked widget to show on Advanced Case Actions
035e12eb002ba910e53f72c8f14a22c974c4a540 (origin/master, origin/HEAD, master) Merge pull request #1255 from dimagi/gh/upgrade-less
```
> Checkout and fetch ./vellum-repo staging
Building Vellum...
Checkout and fetch HQ vellum-staging
git reset --hard origin/master
Overwriting HQ Vellum with new build
Pushing HQ origin/vellum-staging
Vellum Changes Since Last HQ Deploy
4cfa9bd2 Merge branch 'dependabot/npm_and_yarn/underscore-1.13.8' into staging

So it looks like the rebuild kept the underscore upgrade and rebuilt cleanly. 
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested [here](https://github.com/dimagi/commcare-hq/actions/runs/27453174255/job/81152494032). Ultimately this is pretty safe as it is only impacting our staging build pipeline. In the worst case, this would inadvertently not include changes we expect to see in vellum.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
