### PR TITLE
Send app structure to OCS chat widget

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap3/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap3/app_manager.js
@@ -14,7 +14,7 @@ import menu from "app_manager/js/menu";
 import previewApp from "app_manager/js/bootstrap3/preview_app";
 import sectionChanger from "app_manager/js/section_changer";
 import "hqwebapp/js/components/inline_edit";  // app, menu, and form names and comments all use these
-import "app_manager/js/ocs_widget_app_manager_context";  // publishes App Builder context to the OCS chat widget
+import "app_manager/js/ocs_widget_app_manager_context";
 import "select2/dist/js/select2.full.min";
 
 var module = main.eventize({});

--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap3/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap3/app_manager.js
@@ -14,6 +14,7 @@ import menu from "app_manager/js/menu";
 import previewApp from "app_manager/js/bootstrap3/preview_app";
 import sectionChanger from "app_manager/js/section_changer";
 import "hqwebapp/js/components/inline_edit";  // app, menu, and form names and comments all use these
+import "app_manager/js/ocs_widget_app_manager_context";  // publishes App Builder context to the OCS chat widget
 import "select2/dist/js/select2.full.min";
 
 var module = main.eventize({});

--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
@@ -15,7 +15,7 @@ import menu from "app_manager/js/menu";
 import previewApp from "app_manager/js/bootstrap5/preview_app";
 import sectionChanger from "app_manager/js/section_changer";
 import "hqwebapp/js/components/inline_edit";  // app, menu, and form names and comments all use these
-import "app_manager/js/ocs_widget_app_manager_context";  // publishes App Builder context to the OCS chat widget
+import "app_manager/js/ocs_widget_app_manager_context";
 import "select2/dist/js/select2.full.min";
 
 var module = main.eventize({});

--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
@@ -15,6 +15,7 @@ import menu from "app_manager/js/menu";
 import previewApp from "app_manager/js/bootstrap5/preview_app";
 import sectionChanger from "app_manager/js/section_changer";
 import "hqwebapp/js/components/inline_edit";  // app, menu, and form names and comments all use these
+import "app_manager/js/ocs_widget_app_manager_context";  // publishes App Builder context to the OCS chat widget
 import "select2/dist/js/select2.full.min";
 
 var module = main.eventize({});

--- a/corehq/apps/app_manager/static/app_manager/js/ocs_widget_app_manager_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/ocs_widget_app_manager_context.js
@@ -11,10 +11,10 @@ function _readStructure() {
         app_name: _text(document.querySelector('[data-ocs-app-name]')),
         current_language: initialPageData.get('lang'),
         available_languages: initialPageData.get('langs_for_ocs_context') || [],
-        modules: [].slice.call(document.querySelectorAll('[data-ocs-module]')).map(function (moduleEl) {
+        modules: [...document.querySelectorAll('[data-ocs-module]')].map(function (moduleEl) {
             return {
                 name: _text(moduleEl.querySelector('[data-ocs-module-name]')),
-                forms: [].slice.call(moduleEl.querySelectorAll('[data-ocs-form-name]')).map(_text),
+                forms: [...moduleEl.querySelectorAll('[data-ocs-form-name]')].map(_text),
             };
         }),
     };

--- a/corehq/apps/app_manager/static/app_manager/js/ocs_widget_app_manager_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/ocs_widget_app_manager_context.js
@@ -1,0 +1,37 @@
+import $ from "jquery";
+import initialPageData from "hqwebapp/js/initial_page_data";
+import ocsContext, {WIDGET_SELECTOR} from "hqwebapp/js/ocs_widget_context_setter";
+
+function _text(el) {
+    return el?.textContent.trim() ?? '';
+}
+
+function _readStructure() {
+    return {
+        app_name: _text(document.querySelector('[data-ocs-app-name]')),
+        current_language: initialPageData.get('lang'),
+        available_languages: initialPageData.get('langs_for_ocs_context') || [],
+        modules: [].slice.call(document.querySelectorAll('[data-ocs-module]')).map(function (moduleEl) {
+            return {
+                name: _text(moduleEl.querySelector('[data-ocs-module-name]')),
+                forms: [].slice.call(moduleEl.querySelectorAll('[data-ocs-form-name]')).map(_text),
+            };
+        }),
+    };
+}
+
+function _readDomThenUpdate() {
+    if (!document.querySelector('[data-ocs-app-name]')) {
+        return;
+    }
+    ocsContext.setAppStructure(_readStructure());
+}
+
+$(function () {
+    if (!document.querySelector(WIDGET_SELECTOR)) {
+        return;
+    }
+    _readDomThenUpdate();
+
+    $(document).on('inline-edit-save', _readDomThenUpdate);
+});

--- a/corehq/apps/app_manager/templates/app_manager/bootstrap3/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/bootstrap3/apps_base.html
@@ -63,6 +63,8 @@
 
     {% initial_page_data 'latest_commcare_version' latest_commcare_version %}
     {% initial_page_data 'app_subset' app_subset %}
+    {% initial_page_data 'langs_for_ocs_context' langs_for_ocs_context %}
+    {% initial_page_data 'lang' lang %}
     {% initial_page_data 'formdesigner' formdesigner %}
     {% initial_page_data 'add_ons' add_ons %}
     {% initial_page_data 'add_ons_layout' add_ons_layout %}

--- a/corehq/apps/app_manager/templates/app_manager/bootstrap3/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/bootstrap3/module_view_report.html
@@ -8,7 +8,6 @@
 {% js_entry_b3 'app_manager/js/modules/bootstrap3/module_view_report' %}
 
 {% block form-view %}
-  {% initial_page_data 'lang' lang %}
   {% initial_page_data 'multimedia_object_map' multimedia.object_map %}
   {% initial_page_data 'multimedia_upload_managers' multimedia.upload_managers_js %}
   {% initial_page_data 'nav_menu_media_specifics' nav_menu_media_specifics %}

--- a/corehq/apps/app_manager/templates/app_manager/bootstrap5/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/bootstrap5/apps_base.html
@@ -63,6 +63,8 @@
 
     {% initial_page_data 'latest_commcare_version' latest_commcare_version %}
     {% initial_page_data 'app_subset' app_subset %}
+    {% initial_page_data 'langs_for_ocs_context' langs_for_ocs_context %}
+    {% initial_page_data 'lang' lang %}
     {% initial_page_data 'formdesigner' formdesigner %}
     {% initial_page_data 'add_ons' add_ons %}
     {% initial_page_data 'add_ons_layout' add_ons_layout %}

--- a/corehq/apps/app_manager/templates/app_manager/bootstrap5/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/bootstrap5/module_view_report.html
@@ -8,7 +8,6 @@
 {% js_entry 'app_manager/js/modules/bootstrap5/module_view_report' %}
 
 {% block form-view %}
-  {% initial_page_data 'lang' lang %}
   {% initial_page_data 'multimedia_object_map' multimedia.object_map %}
   {% initial_page_data 'multimedia_upload_managers' multimedia.upload_managers_js %}
   {% initial_page_data 'nav_menu_media_specifics' nav_menu_media_specifics %}

--- a/corehq/apps/app_manager/templates/app_manager/languages.html
+++ b/corehq/apps/app_manager/templates/app_manager/languages.html
@@ -2,7 +2,6 @@
 {% load xforms_extras %}
 {% load hq_shared_tags %}
 
-{% initial_page_data 'lang' lang %}
 {% initial_page_data 'translations' translations %}
 {% initial_page_data 'smart_lang_display_enabled' smart_lang_display_enabled %}
 {% registerurl "edit_app_langs" domain app.id %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap3/appnav_menu_header.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap3/appnav_menu_header.html
@@ -15,7 +15,7 @@
   <h2 class="appnav-name">
     <a href="{% url 'release_manager' domain app_id %}"
        class="appnav-responsive">
-      <span class="variable-app_name appname-text">{{ app_name }}</span>
+      <span class="variable-app_name appname-text" data-ocs-app-name>{{ app_name }}</span>
     </a>
   </h2>
   <div id="js-publish-status"

--- a/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/appnav_menu_header.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bootstrap5/appnav_menu_header.html
@@ -15,7 +15,7 @@
   <h2 class="appnav-name">
     <a href="{% url 'release_manager' domain app_id %}"
        class="appnav-responsive">
-      <span class="variable-app_name appname-text">{{ app_name }}</span>
+      <span class="variable-app_name appname-text" data-ocs-app-name>{{ app_name }}</span>
     </a>
   </h2>
   <div id="js-publish-status" class="appnav-name-publish d-none">

--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/bootstrap3/appnav_menu.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/bootstrap3/appnav_menu.html
@@ -13,6 +13,7 @@
         data-index="{{ module.id }}"
         data-uid="{{ module.unique_id }}"
         data-rootmoduleuid="{{ module.root_module_id|default:"" }}"
+        data-ocs-module
       >
         {% include 'app_manager/partials/menu/bootstrap3/module_link.html' %}
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/bootstrap3/form_link.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/bootstrap3/form_link.html
@@ -45,7 +45,7 @@
             data-html="true"
             >
         </i>
-        <span {% if form == selected_form %}class="variable-form_name"{% endif %}>
+        <span data-ocs-form-name {% if form == selected_form %}class="variable-form_name"{% endif %}>
             {{ form.name|html_trans_prefix:langs }}
         </span>
     </a>

--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/bootstrap3/module_link.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/bootstrap3/module_link.html
@@ -37,6 +37,7 @@
             data-placement="right"
             data-container="body"></i>
         <span
+          data-ocs-module-name
           {% if module.unique_id == selected_module.unique_id %}class="variable-module_name"{% endif %}
           {% if module.case_type %}
             title="{% blocktrans  with module.case_type as case_type %}case type: {{case_type}}{% endblocktrans %}"

--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/bootstrap5/appnav_menu.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/bootstrap5/appnav_menu.html
@@ -13,6 +13,7 @@
         data-index="{{ module.id }}"
         data-uid="{{ module.unique_id }}"
         data-rootmoduleuid="{{ module.root_module_id|default:"" }}"
+        data-ocs-module
       >
         {% include 'app_manager/partials/menu/bootstrap5/module_link.html' %}
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/bootstrap5/form_link.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/bootstrap5/form_link.html
@@ -45,7 +45,7 @@
             data-bs-html="true"
             >
         </i>
-        <span {% if form == selected_form %}class="variable-form_name"{% endif %}>
+        <span data-ocs-form-name {% if form == selected_form %}class="variable-form_name"{% endif %}>
             {{ form.name|html_trans_prefix:langs }}
         </span>
     </a>

--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/bootstrap5/module_link.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/bootstrap5/module_link.html
@@ -37,6 +37,7 @@
             data-bs-placement="right"
             data-bs-container="body"></i>
         <span
+          data-ocs-module-name
           {% if module.unique_id == selected_module.unique_id %}class="variable-module_name"{% endif %}
           {% if module.case_type %}
             title="{% blocktrans  with module.case_type as case_type %}case type: {{case_type}}{% endblocktrans %}"

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -369,8 +369,6 @@ def get_apps_base_context(request, domain, app):
         'linked_name': linked_name,
         'app_subset': {
             'commcare_minor_release': app.commcare_minor_release,
-            'doc_type': app.get_doc_type(),
-            'form_counts_by_module': [len(m.forms) for m in app.modules] if not app.is_remote_app() else [],
             'version': app.version,
         } if app else {},
         'timezone': timezone,

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -364,6 +364,7 @@ def get_apps_base_context(request, domain, app):
     context = {
         'lang': lang,
         'langs': langs,
+        'langs_for_ocs_context': app.langs if app and app.langs else [],
         'domain': domain,
         'app': app,
         'linked_name': linked_name,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
@@ -7,7 +7,7 @@
 *  Widget API: https://docs.openchatstudio.com/chat_widget/reference/#page-context
 */
 
-const WIDGET_SELECTOR = 'open-chat-studio-widget';
+export const WIDGET_SELECTOR = 'open-chat-studio-widget';
 let _currentContext = {};
 
 function _publish() {
@@ -57,6 +57,11 @@ function setPermissions(permissions) {
     _publish();
 }
 
+function setAppStructure(appStructure) {
+    _currentContext.app_structure = appStructure;
+    _publish();
+}
+
 export default {
     setUrl: setUrl,
     setPageTitle: setPageTitle,
@@ -66,4 +71,5 @@ export default {
     setIsDomainAdmin: setIsDomainAdmin,
     setIsEnterpriseAdmin: setIsEnterpriseAdmin,
     setPermissions: setPermissions,
+    setAppStructure: setAppStructure,
 };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
@@ -7,7 +7,7 @@
 *  Widget API: https://docs.openchatstudio.com/chat_widget/reference/#page-context
 */
 
-export const WIDGET_SELECTOR = 'open-chat-studio-widget';
+const WIDGET_SELECTOR = 'open-chat-studio-widget';
 let _currentContext = {};
 
 function _publish() {
@@ -62,6 +62,7 @@ function setAppStructure(appStructure) {
     _publish();
 }
 
+export {WIDGET_SELECTOR};
 export default {
     setUrl: setUrl,
     setPageTitle: setPageTitle,

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/apps_base.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/apps_base.html.diff.txt
@@ -41,7 +41,7 @@
        {% endif %}
      </nav>
    {% endif %}
-@@ -71,7 +71,7 @@
+@@ -73,7 +73,7 @@
      {% registerurl "all_case_types" domain %}
      {% block pre_form_content %}{% endblock %}
      {% block form-view %}{% endblock %}
@@ -50,7 +50,7 @@
      <script type="text/html" id="XPathValidator.template">
        <div class="js-xpath-input-target control-group" data-bind="css: {error: xpathValidator.error}">
          <textarea class="form-control vertical-resize" spellcheck="false"
-@@ -90,12 +90,12 @@
+@@ -92,12 +92,12 @@
  {% block modals %}
    {{ block.super }}
    {% if app.is_deleted %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/module_view_report.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/module_view_report.html.diff.txt
@@ -13,8 +13,8 @@
 +{% js_entry 'app_manager/js/modules/bootstrap5/module_view_report' %}
  
  {% block form-view %}
-   {% initial_page_data 'lang' lang %}
-@@ -21,12 +21,12 @@
+   {% initial_page_data 'multimedia_object_map' multimedia.object_map %}
+@@ -20,12 +20,12 @@
    {% registerurl "edit_report_module" domain app.id module.unique_id %}
    {% registerurl "validate_module_for_build" domain app.id module.unique_id %}
  

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/appnav_menu_header.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/appnav_menu_header.html.diff.txt
@@ -12,7 +12,7 @@
      </a>
    </div>
 @@ -18,9 +18,7 @@
-       <span class="variable-app_name appname-text">{{ app_name }}</span>
+       <span class="variable-app_name appname-text" data-ocs-app-name>{{ app_name }}</span>
      </a>
    </h2>
 -  <div id="js-publish-status"

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/menu/appnav_menu.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/menu/appnav_menu.html.diff.txt
@@ -1,15 +1,15 @@
 --- 
 +++ 
-@@ -14,7 +14,7 @@
-         data-uid="{{ module.unique_id }}"
+@@ -15,7 +15,7 @@
          data-rootmoduleuid="{{ module.root_module_id|default:"" }}"
+         data-ocs-module
        >
 -        {% include 'app_manager/partials/menu/bootstrap3/module_link.html' %}
 +        {% include 'app_manager/partials/menu/bootstrap5/module_link.html' %}
  
          <ul
            class="appnav-menu appnav-menu-nested see sortable sortable-forms
-@@ -29,7 +29,7 @@
+@@ -30,7 +30,7 @@
                  data-uid="{{ form.unique_id }}"
                  {% if form.get_action_type == 'open' %}data-appear="first"{% endif %}
                >
@@ -18,7 +18,7 @@
                </li>
              {% endfor %}
            {% endwith %}
-@@ -46,7 +46,7 @@
+@@ -47,7 +47,7 @@
            id="new-module-form"
            action="{% url "new_module" domain app.id %}"
            method="post"
@@ -27,7 +27,7 @@
          >
            {% csrf_token %}
            <input id="new-module-type" type="hidden" name="module_type" />
-@@ -56,8 +56,8 @@
+@@ -57,8 +57,8 @@
            href="#"
            class="appnav-add add-new-module"
            data-slug="module"
@@ -38,7 +38,7 @@
          >
            <i class="new-module-icon fa fa-plus"></i>
            {% trans "Add..." %}
-@@ -71,15 +71,13 @@
+@@ -72,15 +72,13 @@
    <div class="modal-dialog" role="document">
      <div class="modal-content">
        <div class="modal-header">
@@ -58,7 +58,7 @@
        </div>
        <form
          action="{% url "move_child_modules_after_parents" domain app.id %}"
-@@ -103,7 +101,7 @@
+@@ -104,7 +102,7 @@
            {% endblocktrans %}
          </div>
          <div class="modal-footer">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/menu/form_link.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/menu/form_link.html.diff.txt
@@ -32,7 +32,7 @@
 +            data-bs-html="true"
              >
          </i>
-         <span {% if form == selected_form %}class="variable-form_name"{% endif %}>
+         <span data-ocs-form-name {% if form == selected_form %}class="variable-form_name"{% endif %}>
 @@ -67,12 +67,17 @@
        <div class="modal-dialog" role="document">
          <div class="modal-content">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/menu/module_link.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/partials/menu/module_link.html.diff.txt
@@ -9,7 +9,7 @@
         class="appnav-delete">
        <i class="fa-regular fa-trash-can"></i>
      </a>
-@@ -33,16 +33,16 @@
+@@ -33,17 +33,17 @@
            <i class="fa fa-folder-open appnav-primary-icon"
          {% endif %}
              title="{% if request|toggle_enabled:"SUPPORT" %}{% blocktrans with module.id as index %}This is menu {{ index }}{% endblocktrans %}{% endif %}"
@@ -20,6 +20,7 @@
 +            data-bs-placement="right"
 +            data-bs-container="body"></i>
          <span
+           data-ocs-module-name
            {% if module.unique_id == selected_module.unique_id %}class="variable-module_name"{% endif %}
            {% if module.case_type %}
              title="{% blocktrans  with module.case_type as case_type %}case type: {{case_type}}{% endblocktrans %}"
@@ -32,7 +33,7 @@
            {% endif %}
          >
              {{ module.name|html_trans_prefix:langs }}
-@@ -70,7 +70,6 @@
+@@ -71,7 +71,6 @@
        <div class="modal-dialog" role="document">
          <div class="modal-content">
            <div class="modal-header">
@@ -40,7 +41,7 @@
              {% if module.module_type == 'basic' %}
                {% if module.is_surveys %}
                  {% trans "Survey Menu" as menu %}
-@@ -91,6 +90,12 @@
+@@ -92,6 +91,12 @@
                  Are you sure you want to delete this {{ menu }}?
                {% endblocktrans %}
              </h4>
@@ -53,7 +54,7 @@
            </div>
            <form action="{% url "delete_module" domain app.id module.unique_id %}"
                  method="post">
-@@ -107,10 +112,10 @@
+@@ -108,10 +113,10 @@
                </p>
              </div>
              <div class="modal-footer">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/app_manager.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/app_manager.js.diff.txt
@@ -20,8 +20,8 @@
 +import previewApp from "app_manager/js/bootstrap5/preview_app";
  import sectionChanger from "app_manager/js/section_changer";
  import "hqwebapp/js/components/inline_edit";  // app, menu, and form names and comments all use these
- import "select2/dist/js/select2.full.min";
-@@ -179,25 +180,30 @@
+ import "app_manager/js/ocs_widget_app_manager_context";  // publishes App Builder context to the OCS chat widget
+@@ -180,25 +181,30 @@
   * @private
   */
  var _initAddItemPopovers = function () {
@@ -67,7 +67,7 @@
              var dataType = $(e.target).closest('button').data('type'),
                  stopSubmit = $(e.target).closest('button').data('stopsubmit') === 'yes',
                  $form;
-@@ -207,7 +213,7 @@
+@@ -208,7 +214,7 @@
              }
  
              var caseAction =  $(e.target).closest('button').data('case-action'),
@@ -76,7 +76,7 @@
                  moduleId = $popoverContent.data("module-unique-id"),
                  $trigger = $('.js-add-new-item[data-module-unique-id="' + moduleId + '"]');
  
-@@ -222,13 +228,13 @@
+@@ -223,13 +229,13 @@
          });
      }).on('click', function (e) {
          e.preventDefault();
@@ -92,7 +92,7 @@
          }
      });
  };
-@@ -343,7 +349,7 @@
+@@ -344,7 +350,7 @@
          });
      }
      function promptToSaveOrdering() {
@@ -101,7 +101,7 @@
      }
      function initSortable($sortable) {
          var options = {
-@@ -480,7 +486,9 @@
+@@ -481,7 +487,9 @@
          }
      });
  
@@ -112,7 +112,7 @@
  
      // https://github.com/twitter/bootstrap/issues/6122
      // this is necessary to get popovers to be able to extend
-@@ -508,13 +516,17 @@
+@@ -509,13 +517,17 @@
      });
  
      // Handling for popup displayed when accessing a deleted app
@@ -137,7 +137,7 @@
  
      // Set up app preview
      previewApp.initPreviewWindow();
-@@ -536,15 +548,15 @@
+@@ -537,15 +549,15 @@
          var $form = $('#new-module-form');
  
          if (moduleType === "case") {
@@ -156,7 +156,7 @@
              $form.submit();
          }
      });
-@@ -586,15 +598,13 @@
+@@ -587,15 +599,13 @@
  
              $caseType.on('change', function () {
                  var valueNoSpaces = $(this).val();
@@ -173,7 +173,7 @@
                  $createBtn.prop('disabled', false);
  
                  if (!valueNoSpaces) {
-@@ -603,9 +613,8 @@
+@@ -604,9 +614,8 @@
                  }
  
                  function displayError(errorMsg) {
@@ -184,7 +184,7 @@
                      $help.hide();
                      $createBtn.prop('disabled', true);
                  }
-@@ -642,14 +651,14 @@
+@@ -643,14 +652,14 @@
          newCaseTypeHiddenInput.val(value);
  
          $('.new-module-icon').removeClass().addClass("fa fa-refresh fa-spin");
@@ -202,7 +202,7 @@
      });
  
      // Clear selection when modal is hidden
-@@ -671,7 +680,7 @@
+@@ -672,7 +681,7 @@
      $('.new-module-option').each(function () {
          var type = $(this).data('type');
          if (hoverHelpTexts[type]) {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/app_manager.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/app_manager.js.diff.txt
@@ -20,7 +20,7 @@
 +import previewApp from "app_manager/js/bootstrap5/preview_app";
  import sectionChanger from "app_manager/js/section_changer";
  import "hqwebapp/js/components/inline_edit";  // app, menu, and form names and comments all use these
- import "app_manager/js/ocs_widget_app_manager_context";  // publishes App Builder context to the OCS chat widget
+ import "app_manager/js/ocs_widget_app_manager_context";
 @@ -180,25 +181,30 @@
   * @private
   */


### PR DESCRIPTION
## Product Description

Send App name, languages, module/form list to OCS bot so that bot have Structural awareness of the app.

I try to break the things need to be sent to OCS bot down to smaller PRs. If you're interested in the full list, you can find them in https://docs.google.com/document/d/10ew68kDMgaHNeDwOdeKrA4P1R31jNQaVDVryqCBGZso/edit?tab=t.0

The published shape:

```js
pageContext.app_structure = {
  app_name: "Maternal Health",
  current_language: "en",
  available_languages: ["en", "hin"],
  modules: [
    {name: "Household", forms: ["Register", "Update"]},
    ...
  ],
}
```

## Technical Summary

Ticket: https://dimagi.atlassian.net/browse/SAAS-19846
Dev spec: https://docs.google.com/document/d/10ew68kDMgaHNeDwOdeKrA4P1R31jNQaVDVryqCBGZso/edit?tab=t.0
Test run in: https://github.com/dimagi/commcare-hq/actions/runs/27572446675

- `current_language` and `available_languages` will be extracted from `initial_page_data`.
- `app_name` and modules/forms list will be scraped from DOM: It walks the App Builder sidebar to collect the app name, module names and form names with their translated values

#### Why scrape the DOM instead of serializing server-side?

The sidebar is already server-rendered with the correctly translated module/form names. 
- If I grab the structure all from server side, it means I need to render the app_name, modules/form list to `initial_page_data` and they will be included in the html, despite of they're already available in html. I don't like this duplication.
- If re-serializing server-side, it also means I need to translate module name, form name to the selected language again

Thus I decide to scrape the DOM. I added some `data-*` class to related elements so it is easier to walk through.

## Feature Flag

`OCS_CHATBOT` - But will soon be released to all users

## Safety Assurance

### Safety story

Pure additions to send some context to OCS. All information is already public, no sensitive data.

### Automated test coverage


### QA Plan

Not planning on QA. List this down as a reference of what the expected behavior should be.

Enable `OCS_CHATBOT` feature preview:

1. **Open an app in App Builder** → Verify context has `app_name`, `current_language`, `available_languages`, and `modules` with `name` and `forms`.
2. **Inline-rename a module, a form, app's name** → context should be updated accordingly
3. **Switch language**  → `current_language` matches the newly selected language.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.

### Labels & Review

- [x] Risk label is set correctly (low — additions only, behind feature preview).
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.