### PR TITLE
ProjectDB: populate tables from cases

### DIFF
--- a/corehq/apps/project_db/README.rst
+++ b/corehq/apps/project_db/README.rst
@@ -50,3 +50,16 @@ TODOs
   Postgres schema rather than a Django model, the standard model-based
   registration won't catch it; deleting a domain would orphan its
   ``projectdb_<domain>`` schema and data.
+
+- **Typed property collisions** If a project had a ``dob`` prop and
+  a ``dob__date`` prop, I think that could cause undefined behavior.
+  Consider adding type as a prefix, maybe even before prop?  Eg
+  instead of ``prop__dob__date`` try ``date_prop__dob``.
+
+- **Store raw case prop name as a comment** This could then be used to know how
+  to insert a case based on inspecting the table.  It'd change ``case_to_row``
+  to iterate through columns instead of properties
+
+- **Date vs Datetime** Looks like the DD only supports date
+  properties, not datetime - does it intend the latter? Should we
+  support both?

--- a/corehq/apps/project_db/populate.py
+++ b/corehq/apps/project_db/populate.py
@@ -1,7 +1,23 @@
 import datetime
 from decimal import Decimal, InvalidOperation
 
+from sqlalchemy.dialects.postgresql import insert
+
 from corehq.apps.data_dictionary.models import CaseProperty
+
+
+def upsert_case(conn, table, case):
+    """Insert or update a single case into a project DB table"""
+    table_columns = set(table.c.keys())
+    values = case_to_row(case, table_columns)
+
+    stmt = insert(table).values(**values)
+    update_dict = {k: v for k, v in values.items() if k != 'case_id'}
+    stmt = stmt.on_conflict_do_update(
+        index_elements=['case_id'],
+        set_=update_dict,
+    )
+    conn.execute(stmt)
 
 
 def case_to_row(case, table_columns):

--- a/corehq/apps/project_db/populate.py
+++ b/corehq/apps/project_db/populate.py
@@ -1,0 +1,56 @@
+import datetime
+from decimal import Decimal, InvalidOperation
+
+from corehq.apps.data_dictionary.models import CaseProperty
+
+
+def case_to_row(case, table_columns):
+    """Map case to table column names for insertion"""
+    ids_by_identifier = {idx.identifier: idx.referenced_id for idx in case.live_indices}
+    row = {  # Mirrors CaseTable._static_columns
+        'case_id': case.case_id,
+        'owner_id': case.owner_id,
+        'case_name': case.name,
+        'opened_on': case.opened_on,
+        'closed_on': case.closed_on,
+        'modified_on': case.modified_on,
+        'closed': case.closed,
+        'external_id': case.external_id,
+        'server_modified_on': case.server_modified_on,
+        'parent_id': ids_by_identifier.get('parent'),
+        'host_id': ids_by_identifier.get('host'),
+    }
+    for key, value in case.case_json.items():
+        col_name = f'prop__{key}'
+        if col_name in table_columns:
+            row[col_name] = str(value)
+            for suffix, coerce_fn in _TYPED_COERCIONS:
+                typed_col = f'{col_name}__{suffix}'
+                if typed_col in table_columns:
+                    row[typed_col] = coerce_fn(value)
+    return row
+
+
+def coerce_to_date(value):
+    if not value:
+        return None
+    try:
+        return datetime.date.fromisoformat(value[:10])
+    except (ValueError, TypeError):
+        return None
+
+
+def coerce_to_number(value):
+    if not value or not str(value).strip():
+        return None
+    try:
+        return Decimal(value)
+    except (InvalidOperation, TypeError):
+        return None
+
+
+# Parallels CaseTable.COERCED_PROPERTY_TYPES
+_TYPED_COERCIONS = [
+    (CaseProperty.DataType.DATE, coerce_to_date),
+    (CaseProperty.DataType.NUMBER, coerce_to_number),
+]

--- a/corehq/apps/project_db/populate.py
+++ b/corehq/apps/project_db/populate.py
@@ -5,6 +5,22 @@ from sqlalchemy.dialects.postgresql import insert
 
 from corehq.apps.data_dictionary.models import CaseProperty
 
+from .table_ddl import CaseTable, get_project_db_engine
+
+
+def send_to_project_db(domain, cases):
+    """Upsert CommCareCases into the appropriate project DB tables"""
+    tables = {}
+    for case_type in {c.type for c in cases}:
+        if (table := CaseTable(domain, case_type).reflect()) is not None:
+            tables[case_type] = table
+
+    if tables:
+        with get_project_db_engine().begin() as conn:
+            for case in cases:
+                if (table := tables.get(case.type)) is not None:
+                    upsert_case(conn, table, case)
+
 
 def upsert_case(conn, table, case):
     """Insert or update a single case into a project DB table"""

--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -103,6 +103,19 @@ class CaseTable:
             Column('host_id', Text, index=True),
         ]
 
+    def reflect(self):
+        """Reflect a SQLAlchemy ``Table`` from the database by inspection"""
+        try:
+            return Table(
+                self.case_type,
+                sqlalchemy.MetaData(),
+                schema=self.domain_schema.name,
+                autoload=True,
+                autoload_with=get_project_db_engine(),
+            )
+        except sqlalchemy.exc.NoSuchTableError:
+            return None
+
 
 def create_or_update_project_db(domain):
     metadata = sqlalchemy.MetaData()

--- a/corehq/apps/project_db/tests/test_populate.py
+++ b/corehq/apps/project_db/tests/test_populate.py
@@ -2,13 +2,18 @@ import datetime
 from decimal import Decimal
 
 import pytest
+from unmagic import use
 
 from corehq.apps.project_db.populate import (
     case_to_row,
     coerce_to_date,
     coerce_to_number,
+    upsert_case,
 )
+from corehq.apps.project_db.table_ddl import CaseTable, get_project_db_engine
 from corehq.form_processor.models import CommCareCase
+
+from .util import project_db_table
 
 
 @pytest.mark.parametrize('value, expected', [
@@ -128,3 +133,17 @@ def test_case_json_keys_cannot_collide_with_fixed_fields():
     # case_json values are namespaced under prop__, so they coexist safely
     assert result['prop__case_id'] == 'fake-id'
     assert result['prop__owner_id'] == 'fake-owner'
+
+
+@use('db', project_db_table('test-upsert', 'patient', {'first_name': 'plain'}))
+def test_upsert():
+    table = CaseTable('test-upsert', 'patient').reflect()
+    with get_project_db_engine().begin() as conn:
+        upsert_case(conn, table, _make_case(case_id='c1', name='Alice'))
+        rows = conn.execute(table.select()).fetchall()
+        assert [row['case_id'] for row in rows] == ['c1']
+
+        upsert_case(conn, table, _make_case(case_id='c1', name='Bob'))
+        rows = conn.execute(table.select()).fetchall()
+        assert len(rows) == 1  # updated in place, not inserted twice
+        assert rows[0]['case_name'] == 'Bob'

--- a/corehq/apps/project_db/tests/test_populate.py
+++ b/corehq/apps/project_db/tests/test_populate.py
@@ -1,0 +1,130 @@
+import datetime
+from decimal import Decimal
+
+import pytest
+
+from corehq.apps.project_db.populate import (
+    case_to_row,
+    coerce_to_date,
+    coerce_to_number,
+)
+from corehq.form_processor.models import CommCareCase
+
+
+@pytest.mark.parametrize('value, expected', [
+    ('2024-03-15',          datetime.date(2024, 3, 15)),
+    ('2024-03-15T10:30:00', datetime.date(2024, 3, 15)),
+    (None,                  None),
+    ('',                    None),
+    ('not-a-date',          None),
+    ('2024-13-01',          None),
+])
+def test_coerce_to_date(value, expected):
+    assert coerce_to_date(value) == expected
+
+
+@pytest.mark.parametrize('value, expected', [
+    ('42',   Decimal('42')),
+    ('3.14', Decimal('3.14')),
+    ('-7.5', Decimal('-7.5')),
+    (None,   None),
+    ('',     None),
+    ('abc',  None),
+    ('  ',   None),
+])
+def test_coerce_to_number(value, expected):
+    assert coerce_to_number(value) == expected
+
+
+def _make_index(identifier, referenced_id):
+    return {'identifier': identifier, 'referenced_id': referenced_id}
+
+
+def _make_case(case_json=None, indices=None, **fields):
+    return CommCareCase(
+        case_id=fields.get('case_id', 'abc123'),
+        domain=fields.get('domain', 'test-domain'),
+        type=fields.get('type', 'patient'),
+        name=fields.get('name', 'Test Case'),
+        owner_id=fields.get('owner_id', 'owner1'),
+        opened_on=fields.get('opened_on', datetime.datetime(2025, 1, 1)),
+        closed_on=fields.get('closed_on', None),
+        modified_on=fields.get('modified_on', datetime.datetime(2025, 6, 1)),
+        closed=fields.get('closed', False),
+        external_id=fields.get('external_id', ''),
+        server_modified_on=fields.get('server_modified_on', datetime.datetime(2025, 6, 1)),
+        case_json=case_json or {},
+        indices=indices or [],
+    )
+
+
+def test_static_fields_mapped_to_columns():
+    case = _make_case(
+        case_id='abc123',
+        owner_id='owner1',
+        name='My Case',
+        opened_on=datetime.datetime(2025, 1, 1),
+        closed_on=datetime.datetime(2025, 3, 1),
+        modified_on=datetime.datetime(2025, 6, 1),
+        closed=True,
+        external_id='ext-1',
+        server_modified_on=datetime.datetime(2025, 6, 2),
+        indices=[_make_index('parent', 'p1'), _make_index('host', 'h1')],
+    )
+    assert case_to_row(case, table_columns=set()) == {
+        'case_id': 'abc123',
+        'owner_id': 'owner1',
+        'case_name': 'My Case',
+        'opened_on': datetime.datetime(2025, 1, 1),
+        'closed_on': datetime.datetime(2025, 3, 1),
+        'modified_on': datetime.datetime(2025, 6, 1),
+        'closed': True,
+        'external_id': 'ext-1',
+        'server_modified_on': datetime.datetime(2025, 6, 2),
+        'parent_id': 'p1',
+        'host_id': 'h1',
+    }
+
+
+@pytest.mark.parametrize('case_json, columns, expected_props', [
+    # property dropped when it has no column
+    ({'color': 'red', 'size': 'large'}, {'prop__color'}, {'prop__color': 'red'}),
+    # raw value coerced to str
+    ({'count': 42}, {'prop__count'}, {'prop__count': '42'}),
+    # typed columns populated via coercion
+    ({'dob': '1990-05-20', 'weight': '70.5'},
+     {'prop__dob', 'prop__dob__date', 'prop__weight', 'prop__weight__number'},
+     {'prop__dob': '1990-05-20', 'prop__dob__date': datetime.date(1990, 5, 20),
+      'prop__weight': '70.5', 'prop__weight__number': Decimal('70.5')}),
+    # typed value skipped when only the raw column exists
+    ({'dob': '1990-05-20'}, {'prop__dob'}, {'prop__dob': '1990-05-20'}),
+])
+def test_property_columns(case_json, columns, expected_props):
+    result = case_to_row(_make_case(case_json=case_json), columns)
+    assert {k: v for k, v in result.items() if k.startswith('prop__')} == expected_props
+
+
+@pytest.mark.parametrize('indices, expected_parent, expected_host', [
+    ([],                             None, None),
+    ([_make_index('parent', 'p1')],  'p1', None),
+    ([_make_index('host',   'h1')],  None, 'h1'),
+    ([_make_index('custom', 'x1')],  None, None),
+])
+def test_index_extraction(indices, expected_parent, expected_host):
+    result = case_to_row(_make_case(indices=indices), table_columns=set())
+    assert result['parent_id'] == expected_parent
+    assert result['host_id'] == expected_host
+
+
+def test_case_json_keys_cannot_collide_with_fixed_fields():
+    case = _make_case(
+        case_id='real-id',
+        owner_id='real-owner',
+        case_json={'case_id': 'fake-id', 'owner_id': 'fake-owner'},
+    )
+    result = case_to_row(case, table_columns={'prop__case_id', 'prop__owner_id'})
+    assert result['case_id'] == 'real-id'
+    assert result['owner_id'] == 'real-owner'
+    # case_json values are namespaced under prop__, so they coexist safely
+    assert result['prop__case_id'] == 'fake-id'
+    assert result['prop__owner_id'] == 'fake-owner'

--- a/corehq/apps/project_db/tests/test_populate.py
+++ b/corehq/apps/project_db/tests/test_populate.py
@@ -1,5 +1,6 @@
 import datetime
 from decimal import Decimal
+import uuid
 
 import pytest
 from unmagic import use
@@ -8,6 +9,7 @@ from corehq.apps.project_db.populate import (
     case_to_row,
     coerce_to_date,
     coerce_to_number,
+    send_to_project_db,
     upsert_case,
 )
 from corehq.apps.project_db.table_ddl import CaseTable, get_project_db_engine
@@ -47,7 +49,7 @@ def _make_index(identifier, referenced_id):
 
 def _make_case(case_json=None, indices=None, **fields):
     return CommCareCase(
-        case_id=fields.get('case_id', 'abc123'),
+        case_id=fields.get('case_id', str(uuid.uuid4())),
         domain=fields.get('domain', 'test-domain'),
         type=fields.get('type', 'patient'),
         name=fields.get('name', 'Test Case'),
@@ -147,3 +149,18 @@ def test_upsert():
         rows = conn.execute(table.select()).fetchall()
         assert len(rows) == 1  # updated in place, not inserted twice
         assert rows[0]['case_name'] == 'Bob'
+
+
+@use('db', project_db_table('test-send', 'patient', {'first_name': 'plain'}))
+def test_send_to_project_db():
+    send_to_project_db('test-send', [
+        _make_case({'first_name': 'Alice'}, type='patient'),
+        _make_case({'first_name': 'Bob'}, type='patient'),
+        _make_case({}, type='clinic'),
+    ])
+
+    table = CaseTable('test-send', 'patient').reflect()
+    with get_project_db_engine().begin() as conn:
+        rows = conn.execute(table.select()).fetchall()
+    assert [r[0] for r in rows] == ['Alice', 'Bob']
+    assert CaseTable('test-upsert', 'clinic').reflect() is None

--- a/corehq/apps/project_db/tests/test_table_ddl.py
+++ b/corehq/apps/project_db/tests/test_table_ddl.py
@@ -11,6 +11,8 @@ from corehq.apps.project_db.table_ddl import (
     get_project_db_engine,
 )
 
+from .util import project_db_table
+
 
 def test_schema_name():
     assert DomainSchema('my-domain').name == 'projectdb_my-domain'
@@ -125,3 +127,18 @@ def _assert_db_updated_as_expected(schema):
         # Both a plain and a date column for dob
         assert isinstance(columns['prop__dob'], sqlalchemy.Text)
         assert isinstance(columns['prop__dob__date'], sqlalchemy.Date)
+
+
+@use('db', project_db_table('test-reflect', 'patient', {
+    'nickname': 'plain',
+    'dob': 'date'
+}))
+def test_case_table_reflect():
+    table = CaseTable('test-reflect', 'patient').reflect()
+    assert table.name == 'patient'
+    assert table.schema == 'projectdb_test-reflect'
+    for column in CaseTable._static_columns():
+        assert column.name in table.c
+    assert isinstance(table.c['prop__nickname'].type, sqlalchemy.Text)
+    assert isinstance(table.c['prop__dob'].type, sqlalchemy.Text)
+    assert isinstance(table.c['prop__dob__date'].type, sqlalchemy.Date)

--- a/corehq/apps/project_db/tests/util.py
+++ b/corehq/apps/project_db/tests/util.py
@@ -1,0 +1,22 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from corehq.apps.project_db.table_ddl import (
+    CaseTable,
+    DomainSchema,
+    create_or_update_project_db,
+    get_project_db_engine,
+)
+
+
+@contextmanager
+def project_db_table(domain, case_type, properties):
+    """Pytest fixture to construct a ProjectDB table"""
+    with patch('corehq.apps.project_db.table_ddl._get_case_types', return_value=[case_type]), \
+         patch.object(CaseTable, '_get_dd_properties', return_value=properties.items()):
+        create_or_update_project_db(domain)
+    try:
+        yield
+    finally:
+        with get_project_db_engine().begin() as conn:
+            DomainSchema(domain).drop(conn)


### PR DESCRIPTION
## Product Description
No user-facing effects

## Technical Summary
https://docs.google.com/document/d/1ayuYQx7DD6dfc2-zzeLat4R8kXZkTp6WlPcD4rcw0YU/edit?tab=t.0
I'm pulling/rewriting pieces of https://github.com/dimagi/commcare-hq/pull/37486

PR onto `es/project-db-1` (https://github.com/dimagi/commcare-hq/pull/37825).
That PR adds the DDL to set up table structure, this PR adds code to populate those tables from cases.

## Feature Flag
N/A

## Safety Assurance

### Safety story
The code is inert - nothing calls it yet. All writes target the per-domain schema, isolated from application tables.

### Automated test coverage
Yep

### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations


### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
