### PR TITLE
Make CommCareCase domain dumps much faster

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -35,7 +35,8 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('form_processor.XFormOperation', SimpleFilter('form__domain'),
                                  pagination_key=('form_id', 'pk'), use_fk_index_hint=True),
 
-    FilteredModelIteratorBuilder('form_processor.CommCareCase', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('form_processor.CommCareCase', SimpleFilter('domain'),
+                                 pagination_key=("type", "id")),
     FilteredModelIteratorBuilder('form_processor.CommCareCaseIndex', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.CaseAttachment', SimpleFilter('case__domain'),
                                  pagination_key=('case_id', 'pk'), use_fk_index_hint=True),

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -5,7 +5,8 @@ import time
 from django.core.paginator import Paginator
 from django.core.paginator import EmptyPage
 from django.db import DEFAULT_DB_ALIAS, connections
-from django.db.models import Q
+from django.db.models import F
+from django.db.models.fields.tuple_lookups import Tuple, TupleGreaterThan
 from django.db.utils import InterfaceError, OperationalError
 
 logger = logging.getLogger(__name__)
@@ -186,25 +187,25 @@ def _fk_index_column(model_cls, pagination_key):
 
 
 def _lexicographic_greater_than(fields, values):
-    """Build the tuple comparison ``(a, b, ...) > (va, vb, ...)`` as a Q
-    expression, expanding it to ``a > va OR (a = va AND b > vb) OR ...``.
+    """Build the keyset bound ``(a, b, ...) > (va, vb, ...)`` as a lookup for
+    ``QuerySet.filter``.
 
-    TODO: for a compound key this OR form can't seek the leading field's own
-    index -- Postgres won't derive a bound on ``a`` from inside the OR [1], so it
-    scans from the start. Callers that page a child model by its parent's id avoid
-    this by seeking the parent's index via ``use_fk_index_hint`` instead. A
-    single-table compound-key caller that wanted a leading-index seek would need
-    to AND back a redundant ``a >= va`` (a planner hint), or better, switch to a
-    row-value comparison ``(a, b, ...) > (va, vb, ...)``, which Postgres supports
-    and can seek with [1].
+    This is a row-value comparison, not the equivalent
+    ``a > va OR (a = va AND b > vb) OR ...``: Postgres can seek a matching
+    multicolumn index with the row-value form, but only ever *filters* with the
+    ``OR`` form -- scanning from the start of each page for a compound key [1].
+
+    Django exposes no lookup syntax for this, so we reuse its composite-primary-key
+    tuple lookups directly. They emit the row-value form where the backend supports
+    tuple lookups (Postgres does), else fall back to the equivalent ``OR`` form;
+    ``test_keyset_seek_emits_a_row_value_comparison_in_the_query`` guards against a
+    silent fallback. ``F`` resolves the ``pk`` alias and a foreign key's attname
+    (e.g. ``case_id``) as ``filter`` does.
 
     [1] https://use-the-index-luke.com/sql/partial-results/fetch-next-page#sb-equivalent-logic
     """
-    condition = Q()
-    for index, (field, value) in enumerate(zip(fields, values)):
-        ties = dict(zip(fields[:index], values[:index]))
-        condition |= Q(**ties, **{f"{field}__gt": value})
-    return condition
+    lhs = Tuple(*(F(field) for field in fields))
+    return TupleGreaterThan(lhs, list(values))
 
 
 def _fetch_chunk(queryset, limit):

--- a/corehq/util/tests/test_queries.py
+++ b/corehq/util/tests/test_queries.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 import pytest
 from django.contrib.auth.models import User
 from django.db import connections
-from django.db.models import Q
 from django.db.utils import InterfaceError, OperationalError
 from django.test.testcases import TestCase
 
@@ -17,18 +16,13 @@ from corehq.util.queries import (
 
 
 def test_lexicographic_greater_than_single_field():
-    assert _lexicographic_greater_than(('id',), (5,)) == Q(id__gt=5)
+    qs = User.objects.filter(_lexicographic_greater_than(('pk',), (5,)))
+    assert '("auth_user"."id") > (' in str(qs.query)
 
 
 def test_lexicographic_greater_than_multiple_fields():
-    assert (
-        _lexicographic_greater_than(('a', 'b'), (1, 2))
-        == (Q(a__gt=1) | Q(a=1, b__gt=2))
-    )
-    assert (
-        _lexicographic_greater_than(('a', 'b', 'c'), (1, 2, 3))
-        == (Q(a__gt=1) | Q(a=1, b__gt=2) | Q(a=1, b=2, c__gt=3))
-    )
+    qs = User.objects.filter(_lexicographic_greater_than(('last_name', 'pk'), ('Tenenbaum', 5)))
+    assert '("auth_user"."last_name", "auth_user"."id") > (' in str(qs.query)
 
 
 def test_fk_index_column_returns_the_parent_column():
@@ -69,8 +63,28 @@ def test_use_fk_index_hint_seeks_the_parent_column_while_keyset_stays_on_the_chi
     seeked_page = pages[1]
     # raw bound on the parent column -- the planner hint
     assert '"form_processor_commcarecasesql"."case_id" >= ' in seeked_page
-    # keyset still on the child's own column
-    assert '"form_processor_casetransaction"."case_id"' in seeked_page
+    # keyset still on the child's own column, as a row-value comparison
+    assert ('("form_processor_casetransaction"."case_id", '
+            '"form_processor_casetransaction"."id") > (' in seeked_page)
+
+
+def test_keyset_seek_emits_a_row_value_comparison_in_the_query():
+    # The compound keyset bound is a row-value comparison ``(a, b) > (x, y)`` --
+    # the form Postgres can seek a multicolumn index with.
+    pages = []
+
+    def capture(queryset, limit):
+        pages.append(str(queryset.query))   # compiles SQL; no db access
+        return [SimpleNamespace(last_name='Tenenbaum', pk=5)] if len(pages) == 1 else []
+
+    with patch.object(queries, '_fetch_chunk', side_effect=capture):
+        list(queryset_to_iterator(
+            User.objects.using('default'), User, limit=1,
+            ignore_ordering=True, pagination_key=('last_name', 'pk'),
+        ))
+
+    assert len(pages) == 2  # first page, then the seeked page
+    assert '("auth_user"."last_name", "auth_user"."id") > (' in pages[1]
 
 
 class TestQuerysetToIterator(TestCase):


### PR DESCRIPTION
## Product Description

No user-facing change. Speeds up `dump_domain_data` for domains with large
`CommCareCase` tables.

## Technical Summary

I know I have made the "much faster" promise [before](https://github.com/dimagi/commcare-hq/pull/37788), but this time I really think I have it (albeit for a different, simpler-to-query model).

**Before**
The `CommCareCase` dump paginates by pk (`id`). There's no `(domain, id)` index,
so the per-page query `WHERE domain = X AND id > cursor ORDER BY id LIMIT 5000`
seeks the pk index and scans forward, **filtering by `domain`** — so dumping one
domain reads a large swath of the whole (multi-domain) table to find its rows.

**After**
The `CommCareCase` dump paginates by `('type', 'id')` using a native Postgres tuple comparison to ride the existing [`Index(["domain", "type", "id"])`](https://github.com/dimagi/commcare-hq/blob/59094f2bae43a0d93b4d8e3fec8fa3453b92470a/corehq/form_processor/models/cases.py#L828), so each page seeks straight to the domain's own rows instead of scanning and filtering, and indeed seeks straight to the last point in the index the previous query had reached.

The native tuple comparison is crucial and worth dwelling on. Previously the code for using a compound pagination key used `a > x OR (a = x AND b > y)` which Postgres can filter on but cannot use as an index condition—meaning it wouldn't be able to seek to the right starting point in the (domain, type, id) index, so without this, the new pagination key would have actually made things worse. The original query was/is linear in the number rows in the _table_, the query with updated pagination but without this tuple comparison fix would have been _quadratic_ in the number of rows in the _domain_, and the final query with update pagination and tuple fix is _linear_.

The two commits have a simple relationship to each other: first, fix the internals that will make the new pagination key work, then use the new pagination key.

## Safety Assurance

### Safety story

The row-value comparison is logically equivalent to the OR form it replaces, and
the new keyset returns the same rows in a fully-ordered sequence. Verified the
plan on a production-sized shard with
`EXPLAIN (ANALYZE, BUFFERS)`: the domain equality and `ROW(type, id)` comparison
both land in the Index Cond (a seek, not a filter), with no Sort node and zero
rows removed by filter. Unlike some previous efforts I've made, this query plan makes clear there is no tradeoff—it perfectly rides an index, so it is basically the very best a query plan could possibly be for the thing we're trying to do here.

### Automated test coverage

`corehq/util/tests/test_queries.py` asserts the compiled SQL is the row-value
form and guards against a silent fallback to the OR form; the existing
`TestQuerysetToIterator` suite covers end-to-end correctness.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

