### PR TITLE
Send form designer context to OCS chat widget

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,6 +28,7 @@ module.exports = function (grunt) {
     var apps = [
         'app_manager/bootstrap3',
         'app_manager/bootstrap5',
+        'app_manager/form_designer_context',
         'export',
         'notifications/bootstrap3',
         'notifications/bootstrap5',

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_utils.js
@@ -91,7 +91,25 @@ var handleAjaxAppChange = function (callback) {
     });
 };
 
+var versionGE = function (commcareVersion1, commcareVersion2) {
+    function parse(version) {
+        version = version.split('.');
+        version = [parseInt(version[0]), parseInt(version[1])];
+        return version;
+    }
+    commcareVersion1 = parse(commcareVersion1);
+    commcareVersion2 = parse(commcareVersion2);
+    if (commcareVersion1[0] > commcareVersion2[0]) {
+        return true;
+    } else if (commcareVersion1[0] === commcareVersion2[0]) {
+        return commcareVersion1[1] >= commcareVersion2[1];
+    } else {
+        return false;
+    }
+};
+
 export default {
     bitlyNatoPhonetic: bitlyNatoPhonetic,
     handleAjaxAppChange: handleAjaxAppChange,
+    versionGE: versionGE,
 };

--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap3/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap3/app_manager.js
@@ -10,6 +10,7 @@ import google from "analytix/js/google";
 import noopMetrics from "analytix/js/noopMetrics";
 import alertUser from "hqwebapp/js/bootstrap3/alert_user";
 import main from "hqwebapp/js/bootstrap3/main";
+import appManagerUtils from "app_manager/js/app_manager_utils";
 import menu from "app_manager/js/menu";
 import previewApp from "app_manager/js/bootstrap3/preview_app";
 import sectionChanger from "app_manager/js/section_changer";
@@ -48,7 +49,7 @@ module.updatePageTitle = function (pageTitle) {
 };
 
 module.checkCommcareVersion = function (version) {
-    return module.versionGE(module.commcareVersion(), version);
+    return appManagerUtils.versionGE(module.commcareVersion(), version);
 };
 
 module.checkAreWeThereYet = function (version) {
@@ -56,25 +57,7 @@ module.checkAreWeThereYet = function (version) {
         // We don't know the latest version. Assume this version has arrived
         return true;
     } else {
-        return module.versionGE(module.latestCommcareVersion(), version);
-    }
-};
-
-module.versionGE = function (commcareVersion1, commcareVersion2) {
-    function parse(version) {
-        version = version.split('.');
-        version = [parseInt(version[0]), parseInt(version[1])];
-        return version;
-    }
-    commcareVersion1 = parse(commcareVersion1);
-    commcareVersion2 = parse(commcareVersion2);
-    if (commcareVersion1[0] > commcareVersion2[0]) {
-        return true;
-    } else if (commcareVersion1[0] === commcareVersion2[0]) {
-        return commcareVersion1[1] >= commcareVersion2[1];
-
-    } else {
-        return false;
+        return appManagerUtils.versionGE(module.latestCommcareVersion(), version);
     }
 };
 

--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap5/app_manager.js
@@ -12,6 +12,7 @@ import noopMetrics from "analytix/js/noopMetrics";
 import alertUser from "hqwebapp/js/bootstrap5/alert_user";
 import main from "hqwebapp/js/bootstrap5/main";
 import menu from "app_manager/js/menu";
+import appManagerUtils from "app_manager/js/app_manager_utils";
 import previewApp from "app_manager/js/bootstrap5/preview_app";
 import sectionChanger from "app_manager/js/section_changer";
 import "hqwebapp/js/components/inline_edit";  // app, menu, and form names and comments all use these
@@ -49,7 +50,7 @@ module.updatePageTitle = function (pageTitle) {
 };
 
 module.checkCommcareVersion = function (version) {
-    return module.versionGE(module.commcareVersion(), version);
+    return appManagerUtils.versionGE(module.commcareVersion(), version);
 };
 
 module.checkAreWeThereYet = function (version) {
@@ -57,25 +58,7 @@ module.checkAreWeThereYet = function (version) {
         // We don't know the latest version. Assume this version has arrived
         return true;
     } else {
-        return module.versionGE(module.latestCommcareVersion(), version);
-    }
-};
-
-module.versionGE = function (commcareVersion1, commcareVersion2) {
-    function parse(version) {
-        version = version.split('.');
-        version = [parseInt(version[0]), parseInt(version[1])];
-        return version;
-    }
-    commcareVersion1 = parse(commcareVersion1);
-    commcareVersion2 = parse(commcareVersion2);
-    if (commcareVersion1[0] > commcareVersion2[0]) {
-        return true;
-    } else if (commcareVersion1[0] === commcareVersion2[0]) {
-        return commcareVersion1[1] >= commcareVersion2[1];
-
-    } else {
-        return false;
+        return appManagerUtils.versionGE(module.latestCommcareVersion(), version);
     }
 };
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/form_designer.js
@@ -67,6 +67,7 @@ $(function () {
             $("#formdesigner").vellum("get").data.core.form.on("question-create", function () {
                 noopMetricsTrack();
             });
+            document.dispatchEvent(new CustomEvent('vellum:ready'));
         },
     });
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap3/form_designer.js
@@ -4,6 +4,7 @@ import _ from "underscore";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import noopMetrics from "analytix/js/noopMetrics";
 import appManager from "app_manager/js/bootstrap3/app_manager";
+import "app_manager/js/forms/ocs_widget_form_designer_context";
 import "jquery-ui/ui/widgets/sortable";
 import "jquery-ui-built-themes/redmond/jquery-ui.min.css";
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/form_designer.js
@@ -4,6 +4,7 @@ import _ from "underscore";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import noopMetrics from "analytix/js/noopMetrics";
 import appManager from "app_manager/js/bootstrap5/app_manager";
+import "app_manager/js/forms/ocs_widget_form_designer_context";
 import "jquery-ui/ui/widgets/sortable";
 import "jquery-ui-built-themes/redmond/jquery-ui.min.css";
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/bootstrap5/form_designer.js
@@ -67,6 +67,7 @@ $(function () {
             $("#formdesigner").vellum("get").data.core.form.on("question-create", function () {
                 noopMetricsTrack();
             });
+            document.dispatchEvent(new CustomEvent('vellum:ready'));
         },
     });
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -38,15 +38,15 @@ function _publishCurrentSelectedQuestion() {
         return;
     }
     ocsContext.setCurrentSelectedQuestion({
-        type: mug.options?.typeName,
-        question_id: mug.p?.nodeID || undefined,
+        type: mug.options.typeName,
+        question_id: mug.p.nodeID || undefined,
         path: mug.hashtagPath || undefined,
     });
 }
 
 function _initListener() {
     const vellum = _vellum();
-    const form = vellum?.data?.core?.form;
+    const form = vellum?.data.core.form;
     if (!form) {
         return;
     }

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -24,7 +24,7 @@ function _publishXml() {
 function extractQuestionTypes(form) {
     const types = {};
     form.walkMugs(function (mug) {
-        if (mug.options.typeName) {
+        if (mug.absolutePath && mug.options.typeName) {
             types[mug.absolutePath] = mug.options.typeName;
         }
     });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import _ from "underscore";
+import initialPageData from "hqwebapp/js/initial_page_data";
 import ocsContext, {WIDGET_SELECTOR} from "hqwebapp/js/ocs_widget_context_setter";
 
 const FORMDESIGNER = '#formdesigner';
@@ -53,6 +54,7 @@ function _initListener() {
     _publishXml();
     _publishQuestionTypes();
     _publishCurrentSelectedQuestion();
+    ocsContext.setModuleName(initialPageData.get('module_name'));
     form.on('change', _.debounce(function () {
         _publishXml();
         _publishQuestionTypes();

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -92,7 +92,7 @@ function _initListener() {
         _publishXml();
         _publishQuestionTypes();
     }, PUBLISH_DEBOUNCE_MS));
-    // User clicks a different question without editing don't fire form.change.
+    // User clicks a different question without editing doesn't fire form.change.
     vellum.data.core.$tree.on('select_node.jstree', _publishCurrentSelectedQuestion);
 }
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -10,11 +10,25 @@ function _vellum() {
     return $(FORMDESIGNER).vellum("get");
 }
 
+function extractFormXml(vellum) {
+    return vellum.createXML({withCaseMappings: true});
+}
+
 function _publishXml() {
-    const xml = $(FORMDESIGNER).vellum("createXML", {withCaseMappings: true});
+    const xml = extractFormXml(_vellum());
     if (xml) {
         ocsContext.setFormXml(xml);
     }
+}
+
+function extractQuestionTypes(form) {
+    const types = {};
+    form.walkMugs(function (mug) {
+        if (mug.options.typeName) {
+            types[mug.absolutePath] = mug.options.typeName;
+        }
+    });
+    return types;
 }
 
 function _publishQuestionTypes() {
@@ -22,16 +36,10 @@ function _publishQuestionTypes() {
     if (!form) {
         return;
     }
-    const types = {};
-    form.walkMugs(function (mug) {
-        if (mug.options.typeName) {
-            types[mug.absolutePath] = mug.options.typeName;
-        }
-    });
-    ocsContext.setQuestionTypes(types);
+    ocsContext.setQuestionTypes(extractQuestionTypes(form));
 }
 
-function _buildSelectedQuestion(mug) {
+function buildSelectedQuestion(mug) {
     if (!mug) {
         return null;
     }
@@ -62,10 +70,12 @@ function _buildSelectedQuestion(mug) {
     };
 }
 
+function extractSelectedQuestion(vellum) {
+    return buildSelectedQuestion(vellum?.getCurrentlySelectedMug());
+}
+
 function _publishCurrentSelectedQuestion() {
-    ocsContext.setCurrentSelectedQuestion(
-        _buildSelectedQuestion(_vellum()?.getCurrentlySelectedMug()),
-    );
+    ocsContext.setCurrentSelectedQuestion(extractSelectedQuestion(_vellum()));
 }
 
 function _initListener() {
@@ -92,3 +102,5 @@ $(function () {
     }
     document.addEventListener('vellum:ready', _initListener, {once: true});
 });
+
+export {extractFormXml, extractQuestionTypes, extractSelectedQuestion};

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -5,6 +5,10 @@ import ocsContext, {WIDGET_SELECTOR} from "hqwebapp/js/ocs_widget_context_setter
 const FORMDESIGNER = '#formdesigner';
 const PUBLISH_DEBOUNCE_MS = 1000;
 
+function _vellum() {
+    return $(FORMDESIGNER).vellum("get");
+}
+
 function _publishXml() {
     const xml = $(FORMDESIGNER).vellum("createXML", {withCaseMappings: true});
     if (xml) {
@@ -13,7 +17,7 @@ function _publishXml() {
 }
 
 function _initListener() {
-    const form = $(FORMDESIGNER).vellum("get")?.data?.core?.form;
+    const form = _vellum()?.data?.core?.form;
     if (!form) {
         return;
     }

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -1,0 +1,29 @@
+import $ from "jquery";
+import _ from "underscore";
+import ocsContext, {WIDGET_SELECTOR} from "hqwebapp/js/ocs_widget_context_setter";
+
+const FORMDESIGNER = '#formdesigner';
+const PUBLISH_DEBOUNCE_MS = 1000;
+
+function _publishXml() {
+    const xml = $(FORMDESIGNER).vellum("createXML", {withCaseMappings: true});
+    if (xml) {
+        ocsContext.setFormXml(xml);
+    }
+}
+
+function _initListener() {
+    const form = $(FORMDESIGNER).vellum("get")?.data?.core?.form;
+    if (!form) {
+        return;
+    }
+    _publishXml();
+    form.on('change', _.debounce(_publishXml, PUBLISH_DEBOUNCE_MS));
+}
+
+$(function () {
+    if (!document.querySelector(WIDGET_SELECTOR)) {
+        return;
+    }
+    document.addEventListener('vellum:ready', _initListener, {once: true});
+});

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -46,14 +46,14 @@ function buildSelectedQuestion(mug) {
     const parent = mug.parentMug;
     const belongsToQuestion = parent && {
         type: parent.options.typeName,
-        question_id: parent.p.nodeID || undefined,
-        path: parent.hashtagPath || undefined,
+        question_id: parent.p.nodeID,
+        path: parent.hashtagPath,
     };
 
     if (mug.__className === "Choice") {
         return {
             type: mug.options.typeName,
-            value: mug.p.nodeID || undefined,
+            value: mug.p.nodeID,
             belongs_to_question: belongsToQuestion,
         };
     }
@@ -65,8 +65,8 @@ function buildSelectedQuestion(mug) {
     }
     return {
         type: mug.options.typeName,
-        question_id: mug.p.nodeID || undefined,
-        path: mug.hashtagPath || undefined,
+        question_id: mug.p.nodeID,
+        path: mug.hashtagPath,
     };
 }
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -18,13 +18,13 @@ function _publishXml() {
 }
 
 function _publishQuestionTypes() {
-    const form = _vellum()?.data?.core?.form;
+    const form = _vellum()?.data.core.form;
     if (!form) {
         return;
     }
     const types = {};
     form.walkMugs(function (mug) {
-        if (mug.options?.typeName) {
+        if (mug.options.typeName) {
             types[mug.absolutePath] = mug.options.typeName;
         }
     });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -23,11 +23,10 @@ function _publishQuestionTypes() {
         return;
     }
     const types = {};
-    form.tree.walk(function (mug, _nodeID, processChildren) {
-        if (mug && mug.options?.typeName) {
+    form.walkMugs(function (mug) {
+        if (mug.options?.typeName) {
             types[mug.absolutePath] = mug.options.typeName;
         }
-        processChildren();
     });
     ocsContext.setQuestionTypes(types);
 }

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -16,13 +16,32 @@ function _publishXml() {
     }
 }
 
+function _publishQuestionTypes() {
+    const form = _vellum()?.data?.core?.form;
+    if (!form) {
+        return;
+    }
+    const types = {};
+    form.tree.walk(function (mug, _nodeID, processChildren) {
+        if (mug && mug.options?.typeName) {
+            types[mug.absolutePath] = mug.options.typeName;
+        }
+        processChildren();
+    });
+    ocsContext.setQuestionTypes(types);
+}
+
 function _initListener() {
     const form = _vellum()?.data?.core?.form;
     if (!form) {
         return;
     }
     _publishXml();
-    form.on('change', _.debounce(_publishXml, PUBLISH_DEBOUNCE_MS));
+    _publishQuestionTypes();
+    form.on('change', _.debounce(function () {
+        _publishXml();
+        _publishQuestionTypes();
+    }, PUBLISH_DEBOUNCE_MS));
 }
 
 $(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -31,17 +31,34 @@ function _publishQuestionTypes() {
     ocsContext.setQuestionTypes(types);
 }
 
+function _publishCurrentSelectedQuestion() {
+    const mug = _vellum()?.getCurrentlySelectedMug();
+    if (!mug) {
+        ocsContext.setCurrentSelectedQuestion(null);
+        return;
+    }
+    ocsContext.setCurrentSelectedQuestion({
+        type: mug.options?.typeName,
+        question_id: mug.p?.nodeID || undefined,
+        path: mug.hashtagPath || undefined,
+    });
+}
+
 function _initListener() {
-    const form = _vellum()?.data?.core?.form;
+    const vellum = _vellum();
+    const form = vellum?.data?.core?.form;
     if (!form) {
         return;
     }
     _publishXml();
     _publishQuestionTypes();
+    _publishCurrentSelectedQuestion();
     form.on('change', _.debounce(function () {
         _publishXml();
         _publishQuestionTypes();
     }, PUBLISH_DEBOUNCE_MS));
+    // User clicks a different question without editing don't fire form.change.
+    vellum.data.core.$tree.on('select_node.jstree', _publishCurrentSelectedQuestion);
 }
 
 $(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -31,17 +31,41 @@ function _publishQuestionTypes() {
     ocsContext.setQuestionTypes(types);
 }
 
-function _publishCurrentSelectedQuestion() {
-    const mug = _vellum()?.getCurrentlySelectedMug();
+function _buildSelectedQuestion(mug) {
     if (!mug) {
-        ocsContext.setCurrentSelectedQuestion(null);
-        return;
+        return null;
     }
-    ocsContext.setCurrentSelectedQuestion({
+    const parent = mug.parentMug;
+    const belongsToQuestion = parent && {
+        type: parent.options.typeName,
+        question_id: parent.p.nodeID || undefined,
+        path: parent.hashtagPath || undefined,
+    };
+
+    if (mug.__className === "Choice") {
+        return {
+            type: mug.options.typeName,
+            value: mug.p.nodeID || undefined,
+            belongs_to_question: belongsToQuestion,
+        };
+    }
+    if (mug.__className === "Itemset") {
+        return {
+            type: mug.options.typeName,
+            belongs_to_question: belongsToQuestion,
+        };
+    }
+    return {
         type: mug.options.typeName,
         question_id: mug.p.nodeID || undefined,
         path: mug.hashtagPath || undefined,
-    });
+    };
+}
+
+function _publishCurrentSelectedQuestion() {
+    ocsContext.setCurrentSelectedQuestion(
+        _buildSelectedQuestion(_vellum()?.getCurrentlySelectedMug()),
+    );
 }
 
 function _initListener() {

--- a/corehq/apps/app_manager/static/app_manager/js/releases/bootstrap3/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/bootstrap3/releases.js
@@ -5,7 +5,7 @@ import google from "analytix/js/google";
 import noopMetrics from "analytix/js/noopMetrics";
 import downloadAsyncModal from "app_manager/js/bootstrap3/download_async_modal";
 import initialPageData from "hqwebapp/js/initial_page_data";
-import appManager from "app_manager/js/bootstrap3/app_manager";
+import appManagerUtils from "app_manager/js/app_manager_utils";
 import menu from "app_manager/js/menu";
 import "hqwebapp/js/bootstrap3/knockout_bindings.ko";  // openModal binding
 
@@ -37,7 +37,7 @@ function savedAppModel(appData, releasesMain) {
     self.app_code = ko.observable(null);
     self.failed_url_generation = ko.observable(false);
     self.allowOfflineInstall = ko.observable(function () {
-        return appManager.versionGE(self.build_spec.version(), '2.13.0');
+        return appManagerUtils.versionGE(self.build_spec.version(), '2.13.0');
     });
     self.build_profile = ko.observable('');
 

--- a/corehq/apps/app_manager/static/app_manager/js/releases/bootstrap5/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/bootstrap5/releases.js
@@ -6,7 +6,7 @@ import google from "analytix/js/google";
 import noopMetrics from "analytix/js/noopMetrics";
 import downloadAsyncModal from "app_manager/js/bootstrap5/download_async_modal";
 import initialPageData from "hqwebapp/js/initial_page_data";
-import appManager from "app_manager/js/bootstrap5/app_manager";
+import appManagerUtils from "app_manager/js/app_manager_utils";
 import menu from "app_manager/js/menu";
 import "hqwebapp/js/bootstrap5/knockout_bindings.ko";  // openModal binding
 
@@ -38,7 +38,7 @@ function savedAppModel(appData, releasesMain) {
     self.app_code = ko.observable(null);
     self.failed_url_generation = ko.observable(false);
     self.allowOfflineInstall = ko.observable(function () {
-        return appManager.versionGE(self.build_spec.version(), '2.13.0');
+        return appManagerUtils.versionGE(self.build_spec.version(), '2.13.0');
     });
     self.build_profile = ko.observable('');
 

--- a/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/main.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/main.js
@@ -1,0 +1,8 @@
+import hqMocha from "mocha/js/main";
+
+import "bootstrap";
+import "jquery.vellum.dev";
+
+import "app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec";
+
+hqMocha.run();

--- a/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
@@ -89,6 +89,16 @@ describe("OCS form designer context extractors", function () {
             assert.equal(types["/data/first_name"], "Text");
             assert.equal(types["/data/age"], "Integer");
         });
+
+        it("excludes control-only mugs (choices, lookup tables) that have no path", function () {
+            addQuestion("Select", "color");
+            addQuestion("Choice", "red");
+
+            const types = extractQuestionTypes(vellum.data.core.form);
+
+            assert.equal(types["/data/color"], "Multiple Choice");
+            assert.notProperty(types, "null");
+        });
     });
 
     describe("extractSelectedQuestion", function () {

--- a/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
@@ -1,0 +1,128 @@
+import $ from "jquery";
+
+import {
+    extractFormXml,
+    extractQuestionTypes,
+    extractSelectedQuestion,
+} from "app_manager/js/forms/ocs_widget_form_designer_context";
+
+// Minimum options to boot the bundled Vellum
+const VELLUM_OPTIONS = {
+    core: {
+        loadDelay: 0,
+        formName: "Test Form",
+        dataSourcesEndpoint: function (callback) { callback([]); },
+        saveUrl: function () {},
+    },
+    javaRosa: {
+        langs: ["en"],
+        displayLanguage: "en",
+    },
+    features: {
+        disable_popovers: true,
+    },
+    intents: {
+        templates: [{id: "intent", name: "Intent", mime: "text/plain"}],
+    },
+};
+
+function bootVellum() {
+    return new Promise(function (resolve) {
+        const $fd = $('<div/>').appendTo("body");
+        let ready = false;
+        VELLUM_OPTIONS.core.onReady = function () {
+            if (!ready) {
+                ready = true;
+                resolve({$fd: $fd, vellum: $fd.vellum("get")});
+            }
+        };
+        $fd.vellum(VELLUM_OPTIONS);
+    });
+}
+
+describe("OCS form designer context extractors", function () {
+    this.timeout(20000);
+
+    let $fd, vellum;
+
+    function addQuestion(type, nodeID) {
+        const mug = $fd.vellum("addQuestion", type);
+        if (nodeID) {
+            mug.p.nodeID = nodeID;
+        }
+        return mug;
+    }
+
+    before(async function () {
+        ({$fd, vellum} = await bootVellum());
+    });
+
+    beforeEach(function () {
+        vellum.loadXML("");
+    });
+
+    after(function () {
+        if (vellum) {
+            vellum.destroy();
+        }
+        $fd.remove();
+    });
+
+    describe("extractFormXml", function () {
+        it("returns the form XML including its questions", function () {
+            addQuestion("Text", "village_name");
+
+            const xml = extractFormXml(vellum);
+
+            assert.isString(xml);
+            assert.include(xml, '<bind nodeset="/data/village_name" type="xsd:string" />');
+        });
+    });
+
+    describe("extractQuestionTypes", function () {
+        it("maps each mug's absolute path to its Vellum type name", function () {
+            addQuestion("Text", "first_name");
+            addQuestion("Int", "age");
+
+            const types = extractQuestionTypes(vellum.data.core.form);
+
+            assert.equal(types["/data/first_name"], "Text");
+            assert.equal(types["/data/age"], "Integer");
+        });
+    });
+
+    describe("extractSelectedQuestion", function () {
+        it("returns null when nothing is selected", function () {
+            vellum.data.core.$tree.jstree("deselect_all");
+
+            assert.isNull(extractSelectedQuestion(vellum));
+        });
+
+        it("builds the shape for the selected question", function () {
+            const mug = addQuestion("Text", "patient_name");
+            vellum.setCurrentMug(mug);
+
+            assert.deepEqual(extractSelectedQuestion(vellum), {
+                type: "Text",
+                question_id: "patient_name",
+                path: mug.hashtagPath,
+            });
+        });
+
+        it("builds the shape for a selected choice and its parent question", function () {
+            const select = addQuestion("Select", "color");
+            const choice = addQuestion("Choice", "red");
+            vellum.setCurrentMug(choice);
+
+            assert.deepEqual(extractSelectedQuestion(vellum), {
+                type: "Choice",
+                value: "red",
+                belongs_to_question: {
+                    type: "Multiple Choice",
+                    question_id: "color",
+                    path: select.hashtagPath,
+                },
+            });
+        });
+    });
+});

--- a/corehq/apps/app_manager/templates/app_manager/bootstrap3/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/bootstrap3/form_designer.html
@@ -32,6 +32,7 @@
 {% block form-view %}
   {% initial_page_data 'days_since_created' request.couch_user.days_since_created %}
   {% initial_page_data 'form_name' form.name|trans:langs %}
+  {% initial_page_data 'module_name' module.name|trans:langs %}
   {% initial_page_data 'form_comment' form.comment %}
   {% initial_page_data 'form_uses_cases' form.uses_cases %}
   {% initial_page_data 'is_registration_form' form.is_registration_form %}

--- a/corehq/apps/app_manager/templates/app_manager/bootstrap5/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/bootstrap5/form_designer.html
@@ -32,6 +32,7 @@
 {% block form-view %}
   {% initial_page_data 'days_since_created' request.couch_user.days_since_created %}
   {% initial_page_data 'form_name' form.name|trans:langs %}
+  {% initial_page_data 'module_name' module.name|trans:langs %}
   {% initial_page_data 'form_comment' form.comment %}
   {% initial_page_data 'form_uses_cases' form.uses_cases %}
   {% initial_page_data 'is_registration_form' form.is_registration_form %}

--- a/corehq/apps/app_manager/templates/app_manager/spec/form_designer_context/mocha.html
+++ b/corehq/apps/app_manager/templates/app_manager/spec/form_designer_context/mocha.html
@@ -1,0 +1,4 @@
+{% extends "mocha/base.html" %}
+{% load hq_shared_tags %}
+
+{% js_entry_b3 "app_manager/spec/form_designer_context/main" %}

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
@@ -62,6 +62,16 @@ function setAppStructure(appStructure) {
     _publish();
 }
 
+function _setFormContextField(field, value) {
+    _currentContext.form_context = _currentContext.form_context || {};
+    _currentContext.form_context[field] = value;
+    _publish();
+}
+
+function setFormXml(formXml) {
+    _setFormContextField('form_xml', formXml);
+}
+
 export {WIDGET_SELECTOR};
 export default {
     setUrl: setUrl,
@@ -73,4 +83,5 @@ export default {
     setIsEnterpriseAdmin: setIsEnterpriseAdmin,
     setPermissions: setPermissions,
     setAppStructure: setAppStructure,
+    setFormXml: setFormXml,
 };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
@@ -76,6 +76,10 @@ function setQuestionTypes(questionTypes) {
     _setFormContextField('question_types', questionTypes);
 }
 
+function setCurrentSelectedQuestion(currentSelectedQuestion) {
+    _setFormContextField('current_selected_question', currentSelectedQuestion);
+}
+
 export {WIDGET_SELECTOR};
 export default {
     setUrl: setUrl,
@@ -89,4 +93,5 @@ export default {
     setAppStructure: setAppStructure,
     setFormXml: setFormXml,
     setQuestionTypes: setQuestionTypes,
+    setCurrentSelectedQuestion: setCurrentSelectedQuestion,
 };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
@@ -72,6 +72,10 @@ function setFormXml(formXml) {
     _setFormContextField('form_xml', formXml);
 }
 
+function setQuestionTypes(questionTypes) {
+    _setFormContextField('question_types', questionTypes);
+}
+
 export {WIDGET_SELECTOR};
 export default {
     setUrl: setUrl,
@@ -84,4 +88,5 @@ export default {
     setPermissions: setPermissions,
     setAppStructure: setAppStructure,
     setFormXml: setFormXml,
+    setQuestionTypes: setQuestionTypes,
 };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_context_setter.js
@@ -80,6 +80,10 @@ function setCurrentSelectedQuestion(currentSelectedQuestion) {
     _setFormContextField('current_selected_question', currentSelectedQuestion);
 }
 
+function setModuleName(moduleName) {
+    _setFormContextField('module_name', moduleName);
+}
+
 export {WIDGET_SELECTOR};
 export default {
     setUrl: setUrl,
@@ -94,4 +98,5 @@ export default {
     setFormXml: setFormXml,
     setQuestionTypes: setQuestionTypes,
     setCurrentSelectedQuestion: setCurrentSelectedQuestion,
+    setModuleName: setModuleName,
 };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_global_context.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_global_context.js
@@ -59,8 +59,19 @@ function _observePageTitleChanges() {
 }
 
 function _observeUrlChanges() {
-    window.addEventListener('hashchange', ocsContext.setUrl(window.location.href));
-    window.addEventListener('popstate', ocsContext.setUrl(window.location.href));
+    var update = function () { ocsContext.setUrl(window.location.href); };
+    window.addEventListener('hashchange', update);
+    window.addEventListener('popstate', update);
+    // history.pushState/replaceState don't fire any event natively, so
+    // monkey-patch them. Vellum uses replaceState when the user selects
+    // a different question — without this, the URL change goes unseen.
+    ['pushState', 'replaceState'].forEach(function (method) {
+        var original = history[method];
+        history[method] = function () {
+            original.apply(this, arguments);
+            update();
+        };
+    });
 }
 
 // Only listen to top window to ignore App Preview iframe

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_global_context.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_widget_global_context.js
@@ -34,7 +34,7 @@ function _fetchMyRole() {
             if (data.permissions !== undefined) {
                 ocsContext.setPermissions(data.permissions);
             }
-        })
+        });
 }
 
 function _setInitialContext() {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/form_designer.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/app_manager/form_designer.html.diff.txt
@@ -15,7 +15,7 @@
  
  {% block title %}{# controlled by app_manager/js/form_designer.js #}{% endblock %}
  
-@@ -42,7 +42,7 @@
+@@ -43,7 +43,7 @@
    <div id="formdesigner" class="clearfix loading"></div>
  
    <script type="text/html" id="js-fd-form-actions">
@@ -24,7 +24,7 @@
        <!-- B5 TODO: Replace btn-form-action with bootstrap 5 utils after migration -->
        <a
          class="btn btn-form-action track-usage-link custom-button-style"
-@@ -67,7 +67,7 @@
+@@ -68,7 +68,7 @@
    </script>
  
    <script type="text/html" id="js-fd-view-submissions-only">
@@ -33,7 +33,7 @@
        {% include "app_manager/partials/view_submissions_button.html" with btn_style='btn-form-action custom-button-style' %}
      </div>
    </script>
-@@ -85,7 +85,7 @@
+@@ -86,7 +86,7 @@
    </script>
  
    <script type="text/html" id="fd-hq-helptext-close">

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/app_manager.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/app_manager.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -2,16 +2,17 @@
+@@ -2,17 +2,18 @@
  import $ from "jquery";
  import ko from "knockout";
  import _ from "underscore";
@@ -15,13 +15,15 @@
 -import main from "hqwebapp/js/bootstrap3/main";
 +import alertUser from "hqwebapp/js/bootstrap5/alert_user";
 +import main from "hqwebapp/js/bootstrap5/main";
- import menu from "app_manager/js/menu";
++import menu from "app_manager/js/menu";
+ import appManagerUtils from "app_manager/js/app_manager_utils";
+-import menu from "app_manager/js/menu";
 -import previewApp from "app_manager/js/bootstrap3/preview_app";
 +import previewApp from "app_manager/js/bootstrap5/preview_app";
  import sectionChanger from "app_manager/js/section_changer";
  import "hqwebapp/js/components/inline_edit";  // app, menu, and form names and comments all use these
  import "app_manager/js/ocs_widget_app_manager_context";
-@@ -180,25 +181,30 @@
+@@ -163,25 +164,30 @@
   * @private
   */
  var _initAddItemPopovers = function () {
@@ -67,7 +69,7 @@
              var dataType = $(e.target).closest('button').data('type'),
                  stopSubmit = $(e.target).closest('button').data('stopsubmit') === 'yes',
                  $form;
-@@ -208,7 +214,7 @@
+@@ -191,7 +197,7 @@
              }
  
              var caseAction =  $(e.target).closest('button').data('case-action'),
@@ -76,7 +78,7 @@
                  moduleId = $popoverContent.data("module-unique-id"),
                  $trigger = $('.js-add-new-item[data-module-unique-id="' + moduleId + '"]');
  
-@@ -223,13 +229,13 @@
+@@ -206,13 +212,13 @@
          });
      }).on('click', function (e) {
          e.preventDefault();
@@ -92,7 +94,7 @@
          }
      });
  };
-@@ -344,7 +350,7 @@
+@@ -327,7 +333,7 @@
          });
      }
      function promptToSaveOrdering() {
@@ -101,7 +103,7 @@
      }
      function initSortable($sortable) {
          var options = {
-@@ -481,7 +487,9 @@
+@@ -464,7 +470,9 @@
          }
      });
  
@@ -112,7 +114,7 @@
  
      // https://github.com/twitter/bootstrap/issues/6122
      // this is necessary to get popovers to be able to extend
-@@ -509,13 +517,17 @@
+@@ -492,13 +500,17 @@
      });
  
      // Handling for popup displayed when accessing a deleted app
@@ -137,7 +139,7 @@
  
      // Set up app preview
      previewApp.initPreviewWindow();
-@@ -537,15 +549,15 @@
+@@ -520,15 +532,15 @@
          var $form = $('#new-module-form');
  
          if (moduleType === "case") {
@@ -156,7 +158,7 @@
              $form.submit();
          }
      });
-@@ -587,15 +599,13 @@
+@@ -570,15 +582,13 @@
  
              $caseType.on('change', function () {
                  var valueNoSpaces = $(this).val();
@@ -173,7 +175,7 @@
                  $createBtn.prop('disabled', false);
  
                  if (!valueNoSpaces) {
-@@ -604,9 +614,8 @@
+@@ -587,9 +597,8 @@
                  }
  
                  function displayError(errorMsg) {
@@ -184,7 +186,7 @@
                      $help.hide();
                      $createBtn.prop('disabled', true);
                  }
-@@ -643,14 +652,14 @@
+@@ -626,14 +635,14 @@
          newCaseTypeHiddenInput.val(value);
  
          $('.new-module-icon').removeClass().addClass("fa fa-refresh fa-spin");
@@ -202,7 +204,7 @@
      });
  
      // Clear selection when modal is hidden
-@@ -672,7 +681,7 @@
+@@ -655,7 +664,7 @@
      $('.new-module-option').each(function () {
          var type = $(this).data('type');
          if (hoverHelpTexts[type]) {

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/forms/form_designer.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/forms/form_designer.js.diff.txt
@@ -6,6 +6,6 @@
  import noopMetrics from "analytix/js/noopMetrics";
 -import appManager from "app_manager/js/bootstrap3/app_manager";
 +import appManager from "app_manager/js/bootstrap5/app_manager";
+ import "app_manager/js/forms/ocs_widget_form_designer_context";
  import "jquery-ui/ui/widgets/sortable";
  import "jquery-ui-built-themes/redmond/jquery-ui.min.css";
- 

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/releases/releases.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/releases/releases.js.diff.txt
@@ -10,8 +10,7 @@
 -import downloadAsyncModal from "app_manager/js/bootstrap3/download_async_modal";
 +import downloadAsyncModal from "app_manager/js/bootstrap5/download_async_modal";
  import initialPageData from "hqwebapp/js/initial_page_data";
--import appManager from "app_manager/js/bootstrap3/app_manager";
-+import appManager from "app_manager/js/bootstrap5/app_manager";
+ import appManagerUtils from "app_manager/js/app_manager_utils";
  import menu from "app_manager/js/menu";
 -import "hqwebapp/js/bootstrap3/knockout_bindings.ko";  // openModal binding
 +import "hqwebapp/js/bootstrap5/knockout_bindings.ko";  // openModal binding


### PR DESCRIPTION
## Product Description

Adds form-designer-specific context to the OCS chat widget's `pageContext` so the bot can answer questions about the form being edited (its XML, its question types, the currently-selected question, and the parent module).

Basically everything in form designer except for the error that user saw, which will be added in a follow up PR.

The published shape:

```js
pageContext.form_context = {
    form_xml: "<?xml ...",
    question_types: {
        "/data/name": "Text",
        "/data/age": "Integer",
        "/data/photo": "Image Capture",
        "/data/computed_x": "Hidden Value"
    },
    current_selected_question: {
        type: "Text",
        question_id: "name",
        path: "#form/name"
    },
    module_name: "Household"
}
```

## Technical Summary

Ticket: https://dimagi.atlassian.net/browse/SAAS-19847
Test triggered manually: https://github.com/dimagi/commcare-hq/actions/runs/27696323067

Review by commit 🐟 

Each commit add a piece of information to `pageContext.form_context`


## Feature Flag

`OCS_CHATBOT` feature preview.

## Safety Assurance

### Safety story

- Pure additions to send data to OCS. No existing function are impacted.


### Automated test coverage


### QA Plan


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.

### Labels & Review

- [x] Risk label is set correctly (low — additions only, behind feature preview).
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.