### PR TITLE
Make `CaseTransaction` dump much faster (for real this time) by avoid the cross-table join

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -10,6 +10,7 @@ from corehq.apps.dump_reload.exceptions import DomainDumpError
 from corehq.apps.dump_reload.interface import DataDumper
 from corehq.apps.dump_reload.sql.filters import (
     DEFAULT_CHUNK_SIZE,
+    CaseIDFilter,
     FilteredModelIteratorBuilder,
     ManyFilters,
     MultimediaBlobMetaFilter,
@@ -40,8 +41,8 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('form_processor.CommCareCaseIndex', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.CaseAttachment', SimpleFilter('case__domain'),
                                  pagination_key=('case_id', 'pk'), use_fk_index_hint=True),
-    FilteredModelIteratorBuilder('form_processor.CaseTransaction', SimpleFilter('case__domain'),
-                                 pagination_key=('case_id', 'pk'), use_fk_index_hint=True),
+    FilteredModelIteratorBuilder('form_processor.CaseTransaction', CaseIDFilter(),
+                                 pagination_key=('case_id', 'pk')),
     FilteredModelIteratorBuilder('form_processor.LedgerValue', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.LedgerTransaction', SimpleFilter('case__domain'),
                                  pagination_key=('case_id', 'pk'), use_fk_index_hint=True),

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -92,6 +92,52 @@ class IDFilter(DomainFilter):
             yield Q(**{query_kwarg: chunk})
 
 
+class CaseIDFilter(IDFilter):
+    """Filter a case-owned model to a domain by its case_ids.
+
+    Streams the domain's case_ids for a shard and yields them in
+    ``Q(case_id__in=chunk)`` batches. This avoids joining the model back to
+    ``CommCareCase`` (via ``case__domain``) just to resolve the domain, seeking the
+    model's own indexed ``case_id`` column instead.
+
+    Case IDs are not chunked in sorted order, so the final results will not
+    be globally sorted. Results for each case id chunk will be sorted as
+    necessary for pagination, but will not be sorted with respect to the results
+    for other chunks.
+
+    Limitation: Consumers must paginate by ``('case_id', 'pk')``, not a deeper key like
+    ``('case_id', 'server_date', 'pk')``. A deeper key performs atrociously for unintuitive
+    reasons. It surfaces on queries where the cursor
+    case_id is greater than the alphabetically first case_id in the chunk, and results in
+    (I think) a linear index scan of a huge range from the first case_id to the cursor case_id
+    that returns no results (because they're all less than the cursor). This pathological
+    behavior may be fixed in PG 17+.
+    """
+
+    def __init__(self, chunksize=1000):
+        super().__init__('case_id', None, chunksize=chunksize)
+
+    def get_ids(self, domain_name, db_alias=None):
+        """Stream the domain's case_ids on a shard, paginating by ``(type, id)``"""
+        from corehq.form_processor.models import CommCareCase
+        queryset = (
+            CommCareCase.objects.using(db_alias)
+            .filter(domain=domain_name)
+            .only('case_id', 'type')
+        )
+        for case in queryset_to_iterator(
+            queryset, CommCareCase, limit=DEFAULT_CHUNK_SIZE,
+            ignore_ordering=True, pagination_key=('type', 'id'),
+        ):
+            yield case.case_id
+
+    def count(self, domain_name):
+        # count is per-shard but db_alias is unknown here, and IDFilter.count would
+        # call get_ids() against the wrong (non-partition) database. Return None so
+        # the builder counts each Q(case_id__in=...) queryset per shard instead.
+        return None
+
+
 class UserIDFilter(IDFilter):
     def __init__(self, user_id_field, include_web_users=True):
         super().__init__(user_id_field, None)

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -3,7 +3,12 @@ from django.test import TestCase
 
 from casexml.apps.case.mock import CaseFactory
 
-from corehq.apps.dump_reload.sql.filters import MultimediaBlobMetaFilter, FilteredModelIteratorBuilder
+from corehq.apps.dump_reload.sql.filters import (
+    CaseIDFilter,
+    FilteredModelIteratorBuilder,
+    MultimediaBlobMetaFilter,
+    SimpleFilter,
+)
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.blobs.models import BlobMeta
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
@@ -12,7 +17,6 @@ from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 from corehq.motech.repeaters.models import Repeater
 from corehq.motech.models import ConnectionSettings
-from corehq.apps.dump_reload.sql.filters import SimpleFilter
 
 
 class TestUseAllObjectsInModelIteratorBuilder(TestCase):
@@ -140,6 +144,48 @@ class TestPagingChildModelByParentId(TestCase):
         assert {txn.case_id for txn in transactions} == {case.case_id for case in self.cases}
         # no dupes; (case_id, id) is the unique key -- id (pk) repeats across shards
         assert len({(txn.case_id, txn.id) for txn in transactions}) == len(transactions)
+
+
+@sharded
+class TestCaseIDFilter(TestCase):
+    domain = 'test-caseid-filter'
+    other_domain = 'test-caseid-filter-other'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.cases = [CaseFactory(cls.domain).create_case() for _ in range(3)]
+        cls.other_case = CaseFactory(cls.other_domain).create_case()
+        cls.addClassCleanup(FormProcessorTestUtils.delete_all_cases_forms_ledgers, cls.domain)
+        cls.addClassCleanup(FormProcessorTestUtils.delete_all_cases_forms_ledgers, cls.other_domain)
+
+    def _ids_across_shards(self, filter_):
+        ids = []
+        for db_alias in get_db_aliases_for_partitioned_query():
+            ids.extend(filter_.get_ids(self.domain, db_alias=db_alias))
+        return ids
+
+    def test_get_ids_returns_only_this_domains_case_ids(self):
+        found = set(self._ids_across_shards(CaseIDFilter()))
+        assert found == {case.case_id for case in self.cases}
+        assert self.other_case.case_id not in found
+
+    def test_get_filters_yields_chunked_case_id_in_queries(self):
+        chunks = [
+            q
+            for db_alias in get_db_aliases_for_partitioned_query()
+            for q in CaseIDFilter(chunksize=2).get_filters(self.domain, db_alias=db_alias)
+        ]
+        all_ids = []
+        for q in chunks:
+            (lookup, ids), = q.children  # Q(case_id__in=[...]) -> [('case_id__in', [...])]
+            assert lookup == 'case_id__in'
+            assert len(ids) <= 2
+            all_ids.extend(ids)
+        assert set(all_ids) == {case.case_id for case in self.cases}
+
+    def test_count_is_none(self):
+        assert CaseIDFilter().count(self.domain) is None
 
 
 def test_dump_builders_with_fk_index_hint_have_a_foreign_key_leading_key():

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -188,6 +188,39 @@ class TestCaseIDFilter(TestCase):
         assert CaseIDFilter().count(self.domain) is None
 
 
+@sharded
+class TestCaseTransactionDumpViaCaseIDFilter(TestCase):
+    domain = 'test-casetxn-caseid-filter'
+    other_domain = 'test-casetxn-caseid-filter-other'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.cases = [CaseFactory(cls.domain).create_case() for _ in range(3)]
+        cls.other_case = CaseFactory(cls.other_domain).create_case()
+        cls.addClassCleanup(FormProcessorTestUtils.delete_all_cases_forms_ledgers, cls.domain)
+        cls.addClassCleanup(FormProcessorTestUtils.delete_all_cases_forms_ledgers, cls.other_domain)
+
+    def test_dumps_exactly_this_domains_transactions(self):
+        builder = FilteredModelIteratorBuilder(
+            'form_processor.CaseTransaction',
+            CaseIDFilter(chunksize=2),  # 3 cases over batches of 2 ids
+            pagination_key=('case_id', 'pk'),
+        )
+        transactions = [
+            txn
+            for db_alias in get_db_aliases_for_partitioned_query()
+            # chunk_size=1 forces queryset_to_iterator to page within each IN batch
+            for iterator in builder.build(self.domain, CaseTransaction, db_alias).iterators(1)
+            for txn in iterator
+        ]
+
+        assert {txn.case_id for txn in transactions} == {case.case_id for case in self.cases}
+        assert self.other_case.case_id not in {txn.case_id for txn in transactions}
+        # no dupes; (case_id, id) is the unique key -- id (pk) repeats across shards
+        assert len({(txn.case_id, txn.id) for txn in transactions}) == len(transactions)
+
+
 def test_dump_builders_with_fk_index_hint_have_a_foreign_key_leading_key():
     """Guard the dump config: every builder that sets use_fk_index_hint must have a
     leading pagination key backed by a foreign key (so the parent column can be


### PR DESCRIPTION
## Product Description
No user-facing change. This affects how the SQL domain-data dump selects a domain's `CaseTransaction` rows.

## Technical Summary
**Problem.** `CaseTransaction` is a primary bottleneck in `dump_domain_data` and my [past attempt](https://github.com/dimagi/commcare-hq/pull/37788) to speed it up yielded very disappointing results. The fundamental issue is the join between `CaseTransaction` and `CommCareCase` to filter by domain (which lives only on the case), and the fact that there is no single query structure to do this that is both pageable (which requires a total ordering) and executable using an query plan that efficiently rides indices. Adding a (domain, case_id) index on CommCareCase would likely fix this, but we'd like to avoid adding an index solely for this purpose.

**Solution.** A new `CaseIDFilter` filters `CaseTransaction` by the domain's case_ids directly (`case_id IN (...)`) for 1000 case ids at a time, so the query seeks `CaseTransaction`'s own `case_id` index and never touches the case table. Case ids are fetched in a separate paginated query, such that case_ids are streamed in and never all held in memory at once.

One might wonder why this is possible to do efficiently as two queries plus some python level orchestration but not possible to do in postgres. An important clue to that change is that the results will be sorted within each 1000 case id chunk, but not globally. The sorting lets us do pagination on the `CaseTransaction` query, and (case_id, id) is the sort order of choice, but we're now liberated from sorting all ~1M case_ids globally to get a global (case_id, id) ordering—the query planner sorts the 1000 cases to structure its index seeking and doesn't need to know or care bout any of the other case ids. And this is completely fine for our purposes because we don't care about the order in which we get the rows, just that we're getting all of them and with no duplicates.

### Tangent: Feel free to skip

This section is more for posterity / to document the surprising details of a direction not chosen.

#### Why `('case_id', 'pk')` and not `('case_id', 'server_date', 'pk')`?

Initially, I thought I'd use `('case_id', 'server_date', 'pk')` because it would help allow faster seeks when a single case had thousands of transactions against it. However, I discovered in the process that if the case_id in our cursor (the keyset from the last row of the last query) is greater than any of the keys in the case_id chunk—which would be common—the otherwise very efficient query degrades _atrociously_. Logically, the query planner could just throw away any case_ids in the `case_id IN (...)` clause that are less than the case_id in our cursor—any rows fetched for those case_ids would obviously be filtered out by the (case_id, ...) > (last_case_id, ...) condition. (According to Claude, Postgres does this starting with PG 17, but I haven't confirmed that.) Further, for some reason, even though the query plan is exactly the same, the executor seeks to the index using the first case id from the sorted list, _and then does a linear scan of the whole index_ until it gets to a matching row—this is Claude's guess, and I haven't confirmed it against other sources, but it matches the scale of the degradation: milliseconds versus minutes.

I don't think I'll try to get to the bottom of this; instead, I reverted to using the shallower `('case_id', 'pk')`, which I confirmed empirically does not exhibit this same pathological behavior.

### Update (June 18, 2026): Empirical Results
On a representative large production domain, a test run shows that this takes the rate for a `CaseTransaction` dump from about **6 hours** per 1M rows to about **11 minutes** per 1M rows, a 30x+ improvement. (This is an end-to-end run across millions of rows, not spot checking individual SQL queries or extrapolation from a tiny sample.) Huge win!

## Feature Flag
None.

## Safety Assurance

### Safety story

Even though the change in the query structure is quite significant, the implementation uses well-worn patterns (IDFilter, queryset_to_iterator, paginating cases on `(type, id)`), that we've seen work, and the overall dump/reload round-trip is tested.

The one thing I want to look out for is whether the somewhat pathological case of thousands of transactions for a single case id ends up being a practical issue. If there are k transactions for one case, then for large k, fetching those k transactions becomes quadratic in k. I've seen examples of k around 24,000 (~5 pages of 5,000), and if there are a few of those, I don't think this would dominate. But if there's even one case with many times more than that, then the quadratic relationship begins to dominate and could become a significant problem.

### Automated test coverage
`corehq/apps/dump_reload/tests/test_sql_filters.py`:
- `TestCaseIDFilter` — domain isolation, chunked `Q(case_id__in=...)` batches, `count()` semantics.
- `TestCaseTransactionDumpViaCaseIDFilter` — end-to-end through the builder across shards and multiple `IN` chunks, with keyset paging forced inside a chunk, asserting exactly the domain's transactions and no duplicates.

`TestSQLDumpLoadShardedModels` exercises the real dump config end-to-end. It can't run in a local env without a Kafka broker (case creation in test setup publishes to Kafka, unrelated to this diff), so **CI is the gate** for the round-trip.

### QA Plan
Covered by the automated tests and the CI round-trip. A domain dump/reload on staging would exercise it end-to-end if desired.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
