### PR TITLE
Pick best currently-available option for each case/form child-model in `dump_domain_data`

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -33,14 +33,12 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('blobs.BlobMeta', MultimediaBlobMetaFilter()),
 
     FilteredModelIteratorBuilder('form_processor.XFormInstance', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('form_processor.XFormOperation', SimpleFilter('form__domain'),
-                                 pagination_key=('form_id', 'pk'), use_fk_index_hint=True),
+    FilteredModelIteratorBuilder('form_processor.XFormOperation', SimpleFilter('form__domain')),
 
     FilteredModelIteratorBuilder('form_processor.CommCareCase', SimpleFilter('domain'),
                                  pagination_key=("type", "id")),
     FilteredModelIteratorBuilder('form_processor.CommCareCaseIndex', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('form_processor.CaseAttachment', SimpleFilter('case__domain'),
-                                 pagination_key=('case_id', 'pk'), use_fk_index_hint=True),
+    FilteredModelIteratorBuilder('form_processor.CaseAttachment', SimpleFilter('case__domain')),
     FilteredModelIteratorBuilder('form_processor.CaseTransaction', CaseIDFilter(),
                                  pagination_key=('case_id', 'pk')),
     FilteredModelIteratorBuilder('form_processor.LedgerValue', SimpleFilter('domain')),

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -42,8 +42,8 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('form_processor.CaseTransaction', CaseIDFilter(),
                                  pagination_key=('case_id', 'pk')),
     FilteredModelIteratorBuilder('form_processor.LedgerValue', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('form_processor.LedgerTransaction', SimpleFilter('case__domain'),
-                                 pagination_key=('case_id', 'pk'), use_fk_index_hint=True),
+    FilteredModelIteratorBuilder('form_processor.LedgerTransaction', CaseIDFilter(),
+                                 pagination_key=('case_id', 'pk')),
 
     FilteredModelIteratorBuilder('case_search.DomainsNotInCaseSearchIndex', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('case_search.CaseSearchConfig', SimpleFilter('domain')),

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -9,10 +9,13 @@ from corehq.apps.dump_reload.sql.filters import (
     MultimediaBlobMetaFilter,
     SimpleFilter,
 )
+from corehq.apps.commtrack.helpers import make_product
+from corehq.apps.commtrack.tests.util import get_single_balance_block
+from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.blobs.models import BlobMeta
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
-from corehq.form_processor.models import CaseTransaction
+from corehq.form_processor.models import CaseTransaction, LedgerTransaction
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 from corehq.motech.repeaters.models import Repeater
@@ -221,6 +224,50 @@ class TestCaseTransactionDumpViaCaseIDFilter(TestCase):
         assert len({(txn.case_id, txn.id) for txn in transactions}) == len(transactions)
 
 
+@sharded
+class TestLedgerTransactionDumpViaCaseIDFilter(TestCase):
+    domain = 'test-ledgertxn-caseid-filter'
+    other_domain = 'test-ledgertxn-caseid-filter-other'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product = make_product(cls.domain, 'A Product', 'prodcode_a')
+        cls.other_product = make_product(cls.other_domain, 'A Product', 'prodcode_a')
+        cls.addClassCleanup(cls.product.delete)
+        cls.addClassCleanup(cls.other_product.delete)
+        cls.cases = [CaseFactory(cls.domain).create_case() for _ in range(3)]
+        cls.other_case = CaseFactory(cls.other_domain).create_case()
+        cls.addClassCleanup(FormProcessorTestUtils.delete_all_cases_forms_ledgers, cls.domain)
+        cls.addClassCleanup(FormProcessorTestUtils.delete_all_cases_forms_ledgers, cls.other_domain)
+        for case in cls.cases:
+            cls._set_balance(cls.domain, case.case_id, cls.product._id)
+        cls._set_balance(cls.other_domain, cls.other_case.case_id, cls.other_product._id)
+
+    @staticmethod
+    def _set_balance(domain, case_id, product_id):
+        submit_case_blocks([get_single_balance_block(case_id, product_id, 100)], domain)
+
+    def test_dumps_exactly_this_domains_transactions(self):
+        builder = FilteredModelIteratorBuilder(
+            'form_processor.LedgerTransaction',
+            CaseIDFilter(chunksize=2),  # 3 cases over batches of 2 ids
+            pagination_key=('case_id', 'pk'),
+        )
+        transactions = [
+            txn
+            for db_alias in get_db_aliases_for_partitioned_query()
+            # chunk_size=1 forces queryset_to_iterator to page within each IN batch
+            for iterator in builder.build(self.domain, LedgerTransaction, db_alias).iterators(1)
+            for txn in iterator
+        ]
+
+        assert {txn.case_id for txn in transactions} == {case.case_id for case in self.cases}
+        assert self.other_case.case_id not in {txn.case_id for txn in transactions}
+        # no dupes; (case_id, id) is the unique key -- id (pk) repeats across shards
+        assert len({(txn.case_id, txn.id) for txn in transactions}) == len(transactions)
+
+
 def test_dump_builders_with_fk_index_hint_have_a_foreign_key_leading_key():
     """Guard the dump config: every builder that sets use_fk_index_hint must have a
     leading pagination key backed by a foreign key (so the parent column can be
@@ -235,7 +282,7 @@ def test_dump_builders_with_fk_index_hint_have_a_foreign_key_leading_key():
         for builder in builders
         if builder.use_fk_index_hint
     ]
-    assert builders, "expected some dump builders to set use_fk_index_hint"
+    # No builders currently set use_fk_index_hint; this guards any that are added.
     for builder in builders:
         _, model_cls = get_model_class(builder.model_label)
         # raises ValueError unless pagination_key[0] is a foreign key's column


### PR DESCRIPTION
## Product Description
No user-facing change. Tunes how the `dump_domain_data` command pages the case/form child models.

## Technical Summary

Follow-up to #37788. That PR paged the case/form child models (`XFormOperation`, `CaseAttachment`, `CaseTransaction`, `LedgerTransaction`) by `(case_id/form_id, pk)` and forced the planner to seek the parent's id index, trading a child-table scan for a parent-table scan.

Empirically that tradeoff did not pay off even for `CaseTransaction`, the child table with the most rows — and it makes even less sense for the smaller tables. So this drops the #37788 optimization from the three remaining child models, then applies a different, genuinely-helpful approach to the one that warrants it:

- **`XFormOperation`, `CaseAttachment` → revert to the default `('pk',)` pagination.**
  - `CaseAttachment` is already trivially fast: few rows, often zero matches (it's lightly used / deprecated).
  -  For `XFormOperation`, EXPLAIN showed #37788's plan was actually *worse* than plain `pk` — a sort on top of roughly the original plan — so plain `pk` is the better of the two. It's also form-owned, so `CaseIDFilter` (which keys on `case_id`) doesn't apply; a `form_id` equivalent could be built, but `XFormOperation` only adds a few hours even on a large domain, so I'm deferring that.
- **`LedgerTransaction` → switch to `CaseIDFilter`** (the same approach #37847 uses for `CaseTransaction`). It's sharded by `case_id` and has enough rows that avoiding the join to `CommCareCase` is worthwhile.

`CaseTransaction` has since been (successfully) optimized by #37847, which does empirically help.

The `pagination_key` / `use_fk_index_hint` plumbing is intentionally left in place; I want to continue to have access to the full variety of tools/options as I continue to optimize queries, and once I'm done for the time being, I'll clean up unused plumbing—`use_fk_index_hint` may very well be removed in that cleanup, but I'll leave that for then.

## Feature Flag
None

## Safety Assurance

### Safety story
- **`XFormOperation` / `CaseAttachment`** — pure revert to previously-shipped behavior: back to `('pk',)` pagination, the same plan and order they used before #37788.
- **`LedgerTransaction`** — now filtered by the domain's `case_id`s (`CaseIDFilter`) instead of the `case__domain` join. Same set of rows (every ledger transaction's case belongs to exactly one domain), reordered (grouped by `case_id` chunk; load is order-independent). This is the same filter+pagination approach already reviewed in #37847 for `CaseTransaction`.
- No change to `CaseTransaction` or to any shared plumbing.
- Operator tooling, run on demand; no live request paths affected.

### Automated test coverage
- New `TestLedgerTransactionDumpViaCaseIDFilter` (sharded), mirroring the `CaseTransaction` test: pages `LedgerTransaction` via `CaseIDFilter` at a small chunk size across shards, asserting it returns exactly the domain's transactions, excludes other domains, and yields no duplicates across page/shard boundaries.
- Existing `dump_reload` tests exercise the iterator builders end to end (`test_dump_domain_data.py`).

### QA Plan
None — covered by automated tests.

### Migrations
None.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
