### PR TITLE
Add feature flag and permissions for Public Webforms

### DIFF
--- a/corehq/apps/accounting/bootstrap/features.py
+++ b/corehq/apps/accounting/bootstrap/features.py
@@ -167,6 +167,7 @@ advanced_v0 = pro_v1 + [
     privileges.LOCATION_COLUMNS_IN_USER_LAST_ACTIVITY_REPORT,
     privileges.LOCKED_ADMIN_QUESTIONS,
     privileges.VELLUM_SAVE_TO_CASE,
+    privileges.PUBLIC_WEBFORMS,
 ]
 
 enterprise_v0 = advanced_v0 + [

--- a/corehq/apps/accounting/migrations/0119_public_webforms_priv.py
+++ b/corehq/apps/accounting/migrations/0119_public_webforms_priv.py
@@ -1,0 +1,39 @@
+from django.core.management import call_command
+from django.db import migrations
+
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.privileges import PUBLIC_WEBFORMS
+
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _grandfather_privilege(apps, schema_editor):
+    call_command('cchq_prbac_bootstrap')
+
+    skip_editions = ','.join((
+        SoftwarePlanEdition.PAUSED,
+        SoftwarePlanEdition.FREE,
+        SoftwarePlanEdition.STANDARD,
+        SoftwarePlanEdition.PRO,
+    ))
+    call_command(
+        'cchq_prbac_grandfather_privs',
+        PUBLIC_WEBFORMS,
+        skip_edition=skip_editions,
+        noinput=True,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0118_vellum_save_to_case_priv'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _grandfather_privilege,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -262,6 +262,9 @@ class Command(BaseCommand):
              name='Advanced Case Actions (old Save To Case questions)',
              description="Allow adding Advanced Case Actions (old Save To Case questions) "
                          "in the form builder."),
+        Role(slug=privileges.PUBLIC_WEBFORMS,
+             name='Public Webforms',
+             description="Allow creating publicly accessible webforms."),
     ]
 
     BOOTSTRAP_PLANS = [

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -204,6 +204,7 @@ class HqPermissions(DocumentSchema):
     edit_apps = BooleanProperty(default=False)
     view_apps = BooleanProperty(default=False)
     edit_locked_questions_in_apps = BooleanProperty(default=False)
+    edit_public_webforms = BooleanProperty(default=False)
 
     edit_shared_exports = BooleanProperty(default=False)
     access_all_locations = BooleanProperty(default=True)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -311,6 +311,9 @@ class HqPermissions(DocumentSchema):
 
         if self.edit_apps:
             self.view_apps = True
+        else:
+            self.edit_locked_questions_in_apps = False
+            self.edit_public_webforms = False
 
         if not (self.view_reports or self.view_report_list):
             self.download_reports = False

--- a/corehq/apps/users/static/users/js/edit_role.js
+++ b/corehq/apps/users/static/users/js/edit_role.js
@@ -248,10 +248,7 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-user-tableau-config-checkbox",
                     screenReaderEditAndViewText: gettext("Edit & View tableau configuration for web users"),
                     screenReaderViewOnlyText: gettext("View-Only tableau configuration for web users"),
-                    showAllowCheckbox: false,
-                    allowCheckboxText: null,
-                    allowCheckboxId: null,
-                    allowCheckboxPermission: null,
+                    nestedPermissions: [],
                 },
                 {
                     showOption: true,
@@ -274,10 +271,7 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-commcare-users-checkbox",
                     screenReaderEditAndViewText: gettext("Edit & View Web Users"),
                     screenReaderViewOnlyText: gettext("View-Only Web Users"),
-                    showAllowCheckbox: false,
-                    allowCheckboxText: null,
-                    allowCheckboxId: null,
-                    allowCheckboxPermission: null,
+                    nestedPermissions: [],
                 },
                 {
                     get showOption() {
@@ -302,18 +296,22 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-groups-checkbox",
                     screenReaderEditAndViewText: gettext("Edit & View Groups"),
                     screenReaderViewOnlyText: gettext("View-Only Web Groups"),
-                    showAllowCheckbox: true,
-                    allowCheckboxText: gettext("Allow changing group membership (requires edit groups)."),
-                    allowCheckboxId: "edit-users-groups-checkbox",
-                    get allowCheckboxPermission() {
-                        return self.role.permissions.edit_users_in_groups;
-                    },
-                    set allowCheckboxPermission(value) { // Add this setter
-                        self.role.permissions.edit_users_in_groups = value;
-                    },
-                    get allowCheckboxImpliedEnabled() {
-                        return self.role.permissions.edit_commcare_users;
-                    },
+                    nestedPermissions: [
+                        {
+                            show: true,
+                            text: gettext("Allow changing group membership (requires edit groups)."),
+                            id: "edit-users-groups-checkbox",
+                            get permission() {
+                                return self.role.permissions.edit_users_in_groups;
+                            },
+                            set permission(value) {
+                                self.role.permissions.edit_users_in_groups = value;
+                            },
+                            get impliedEnabled() {
+                                return self.role.permissions.edit_commcare_users;
+                            },
+                        },
+                    ],
                 },
                 {
                     showOption: true,
@@ -336,18 +334,22 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-locations-checkbox",
                     screenReaderEditAndViewText: gettext("Edit & View Locations"),
                     screenReaderViewOnlyText: gettext("View-Only Web Locations"),
-                    showAllowCheckbox: true,
-                    allowCheckboxText: gettext("Allow changing workers at a location."),
-                    allowCheckboxId: "edit-users-locations-checkbox",
-                    get allowCheckboxPermission() {
-                        return self.role.permissions.edit_users_in_locations;
-                    },
-                    set allowCheckboxPermission(value) { // Add this setter
-                        self.role.permissions.edit_users_in_locations = value;
-                    },
-                    get allowCheckboxImpliedEnabled() {
-                        return self.role.permissions.edit_commcare_users;
-                    },
+                    nestedPermissions: [
+                        {
+                            show: true,
+                            text: gettext("Allow changing workers at a location."),
+                            id: "edit-users-locations-checkbox",
+                            get permission() {
+                                return self.role.permissions.edit_users_in_locations;
+                            },
+                            set permission(value) {
+                                self.role.permissions.edit_users_in_locations = value;
+                            },
+                            get impliedEnabled() {
+                                return self.role.permissions.edit_commcare_users;
+                            },
+                        },
+                    ],
                 },
                 {
                     get showOption() {
@@ -372,10 +374,7 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-data-dict-checkbox",
                     screenReaderEditAndViewText: gettext("Edit & View Data Dictionary"),
                     screenReaderViewOnlyText: gettext("View-Only Data Dictionary"),
-                    showAllowCheckbox: false,
-                    allowCheckboxText: null,
-                    allowCheckboxId: null,
-                    allowCheckboxPermission: null,
+                    nestedPermissions: [],
                 },
                 {
                     showOption: true,
@@ -393,10 +392,7 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-data-checkbox",
                     screenReaderEditAndViewText: gettext("Edit & View Data"),
                     screenReaderViewOnlyText: null,
-                    showAllowCheckbox: false,
-                    allowCheckboxText: null,
-                    allowCheckboxId: null,
-                    allowCheckboxPermission: null,
+                    nestedPermissions: [],
                 },
                 {
                     showOption: true,
@@ -414,10 +410,7 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-messaging-checkbox",
                     screenReaderEditAndViewText: gettext("Access Messaging"),
                     screenReaderViewOnlyText: null,
-                    showAllowCheckbox: false,
-                    allowCheckboxText: null,
-                    allowCheckboxId: null,
-                    allowCheckboxPermission: null,
+                    nestedPermissions: [],
                 },
                 {
                     // Since disabling "Full Organization Access" automatically disables "Access APIs"
@@ -446,10 +439,7 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-apis-checkbox",
                     screenReaderEditAndViewText: gettext("Access APIs"),
                     screenReaderViewOnlyText: null,
-                    showAllowCheckbox: false,
-                    allowCheckboxText: null,
-                    allowCheckboxId: null,
-                    allowCheckboxPermission: null,
+                    nestedPermissions: [],
                 },
                 {
                     get showOption() {
@@ -474,16 +464,22 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-apps-checkbox",
                     screenReaderEditAndViewText: gettext("Edit & View Apps"),
                     screenReaderViewOnlyText: gettext("View-Only Applications"),
-                    showAllowCheckbox: privileges.hasPrivilege("locked_admin_questions"),
-                    allowCheckboxText: gettext("Allow locking and unlocking questions in forms."),
-                    allowCheckboxId: "edit-locked-questions-checkbox",
-                    get allowCheckboxPermission() {
-                        return self.role.permissions.edit_locked_questions_in_apps;
-                    },
-                    set allowCheckboxPermission(value) {
-                        self.role.permissions.edit_locked_questions_in_apps = value;
-                    },
-                    allowCheckboxImpliedEnabled: false,
+                    nestedPermissions: [
+                        {
+                            get show() {
+                                return privileges.hasPrivilege("locked_admin_questions");
+                            },
+                            text: gettext("Allow locking and unlocking questions in forms."),
+                            id: "edit-locked-questions-checkbox",
+                            get permission() {
+                                return self.role.permissions.edit_locked_questions_in_apps;
+                            },
+                            set permission(value) {
+                                self.role.permissions.edit_locked_questions_in_apps = value;
+                            },
+                            impliedEnabled: false,
+                        },
+                    ],
                 },
                 {
                     get showOption() {
@@ -503,10 +499,7 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-roles-checkbox",
                     screenReaderEditAndViewText: null,
                     screenReaderViewOnlyText: gettext("View Roles and Permissions"),
-                    showAllowCheckbox: false,
-                    allowCheckboxText: null,
-                    allowCheckboxId: null,
-                    allowCheckboxPermission: null,
+                    nestedPermissions: [],
                 },
                 {
                     get showOption() {
@@ -531,10 +524,7 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-dropzone-checkbox",
                     screenReaderEditAndViewText: gettext("Edit & Download files from the Dropzone "),
                     screenReaderViewOnlyText: gettext("View-Only Dropzone"),
-                    showAllowCheckbox: false,
-                    allowCheckboxText: null,
-                    allowCheckboxId: null,
-                    allowCheckboxPermission: null,
+                    nestedPermissions: [],
                 },
                 {
                     get showOption() {
@@ -554,10 +544,7 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-shared-exports-checkbox",
                     screenReaderEditAndViewText: null,
                     screenReaderViewOnlyText: null,
-                    showAllowCheckbox: false,
-                    allowCheckboxText: null,
-                    allowCheckboxId: null,
-                    allowCheckboxPermission: null,
+                    nestedPermissions: [],
                 },
                 {
                     get showOption() {
@@ -582,10 +569,7 @@ Alpine.data('initRole', (roleJson) => {
                     viewCheckboxLabel: "view-commcare-analytics-checkbox",
                     screenReaderEditAndViewText: gettext("Edit & View CommCare Analytics"),
                     screenReaderViewOnlyText: gettext("View-Only CommCare Analytics"),
-                    showAllowCheckbox: false,
-                    allowCheckboxText: null,
-                    allowCheckboxId: null,
-                    allowCheckboxPermission: null,
+                    nestedPermissions: [],
                 },
             ]; // end accessAreas
 

--- a/corehq/apps/users/static/users/js/edit_role.js
+++ b/corehq/apps/users/static/users/js/edit_role.js
@@ -479,6 +479,23 @@ Alpine.data('initRole', (roleJson) => {
                             },
                             impliedEnabled: false,
                         },
+                        {
+                            get show() {
+                                return (
+                                    toggles.toggleEnabled("PUBLIC_WEBFORMS") &&
+                                    privileges.hasPrivilege("public_webforms")
+                                );
+                            },
+                            text: gettext("Allow creating and modifying public webforms."),
+                            id: "edit-public-webforms-checkbox",
+                            get permission() {
+                                return self.role.permissions.edit_public_webforms;
+                            },
+                            set permission(value) {
+                                self.role.permissions.edit_public_webforms = value;
+                            },
+                            impliedEnabled: false,
+                        },
                     ],
                 },
                 {

--- a/corehq/apps/users/templates/users/edit_role.html
+++ b/corehq/apps/users/templates/users/edit_role.html
@@ -208,61 +208,26 @@
                     </div>
                     <div class="col-md-10 form-label">
                       <div x-html="area.text"></div>
-                      {# PLACEHOLDER checkbox when implicitly enabled by another permission and editPermission() is true #}
-                      <div
-                        class="form-check"
-                        x-show="area.allowCheckboxImpliedEnabled && area.editPermission && area.showAllowCheckbox"
-                      >
-                        <input
-                          class="form-check-input"
-                          type="checkbox"
-                          checked="checked"
-                          disabled="disabled"
-                          :id="area.allowCheckboxId + '-disabled'"
-                        />
-                        <label
-                          class="form-check-label"
-                          x-text="area.allowCheckboxText"
-                          :for="area.allowCheckboxId + '-disabled'"
-                        ></label>
-                      </div>
-                      {# end PLACEHOLDER #}
-                      {# REAL checkbox for allowCheckboxPermission #}
-                      <div
-                        class="form-check"
-                        x-show="!area.allowCheckboxImpliedEnabled && area.editPermission && area.showAllowCheckbox"
-                      >
-                        <input
-                          class="form-check-input"
-                          type="checkbox"
-                          :id="area.allowCheckboxId"
-                          x-model="area.allowCheckboxPermission"
-                        />
-                        <label
-                          class="form-check-label"
-                          :for="area.allowCheckboxId"
-                          x-text="area.allowCheckboxText"
-                        ></label>
-                      </div>
-                      {# end REAL #}
-                      {# PLACEHOLDER checkbox when showAllowCheckbox is false #}
-                      <div
-                        class="form-check"
-                        x-show="!area.editPermission && area.showAllowCheckbox"
-                      >
-                        <input
-                          class="form-check-input"
-                          type="checkbox"
-                          disabled="disabled"
-                          :id="area.allowCheckboxId + '-disabled2'"
-                        />
-                        <label
-                          class="form-check-label"
-                          :for="area.allowCheckboxId + '-disabled2'"
-                          x-text="area.allowCheckboxText"
-                        ></label>
-                      </div>
-                      {# end PLACEHOLDER #}
+                      <template x-for="nested in area.nestedPermissions">
+                        <div
+                          class="form-check"
+                          x-show="nested.show"
+                        >
+                          <input
+                            class="form-check-input"
+                            type="checkbox"
+                            x-model="nested.permission"
+                            :id="nested.id"
+                            :disabled="!area.editPermission || nested.impliedEnabled"
+                            :checked="area.editPermission && nested.impliedEnabled"
+                          />
+                          <label
+                            class="form-check-label"
+                            x-text="nested.text"
+                            :for="nested.id"
+                          ></label>
+                        </div>
+                      </template>
                     </div>
                   </div>
                 </template>

--- a/corehq/apps/users/tests/test_models_role.py
+++ b/corehq/apps/users/tests/test_models_role.py
@@ -354,6 +354,14 @@ class HqPermissionsTest(SimpleTestCase):
         self.hq_permissions.view_report_list = ["a"]
         self._check_normalized_permission("download_reports", expect_changed=False)
 
+    def test_edit_locked_questions_removed_when_edit_apps_false(self):
+        self.hq_permissions.edit_apps = False
+        self._check_normalized_permission("edit_locked_questions_in_apps", expect_changed=True)
+
+    def test_edit_public_webforms_removed_when_edit_apps_false(self):
+        self.hq_permissions.edit_apps = False
+        self._check_normalized_permission("edit_public_webforms", expect_changed=True)
+
     def _check_normalized_permission(self, permission, initial_value=True, expect_changed=True):
         setattr(self.hq_permissions, permission, initial_value)
         self.hq_permissions.normalize()

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -139,6 +139,8 @@ LOCKED_ADMIN_QUESTIONS = 'locked_admin_questions'
 
 VELLUM_SAVE_TO_CASE = 'save_to_case'
 
+PUBLIC_WEBFORMS = 'public_webforms'
+
 MAX_PRIVILEGES = [
     LOOKUP_TABLES,
     API_ACCESS,
@@ -211,6 +213,7 @@ MAX_PRIVILEGES = [
     LOCATION_COLUMNS_IN_USER_LAST_ACTIVITY_REPORT,
     LOCKED_ADMIN_QUESTIONS,
     VELLUM_SAVE_TO_CASE,
+    PUBLIC_WEBFORMS,
 ]
 
 # These are special privileges related to their own rates in a SoftwarePlanVersion
@@ -300,4 +303,5 @@ class Titles(object):
             ),
             LOCKED_ADMIN_QUESTIONS: _("Locked Admin Questions"),
             VELLUM_SAVE_TO_CASE: _("Save to Case"),
+            PUBLIC_WEBFORMS: _("Public Webforms"),
         }.get(privilege, privilege)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -912,6 +912,17 @@ EXTENSION_CASES_SYNC_ENABLED = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
+PUBLIC_WEBFORMS = FeatureRelease(
+    'public_webforms',
+    "Public Webforms",
+    TAG_RELEASE,
+    [NAMESPACE_DOMAIN],
+    owner='Evan Joseph-Pinero',
+    description="""
+        Enables access to public webform permissions and functionality while the feature is in development.
+    """
+)
+
 WEB_APPS_PERMISSIONS_VIA_GROUPS = StaticToggle(
     'web_apps_permissions_via_groups',
     "USH: Allow users to control access to specific web apps via mobile worker groups.",

--- a/migrations.lock
+++ b/migrations.lock
@@ -138,6 +138,7 @@ accounting
  0116_creditadjustment_payment_type
  0117_locked_admin_questions_priv
  0118_vellum_save_to_case_priv
+ 0119_public_webforms_priv
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Product Description
Allows multiple checkbox permissions to be nested under a top-level permission on the Edit Role screen, and adds the Public Webforms user role permission for Advanced plans and up with the PUBLIC_WEBFORMS feature flag enabled.

<img width="605" height="90" alt="image" src="https://github.com/user-attachments/assets/0d35d40b-e241-4484-aa57-466bccb41684" />

There is one subtle behavioral change:
- Previously, if a nested permission relying on "edit" on the parent was saved as enabled, then "edit" on the parent was unchecked and rechecked, the nested permission would return to its original checked state.

<img width="498" height="54" alt="Screen Recording 2026-06-18 at 2 34 00 PM" src="https://github.com/user-attachments/assets/86072de7-6317-48c8-919d-0e536ce35a8c" />



- Now, that nested permission will keep the unchecked state

<img width="498" height="54" alt="Screen Recording 2026-06-18 at 2 33 06 PM" src="https://github.com/user-attachments/assets/97aeeef6-18fa-4d38-abfc-3d48ae6a83b2" />



In either case, the UI is still accurate in what will be saved.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19910
Does a couple of very standard things:
- Adds a software plan privilege "public_webforms" to Advanced plans and above, via accounting migration
- Adds a user role permission "edit_public_webforms"

Also makes some structural changes to the UI of the Edit Role page, specifically:
- What was previously a single `allowCheckbox` is now an array of `nestedPermissions`
- Nested permissions each control their own visibility
- "Placeholder" HTML elements for disabled allowCheckboxes/nestedPermissions are consolidated into a single template. This is done in part because an Alpine `<template x-for>` element can only contain a single top-level element, and nesting the checkbox `<div>`s results in style changes, and in part because I think it's nicer to work with.

## Feature Flag
Adds PUBLIC_WEBFORMS and gates UI components behind it.

## Safety Assurance

### Safety story
Tested UI thoroughly locally, including various saving/refreshing/checking/unchecking combinations to see that options are properly set and retained, and what is saved matches what is shown in the UI. Backend changes including the migration here are in line with other privilege additions.

### Automated test coverage
Added test cases for permission normalizing.

### QA Plan
Not for this particular change.


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code. Pay particular attention to _backward incompatible_ operations like `RemoveField`, `RenameField`, `RemoveConstraint`, and [others described here](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md) that can cause errors when migrations are applied to a live database.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
