### PR TITLE
Speed up blob exports by fetching from S3 in parallel

### DIFF
--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -20,6 +20,10 @@ from .targzipdb import TarGzipBlobDB
 DEFAULT_CONCURRENCY = 15  # benchmarked sweet spot; the S3 pool is auto-bumped to match
 SPILL_THRESHOLD = 10 * 1024 * 1024  # buffer blobs in RAM up to 10 MB, then spill to disk
 PROGRESS_INTERVAL = 10_000  # print a progress line every N objects processed
+# Blobs are largely already compressed at rest, so gzip's default level 9 burns
+# CPU scanning incompressible data for almost no size gain. Level 1 keeps the
+# .tar.gz format (readable by run_blob_import) at a fraction of the CPU.
+COMPRESS_LEVEL = 1
 
 _Fetched = namedtuple('_Fetched', 'key fileobj content_length')
 _Missing = namedtuple('_Missing', 'key')
@@ -41,7 +45,7 @@ class BlobDbBackendExporter(object):
         self.missing_ids_filename = "missing_blob_ids.txt"
 
     def __enter__(self):
-        self.db.open('w:gz')
+        self.db.open('w:gz', compresslevel=COMPRESS_LEVEL)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.db.close()

--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -35,6 +35,23 @@ class BlobDbBackendExporter(object):
             print(PROCESSING_COMPLETE_MESSAGE.format(len(self.missing_ids), self.total_blobs))
             print(f"Missing blob ids have been written in the log file: {self.missing_ids_filename}")
 
+    def run(self, metas, progress_interval=PROGRESS_INTERVAL):
+        """Export each blob in ``metas``, logging per-chunk throughput every
+        ``progress_interval`` objects and a total-time summary at the end."""
+        start = batch_start = time.monotonic()
+        for meta in metas:
+            self.process_object(meta)
+            if self.total_blobs % progress_interval == 0:
+                now = time.monotonic()
+                batch_elapsed = now - batch_start
+                rate = format_rate(batch_elapsed, progress_interval, unit='objects')
+                print(f"Processed {self.total_blobs} objects "
+                      f"(last {progress_interval} in {batch_elapsed:.1f}s, {rate})")
+                batch_start = now
+        elapsed = time.monotonic() - start
+        rate = format_rate(elapsed, self.total_blobs, unit='objects')
+        print(f"Processed {self.total_blobs} objects in {elapsed:.1f}s ({rate})")
+
     def process_object(self, meta):
         self.total_blobs += 1
         if meta.key in self._already_exported:
@@ -77,28 +94,20 @@ class BlobExporter:
             )
 
         migrator = BlobDbBackendExporter(filename, already_exported)
-        start = batch_start = time.monotonic()
         with migrator:
             iterator_builders = APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP['blobs.BlobMeta']
             builders = get_all_model_iterators_builders_for_domain(
                 BlobMeta, self.domain, iterator_builders, limit_to_db
             )
-            for model_class, builder in builders:
-                for iterator in builder.iterators():
-                    for obj in iterator:
-                        migrator.process_object(obj)
-                        if migrator.total_blobs % progress_interval == 0:
-                            now = time.monotonic()
-                            batch_elapsed = now - batch_start
-                            rate = format_rate(batch_elapsed, progress_interval, unit='objects')
-                            print(f"Processed {migrator.total_blobs} objects "
-                                  f"(last {progress_interval} in {batch_elapsed:.1f}s, {rate})")
-                            batch_start = now
+            migrator.run(self._iter_metas(builders), progress_interval=progress_interval)
 
-        elapsed = time.monotonic() - start
-        rate = format_rate(elapsed, migrator.total_blobs, unit='objects')
-        print(f"Processed {migrator.total_blobs} objects in {elapsed:.1f}s ({rate})")
         return migrator.total_blobs, 0
+
+    @staticmethod
+    def _iter_metas(builders):
+        for model_class, builder in builders:
+            for iterator in builder.iterators():
+                yield from iterator
 
 
 class ExportError(Exception):

--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -1,5 +1,6 @@
 import os
 import time
+from collections import namedtuple
 
 from corehq.apps.dump_reload.sql.dump import (
     APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP,
@@ -13,6 +14,10 @@ from .models import BlobMeta
 from .targzipdb import TarGzipBlobDB
 
 PROGRESS_INTERVAL = 10_000  # print a progress line every N objects processed
+
+_Fetched = namedtuple('_Fetched', 'key fileobj content_length')
+_Missing = namedtuple('_Missing', 'key')
+_Skipped = namedtuple('_Skipped', 'key')
 
 
 class BlobDbBackendExporter(object):
@@ -40,7 +45,8 @@ class BlobDbBackendExporter(object):
         ``progress_interval`` objects and a total-time summary at the end."""
         start = batch_start = time.monotonic()
         for meta in metas:
-            self.process_object(meta)
+            self._write_object(self._fetch_object(meta))
+            self.total_blobs += 1
             if self.total_blobs % progress_interval == 0:
                 now = time.monotonic()
                 batch_elapsed = now - batch_start
@@ -52,19 +58,24 @@ class BlobDbBackendExporter(object):
         rate = format_rate(elapsed, self.total_blobs, unit='objects')
         print(f"Processed {self.total_blobs} objects in {elapsed:.1f}s ({rate})")
 
-    def process_object(self, meta):
-        self.total_blobs += 1
+    def _fetch_object(self, meta):
+        """Fetch one blob, returning a _Fetched/_Missing/_Skipped result."""
         if meta.key in self._already_exported:
-            # This object is already in an another dump
-            return
-
+            return _Skipped(meta.key)
         try:
             content = self.src_db.get(meta.key, CODES.maybe_compressed)
         except NotFound:
-            self.missing_ids.append(meta.key)
-        else:
-            with content:
-                self.db.copy_blob(content, key=meta.key)
+            return _Missing(meta.key)
+        return _Fetched(meta.key, content, content.content_length)
+
+    def _write_object(self, result):
+        """Apply one fetched result: write it to the tar, or record it missing."""
+        if isinstance(result, _Fetched):
+            with result.fileobj as fileobj:
+                self.db.copy_blob(fileobj, result.key, result.content_length)
+        elif isinstance(result, _Missing):
+            self.missing_ids.append(result.key)
+        # _Skipped: already in another dump; counted but not written.
 
     def _write_missing_ids(self):
         if os.path.exists(self.missing_ids_filename):

--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -1,6 +1,10 @@
 import os
+import shutil
 import time
 from collections import namedtuple
+from tempfile import SpooledTemporaryFile
+
+from gevent.pool import Pool
 
 from corehq.apps.dump_reload.sql.dump import (
     APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP,
@@ -13,6 +17,8 @@ from .migrate import PROCESSING_COMPLETE_MESSAGE
 from .models import BlobMeta
 from .targzipdb import TarGzipBlobDB
 
+DEFAULT_CONCURRENCY = 15  # default number of parallel S3 fetches
+SPILL_THRESHOLD = 10 * 1024 * 1024  # buffer blobs in RAM up to 10 MB, then spill to disk
 PROGRESS_INTERVAL = 10_000  # print a progress line every N objects processed
 
 _Fetched = namedtuple('_Fetched', 'key fileobj content_length')
@@ -22,10 +28,14 @@ _Skipped = namedtuple('_Skipped', 'key')
 
 class BlobDbBackendExporter(object):
 
-    def __init__(self, filename, already_exported):
+    def __init__(self, filename, already_exported, concurrency=DEFAULT_CONCURRENCY):
         self.db = TarGzipBlobDB(filename)
         self._already_exported = already_exported or set()
         self.src_db = get_blob_db()
+        self.concurrency = concurrency
+        # Spill large blob buffers next to the output archive (the operator's
+        # chosen --dir), not the system temp dir which may be small or tmpfs.
+        self._spill_dir = os.path.dirname(os.path.abspath(filename))
         self.total_blobs = 0
         self.missing_ids = []
         self.missing_ids_filename = "missing_blob_ids.txt"
@@ -41,35 +51,61 @@ class BlobDbBackendExporter(object):
             print(f"Missing blob ids have been written in the log file: {self.missing_ids_filename}")
 
     def run(self, metas, progress_interval=PROGRESS_INTERVAL):
-        """Export each blob in ``metas``, logging per-chunk throughput every
-        ``progress_interval`` objects and a total-time summary at the end."""
+        """Fetch blobs concurrently and write them to the tar archive serially.
+
+        ``_fetch_object`` runs in many worker greenlets; ``_write_object``
+        runs only here in the single consume loop, so it is the sole tar
+        writer and entries cannot interleave.
+        """
+        pool = Pool(self.concurrency)
         start = batch_start = time.monotonic()
-        for meta in metas:
-            self._write_object(self._fetch_object(meta))
-            self.total_blobs += 1
-            if self.total_blobs % progress_interval == 0:
-                now = time.monotonic()
-                batch_elapsed = now - batch_start
-                rate = format_rate(batch_elapsed, progress_interval, unit='objects')
-                print(f"Processed {self.total_blobs} objects "
-                      f"(last {progress_interval} in {batch_elapsed:.1f}s, {rate})")
-                batch_start = now
+        try:
+            for result in pool.imap_unordered(self._fetch_object, metas, maxsize=self.concurrency):
+                self._write_object(result)
+                self.total_blobs += 1
+                if self.total_blobs % progress_interval == 0:
+                    now = time.monotonic()
+                    batch_elapsed = now - batch_start
+                    rate = format_rate(batch_elapsed, progress_interval, unit='objects')
+                    print(f"Processed {self.total_blobs} objects "
+                          f"(last {progress_interval} in {batch_elapsed:.1f}s, {rate})")
+                    batch_start = now
+        finally:
+            # On the fail-fast path (a fetch raising a non-NotFound error),
+            # stop outstanding fetchers so their buffers are released promptly
+            # rather than relying on process exit.
+            pool.kill()
         elapsed = time.monotonic() - start
         rate = format_rate(elapsed, self.total_blobs, unit='objects')
         print(f"Processed {self.total_blobs} objects in {elapsed:.1f}s ({rate})")
 
     def _fetch_object(self, meta):
-        """Fetch one blob, returning a _Fetched/_Missing/_Skipped result."""
+        """Fetch and fully buffer one blob, returning a _Fetched/_Missing/_Skipped result.
+
+        Safe for concurrent use -- it only reads shared state and buffers into
+        its own file, never touching the tar, so many fetches can run in
+        parallel.
+        """
         if meta.key in self._already_exported:
             return _Skipped(meta.key)
         try:
             content = self.src_db.get(meta.key, CODES.maybe_compressed)
         except NotFound:
             return _Missing(meta.key)
-        return _Fetched(meta.key, content, content.content_length)
+        spool = SpooledTemporaryFile(max_size=SPILL_THRESHOLD, dir=self._spill_dir)
+        with content:
+            content_length = content.content_length
+            shutil.copyfileobj(content, spool)
+        spool.seek(0)
+        return _Fetched(meta.key, spool, content_length)
 
     def _write_object(self, result):
-        """Apply one fetched result: write it to the tar, or record it missing."""
+        """Apply one fetched result: write it to the tar, or record it missing.
+
+        Not safe for concurrent use -- it writes to the shared tar stream, so
+        callers must invoke it serially. Interleaved calls (e.g. from multiple
+        greenlets) would corrupt the archive.
+        """
         if isinstance(result, _Fetched):
             with result.fileobj as fileobj:
                 self.db.copy_blob(fileobj, result.key, result.content_length)
@@ -94,7 +130,7 @@ class BlobExporter:
         self.domain = domain
 
     def migrate(self, filename, progress_interval=PROGRESS_INTERVAL, limit_to_db=None,
-                already_exported=None, force=False):
+                already_exported=None, force=False, concurrency=DEFAULT_CONCURRENCY):
         if not self.domain:
             raise ExportError("Must specify domain")
 
@@ -104,7 +140,7 @@ class BlobExporter:
                 "To re-run the export use 'reset'".format(self.slug)
             )
 
-        migrator = BlobDbBackendExporter(filename, already_exported)
+        migrator = BlobDbBackendExporter(filename, already_exported, concurrency)
         with migrator:
             iterator_builders = APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP['blobs.BlobMeta']
             builders = get_all_model_iterators_builders_for_domain(

--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -17,7 +17,7 @@ from .migrate import PROCESSING_COMPLETE_MESSAGE
 from .models import BlobMeta
 from .targzipdb import TarGzipBlobDB
 
-DEFAULT_CONCURRENCY = 15  # default number of parallel S3 fetches
+DEFAULT_CONCURRENCY = 15  # benchmarked sweet spot; the S3 pool is auto-bumped to match
 SPILL_THRESHOLD = 10 * 1024 * 1024  # buffer blobs in RAM up to 10 MB, then spill to disk
 PROGRESS_INTERVAL = 10_000  # print a progress line every N objects processed
 

--- a/corehq/blobs/management/commands/run_blob_export.py
+++ b/corehq/blobs/management/commands/run_blob_export.py
@@ -5,10 +5,11 @@ import sys
 
 from django.core.management import BaseCommand, CommandError
 
-from corehq.blobs.export import BlobExporter, PROGRESS_INTERVAL
+from corehq.blobs.export import BlobExporter, DEFAULT_CONCURRENCY, PROGRESS_INTERVAL
 from corehq.util.decorators import change_log_level
 
 USAGE = "Usage: ./manage.py run_blob_export [options] <domain>"
+BOTOCORE_DEFAULT_POOL_SIZE = 10  # botocore's default max_pool_connections
 
 
 class Command(BaseCommand):
@@ -43,6 +44,14 @@ class Command(BaseCommand):
                                  "the exporter to a single database.")
         parser.add_argument('--already_exported', dest='already_exported',
                             help='Pass a file with a list of blob names already exported')
+        parser.add_argument(
+            '--concurrency', type=int, default=DEFAULT_CONCURRENCY,
+            help="Number of blobs to fetch from S3 in parallel (default: "
+                 f"{DEFAULT_CONCURRENCY}). Values above botocore's default "
+                 f"connection-pool size ({BOTOCORE_DEFAULT_POOL_SIZE}) raise "
+                 "max_pool_connections to match, so the extra connections are "
+                 "reused rather than opened and discarded each request.",
+        )
 
     @change_log_level('boto3', logging.WARNING)
     @change_log_level('botocore', logging.WARNING)
@@ -53,6 +62,7 @@ class Command(BaseCommand):
         reset=False,
         progress_interval=PROGRESS_INTERVAL,
         limit_to_db=None,
+        concurrency=DEFAULT_CONCURRENCY,
         **options,
     ):
         already_exported = get_lines_from_file(options['already_exported'])
@@ -73,16 +83,38 @@ class Command(BaseCommand):
                 f"Export file '{export_filename}' exists. Remove the file and re-run the command."
             )
 
+        _ensure_s3_pool_size(concurrency)
         exporter = BlobExporter(domain)
         total, skips = exporter.migrate(
             export_filename,
             progress_interval=progress_interval,
             limit_to_db=limit_to_db,
             already_exported=already_exported,
+            concurrency=concurrency,
         )
         self.stdout.write(f'\nData dumped to file: {export_filename}')
         if skips:
             sys.exit(skips)
+
+
+def _ensure_s3_pool_size(concurrency):
+    """Raise botocore's connection pool to serve ``concurrency`` parallel fetches.
+
+    The pool defaults to ``BOTOCORE_DEFAULT_POOL_SIZE``. botocore doesn't block
+    when it's exceeded; it opens connections beyond the pool and discards them
+    after use, so a higher ``--concurrency`` would otherwise churn connections
+    (new TLS handshake per excess fetch). Must run before the blob db client is
+    built (i.e. before the first ``get_blob_db()`` call).
+    """
+    from django.conf import settings
+    for key in ('S3_BLOB_DB_SETTINGS', 'OLD_S3_BLOB_DB_SETTINGS'):
+        s3_settings = getattr(settings, key, None)
+        if not s3_settings:
+            continue
+        config = s3_settings.get('config') or {}
+        if concurrency > config.get('max_pool_connections', BOTOCORE_DEFAULT_POOL_SIZE):
+            config['max_pool_connections'] = concurrency
+            s3_settings['config'] = config
 
 
 def get_lines_from_file(filename):

--- a/corehq/blobs/management/commands/run_blob_export.py
+++ b/corehq/blobs/management/commands/run_blob_export.py
@@ -106,6 +106,8 @@ def _ensure_s3_pool_size(concurrency):
     (new TLS handshake per excess fetch). Must run before the blob db client is
     built (i.e. before the first ``get_blob_db()`` call).
     """
+    from corehq.blobs import _db
+    assert not _db, "blob db already built; max_pool_connections bump would be ignored"
     from django.conf import settings
     for key in ('S3_BLOB_DB_SETTINGS', 'OLD_S3_BLOB_DB_SETTINGS'):
         s3_settings = getattr(settings, key, None)

--- a/corehq/blobs/targzipdb.py
+++ b/corehq/blobs/targzipdb.py
@@ -17,8 +17,9 @@ class TarGzipBlobDB(AbstractBlobDB):
         self.filename = filename
         self._tgzfile = None
 
-    def open(self, mode='r:gz'):
-        self._tgzfile = tarfile.open(self.filename, mode)
+    def open(self, mode='r:gz', compresslevel=None):
+        kwargs = {} if compresslevel is None else {'compresslevel': compresslevel}
+        self._tgzfile = tarfile.open(self.filename, mode, **kwargs)
 
     def close(self):
         self._tgzfile.close()

--- a/corehq/blobs/targzipdb.py
+++ b/corehq/blobs/targzipdb.py
@@ -36,9 +36,12 @@ class TarGzipBlobDB(AbstractBlobDB):
     def bulk_delete(self, metas):
         raise NotImplementedError
 
-    def copy_blob(self, in_fileobj, key):
+    def copy_blob(self, in_fileobj, key, content_length=None):
         """
         Streams content from ``in_fileobj`` to a tar gzip file.
+
+        :param content_length: Size of the blob in bytes. When ``None``,
+            ``in_fileobj.content_length`` is used.
 
         .. NOTE::
             ``copy_blob()`` does not include BlobMeta. In order to
@@ -46,8 +49,10 @@ class TarGzipBlobDB(AbstractBlobDB):
             need to use the ``dump_domain_data`` management command.
 
         """
+        if content_length is None:
+            content_length = in_fileobj.content_length
         tarinfo = tarfile.TarInfo(name=key)
-        tarinfo.size = in_fileobj.content_length
+        tarinfo.size = content_length
         self._tgzfile.addfile(tarinfo, in_fileobj)
 
     def exists(self, key):

--- a/corehq/blobs/tests/test_export.py
+++ b/corehq/blobs/tests/test_export.py
@@ -10,6 +10,7 @@ from django.test import SimpleTestCase, TestCase
 from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.export import BlobExporter
 from corehq.blobs.management.commands.run_blob_import import Command as ImportCommand
+from corehq.blobs.targzipdb import TarGzipBlobDB
 from corehq.blobs.tests.fixtures import blob_db
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB, new_meta
 
@@ -222,6 +223,23 @@ class MockBigBlobIO(RawIOBase):
 
     def readinto(self, buffer):
         raise NotImplementedError
+
+
+class TestTarGzipCopyBlobContentLength(SimpleTestCase):
+
+    def test_explicit_content_length_used_for_fileobj_without_attribute(self):
+        data = b'spam and eggs'
+        with NamedTemporaryFile(suffix='.tar.gz') as out:
+            db = TarGzipBlobDB(out.name)
+            db.open('w:gz')
+            # io.BytesIO has no `content_length` attribute
+            db.copy_blob(io.BytesIO(data), key='k', content_length=len(data))
+            db.close()
+
+            with tarfile.open(out.name, 'r:gz') as tgz:
+                member = tgz.getmember('k')
+                assert member.size == len(data)
+                assert tgz.extractfile('k').read() == data
 
 
 def test_doctests():

--- a/corehq/blobs/tests/test_export.py
+++ b/corehq/blobs/tests/test_export.py
@@ -1,18 +1,104 @@
 import doctest
 import io
+import os
 import tarfile
+from collections import namedtuple
 from contextlib import chdir, redirect_stdout
 from io import BytesIO, RawIOBase
 from tempfile import NamedTemporaryFile, TemporaryDirectory
+from unittest import mock
 
 from django.test import SimpleTestCase, TestCase
 
 from corehq.blobs import CODES, get_blob_db
-from corehq.blobs.export import BlobExporter
+from corehq.blobs import export as export_module
+from corehq.blobs.exceptions import NotFound
+from corehq.blobs.export import BlobDbBackendExporter, BlobExporter
 from corehq.blobs.management.commands.run_blob_import import Command as ImportCommand
 from corehq.blobs.targzipdb import TarGzipBlobDB
 from corehq.blobs.tests.fixtures import blob_db
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB, new_meta
+
+_Meta = namedtuple('_Meta', 'key')
+
+
+class _FakeStream(io.BytesIO):
+    """BytesIO with a ``content_length``, standing in for a blob read."""
+
+    def __init__(self, data):
+        super().__init__(data)
+        self.content_length = len(data)
+
+
+class _FakeSrcDB:
+    def __init__(self, blobs):
+        self.blobs = blobs  # {key: bytes}
+
+    def get(self, key, type_code=None):
+        if key not in self.blobs:
+            raise NotFound(key)
+        return _FakeStream(self.blobs[key])
+
+
+def _export_with_fake_src(blobs, metas, already_exported=None, src_db=None,
+                          progress_interval=100):
+    """Run an export against a fake source DB; return (names->bytes, missing_ids, total)."""
+    if src_db is None:
+        src_db = _FakeSrcDB(blobs)
+    with mock.patch.object(export_module, 'get_blob_db', return_value=src_db), \
+            NamedTemporaryFile(suffix='.tar.gz') as out, \
+            TemporaryDirectory() as tmpdir:
+        migrator = BlobDbBackendExporter(out.name, already_exported)
+        migrator.missing_ids_filename = os.path.join(tmpdir, 'missing_blob_ids.txt')
+        with migrator:
+            migrator.run(metas, progress_interval=progress_interval)
+        with tarfile.open(out.name, 'r:gz') as tgz:
+            extracted = {n: tgz.extractfile(n).read() for n in tgz.getnames()}
+        return extracted, migrator.missing_ids, migrator.total_blobs
+
+
+class TestExportRun(SimpleTestCase):
+
+    def test_missing_blob_is_recorded(self):
+        blobs = {'present': b'data'}
+        metas = [_Meta('present'), _Meta('absent')]
+
+        extracted, missing, total = _export_with_fake_src(blobs, metas)
+
+        assert set(extracted) == {'present'}
+        assert missing == ['absent']
+        assert total == 2
+
+    def test_already_exported_blobs_are_skipped_but_counted(self):
+        """Already-exported blobs are not re-written, but are still counted --
+        in the total and the per-chunk progress heartbeat -- matching the
+        original sequential exporter."""
+        blobs = {f'k{i}': b'x' for i in range(150)}
+        metas = [_Meta(k) for k in blobs]
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            extracted, missing, total = _export_with_fake_src(
+                blobs, metas, already_exported=set(blobs))
+
+        assert extracted == {}  # nothing re-written
+        assert total == 150  # all counted
+        assert "Processed 100 objects (last 100 in " in out.getvalue()  # and reported
+
+    def test_non_notfound_fetch_error_propagates(self):
+        """A fetch error that is not NotFound must propagate, aborting the export."""
+
+        class _ErrorDB(_FakeSrcDB):
+            def get(self, key, type_code=None):
+                if key == 'bad':
+                    raise RuntimeError("boom")
+                return super().get(key, type_code)
+
+        blobs = {'ok': b'fine', 'bad': b'never'}
+        metas = [_Meta('ok'), _Meta('bad')]
+        src_db = _ErrorDB(blobs)
+        with self.assertRaises(RuntimeError):
+            _export_with_fake_src(blobs, metas, src_db=src_db)
 
 
 class TestBlobExporter(TestCase):

--- a/corehq/blobs/tests/test_export.py
+++ b/corehq/blobs/tests/test_export.py
@@ -1,9 +1,9 @@
 import doctest
 import io
 import tarfile
-from contextlib import redirect_stdout
+from contextlib import chdir, redirect_stdout
 from io import BytesIO, RawIOBase
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from django.test import SimpleTestCase, TestCase
 
@@ -70,7 +70,10 @@ class TestBlobExporter(TestCase):
         orphaned_meta = new_meta(domain=self.domain, type_code=CODES.form_xml, content_length=42)
         orphaned_meta.save()
 
-        with NamedTemporaryFile() as out:
+        # migrate() writes missing_blob_ids.txt to the cwd for the orphaned
+        # meta; run in a temp dir so the test stays idempotent and does not
+        # pollute the repo root.
+        with TemporaryDirectory() as tmpdir, chdir(tmpdir), NamedTemporaryFile() as out:
             self.exporter.migrate(out.name, force=True)
             with tarfile.open(out.name, 'r:gz') as tgzfile:
                 self.assertEqual([expected_meta.key], tgzfile.getnames())

--- a/corehq/blobs/tests/test_export.py
+++ b/corehq/blobs/tests/test_export.py
@@ -8,6 +8,7 @@ from io import BytesIO, RawIOBase
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import mock
 
+import gevent
 from django.test import SimpleTestCase, TestCase
 
 from corehq.blobs import CODES, get_blob_db
@@ -22,33 +23,39 @@ from corehq.blobs.tests.util import TemporaryFilesystemBlobDB, new_meta
 _Meta = namedtuple('_Meta', 'key')
 
 
-class _FakeStream(io.BytesIO):
-    """BytesIO with a ``content_length``, standing in for a blob read."""
+class _YieldingStream(io.BytesIO):
+    """BytesIO that yields to other greenlets on every read, to force
+    interleaving opportunities during the parallel export."""
 
     def __init__(self, data):
         super().__init__(data)
         self.content_length = len(data)
 
+    def read(self, *args, **kwargs):
+        gevent.sleep(0)
+        return super().read(*args, **kwargs)
 
-class _FakeSrcDB:
+
+class _YieldingFakeSrcDB:
     def __init__(self, blobs):
         self.blobs = blobs  # {key: bytes}
 
     def get(self, key, type_code=None):
+        gevent.sleep(0)  # force a context switch before returning the stream
         if key not in self.blobs:
             raise NotFound(key)
-        return _FakeStream(self.blobs[key])
+        return _YieldingStream(self.blobs[key])
 
 
-def _export_with_fake_src(blobs, metas, already_exported=None, src_db=None,
+def _export_with_fake_src(blobs, metas, already_exported=None, concurrency=8, src_db=None,
                           progress_interval=100):
-    """Run an export against a fake source DB; return (names->bytes, missing_ids, total)."""
+    """Run a parallel export against a fake source DB; return (names->bytes, missing_ids, total)."""
     if src_db is None:
-        src_db = _FakeSrcDB(blobs)
+        src_db = _YieldingFakeSrcDB(blobs)
     with mock.patch.object(export_module, 'get_blob_db', return_value=src_db), \
             NamedTemporaryFile(suffix='.tar.gz') as out, \
             TemporaryDirectory() as tmpdir:
-        migrator = BlobDbBackendExporter(out.name, already_exported)
+        migrator = BlobDbBackendExporter(out.name, already_exported, concurrency=concurrency)
         migrator.missing_ids_filename = os.path.join(tmpdir, 'missing_blob_ids.txt')
         with migrator:
             migrator.run(metas, progress_interval=progress_interval)
@@ -58,6 +65,18 @@ def _export_with_fake_src(blobs, metas, already_exported=None, src_db=None,
 
 
 class TestExportRun(SimpleTestCase):
+
+    def test_all_blobs_written_intact_under_concurrency(self):
+        # varied sizes, including a blob larger than a chunk read, to exercise
+        # multi-read copies that interleave across greenlets
+        blobs = {f'key-{i}': bytes([i % 256]) * (i * 37) for i in range(1, 31)}
+        metas = [_Meta(k) for k in blobs]
+
+        extracted, missing, total = _export_with_fake_src(blobs, metas)
+
+        assert extracted == blobs  # every blob present and byte-identical
+        assert missing == []
+        assert total == 30
 
     def test_missing_blob_is_recorded(self):
         blobs = {'present': b'data'}
@@ -85,10 +104,40 @@ class TestExportRun(SimpleTestCase):
         assert total == 150  # all counted
         assert "Processed 100 objects (last 100 in " in out.getvalue()  # and reported
 
+    def test_blob_larger_than_spill_threshold_round_trips(self):
+        with mock.patch.object(export_module, 'SPILL_THRESHOLD', 16):
+            blobs = {'big': b'x' * 1000}  # 1000 > 16 -> spills to disk
+            metas = [_Meta('big')]
+            extracted, missing, total = _export_with_fake_src(blobs, metas)
+        assert extracted == blobs
+
+    def test_spill_files_are_written_to_the_output_directory(self):
+        """Spilled blob buffers go next to the output archive, not the system
+        temp dir, so the operator's chosen disk absorbs the I/O."""
+        captured = []
+        real_spooled = export_module.SpooledTemporaryFile
+
+        def spy(*args, **kwargs):
+            captured.append(kwargs.get('dir'))
+            return real_spooled(*args, **kwargs)
+
+        blobs = {'k': b'data'}
+        with TemporaryDirectory() as outdir:
+            out_path = os.path.join(outdir, 'export.tar.gz')
+            with mock.patch.object(export_module, 'get_blob_db',
+                                   return_value=_YieldingFakeSrcDB(blobs)), \
+                    mock.patch.object(export_module, 'SpooledTemporaryFile',
+                                      side_effect=spy):
+                migrator = BlobDbBackendExporter(out_path, None, concurrency=2)
+                migrator.missing_ids_filename = os.path.join(outdir, 'missing.txt')
+                with migrator:
+                    migrator.run([_Meta('k')], progress_interval=100)
+            assert captured == [outdir]
+
     def test_non_notfound_fetch_error_propagates(self):
         """A fetch error that is not NotFound must propagate, aborting the export."""
 
-        class _ErrorDB(_FakeSrcDB):
+        class _ErrorDB(_YieldingFakeSrcDB):
             def get(self, key, type_code=None):
                 if key == 'bad':
                     raise RuntimeError("boom")

--- a/corehq/blobs/tests/test_run_blob_export.py
+++ b/corehq/blobs/tests/test_run_blob_export.py
@@ -3,7 +3,33 @@ import tempfile
 from contextlib import contextmanager
 from unittest import mock
 
+import pytest
+from django.conf import settings
 from django.core.management import call_command
+from django.test import override_settings
+
+from corehq.blobs.management.commands.run_blob_export import _ensure_s3_pool_size
+
+
+@pytest.mark.parametrize("s3_settings, concurrency, expected", [
+    ({'url': 'x'}, 25, 25),                             # no pool set -> raise to concurrency
+    ({'url': 'x'}, 10, None),                           # at the default -> leave config unset
+    ({'config': {'max_pool_connections': 50}}, 25, 50),  # larger configured pool -> kept
+    ({'config': {'max_pool_connections': 5}}, 25, 25),   # smaller configured pool -> raised
+])
+def test_ensure_s3_pool_size(s3_settings, concurrency, expected):
+    with override_settings(S3_BLOB_DB_SETTINGS=s3_settings, OLD_S3_BLOB_DB_SETTINGS=None):
+        _ensure_s3_pool_size(concurrency)
+        config = settings.S3_BLOB_DB_SETTINGS.get('config')
+        if expected is None:
+            assert config is None or 'max_pool_connections' not in config
+        else:
+            assert config['max_pool_connections'] == expected
+
+
+def test_ensure_s3_pool_size_without_s3_configured_is_noop():
+    with override_settings(S3_BLOB_DB_SETTINGS=None, OLD_S3_BLOB_DB_SETTINGS=None):
+        _ensure_s3_pool_size(25)  # must not raise
 
 
 @contextmanager

--- a/manage.py
+++ b/manage.py
@@ -21,6 +21,7 @@ def main():
         GeventCommand('run_ptop', with_option='--gevent-workers'),
         GeventCommand('run_sql'),
         GeventCommand('run_blob_migration'),
+        GeventCommand('run_blob_export'),
         GeventCommand('check_blob_logs'),
         GeventCommand('preindex_everything'),
         GeventCommand('migrate', env_exclude=['SKIP_GEVENT_PATCHING']),


### PR DESCRIPTION
## Product Description
No user-facing change. `run_blob_export` is an internal operational command that dumps a domain's blobs to a `.tar.gz`. This makes large exports much faster: on a 171k-blob staging domain, parallel fetching alone takes it from **3 h 46 m → ~35 m**, and combined with the read-path change in #37861 the full stack reaches **~18 m (≈12×)** — see Performance below.

## Technical Summary
`run_blob_export` fetched each blob from S3 and streamed it into the tar one at a time, so it was almost entirely network-bound on sequential S3 GETs — most of the wall-clock was spent waiting on one request at a time.

This PR parallelizes the fetches, and then trims the per-blob CPU that becomes the new bottleneck as a result:

- **Concurrent fetch, single writer.** A gevent pool fetches blobs in parallel; each worker greenlet fully buffers one blob into a `SpooledTemporaryFile` (in RAM under 10 MB, spilling to disk above), and a single consume loop (`imap_unordered`) is the **only** greenlet that writes the tar. One writer means tar entries can't interleave. Spilled buffers land next to the output archive (the operator's `--dir`), not the system temp file location.
- **`--concurrency` (default 15).** Tunable parallelism; 15 is the benchmarked sweet spot (see Performance). Passing a value above botocore's default pool size (10) **automatically raises `max_pool_connections` to match**, so the extra connections are pooled and reused rather than opened and discarded each request.
- **gzip level 1.** Blob bytes are largely already compressed at rest (form XML is gzipped on store; multimedia is already a compressed format), so the tar's default level-9 gzip burned CPU scanning incompressible data for almost no size gain — the output in my test was an identical 1.4 GB at either level. Level 1 keeps the `.tar.gz` format for a fraction of the CPU, while still doing some low-hanging compression in the less common case that there's actually something compressible.
- One CPU optimization made for this work has been PR'd and merged separately, because of its being part of a widely-used utility: https://github.com/dimagi/commcare-hq/pull/37861

The one behavior change (besides being faster) that results is that blobs are not written in a deterministic order—they will still be picked up in the same order, but they'll be written in roughly the order that they finish fetching. This shouldn't matter, as the blob import that depends on this isn't meaningfully sensitive to order.

### Performance (staging `qateam`, 171,518 blobs)
| Variant | Wall time | vs. baseline |
|---|---|---|
| Baseline (sequential) | 3 h 46 m | 1.0× |
| **This PR** — parallel fetch (`--concurrency 20`) | ~35 m | ~6.5× |
| Full stack — gzip 1 + `--concurrency 15`, **with #37861** | **18.4 m** | **12.3×** |

The 18-minute figure is the combined result with #37861 (the botocore-client read path), since the optimized staging builds carried both branches; this PR's parallelization alone accounts for at least the ~6.5× (maybe a little more, since concurrency 20 is past the sweet spot and this is before the gzip 1 optimization).

On the full stack a concurrency of 15 had the best result. 10 → 23.0 m; **15 → 18.4 m**; 20 → 20.0 m; 40 → 27.0 m. Above 15, CPU is already saturated and more concurrency just adds overhead and churn; hence the default of 15.

## Feature Flag
N/A

## Safety Assurance

### Safety story
The main risk for something like this is archive corruption from interleaved writes. To eliminate that risk entirely and simply, worker greenlets touch only their own buffer and never the tar, and writes to the tar happen in a single thread (greenlet). Memory stays bounded by the spill threshold x concurrency. Existing semantics are preserved exactly (except for the order of entries within the archive) — total counts (including already-exported and missing blobs), `NotFound` collection into `missing_ids`, the `(total, skips)` return value, and fail-fast on any other fetch error.

### Automated test coverage
- `test_export.py::TestExportRun` drives `BlobDbBackendExporter.run()` against a fake source DB. The concurrency tests use a source whose reads call `gevent.sleep(0)` to **force greenlet interleaving mid-copy**, then assert every blob extracts byte-identical — directly exercising the single-writer guarantee — plus spill-to-disk and spill location landing in `--dir`. It also covers missing-blob recording, `already_exported` skipping (still counted), and fail-fast propagation of non-`NotFound` errors. Those last three (behavior the refactors must preserve) are introduced a commit earlier, *before* the fetch/write split and the concurrency change, so they pin that behavior across both refactors.
- `test_export.py::TestBlobExporter::test_progress_and_summary_report_throughput` (pre-existing, real blob DB) covers the per-chunk and final-summary progress output.
- `test_export.py::TestTarGzipCopyBlobContentLength` covers the explicit-`content_length` path.
- `test_run_blob_export.py::test_ensure_s3_pool_size` covers the connection-pool auto-bump (raises to match concurrency, keeps a larger configured pool, no-op without S3 configured).
- The pre-existing `TestBlobExporter` / `TestExtendingExport` (real temp-filesystem blob DB, including an export → import round-trip) run through the new concurrent path unchanged.

### QA Plan
Beyond automated coverage: I did significant benchmarking on staging with `./manage.py run_blob_export <domain>` and confirmed the resulting file is the right size.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


