### PR TITLE
Report progress and throughput during blob export

### DIFF
--- a/corehq/apps/dump_reload/tests/test_timing.py
+++ b/corehq/apps/dump_reload/tests/test_timing.py
@@ -102,6 +102,14 @@ def test_format_rate(total_seconds, row_count, expected):
     assert format_rate(total_seconds, row_count) == expected
 
 
+@pytest.mark.parametrize("total_seconds, row_count, expected", [
+    (3651.84, 1_000_000, '1.014h /1M objects'),
+    (5.0, 0, 'n/a /1M objects'),
+])
+def test_format_rate_custom_unit(total_seconds, row_count, expected):
+    assert format_rate(total_seconds, row_count, unit='objects') == expected
+
+
 class RecordingLogger:
     def __init__(self):
         self.messages = []

--- a/corehq/apps/dump_reload/timing.py
+++ b/corehq/apps/dump_reload/timing.py
@@ -56,9 +56,12 @@ class DumpTimingLogger:
         self._label = None
 
 
-def format_rate(total_seconds, row_count):
-    """Throughput as hours per million rows, e.g. ``1.014h /1M rows`` (``n/a`` for zero rows)."""
+def format_rate(total_seconds, row_count, unit='rows'):
+    """Throughput as hours per million rows, e.g. ``1.014h /1M rows`` (``n/a`` for zero rows).
+
+    :param unit: noun for the counted things, e.g. ``'objects'``.
+    """
     if not row_count:
-        return 'n/a /1M rows'
+        return f'n/a /1M {unit}'
     hours_per_million = total_seconds / row_count * 1_000_000 / 3600
-    return f'{hours_per_million:.3f}h /1M rows'
+    return f'{hours_per_million:.3f}h /1M {unit}'

--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -1,9 +1,11 @@
 import os
+import time
 
 from corehq.apps.dump_reload.sql.dump import (
     APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP,
     get_all_model_iterators_builders_for_domain,
 )
+from corehq.apps.dump_reload.timing import format_rate
 
 from . import NotFound, get_blob_db, CODES
 from .migrate import PROCESSING_COMPLETE_MESSAGE
@@ -75,6 +77,7 @@ class BlobExporter:
             )
 
         migrator = BlobDbBackendExporter(filename, already_exported)
+        start = batch_start = time.monotonic()
         with migrator:
             iterator_builders = APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP['blobs.BlobMeta']
             builders = get_all_model_iterators_builders_for_domain(
@@ -85,9 +88,16 @@ class BlobExporter:
                     for obj in iterator:
                         migrator.process_object(obj)
                         if migrator.total_blobs % progress_interval == 0:
-                            print(f"Processed {migrator.total_blobs} objects")
+                            now = time.monotonic()
+                            batch_elapsed = now - batch_start
+                            rate = format_rate(batch_elapsed, progress_interval, unit='objects')
+                            print(f"Processed {migrator.total_blobs} objects "
+                                  f"(last {progress_interval} in {batch_elapsed:.1f}s, {rate})")
+                            batch_start = now
 
-        print(f"Processed {migrator.total_blobs} total objects")
+        elapsed = time.monotonic() - start
+        rate = format_rate(elapsed, migrator.total_blobs, unit='objects')
+        print(f"Processed {migrator.total_blobs} objects in {elapsed:.1f}s ({rate})")
         return migrator.total_blobs, 0
 
 

--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -82,9 +82,9 @@ class BlobExporter:
                     for obj in iterator:
                         migrator.process_object(obj)
                         if migrator.total_blobs % chunk_size == 0:
-                            print("Processed {} objects".format(migrator.total_blobs))
+                            print(f"Processed {migrator.total_blobs} objects")
 
-        print("Processed {} total objects".format(migrator.total_blobs))
+        print(f"Processed {migrator.total_blobs} total objects")
         return migrator.total_blobs, 0
 
 

--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -10,6 +10,8 @@ from .migrate import PROCESSING_COMPLETE_MESSAGE
 from .models import BlobMeta
 from .targzipdb import TarGzipBlobDB
 
+PROGRESS_INTERVAL = 100  # print a progress line every N objects processed
+
 
 class BlobDbBackendExporter(object):
 
@@ -61,7 +63,8 @@ class BlobExporter:
     def __init__(self, domain):
         self.domain = domain
 
-    def migrate(self, filename, chunk_size=100, limit_to_db=None, already_exported=None, force=False):
+    def migrate(self, filename, progress_interval=PROGRESS_INTERVAL, limit_to_db=None,
+                already_exported=None, force=False):
         if not self.domain:
             raise ExportError("Must specify domain")
 
@@ -81,7 +84,7 @@ class BlobExporter:
                 for iterator in builder.iterators():
                     for obj in iterator:
                         migrator.process_object(obj)
-                        if migrator.total_blobs % chunk_size == 0:
+                        if migrator.total_blobs % progress_interval == 0:
                             print(f"Processed {migrator.total_blobs} objects")
 
         print(f"Processed {migrator.total_blobs} total objects")

--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -10,7 +10,7 @@ from .migrate import PROCESSING_COMPLETE_MESSAGE
 from .models import BlobMeta
 from .targzipdb import TarGzipBlobDB
 
-PROGRESS_INTERVAL = 100  # print a progress line every N objects processed
+PROGRESS_INTERVAL = 10_000  # print a progress line every N objects processed
 
 
 class BlobDbBackendExporter(object):

--- a/corehq/blobs/management/commands/run_blob_export.py
+++ b/corehq/blobs/management/commands/run_blob_export.py
@@ -5,7 +5,7 @@ import sys
 
 from django.core.management import BaseCommand, CommandError
 
-from corehq.blobs.export import BlobExporter
+from corehq.blobs.export import BlobExporter, PROGRESS_INTERVAL
 from corehq.util.decorators import change_log_level
 
 USAGE = "Usage: ./manage.py run_blob_export [options] <domain>"
@@ -35,8 +35,9 @@ class Command(BaseCommand):
             help="Optionally specify a directory to write the file to. "
                  "The directory will be created if it does not exist.",
         )
-        parser.add_argument('--chunk-size', type=int, default=100,
-                            help='Maximum number of records to read from couch at once.')
+        parser.add_argument('--progress-interval', type=int, default=PROGRESS_INTERVAL,
+                            help='Print a progress line (with throughput) every N objects '
+                                 f'processed (default: {PROGRESS_INTERVAL}).')
         parser.add_argument('--limit-to-db', dest='limit_to_db',
                             help="When specifying a SQL importer use this to restrict "
                                  "the exporter to a single database.")
@@ -50,7 +51,7 @@ class Command(BaseCommand):
         domain=None,
         dir=None,
         reset=False,
-        chunk_size=100,
+        progress_interval=PROGRESS_INTERVAL,
         limit_to_db=None,
         **options,
     ):
@@ -75,7 +76,7 @@ class Command(BaseCommand):
         exporter = BlobExporter(domain)
         total, skips = exporter.migrate(
             export_filename,
-            chunk_size=chunk_size,
+            progress_interval=progress_interval,
             limit_to_db=limit_to_db,
             already_exported=already_exported,
         )

--- a/corehq/blobs/tests/test_export.py
+++ b/corehq/blobs/tests/test_export.py
@@ -1,5 +1,7 @@
 import doctest
+import io
 import tarfile
+from contextlib import redirect_stdout
 from io import BytesIO, RawIOBase
 from tempfile import NamedTemporaryFile
 
@@ -36,6 +38,19 @@ class TestBlobExporter(TestCase):
             self.exporter.migrate(out.name, force=True)
             with tarfile.open(out.name, 'r:gz') as tgzfile:
                 self.assertEqual([expected_meta.key], tgzfile.getnames())
+
+    def test_progress_and_summary_report_throughput(self):
+        for _ in range(3):
+            self.db.put(BytesIO(self.blob_data), meta=new_meta(domain=self.domain, type_code=CODES.form_xml))
+
+        out = io.StringIO()
+        with NamedTemporaryFile() as f, redirect_stdout(out):
+            self.exporter.migrate(f.name, progress_interval=2, force=True)
+        printed = out.getvalue()
+        # per-chunk line at the 2-object boundary, then the final summary
+        assert "Processed 2 objects (last 2 in " in printed
+        assert "Processed 3 objects in " in printed
+        assert "/1M objects)" in printed
 
     def test_different_blob_types_are_exported(self):
         form = self.db.put(BytesIO(self.blob_data), meta=new_meta(domain=self.domain, type_code=CODES.form_xml))


### PR DESCRIPTION
## Product Description
No user-facing change. Adds operator-facing progress/throughput logging to the `run_blob_export` command.

## Technical Summary
A large blob export gives no feedback on how it's going. This adds:

- A progress line every **10,000 objects** (configurable via `--progress-interval`) reporting **that chunk's** wall time and throughput, e.g.
  `Processed 20000 objects (last 10000 in 12.3s, 0.342h /1M objects)`
- A cumulative summary when the export finishes, e.g.
  `Processed 1234567 objects in 1834.2s (0.413h /1M objects)`

The throughput is formatted as hours per million, matching `dump_domain_data`. To reuse that helper, `format_rate` gains an optional `unit` label (default `'rows'`, so its existing callers are unchanged) so it can say `objects`.

The vestigial `--chunk-size` flag — which only set the progress cadence and no longer governs any couch read — is renamed to `--progress-interval` (default 10000) with accurate help. No docs or scripts reference the old flag.

(Procedural note: This PR supersedes #37857, which got confusingly clobbered in a rebase. Probably not relevant, but in case anyone's confused.)

## Feature Flag
N/A

## Safety Assurance

### Safety story
This is observability only: the periodic line and summary are derived from a monotonic clock and the existing object counter; nothing about what gets exported changes. The summary prints after the export loop completes, so a failed export does not emit a misleading rate.

### Automated test coverage
- `test_timing.py`: parametrized `format_rate` cases for the new `unit` label (including the zero-rows `n/a` path).
- `test_export.py::TestBlobExporter::test_progress_and_summary_report_throughput`: exports a handful of blobs with a small `--progress-interval`, captures stdout, and asserts both the per-chunk `Processed N objects (last N in …s, …/1M objects)` line and the final summary line.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

