### PR TITLE
feat: add parameters to case search endpoints

### DIFF
--- a/corehq/apps/case_search/endpoint_capability.py
+++ b/corehq/apps/case_search/endpoint_capability.py
@@ -75,6 +75,8 @@ _OPERATOR_BY_TYPE = {
     ],
 }
 
+FIELD_TYPES = _OPERATOR_BY_TYPE.keys()
+
 # Sentinel input-slot type: the slot has no fixed type of its own and instead
 # takes the type of the field the condition is applied to. Used by operators
 # shared across field types (e.g. lt/gt work on both numbers and dates), where

--- a/corehq/apps/case_search/endpoint_query_spec.py
+++ b/corehq/apps/case_search/endpoint_query_spec.py
@@ -15,7 +15,7 @@ from typing import ClassVar
 
 from attr import Factory, define, field as attr_field, validators
 
-from corehq.apps.case_search.endpoint_capability import FIELD_TYPES, OPERATORS
+from corehq.apps.case_search.endpoint_capability import FIELD_TYPES, INPUT_TYPE_MATCH_FIELD, OPERATORS
 
 # Group node types: all = AND, any = OR, none = NOR (no child matches).
 GROUP_TYPES = ('all', 'any', 'none')
@@ -85,8 +85,25 @@ class ConstantInput:
     def from_json(cls, data):
         return cls(value=data.get('value'))
 
+@define
+class ParameterInput:
+    """A literal input value supplied directly in the spec."""
+
+    type: ClassVar[str] = 'parameter'
+    value: object = None
+
+    def to_json(self):
+        return {'type': self.type, 'value': self.value}
+
+    @classmethod
+    def from_json(cls, data):
+        return cls(value=data.get('value'))
+
 # input type -> class. Add parameter/function input kinds here.
-INPUT_TYPES = {ConstantInput.type: ConstantInput}
+INPUT_TYPES = {
+    ConstantInput.type: ConstantInput,
+    ParameterInput.type: ParameterInput,
+}
 
 def input_from_json(data):
     input_type = data.get('type')
@@ -162,7 +179,7 @@ def node_from_json(data, fields_by_name=None):
     raise ValueError(f'Unknown node type: {node_type!r}')
 
 
-def parse_query_spec(query_spec, case_type_name, capability):
+def parse_query_spec(query_spec, parameters, case_type_name, capability):
     """Validate a query spec against capability metadata and parse it.
 
     :returns: a ``(root, errors)`` tuple. ``root`` is the parsed node tree (an
@@ -173,7 +190,7 @@ def parse_query_spec(query_spec, case_type_name, capability):
     fields_by_name = _fields_by_name(capability, case_type_name, errors)
     operator_input_schemas = capability.get('operator_input_schemas', {})
 
-    _validate_node(query_spec, fields_by_name, operator_input_schemas, errors, depth=0, counter=[0])
+    _validate_node(query_spec, fields_by_name, parameters, operator_input_schemas, errors, depth=0, counter=[0])
     if errors:
         return None, errors
     return node_from_json(query_spec, fields_by_name), errors
@@ -187,7 +204,7 @@ def _fields_by_name(capability, case_type_name, errors):
     return case_types[case_type_name]
 
 
-def _validate_node(node, fields_by_name, operator_input_schemas, errors, depth, counter):
+def _validate_node(node, fields_by_name, parameters, operator_input_schemas, errors, depth, counter):
     counter[0] += 1
     if counter[0] > MAX_TOTAL_NODES:
         errors.append(f'Query has too many nodes (max {MAX_TOTAL_NODES})')
@@ -212,16 +229,16 @@ def _validate_node(node, fields_by_name, operator_input_schemas, errors, depth, 
             )
             return
         for child in children:
-            _validate_node(child, fields_by_name, operator_input_schemas, errors, depth + 1, counter)
+            _validate_node(child, fields_by_name, parameters, operator_input_schemas, errors, depth + 1, counter)
     elif node_type == 'component':
-        _validate_component(node, fields_by_name, operator_input_schemas, errors)
+        _validate_component(node, fields_by_name, parameters, operator_input_schemas, errors)
     else:
         errors.append(
             f"Invalid node type: '{node_type}'. Expected 'all', 'any', 'none', or 'component'."
         )
 
 
-def _validate_component(node, fields_by_name, operator_input_schemas, errors):
+def _validate_component(node, fields_by_name, parameters, operator_input_schemas, errors):
     field_name = node.get('field', '')
     component_name = node.get('operator', '')
     inputs = node.get('inputs', {})
@@ -239,6 +256,12 @@ def _validate_component(node, fields_by_name, operator_input_schemas, errors):
         )
         return
 
+    field_type = field['type']
+    resolved_slots = {
+        slot['name']: field_type if slot['type'] == INPUT_TYPE_MATCH_FIELD else slot['type']
+        for slot in operator_input_schemas.get(component_name, [])
+    }
+
     for slot in operator_input_schemas.get(component_name, []):
         slot_name = slot['name']
         if slot_name not in inputs:
@@ -246,10 +269,10 @@ def _validate_component(node, fields_by_name, operator_input_schemas, errors):
                 f"Missing required input '{slot_name}' for component '{component_name}'"
             )
             continue
-        _validate_input(inputs[slot_name], slot_name, errors)
+        _validate_input(inputs[slot_name], parameters, slot_name, resolved_slots[slot_name], errors)
 
 
-def _validate_input(value, slot_name, errors):
+def _validate_input(value, parameters, slot_name, slot_type, errors):
     if not isinstance(value, dict):
         errors.append(
             f"Invalid input '{slot_name}': expected object, "
@@ -259,3 +282,17 @@ def _validate_input(value, slot_name, errors):
     value_type = value.get('type')
     if value_type not in INPUT_TYPES:
         errors.append(f"Invalid input type '{value_type}' in '{slot_name}'")
+
+    if value_type == ParameterInput.type:
+        param_name = value.get('value')
+        if not param_name:
+            errors.append(f"Input '{slot_name}': parameter name is required")
+
+        referenced_parameter = next((p for p in parameters if p.name == param_name), None)
+        if not referenced_parameter:
+            errors.append(f"Input '{slot_name}': parameter {param_name} not configured")
+        elif referenced_parameter.type != slot_type:
+            errors.append(
+                f"Input '{slot_name}': parameter '{param_name}' has type "
+                f"'{referenced_parameter.type}', expected '{slot_type}'"
+            )

--- a/corehq/apps/case_search/endpoint_query_spec.py
+++ b/corehq/apps/case_search/endpoint_query_spec.py
@@ -49,22 +49,25 @@ def parse_parameter_spec(spec):
             errors.append(f'Parameter {i}: expected object, got {type(item).__name__}')
             continue
 
+        item_errors = []
         name = item.get('name', '').strip()
         if not name or not isinstance(name, str):
-            errors.append(f'Parameter {i}: name is required')
+            item_errors.append(f'Parameter {i}: name is required')
         elif name in seen_names:
-            errors.append(f"Duplicate parameter name: '{name}'")
+            item_errors.append(f"Duplicate parameter name: '{name}'")
         else:
             seen_names.add(name)
 
         param_type = item.get('type', '')
         if param_type not in FIELD_TYPES:
-            errors.append(
+            item_errors.append(
                 f"Parameter '{name or i}': invalid type '{param_type}'."
                 f" Must be one of: {', '.join(FIELD_TYPES)}"
             )
 
-        if not errors:
+        if item_errors:
+            errors.extend(item_errors)
+        else:
             parameters.append(Parameter(name=name, type=param_type))
 
     if errors:

--- a/corehq/apps/case_search/endpoint_query_spec.py
+++ b/corehq/apps/case_search/endpoint_query_spec.py
@@ -87,10 +87,10 @@ class ConstantInput:
 
 @define
 class ParameterInput:
-    """A literal input value supplied directly in the spec."""
+    """An input value supplied by referencing a named parameter."""
 
     type: ClassVar[str] = 'parameter'
-    value: object = None
+    value: str = attr_field(converter=str.strip, validator=validators.min_len(1))
 
     def to_json(self):
         return {'type': self.type, 'value': self.value}
@@ -170,7 +170,7 @@ class GroupNode:
 
 
 def node_from_json(data, fields_by_name=None):
-    """Build a node tree from an already-validated raw spec."""
+    """Build a node tree from a raw spec dict."""
     node_type = data.get('type')
     if node_type in GROUP_TYPES:
         return GroupNode.from_json(data, fields_by_name)
@@ -188,12 +188,23 @@ def parse_query_spec(query_spec, parameters, case_type_name, capability):
     """
     errors = []
     fields_by_name = _fields_by_name(capability, case_type_name, errors)
-    operator_input_schemas = capability.get('operator_input_schemas', {})
-
-    _validate_node(query_spec, fields_by_name, parameters, operator_input_schemas, errors, depth=0, counter=[0])
     if errors:
         return None, errors
-    return node_from_json(query_spec, fields_by_name), errors
+
+    try:
+        root = node_from_json(query_spec, fields_by_name)
+    except (TypeError, ValueError, KeyError, AttributeError):
+        return None, ['Invalid query']
+
+    _check_structural_limits(root, errors)
+    if not errors:
+        _check_semantics(
+            root, fields_by_name, parameters,
+            capability.get('operator_input_schemas', {}), errors,
+        )
+    if errors:
+        return None, errors
+    return root, []
 
 
 def _fields_by_name(capability, case_type_name, errors):
@@ -204,95 +215,70 @@ def _fields_by_name(capability, case_type_name, errors):
     return case_types[case_type_name]
 
 
-def _validate_node(node, fields_by_name, parameters, operator_input_schemas, errors, depth, counter):
+def _check_structural_limits(node, errors, depth=0, counter=None):
+    if counter is None:
+        counter = [0]
     counter[0] += 1
     if counter[0] > MAX_TOTAL_NODES:
         errors.append(f'Query has too many nodes (max {MAX_TOTAL_NODES})')
         return
-    if not isinstance(node, dict):
-        errors.append(
-            f'Invalid node: expected object, got {type(node).__name__}'
-        )
-        return
     if depth > MAX_QUERY_DEPTH:
-        errors.append(
-            f'Query is nested too deeply (max {MAX_QUERY_DEPTH} levels)'
-        )
+        errors.append(f'Query is nested too deeply (max {MAX_QUERY_DEPTH} levels)')
         return
-
-    node_type = node.get('type')
-    if node_type in GROUP_TYPES:
-        children = node.get('children', [])
-        if len(children) > MAX_GROUP_WIDTH:
-            errors.append(
-                f'Group has too many conditions (max {MAX_GROUP_WIDTH})'
-            )
+    if isinstance(node, GroupNode):
+        if len(node.children) > MAX_GROUP_WIDTH:
+            errors.append(f'Group has too many conditions (max {MAX_GROUP_WIDTH})')
             return
-        for child in children:
-            _validate_node(child, fields_by_name, parameters, operator_input_schemas, errors, depth + 1, counter)
-    elif node_type == 'component':
-        _validate_component(node, fields_by_name, parameters, operator_input_schemas, errors)
-    else:
-        errors.append(
-            f"Invalid node type: '{node_type}'. Expected 'all', 'any', 'none', or 'component'."
-        )
+        for child in node.children:
+            _check_structural_limits(child, errors, depth + 1, counter)
 
 
-def _validate_component(node, fields_by_name, parameters, operator_input_schemas, errors):
-    field_name = node.get('field', '')
-    component_name = node.get('operator', '')
-    inputs = node.get('inputs', {})
+def _check_semantics(node, fields_by_name, parameters, operator_input_schemas, errors):
+    if isinstance(node, GroupNode):
+        for child in node.children:
+            _check_semantics(child, fields_by_name, parameters, operator_input_schemas, errors)
+    elif isinstance(node, ComponentNode):
+        _check_component(node, fields_by_name, parameters, operator_input_schemas, errors)
 
-    field = fields_by_name.get(field_name)
+
+def _check_component(node, fields_by_name, parameters, operator_input_schemas, errors):
+    field = fields_by_name.get(node.field)
     if not field:
-        errors.append(f"Unknown field: '{field_name}'")
+        errors.append(f"Unknown field: '{node.field}'")
         return
 
     operation_names = [op['name'] for op in field.get('operations', [])]
-    if component_name not in operation_names:
+    if node.operator not in operation_names:
         errors.append(
-            f"'{component_name}' is not a valid operation for field "
-            f"'{field_name}' (type: {field['type']})"
+            f"'{node.operator}' is not a valid operation for field "
+            f"'{node.field}' (type: {field['type']})"
         )
         return
 
     field_type = field['type']
     resolved_slots = {
         slot['name']: field_type if slot['type'] == INPUT_TYPE_MATCH_FIELD else slot['type']
-        for slot in operator_input_schemas.get(component_name, [])
+        for slot in operator_input_schemas.get(node.operator, [])
     }
 
-    for slot in operator_input_schemas.get(component_name, []):
+    for slot in operator_input_schemas.get(node.operator, []):
         slot_name = slot['name']
-        if slot_name not in inputs:
+        if slot_name not in node.inputs:
             errors.append(
-                f"Missing required input '{slot_name}' for component '{component_name}'"
+                f"Missing required input '{slot_name}' for component '{node.operator}'"
             )
             continue
-        _validate_input(inputs[slot_name], parameters, slot_name, resolved_slots[slot_name], errors)
+        inp = node.inputs[slot_name]
+        if isinstance(inp, ParameterInput):
+            _check_parameter_input(inp, parameters, slot_name, resolved_slots[slot_name], errors)
 
 
-def _validate_input(value, parameters, slot_name, slot_type, errors):
-    if not isinstance(value, dict):
+def _check_parameter_input(inp, parameters, slot_name, slot_type, errors):
+    referenced = next((p for p in parameters if p.name == inp.value), None)
+    if not referenced:
+        errors.append(f"Input '{slot_name}': parameter {inp.value} not configured")
+    elif referenced.type != slot_type:
         errors.append(
-            f"Invalid input '{slot_name}': expected object, "
-            f'got {type(value).__name__}'
+            f"Input '{slot_name}': parameter '{inp.value}' has type "
+            f"'{referenced.type}', expected '{slot_type}'"
         )
-        return
-    value_type = value.get('type')
-    if value_type not in INPUT_TYPES:
-        errors.append(f"Invalid input type '{value_type}' in '{slot_name}'")
-
-    if value_type == ParameterInput.type:
-        param_name = value.get('value')
-        if not param_name:
-            errors.append(f"Input '{slot_name}': parameter name is required")
-
-        referenced_parameter = next((p for p in parameters if p.name == param_name), None)
-        if not referenced_parameter:
-            errors.append(f"Input '{slot_name}': parameter {param_name} not configured")
-        elif referenced_parameter.type != slot_type:
-            errors.append(
-                f"Input '{slot_name}': parameter '{param_name}' has type "
-                f"'{referenced_parameter.type}', expected '{slot_type}'"
-            )

--- a/corehq/apps/case_search/endpoint_query_spec.py
+++ b/corehq/apps/case_search/endpoint_query_spec.py
@@ -15,7 +15,7 @@ from typing import ClassVar
 
 from attr import Factory, define, field as attr_field, validators
 
-from corehq.apps.case_search.endpoint_capability import OPERATORS
+from corehq.apps.case_search.endpoint_capability import FIELD_TYPES, OPERATORS
 
 # Group node types: all = AND, any = OR, none = NOR (no child matches).
 GROUP_TYPES = ('all', 'any', 'none')
@@ -27,6 +27,49 @@ MAX_GROUP_WIDTH = 50
 # Maximum total nodes across the entire query tree.
 MAX_TOTAL_NODES = 200
 
+@define
+class Parameter:
+    name: str = attr_field(converter=str.strip, validator=validators.min_len(1))
+    type: str = attr_field(validator=validators.in_(FIELD_TYPES))
+
+def parse_parameter_spec(spec):
+    """Validate a parameter list spec and parse it.
+
+    :returns: a ``(parameters, errors)`` tuple. ``parameters`` is a list of
+        :class:`Parameter` objects, or ``None`` when ``errors`` is non-empty.
+    """
+    errors = []
+    if not isinstance(spec, list):
+        return None, ['Parameters must be a JSON array.']
+
+    parameters = []
+    seen_names = set()
+    for i, item in enumerate(spec, 1):
+        if not isinstance(item, dict):
+            errors.append(f'Parameter {i}: expected object, got {type(item).__name__}')
+            continue
+
+        name = item.get('name', '').strip()
+        if not name or not isinstance(name, str):
+            errors.append(f'Parameter {i}: name is required')
+        elif name in seen_names:
+            errors.append(f"Duplicate parameter name: '{name}'")
+        else:
+            seen_names.add(name)
+
+        param_type = item.get('type', '')
+        if param_type not in FIELD_TYPES:
+            errors.append(
+                f"Parameter '{name or i}': invalid type '{param_type}'."
+                f" Must be one of: {', '.join(FIELD_TYPES)}"
+            )
+
+        if not errors:
+            parameters.append(Parameter(name=name, type=param_type))
+
+    if errors:
+        return None, errors
+    return parameters, []
 
 @define
 class ConstantInput:
@@ -42,17 +85,14 @@ class ConstantInput:
     def from_json(cls, data):
         return cls(value=data.get('value'))
 
-
 # input type -> class. Add parameter/function input kinds here.
 INPUT_TYPES = {ConstantInput.type: ConstantInput}
-
 
 def input_from_json(data):
     input_type = data.get('type')
     if input_type not in INPUT_TYPES:
         raise ValueError(f"Unknown input type: {input_type!r}")
     return INPUT_TYPES[input_type].from_json(data)
-
 
 @define
 class ComponentNode:

--- a/corehq/apps/case_search/endpoint_views.py
+++ b/corehq/apps/case_search/endpoint_views.py
@@ -14,6 +14,7 @@ from corehq.apps.case_search.endpoint_capability import (
 )
 from corehq.apps.case_search.endpoint_query_spec import (
     MAX_QUERY_DEPTH,
+    parse_parameter_spec,
     parse_query_spec,
 )
 from corehq.apps.case_search.models import (
@@ -116,9 +117,11 @@ class CaseSearchEndpointForm(forms.Form):
         # Only run semantic validation when both fields parsed cleanly.
         if query is not None and parameters is not None:
             capability = self.capability or get_capability(self.domain)
-            _, errors = parse_query_spec(
-                query, cleaned.get('case_type') or '', capability
-            )
+            _, errors = parse_parameter_spec(parameters)
+            if not errors:
+                _, errors = parse_query_spec(
+                    query, cleaned.get('case_type') or '', capability
+                )
             for error in errors:
                 self.add_error(None, error)
         return cleaned
@@ -343,9 +346,19 @@ class CaseSearchEndpointTestView(BaseDomainView):
     def post(self, request, *args, **kwargs):
         case_type = request.POST.get('case_type', '')
         try:
+            parameters = json.loads(request.POST.get('parameters', '[]'))
+        except (json.JSONDecodeError, ValueError):
+            return self._render_results(request, errors=['Invalid parameters JSON.'])
+
+        try:
             query = json.loads(request.POST.get('query') or '{}')
         except (json.JSONDecodeError, ValueError):
             return self._render_results(request, errors=['Invalid query JSON.'])
+
+        parameters, errors = parse_parameter_spec(parameters)
+        if errors:
+            return self._render_results(request, errors=errors)
+
         capability = get_capability(domain=self.domain)
         fields = capability['case_types'][case_type]
         query_root, errors = parse_query_spec(query, case_type, capability)

--- a/corehq/apps/case_search/endpoint_views.py
+++ b/corehq/apps/case_search/endpoint_views.py
@@ -380,7 +380,6 @@ class CaseSearchEndpointTestView(BaseDomainView):
     def _run_query(self, case_type, query, test_param_values):
         helper = QueryHelper(self.domain)
         criteria = criteria_dict_to_criteria_list(test_param_values)
-        print(test_param_values)
         return get_primary_case_search_endpoint_results(helper, [case_type], criteria, query, 20)
 
     def _render_results(self, request, *, errors=None, fields=None, results=None):

--- a/corehq/apps/case_search/endpoint_views.py
+++ b/corehq/apps/case_search/endpoint_views.py
@@ -366,6 +366,8 @@ class CaseSearchEndpointTestView(BaseDomainView):
             return self._render_results(request, errors=errors)
 
         capability = get_capability(domain=self.domain)
+        if case_type not in capability['case_types']:
+            return self._render_results(request, errors=[f"Unknown case type: '{case_type}'"])
         fields = capability['case_types'][case_type]
         query_root, errors = parse_query_spec(query, parameters, case_type, capability)
         if errors:

--- a/corehq/apps/case_search/endpoint_views.py
+++ b/corehq/apps/case_search/endpoint_views.py
@@ -20,6 +20,7 @@ from corehq.apps.case_search.endpoint_query_spec import (
 from corehq.apps.case_search.models import (
     CaseSearchEndpoint,
     CaseSearchEndpointVersion,
+    criteria_dict_to_criteria_list,
 )
 from corehq.apps.case_search.utils import QueryHelper, get_primary_case_search_endpoint_results
 from corehq.apps.domain.views.base import BaseDomainView
@@ -351,6 +352,11 @@ class CaseSearchEndpointTestView(BaseDomainView):
             return self._render_results(request, errors=['Invalid parameters JSON.'])
 
         try:
+            test_param_values = json.loads(request.POST.get('test_param_values', '{}'))
+        except (json.JSONDecodeError, ValueError):
+            return self._render_results(request, errors=['Invalid test parameter values.'])
+
+        try:
             query = json.loads(request.POST.get('query') or '{}')
         except (json.JSONDecodeError, ValueError):
             return self._render_results(request, errors=['Invalid query JSON.'])
@@ -365,16 +371,17 @@ class CaseSearchEndpointTestView(BaseDomainView):
         if errors:
             return self._render_results(request, errors=errors)
         try:
-            results = self._run_query(case_type, query_root)
+            results = self._run_query(case_type, query_root, test_param_values)
         except Exception as e:
             notify_exception(request, str(e))
             return self._render_results(request, errors=['Query Execution Failed'])
         return self._render_results(request, fields=fields, results=results)
 
-    def _run_query(self, case_type, query):
+    def _run_query(self, case_type, query, test_param_values):
         helper = QueryHelper(self.domain)
-        results = get_primary_case_search_endpoint_results(helper, [case_type], [], query, 20)
-        return results
+        criteria = criteria_dict_to_criteria_list(test_param_values)
+        print(test_param_values)
+        return get_primary_case_search_endpoint_results(helper, [case_type], criteria, query, 20)
 
     def _render_results(self, request, *, errors=None, fields=None, results=None):
         # Always 200 so HTMX swaps the partial in (it ignores error statuses).

--- a/corehq/apps/case_search/endpoint_views.py
+++ b/corehq/apps/case_search/endpoint_views.py
@@ -117,10 +117,10 @@ class CaseSearchEndpointForm(forms.Form):
         # Only run semantic validation when both fields parsed cleanly.
         if query is not None and parameters is not None:
             capability = self.capability or get_capability(self.domain)
-            _, errors = parse_parameter_spec(parameters)
+            parameters, errors = parse_parameter_spec(parameters)
             if not errors:
                 _, errors = parse_query_spec(
-                    query, cleaned.get('case_type') or '', capability
+                    query, parameters, cleaned.get('case_type') or '', capability
                 )
             for error in errors:
                 self.add_error(None, error)
@@ -361,7 +361,7 @@ class CaseSearchEndpointTestView(BaseDomainView):
 
         capability = get_capability(domain=self.domain)
         fields = capability['case_types'][case_type]
-        query_root, errors = parse_query_spec(query, case_type, capability)
+        query_root, errors = parse_query_spec(query, parameters, case_type, capability)
         if errors:
             return self._render_results(request, errors=errors)
         try:

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -11,6 +11,7 @@ Alpine.data("endpointForm", () => {
         targetType: initialPageData.get("initial_target_type"),
         targetCasetype: initialPageData.get("initial_case_type"),
         parameters: initialPageData.get("initial_parameters") || [],
+        testParamValues: {},
         query: initialPageData.get("initial_query"),
         capability: initialPageData.get("capability"),
         mode: mode,

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -10,6 +10,7 @@ Alpine.data("endpointForm", () => {
         name: initialPageData.get("initial_name"),
         targetType: initialPageData.get("initial_target_type"),
         targetCasetype: initialPageData.get("initial_case_type"),
+        parameters: initialPageData.get("initial_parameters") || [],
         query: initialPageData.get("initial_query"),
         capability: initialPageData.get("capability"),
         mode: mode,
@@ -78,6 +79,14 @@ Alpine.data("endpointForm", () => {
 
         onCasetypeChange() {
             this.query = { type: "all", children: [] };
+        },
+
+        addParameter() {
+            this.parameters.push({ name: "", type: "text"});
+        },
+
+        removeParameter(idx) {
+            this.parameters.splice(idx, 1);
         },
 
         _newCondition() {

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -29,8 +29,14 @@ Alpine.data("endpointForm", () => {
             return f ? f.operations : [];
         },
 
-        getInputSchemaForOperation(operation) {
-            return this.capability.operator_input_schemas[operation] || [];
+        getInputSchemaForOperation(node) {
+            const operation = node.operator;
+            const inputs = this.capability.operator_input_schemas[operation] || [];
+            return inputs.map(input =>
+                input.type === "match_field"
+                    ? { ...input, type: this.getFieldType(node.field) }
+                    : input
+            );
         },
 
         getFieldType(fieldName) {
@@ -89,6 +95,10 @@ Alpine.data("endpointForm", () => {
             this.parameters.splice(idx, 1);
         },
 
+        getParametersOfType(fieldType) {
+            return this.parameters.filter(param => param.type === fieldType).map(param => param.name);
+        },
+
         _newCondition() {
             return {
                 _id: this._nextId++,
@@ -127,7 +137,7 @@ Alpine.data("endpointForm", () => {
         },
 
         onOperatorChange(node) {
-            const schema = this.getInputSchemaForOperation(node.operator);
+            const schema = this.getInputSchemaForOperation(node);
             if (schema.every((slot) => slot.name in (node.inputs || {}))) {
                 return;
             }
@@ -150,6 +160,11 @@ Alpine.data("endpointForm", () => {
                 node.inputs[slotName] = {
                     type: "constant",
                     value: current.value || "",
+                };
+            } else if (valueType === "parameter") {
+                node.inputs[slotName] = {
+                    type: "parameter",
+                    value: "",
                 };
             }
         },

--- a/corehq/apps/case_search/templates/case_search/endpoint_edit.html
+++ b/corehq/apps/case_search/templates/case_search/endpoint_edit.html
@@ -19,6 +19,7 @@
   {% initial_page_data "initial_name" form.name.value %}
   {% initial_page_data "initial_target_type" form.target_type.value %}
   {% initial_page_data "initial_case_type" form.case_type.value %}
+  {% initial_page_data "initial_parameters" form.parameters.value %}
   {% initial_page_data "initial_query" form.query.value %}
   {% initial_page_data "capability" capability %}
 
@@ -122,32 +123,66 @@
     </div>
 
     {# ── Parameters card ── #}
-    {# Hidden until query conditions can reference parameters; the textarea #}
-    {# still round-trips the stored parameters through the form POST.       #}
-    <div class="card mb-3 d-none">
+    <div class="card mb-3">
       <div class="card-header">
         <i class="fa-solid fa-sliders me-1"></i>{% trans "Parameters" %}
       </div>
       <div class="card-body">
-        <div class="row g-3">
-          <div class="mb-3">
-            <label class="form-label" for="parameters">
-              {% trans "Parameters" %}
-              <small class="text-muted">({% trans "JSON array" %})</small>
-            </label>
-            <textarea
-              class="form-control font-monospace{% if form.parameters.errors %}is-invalid{% endif %}"
-              id="parameters"
-              name="parameters"
-              rows="5"
-            >
-{{ form.parameters.value }}</textarea
-            >
-            {% for error in form.parameters.errors %}
-              <div class="invalid-feedback">{{ error }}</div>
-            {% endfor %}
-          </div>
+        <div class="mb-2">
+          <span class="text-muted small fst-italic">Parameter names need to match case property names to work in case lists.</span>
         </div>
+        <template x-for="(param, idx) in parameters" :key="idx">
+          <div class="d-flex align-items-center gap-2 mb-2">
+            <span
+              class="ep-type-badge d-inline-flex align-items-center justify-content-center flex-shrink-0 rounded-1 bg-secondary text-white"
+            >
+              <i :class="typeIconClass(param.type || 'text')"></i>
+            </span>
+            <input
+              type="text"
+              class="form-control form-control-sm font-monospace flex-grow-1"
+              x-model="param.name"
+              :id="'param-name-' + idx"
+              required
+              pattern=".*\S.*"
+              title="{% trans "Name cannot be empty or only whitespace" %}"
+              placeholder="{% trans "parameter name" %}"
+            />
+            <select
+              class="form-select form-select-sm w-auto"
+              x-model="param.type"
+            >
+              <option value="text">{% trans "text" %}</option>
+              <option value="number">{% trans "number" %}</option>
+              <option value="date">{% trans "date" %}</option>
+            </select>
+            <button
+              type="button"
+              class="btn btn-sm text-secondary border-0 p-1"
+              @click="removeParameter(idx)"
+              :aria-label="'{% trans "Remove parameter" %}'"
+            >
+              <i class="fa-regular fa-trash-can"></i>
+            </button>
+          </div>
+        </template>
+
+        <button
+          type="button"
+          class="btn btn-outline-primary btn-sm"
+          @click="addParameter()"
+        >
+          <i class="fa-solid fa-plus me-1"></i>{% trans "Add Parameter" %}
+        </button>
+
+        <input
+          type="hidden"
+          name="parameters"
+          :value="JSON.stringify(parameters)"
+        />
+        {% for error in form.parameters.errors %}
+          <div class="alert alert-danger mt-2">{{ error }}</div>
+        {% endfor %}
       </div>
     </div>
 

--- a/corehq/apps/case_search/templates/case_search/partials/condition_row.html
+++ b/corehq/apps/case_search/templates/case_search/partials/condition_row.html
@@ -43,10 +43,7 @@
     </select>
   </template>
   <template x-if="node.operator">
-    <template
-      x-for="slot in getInputSchemaForOperation(node)"
-      :key="slot.name"
-    >
+    <template x-for="slot in getInputSchemaForOperation(node)" :key="slot.name">
       <div class="d-flex gap-1 flex-grow-1">
         <select
           class="form-select form-select-sm"
@@ -74,7 +71,9 @@
             :value="getInputValue(node, slot.name).value"
             @change="node.inputs[slot.name].value = $event.target.value"
           >
-            <option value="" disabled selected>{% trans "-- Parameter --" %}</option>
+            <option value="" disabled selected>
+              {% trans "-- Parameter --" %}
+            </option>
             <template x-for="parameter in getParametersOfType(slot.type)">
               <option :value="parameter" x-text="parameter"></option>
             </template>

--- a/corehq/apps/case_search/templates/case_search/partials/condition_row.html
+++ b/corehq/apps/case_search/templates/case_search/partials/condition_row.html
@@ -10,8 +10,7 @@
     <i :class="typeIconClass(getFieldType(node.field))"></i>
   </span>
   <select
-    class="form-select form-select-sm"
-    style="width: auto; min-width: 120px;"
+    class="form-select form-select-sm w-auto"
     @change="node.field = $event.target.value; onFieldChange(node)"
   >
     <option value="" :selected="!node.field">{% trans "-- Field --" %}</option>
@@ -25,8 +24,7 @@
   </select>
   <template x-if="node.field">
     <select
-      class="form-select form-select-sm"
-      style="width: auto; min-width: 120px;"
+      class="form-select form-select-sm w-auto"
       @change="node.operator = $event.target.value; onOperatorChange(node)"
       :disabled="mode === 'readonly'"
     >
@@ -46,8 +44,7 @@
     <template x-for="slot in getInputSchemaForOperation(node)" :key="slot.name">
       <div class="d-flex gap-1 flex-grow-1">
         <select
-          class="form-select form-select-sm"
-          style="width: auto;"
+          class="form-select form-select-sm w-auto"
           :value="getInputValue(node, slot.name).type"
           @change="setInputType(node, slot.name, $event.target.value)"
           :disabled="mode === 'readonly'"
@@ -66,8 +63,7 @@
         </template>
         <template x-if="getInputValue(node, slot.name).type === 'parameter'">
           <select
-            class="form-select form-select-sm"
-            style="width: auto;"
+            class="form-select form-select-sm w-auto"
             :value="getInputValue(node, slot.name).value"
             @change="node.inputs[slot.name].value = $event.target.value"
           >

--- a/corehq/apps/case_search/templates/case_search/partials/condition_row.html
+++ b/corehq/apps/case_search/templates/case_search/partials/condition_row.html
@@ -62,7 +62,7 @@
           <input
             type="text"
             class="form-control form-control-sm"
-            x-model="node.inputs[slot.name].value"
+            x-model="getInputValue(node, slot.name).value"
             :disabled="mode === 'readonly'"
             :placeholder="slot.name"
           />

--- a/corehq/apps/case_search/templates/case_search/partials/condition_row.html
+++ b/corehq/apps/case_search/templates/case_search/partials/condition_row.html
@@ -13,7 +13,6 @@
     class="form-select form-select-sm"
     style="width: auto; min-width: 120px;"
     @change="node.field = $event.target.value; onFieldChange(node)"
-    :disabled="mode === 'readonly'"
   >
     <option value="" :selected="!node.field">{% trans "-- Field --" %}</option>
     <template x-for="field in Object.values(currentFields)" :key="field.name">
@@ -45,7 +44,7 @@
   </template>
   <template x-if="node.operator">
     <template
-      x-for="slot in getInputSchemaForOperation(node.operator)"
+      x-for="slot in getInputSchemaForOperation(node)"
       :key="slot.name"
     >
       <div class="d-flex gap-1 flex-grow-1">
@@ -57,6 +56,7 @@
           :disabled="mode === 'readonly'"
         >
           <option value="constant">{% trans "Value" %}</option>
+          <option value="parameter">{% trans "Parameter" %}</option>
         </select>
         <template x-if="getInputValue(node, slot.name).type === 'constant'">
           <input
@@ -66,6 +66,19 @@
             :disabled="mode === 'readonly'"
             :placeholder="slot.name"
           />
+        </template>
+        <template x-if="getInputValue(node, slot.name).type === 'parameter'">
+          <select
+            class="form-select form-select-sm"
+            style="width: auto;"
+            :value="getInputValue(node, slot.name).value"
+            @change="node.inputs[slot.name].value = $event.target.value"
+          >
+            <option value="" disabled selected>{% trans "-- Parameter --" %}</option>
+            <template x-for="parameter in getParametersOfType(slot.type)">
+              <option :value="parameter" x-text="parameter"></option>
+            </template>
+          </select>
         </template>
       </div>
     </template>

--- a/corehq/apps/case_search/templates/case_search/partials/query_tester.html
+++ b/corehq/apps/case_search/templates/case_search/partials/query_tester.html
@@ -11,9 +11,7 @@
       :for="'param-value-' + idx"
       x-text="param.name"
     ></label>
-    <div
-      class="col-sm-10 "
-    >
+    <div class="col-sm-10 ">
       <input
         type="text"
         class="form-control form-control-sm font-monospace flex-grow-1"
@@ -21,7 +19,6 @@
         x-model="testParamValues[param.name]"
       />
     </div>
-
   </div>
 </template>
 

--- a/corehq/apps/case_search/templates/case_search/partials/query_tester.html
+++ b/corehq/apps/case_search/templates/case_search/partials/query_tester.html
@@ -16,4 +16,9 @@
   {% trans "Test query" %}
 </button>
 
+<span
+  id="test-spinner"
+  class="htmx-indicator spinner-border spinner-border-sm ms-2"
+  role="status"
+></span>
 <div id="test-results"></div>

--- a/corehq/apps/case_search/templates/case_search/partials/query_tester.html
+++ b/corehq/apps/case_search/templates/case_search/partials/query_tester.html
@@ -4,11 +4,33 @@
 {# the rendered results/errors into #test-results. `closest form` also       #}
 {# carries the CSRF token.                                                    #}
 
+<template x-for="(param, idx) in parameters" :key="idx">
+  <div class="row mb-2">
+    <label
+      class="col-sm-2 form-label fw-semibold p-0"
+      :for="'param-value-' + idx"
+      x-text="param.name"
+    ></label>
+    <div
+      class="col-sm-10 "
+    >
+      <input
+        type="text"
+        class="form-control form-control-sm font-monospace flex-grow-1"
+        :id="'param-value-' + idx"
+        x-model="testParamValues[param.name]"
+      />
+    </div>
+
+  </div>
+</template>
+
 <button
   type="button"
   class="btn btn-secondary btn-sm"
   hx-post="{% url 'case_search_endpoint_test' domain %}"
   hx-include="closest form"
+  :hx-vals="JSON.stringify({test_param_values: testParamValues})"
   hx-target="#test-results"
   hx-swap="innerHTML"
   hx-indicator="#test-spinner"

--- a/corehq/apps/case_search/tests/test_endpoint_capability.py
+++ b/corehq/apps/case_search/tests/test_endpoint_capability.py
@@ -99,14 +99,14 @@ def test_date_operations_use_lt_gt_not_before_after():
     assert 'after' not in op_names
 
 
-def test_date_lt_gt_labels_match_data_cleaning_phrasing():
-    labels = {
-        op['name']: str(op['label'])
-        for op in get_operations_for_field_type(FIELD_TYPE_DATE)
-    }
-    assert labels['lt'] == 'before'
-    assert labels['gt'] == 'after'
-    assert labels['equals'] == 'on'
+@pytest.mark.parametrize("op_name,expected_label", [
+    ('lt', 'before'),
+    ('gt', 'after'),
+    ('equals', 'on'),
+])
+def test_date_op_labels(op_name, expected_label):
+    labels = {op['name']: str(op['label']) for op in get_operations_for_field_type(FIELD_TYPE_DATE)}
+    assert labels[op_name] == expected_label
 
 
 @use(patient_case_type)
@@ -129,37 +129,19 @@ def test_excludes_deprecated_case_types():
         deprecated.delete()
 
 
+@pytest.mark.parametrize("prop_name,prop_kwargs", [
+    ('legacy_prop', {'data_type': CaseProperty.DataType.PLAIN, 'deprecated': True}),
+    ('secret', {'data_type': CaseProperty.DataType.PASSWORD}),
+])
 @use(patient_case_type)
-def test_excludes_deprecated_properties():
+def test_excludes_property(prop_name, prop_kwargs):
     case_type = patient_case_type()
-    legacy = CaseProperty.objects.create(
-        case_type=case_type,
-        name='legacy_prop',
-        data_type=CaseProperty.DataType.PLAIN,
-        deprecated=True,
-    )
+    prop = CaseProperty.objects.create(case_type=case_type, name=prop_name, **prop_kwargs)
     try:
         cap = get_capability('test-domain')
-        field_names = cap['case_types']['patient'].keys()
-        assert 'legacy_prop' not in field_names
+        assert prop_name not in cap['case_types']['patient'].keys()
     finally:
-        legacy.delete()
-
-
-@use(patient_case_type)
-def test_excludes_password_fields():
-    case_type = patient_case_type()
-    secret = CaseProperty.objects.create(
-        case_type=case_type,
-        name='secret',
-        data_type=CaseProperty.DataType.PASSWORD,
-    )
-    try:
-        cap = get_capability('test-domain')
-        field_names = cap['case_types']['patient'].keys()
-        assert 'secret' not in field_names
-    finally:
-        secret.delete()
+        prop.delete()
 
 
 def test_get_field_type_raises_for_unmapped_data_type():

--- a/corehq/apps/case_search/tests/test_endpoint_query_spec.py
+++ b/corehq/apps/case_search/tests/test_endpoint_query_spec.py
@@ -125,7 +125,7 @@ def test_invalid_root_type():
         {'type': 'invalid'}, [], 'patient', sample_capability()
     )
     assert root is None
-    assert any('type' in e.lower() for e in errors)
+    assert errors == ['Invalid query']
 
 
 @use(sample_capability)
@@ -187,12 +187,12 @@ def test_missing_required_input_slot():
     assert any('distance' in e for e in errors)
 
 
-@pytest.mark.parametrize("input_value,error_fragment", [
-    ({'type': 'auto_value', 'ref': 'some_ref'}, 'Invalid input type'),
-    ('not_an_object', 'expected object'),
+@pytest.mark.parametrize("input_value", [
+    {'type': 'auto_value', 'ref': 'some_ref'},
+    'not_an_object',
 ])
 @use(sample_capability)
-def test_invalid_input_rejected(input_value, error_fragment):
+def test_invalid_input_rejected(input_value):
     spec = {
         'type': 'component',
         'operator': 'equals',
@@ -200,7 +200,7 @@ def test_invalid_input_rejected(input_value, error_fragment):
         'inputs': {'value': input_value},
     }
     _, errors = parse_query_spec(spec, [], 'patient', sample_capability())
-    assert any(error_fragment in e for e in errors)
+    assert errors == ['Invalid query']
 
 
 @use(sample_capability)
@@ -263,7 +263,7 @@ def test_empty_children_allowed():
 def test_non_dict_child_node_returns_error():
     spec = {'type': 'all', 'children': ['not_a_dict']}
     _, errors = parse_query_spec(spec, [], 'patient', sample_capability())
-    assert any('str' in e for e in errors)
+    assert errors == ['Invalid query']
 
 
 @pytest.mark.parametrize("group_type", ["all", "none"])
@@ -409,7 +409,7 @@ def test_parameter_input_valid(field, param_name, param_type):
     (
         [Parameter(name='region', type=FIELD_TYPE_TEXT)],
         {'type': 'parameter', 'value': ''},
-        'parameter name is required',
+        'Invalid query',
     ),
     (
         [Parameter(name='my_date', type=FIELD_TYPE_DATE)],

--- a/corehq/apps/case_search/tests/test_endpoint_query_spec.py
+++ b/corehq/apps/case_search/tests/test_endpoint_query_spec.py
@@ -67,7 +67,7 @@ def test_valid_simple_spec():
             }
         ],
     }
-    root, errors = parse_query_spec(spec, 'patient', sample_capability())
+    root, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert errors == []
     assert root == GroupNode(
         type='all',
@@ -94,7 +94,7 @@ def test_valid_multi_input_spec():
             'unit': {'type': 'constant', 'value': 'km'},
         },
     }
-    root, errors = parse_query_spec(spec, 'patient', sample_capability())
+    root, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert errors == []
     assert isinstance(root, ComponentNode)
     assert set(root.inputs) == {'point', 'distance', 'unit'}
@@ -114,7 +114,7 @@ def test_ast_round_trips_through_json():
             }
         ],
     }
-    root, errors = parse_query_spec(spec, 'patient', sample_capability())
+    root, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert errors == []
     assert root.to_json() == spec
 
@@ -122,7 +122,7 @@ def test_ast_round_trips_through_json():
 @use(sample_capability)
 def test_invalid_root_type():
     root, errors = parse_query_spec(
-        {'type': 'invalid'}, 'patient', sample_capability()
+        {'type': 'invalid'}, [], 'patient', sample_capability()
     )
     assert root is None
     assert any('type' in e.lower() for e in errors)
@@ -136,7 +136,7 @@ def test_date_field_accepts_lt():
         'field': 'dob',
         'inputs': {'value': {'type': 'constant', 'value': '2020-01-01'}},
     }
-    root, errors = parse_query_spec(spec, 'patient', sample_capability())
+    root, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert errors == []
     assert isinstance(root, ComponentNode)
     assert root.operator == 'lt'
@@ -145,7 +145,7 @@ def test_date_field_accepts_lt():
 @use(sample_capability)
 def test_unknown_case_type():
     spec = {'type': 'all', 'children': []}
-    root, errors = parse_query_spec(spec, 'nonexistent_type', sample_capability())
+    root, errors = parse_query_spec(spec, [], 'nonexistent_type', sample_capability())
     assert root is None
     assert any('nonexistent_type' in e for e in errors)
 
@@ -158,7 +158,7 @@ def test_unknown_field():
         'field': 'nonexistent',
         'inputs': {'value': {'type': 'constant', 'value': 'x'}},
     }
-    root, errors = parse_query_spec(spec, 'patient', sample_capability())
+    root, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert root is None
     assert any('nonexistent' in e for e in errors)
 
@@ -171,7 +171,7 @@ def test_incompatible_component_for_field():
         'field': 'province',
         'inputs': {'point': {'type': 'constant', 'value': '0 0'}},
     }
-    _, errors = parse_query_spec(spec, 'patient', sample_capability())
+    _, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert any('within_distance' in e for e in errors)
 
 
@@ -183,21 +183,20 @@ def test_missing_required_input_slot():
         'field': 'location',
         'inputs': {'point': {'type': 'constant', 'value': '0 0'}},
     }
-    _, errors = parse_query_spec(spec, 'patient', sample_capability())
+    _, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert any('distance' in e for e in errors)
 
 
 @use(sample_capability)
-def test_non_constant_input_type_rejected():
-    for input_type in ['parameter', 'auto_value']:
-        spec = {
-            'type': 'component',
-            'operator': 'equals',
-            'field': 'province',
-            'inputs': {'value': {'type': input_type, 'ref': 'some_ref'}},
-        }
-        _, errors = parse_query_spec(spec, 'patient', sample_capability())
-        assert any('Invalid input type' in e for e in errors), input_type
+def test_unknown_input_type_rejected():
+    spec = {
+        'type': 'component',
+        'operator': 'equals',
+        'field': 'province',
+        'inputs': {'value': {'type': 'auto_value', 'ref': 'some_ref'}},
+    }
+    _, errors = parse_query_spec(spec, [], 'patient', sample_capability())
+    assert any('Invalid input type' in e for e in errors)
 
 
 @use(sample_capability)
@@ -208,7 +207,7 @@ def test_non_dict_input_rejected():
         'field': 'province',
         'inputs': {'value': 'not_an_object'},
     }
-    _, errors = parse_query_spec(spec, 'patient', sample_capability())
+    _, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert any('expected object' in e for e in errors)
 
 
@@ -225,7 +224,7 @@ def test_none_group_accepted():
             }
         ],
     }
-    root, errors = parse_query_spec(spec, 'patient', sample_capability())
+    root, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert errors == []
     assert isinstance(root, GroupNode)
     assert root.type == 'none'
@@ -251,7 +250,7 @@ def test_nested_all_any():
             }
         ],
     }
-    root, errors = parse_query_spec(spec, 'patient', sample_capability())
+    root, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert errors == []
     assert root.type == 'all'
     inner = root.children[0]
@@ -262,7 +261,7 @@ def test_nested_all_any():
 @use(sample_capability)
 def test_empty_children_allowed():
     root, errors = parse_query_spec(
-        {'type': 'all', 'children': []}, 'patient', sample_capability()
+        {'type': 'all', 'children': []}, [], 'patient', sample_capability()
     )
     assert errors == []
     assert root == GroupNode(type='all', children=[])
@@ -271,7 +270,7 @@ def test_empty_children_allowed():
 @use(sample_capability)
 def test_non_dict_child_node_returns_error():
     spec = {'type': 'all', 'children': ['not_a_dict']}
-    _, errors = parse_query_spec(spec, 'patient', sample_capability())
+    _, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert any('str' in e for e in errors)
 
 
@@ -283,7 +282,7 @@ def test_deeply_nested_query_returns_error():
         child = {'type': 'all', 'children': []}
         node['children'] = [child]
         node = child
-    _, errors = parse_query_spec(root, 'patient', sample_capability())
+    _, errors = parse_query_spec(root, [], 'patient', sample_capability())
     assert any('nested too deeply' in e for e in errors)
 
 
@@ -297,7 +296,7 @@ def test_none_group_counts_toward_depth():
         child = {'type': 'none', 'children': []}
         node['children'] = [child]
         node = child
-    _, errors = parse_query_spec(root, 'patient', sample_capability())
+    _, errors = parse_query_spec(root, [], 'patient', sample_capability())
     assert any('nested too deeply' in e for e in errors)
 
 
@@ -307,7 +306,7 @@ def test_group_exceeding_max_width_returns_error():
         'type': 'all',
         'children': [{'type': 'all', 'children': []}] * (MAX_GROUP_WIDTH + 1),
     }
-    _, errors = parse_query_spec(spec, 'patient', sample_capability())
+    _, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert any('too many conditions' in e for e in errors)
 
 
@@ -317,7 +316,7 @@ def test_group_at_max_width_is_valid():
         'type': 'all',
         'children': [{'type': 'all', 'children': []}] * MAX_GROUP_WIDTH,
     }
-    _, errors = parse_query_spec(spec, 'patient', sample_capability())
+    _, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert not any('too many conditions' in e for e in errors)
 
 
@@ -337,7 +336,7 @@ def test_total_node_limit_returns_error():
             for _ in range(MAX_GROUP_WIDTH)
         ],
     }
-    _, errors = parse_query_spec(spec, 'patient', sample_capability())
+    _, errors = parse_query_spec(spec, [], 'patient', sample_capability())
     assert any('too many nodes' in e for e in errors)
 
 
@@ -411,3 +410,68 @@ def test_parse_parameter_spec_all_valid_types(type_val):
     params, errors = parse_parameter_spec([{'name': 'p', 'type': type_val}])
     assert errors == []
     assert params[0].type == type_val
+
+
+# ── parameter input validation in parse_query_spec ───────────────────────────
+
+def _component_spec(field, operator, input_value):
+    return {
+        'type': 'all',
+        'children': [
+            {
+                'type': 'component',
+                'field': field,
+                'operator': operator,
+                'inputs': {'value': input_value},
+            }
+        ],
+    }
+
+
+@use(sample_capability)
+def test_parameter_input_valid():
+    params = [Parameter(name='region', type=FIELD_TYPE_TEXT, required=False)]
+    _, errors = parse_query_spec(
+        _component_spec('province', 'equals', {'type': 'parameter', 'value': 'region'}),
+        params, 'patient', sample_capability(),
+    )
+    assert errors == []
+
+
+@use(sample_capability)
+def test_parameter_input_unknown_parameter():
+    _, errors = parse_query_spec(
+        _component_spec('province', 'equals', {'type': 'parameter', 'value': 'nonexistent'}),
+        [], 'patient', sample_capability(),
+    )
+    assert any('not configured' in e for e in errors)
+
+
+@use(sample_capability)
+def test_parameter_input_empty_name():
+    params = [Parameter(name='region', type=FIELD_TYPE_TEXT, required=False)]
+    _, errors = parse_query_spec(
+        _component_spec('province', 'equals', {'type': 'parameter', 'value': ''}),
+        params, 'patient', sample_capability(),
+    )
+    assert any('parameter name is required' in e for e in errors)
+
+
+@use(sample_capability)
+def test_parameter_input_type_mismatch():
+    params = [Parameter(name='my_date', type=FIELD_TYPE_DATE, required=False)]
+    _, errors = parse_query_spec(
+        _component_spec('province', 'equals', {'type': 'parameter', 'value': 'my_date'}),
+        params, 'patient', sample_capability(),
+    )
+    assert any("has type 'date', expected 'text'" in e for e in errors)
+
+
+@use(sample_capability)
+def test_parameter_input_type_matches_field_type():
+    params = [Parameter(name='cutoff', type=FIELD_TYPE_DATE, required=False)]
+    _, errors = parse_query_spec(
+        _component_spec('dob', 'equals', {'type': 'parameter', 'value': 'cutoff'}),
+        params, 'patient', sample_capability(),
+    )
+    assert errors == []

--- a/corehq/apps/case_search/tests/test_endpoint_query_spec.py
+++ b/corehq/apps/case_search/tests/test_endpoint_query_spec.py
@@ -187,28 +187,20 @@ def test_missing_required_input_slot():
     assert any('distance' in e for e in errors)
 
 
+@pytest.mark.parametrize("input_value,error_fragment", [
+    ({'type': 'auto_value', 'ref': 'some_ref'}, 'Invalid input type'),
+    ('not_an_object', 'expected object'),
+])
 @use(sample_capability)
-def test_unknown_input_type_rejected():
+def test_invalid_input_rejected(input_value, error_fragment):
     spec = {
         'type': 'component',
         'operator': 'equals',
         'field': 'province',
-        'inputs': {'value': {'type': 'auto_value', 'ref': 'some_ref'}},
+        'inputs': {'value': input_value},
     }
     _, errors = parse_query_spec(spec, [], 'patient', sample_capability())
-    assert any('Invalid input type' in e for e in errors)
-
-
-@use(sample_capability)
-def test_non_dict_input_rejected():
-    spec = {
-        'type': 'component',
-        'operator': 'equals',
-        'field': 'province',
-        'inputs': {'value': 'not_an_object'},
-    }
-    _, errors = parse_query_spec(spec, [], 'patient', sample_capability())
-    assert any('expected object' in e for e in errors)
+    assert any(error_fragment in e for e in errors)
 
 
 @use(sample_capability)
@@ -274,26 +266,13 @@ def test_non_dict_child_node_returns_error():
     assert any('str' in e for e in errors)
 
 
+@pytest.mark.parametrize("group_type", ["all", "none"])
 @use(sample_capability)
-def test_deeply_nested_query_returns_error():
-    node = {'type': 'all', 'children': []}
+def test_deeply_nested_group_returns_error(group_type):
+    node = {'type': group_type, 'children': []}
     root = node
     for _ in range(MAX_QUERY_DEPTH + 2):
-        child = {'type': 'all', 'children': []}
-        node['children'] = [child]
-        node = child
-    _, errors = parse_query_spec(root, [], 'patient', sample_capability())
-    assert any('nested too deeply' in e for e in errors)
-
-
-@use(sample_capability)
-def test_none_group_counts_toward_depth():
-    # `none` is a regular group and counts toward the nesting limit like
-    # `all`/`any` (the old `not` wrapper was exempt).
-    node = {'type': 'none', 'children': []}
-    root = node
-    for _ in range(MAX_QUERY_DEPTH + 2):
-        child = {'type': 'none', 'children': []}
+        child = {'type': group_type, 'children': []}
         node['children'] = [child]
         node = child
     _, errors = parse_query_spec(root, [], 'patient', sample_capability())
@@ -376,33 +355,16 @@ def test_parse_parameter_spec_not_a_list():
     assert errors == ['Parameters must be a JSON array.']
 
 
-def test_parse_parameter_spec_item_not_dict():
-    _, errors = parse_parameter_spec(['not_a_dict'])
-    assert any('expected object' in e for e in errors)
-
-
-def test_parse_parameter_spec_missing_name():
-    _, errors = parse_parameter_spec([{'type': FIELD_TYPE_TEXT}])
-    assert any('name is required' in e for e in errors)
-
-
-def test_parse_parameter_spec_empty_name():
-    _, errors = parse_parameter_spec([{'name': '   ', 'type': FIELD_TYPE_TEXT}])
-    assert any('name is required' in e for e in errors)
-
-
-def test_parse_parameter_spec_duplicate_name():
-    spec = [
-        {'name': 'region', 'type': FIELD_TYPE_TEXT},
-        {'name': 'region', 'type': FIELD_TYPE_NUMBER},
-    ]
-    _, errors = parse_parameter_spec(spec)
-    assert any('Duplicate' in e for e in errors)
-
-
-def test_parse_parameter_spec_invalid_type():
-    _, errors = parse_parameter_spec([{'name': 'region', 'type': 'bogus'}])
-    assert any("invalid type 'bogus'" in e for e in errors)
+@pytest.mark.parametrize("spec_input,error_fragment", [
+    (['not_a_dict'], 'expected object'),
+    ([{'type': FIELD_TYPE_TEXT}], 'name is required'),
+    ([{'name': '   ', 'type': FIELD_TYPE_TEXT}], 'name is required'),
+    ([{'name': 'region', 'type': FIELD_TYPE_TEXT}, {'name': 'region', 'type': FIELD_TYPE_NUMBER}], 'Duplicate'),
+    ([{'name': 'region', 'type': 'bogus'}], "invalid type 'bogus'"),
+])
+def test_parse_parameter_spec_invalid(spec_input, error_fragment):
+    _, errors = parse_parameter_spec(spec_input)
+    assert any(error_fragment in e for e in errors)
 
 
 @pytest.mark.parametrize("type_val", [FIELD_TYPE_TEXT, FIELD_TYPE_NUMBER, FIELD_TYPE_DATE])
@@ -428,50 +390,37 @@ def _component_spec(field, operator, input_value):
     }
 
 
+@pytest.mark.parametrize("field,param_name,param_type", [
+    ('province', 'region', FIELD_TYPE_TEXT),
+    ('dob', 'cutoff', FIELD_TYPE_DATE),
+])
 @use(sample_capability)
-def test_parameter_input_valid():
-    params = [Parameter(name='region', type=FIELD_TYPE_TEXT, required=False)]
+def test_parameter_input_valid(field, param_name, param_type):
+    params = [Parameter(name=param_name, type=param_type)]
     _, errors = parse_query_spec(
-        _component_spec('province', 'equals', {'type': 'parameter', 'value': 'region'}),
+        _component_spec(field, 'equals', {'type': 'parameter', 'value': param_name}),
         params, 'patient', sample_capability(),
     )
     assert errors == []
 
 
+@pytest.mark.parametrize("params,input_value,error_fragment", [
+    ([], {'type': 'parameter', 'value': 'nonexistent'}, 'not configured'),
+    (
+        [Parameter(name='region', type=FIELD_TYPE_TEXT)],
+        {'type': 'parameter', 'value': ''},
+        'parameter name is required',
+    ),
+    (
+        [Parameter(name='my_date', type=FIELD_TYPE_DATE)],
+        {'type': 'parameter', 'value': 'my_date'},
+        "has type 'date', expected 'text'",
+    ),
+])
 @use(sample_capability)
-def test_parameter_input_unknown_parameter():
+def test_parameter_input_error(params, input_value, error_fragment):
     _, errors = parse_query_spec(
-        _component_spec('province', 'equals', {'type': 'parameter', 'value': 'nonexistent'}),
-        [], 'patient', sample_capability(),
-    )
-    assert any('not configured' in e for e in errors)
-
-
-@use(sample_capability)
-def test_parameter_input_empty_name():
-    params = [Parameter(name='region', type=FIELD_TYPE_TEXT, required=False)]
-    _, errors = parse_query_spec(
-        _component_spec('province', 'equals', {'type': 'parameter', 'value': ''}),
+        _component_spec('province', 'equals', input_value),
         params, 'patient', sample_capability(),
     )
-    assert any('parameter name is required' in e for e in errors)
-
-
-@use(sample_capability)
-def test_parameter_input_type_mismatch():
-    params = [Parameter(name='my_date', type=FIELD_TYPE_DATE, required=False)]
-    _, errors = parse_query_spec(
-        _component_spec('province', 'equals', {'type': 'parameter', 'value': 'my_date'}),
-        params, 'patient', sample_capability(),
-    )
-    assert any("has type 'date', expected 'text'" in e for e in errors)
-
-
-@use(sample_capability)
-def test_parameter_input_type_matches_field_type():
-    params = [Parameter(name='cutoff', type=FIELD_TYPE_DATE, required=False)]
-    _, errors = parse_query_spec(
-        _component_spec('dob', 'equals', {'type': 'parameter', 'value': 'cutoff'}),
-        params, 'patient', sample_capability(),
-    )
-    assert errors == []
+    assert any(error_fragment in e for e in errors)

--- a/corehq/apps/case_search/tests/test_endpoint_query_spec.py
+++ b/corehq/apps/case_search/tests/test_endpoint_query_spec.py
@@ -1,9 +1,12 @@
 from unmagic import fixture, use
 
+import pytest
+
 from corehq.apps.case_search.endpoint_capability import (
     OPERATOR_INPUT_SCHEMAS,
     FIELD_TYPE_DATE,
     FIELD_TYPE_GEOPOINT,
+    FIELD_TYPE_NUMBER,
     FIELD_TYPE_TEXT,
     get_operations_for_field_type,
 )
@@ -13,6 +16,8 @@ from corehq.apps.case_search.endpoint_query_spec import (
     ComponentNode,
     ConstantInput,
     GroupNode,
+    Parameter,
+    parse_parameter_spec,
     parse_query_spec,
 )
 
@@ -334,3 +339,75 @@ def test_total_node_limit_returns_error():
     }
     _, errors = parse_query_spec(spec, 'patient', sample_capability())
     assert any('too many nodes' in e for e in errors)
+
+
+# ── parse_parameter_spec ──────────────────────────────────────────────────────
+
+def test_parse_parameter_spec_empty_list():
+    params, errors = parse_parameter_spec([])
+    assert errors == []
+    assert params == []
+
+
+def test_parse_parameter_spec_valid_single():
+    params, errors = parse_parameter_spec([{'name': 'region', 'type': FIELD_TYPE_TEXT}])
+    assert errors == []
+    assert params == [Parameter(name='region', type=FIELD_TYPE_TEXT)]
+
+
+def test_parse_parameter_spec_multiple():
+    spec = [
+        {'name': 'region', 'type': FIELD_TYPE_TEXT},
+        {'name': 'age', 'type': FIELD_TYPE_NUMBER},
+    ]
+    params, errors = parse_parameter_spec(spec)
+    assert errors == []
+    assert len(params) == 2
+
+
+def test_parse_parameter_spec_strips_name_whitespace():
+    params, errors = parse_parameter_spec([{'name': '  region  ', 'type': FIELD_TYPE_TEXT}])
+    assert errors == []
+    assert params[0].name == 'region'
+
+
+def test_parse_parameter_spec_not_a_list():
+    params, errors = parse_parameter_spec({'name': 'region'})
+    assert params is None
+    assert errors == ['Parameters must be a JSON array.']
+
+
+def test_parse_parameter_spec_item_not_dict():
+    _, errors = parse_parameter_spec(['not_a_dict'])
+    assert any('expected object' in e for e in errors)
+
+
+def test_parse_parameter_spec_missing_name():
+    _, errors = parse_parameter_spec([{'type': FIELD_TYPE_TEXT}])
+    assert any('name is required' in e for e in errors)
+
+
+def test_parse_parameter_spec_empty_name():
+    _, errors = parse_parameter_spec([{'name': '   ', 'type': FIELD_TYPE_TEXT}])
+    assert any('name is required' in e for e in errors)
+
+
+def test_parse_parameter_spec_duplicate_name():
+    spec = [
+        {'name': 'region', 'type': FIELD_TYPE_TEXT},
+        {'name': 'region', 'type': FIELD_TYPE_NUMBER},
+    ]
+    _, errors = parse_parameter_spec(spec)
+    assert any('Duplicate' in e for e in errors)
+
+
+def test_parse_parameter_spec_invalid_type():
+    _, errors = parse_parameter_spec([{'name': 'region', 'type': 'bogus'}])
+    assert any("invalid type 'bogus'" in e for e in errors)
+
+
+@pytest.mark.parametrize("type_val", [FIELD_TYPE_TEXT, FIELD_TYPE_NUMBER, FIELD_TYPE_DATE])
+def test_parse_parameter_spec_all_valid_types(type_val):
+    params, errors = parse_parameter_spec([{'name': 'p', 'type': type_val}])
+    assert errors == []
+    assert params[0].type == type_val

--- a/corehq/apps/case_search/tests/test_endpoint_views.py
+++ b/corehq/apps/case_search/tests/test_endpoint_views.py
@@ -170,26 +170,20 @@ class TestCaseSearchEndpointNewView(EndpointViewTestCase):
         assert response.status_code == 200
         assert 'already exists' in response.context['form'].errors['name'][0]
 
-    def test_invalid_query_json_error(self):
-        response = self.client.post(
-            self._new_url(), self._post_data(query='not json')
-        )
-        assert response.status_code == 200
-        assert 'query' in response.context['form'].errors
-
-    def test_query_must_be_object_not_array(self):
-        response = self.client.post(
-            self._new_url(), self._post_data(query='[1, 2]')
-        )
-        assert response.status_code == 200
-        assert 'JSON object' in response.context['form'].errors['query'][0]
-
-    def test_parameters_must_be_array(self):
-        response = self.client.post(
-            self._new_url(), self._post_data(parameters='{"not": "array"}')
-        )
-        assert response.status_code == 200
-        assert 'JSON array' in response.context['form'].errors['parameters'][0]
+    def test_form_field_validation_error(self):
+        cases = [
+            ({'query': 'not json'}, 'query', None),
+            ({'query': '[1, 2]'}, 'query', 'JSON object'),
+            ({'parameters': '{"not": "array"}'}, 'parameters', 'JSON array'),
+        ]
+        for overrides, error_field, error_fragment in cases:
+            with self.subTest(overrides=overrides):
+                response = self.client.post(self._new_url(), self._post_data(**overrides))
+                assert response.status_code == 200
+                errors = response.context['form'].errors
+                assert error_field in errors
+                if error_fragment:
+                    assert error_fragment in errors[error_field][0]
 
     def test_invalid_query_spec_rejected(self):
         # An unknown node type surfaces as a non-field (semantic) error.
@@ -356,25 +350,21 @@ class TestCaseSearchEndpointTestView(EndpointViewTestCase):
         assert response.status_code == 200
         assert 'alert-danger' not in response.content.decode()
 
-    def test_invalid_query_json_returns_error(self):
-        response = self.client.post(self._test_url(), {
-            'case_type': 'my_case_type',
-            'query': 'not json',
-        })
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert 'Invalid query JSON' in content
-        assert '<table' not in content
-
-    def test_invalid_filter_spec_returns_error(self):
-        response = self.client.post(self._test_url(), {
-            'case_type': 'my_case_type',
-            'query': json.dumps({'type': 'bogus'}),
-        })
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert 'alert-danger' in content
-        assert '<table' not in content
+    def test_invalid_query_returns_error(self):
+        cases = [
+            ('not json', 'Invalid query JSON'),
+            (json.dumps({'type': 'bogus'}), 'alert-danger'),
+        ]
+        for query, expected_text in cases:
+            with self.subTest(query=query):
+                response = self.client.post(self._test_url(), {
+                    'case_type': 'my_case_type',
+                    'query': query,
+                })
+                assert response.status_code == 200
+                content = response.content.decode()
+                assert expected_text in content
+                assert '<table' not in content
 
     def test_requires_post(self):
         response = self.client.get(self._test_url())

--- a/corehq/apps/case_search/tests/test_endpoint_views.py
+++ b/corehq/apps/case_search/tests/test_endpoint_views.py
@@ -366,6 +366,23 @@ class TestCaseSearchEndpointTestView(EndpointViewTestCase):
                 assert expected_text in content
                 assert '<table' not in content
 
+    def test_unknown_case_type_returns_error(self):
+        response = self.client.post(self._test_url(), {
+            'case_type': 'nonexistent_type',
+            'query': json.dumps(EMPTY_QUERY),
+        })
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'alert-danger' in content
+        assert '<table' not in content
+
+    def test_missing_case_type_returns_error(self):
+        response = self.client.post(self._test_url(), {
+            'query': json.dumps(EMPTY_QUERY),
+        })
+        assert response.status_code == 200
+        assert 'alert-danger' in response.content.decode()
+
     def test_requires_post(self):
         response = self.client.get(self._test_url())
         assert response.status_code == 405

--- a/corehq/apps/case_search/tests/test_utils.py
+++ b/corehq/apps/case_search/tests/test_utils.py
@@ -1,6 +1,11 @@
 from unittest.mock import patch
 
+import pytest
+
+from corehq.apps.case_search.endpoint_capability import FIELD_TYPE_GEOPOINT
+from corehq.apps.case_search.endpoint_query_spec import ComponentNode, ConstantInput, ParameterInput
 from corehq.apps.case_search.utils import (
+    CaseSearchEndpointQueryBuilder,
     CaseSearchProfiler,
     get_expanded_case_results,
 )
@@ -25,3 +30,84 @@ def test_get_expanded_case_results(get_cases_mock):
 def test_profiler_search_class():
     profiler = CaseSearchProfiler()
     assert profiler.search_class == CaseSearchES
+
+
+def _make_geopoint_node(point='12.5 13.5', distance='10', unit='kilometers'):
+    inputs = {}
+    if point is not None:
+        inputs['point'] = ConstantInput(value=point)
+    if distance is not None:
+        inputs['distance'] = ConstantInput(value=distance)
+    if unit is not None:
+        inputs['unit'] = ConstantInput(value=unit)
+    return ComponentNode(
+        operator='within_distance',
+        field='gps_field',
+        field_type=FIELD_TYPE_GEOPOINT,
+        inputs=inputs,
+    )
+
+
+def _make_builder():
+    builder = CaseSearchEndpointQueryBuilder.__new__(CaseSearchEndpointQueryBuilder)
+    builder.param_values = {}
+    return builder
+
+
+def test_parse_component_node_geopoint_within_distance():
+    node = _make_geopoint_node()
+    result = _make_builder()._parse_component_node(node)
+    assert result is not None
+
+
+@pytest.mark.parametrize('missing_input', ['point', 'distance', 'unit'])
+def test_parse_component_node_geopoint_missing_input_returns_none(missing_input):
+    kwargs = {missing_input: None}
+    node = _make_geopoint_node(**kwargs)
+    result = _make_builder()._parse_component_node(node)
+    assert result is None
+
+
+@pytest.mark.parametrize('bad_point,bad_distance,bad_unit', [
+    ('not-a-coordinate', '10', 'kilometers'),
+    ('12.5 13.5', 'not-a-number', 'kilometers'),
+    ('12.5 13.5', '10', 'parsecs'),
+])
+def test_parse_component_node_geopoint_invalid_values_return_none(bad_point, bad_distance, bad_unit):
+    node = _make_geopoint_node(point=bad_point, distance=bad_distance, unit=bad_unit)
+    result = _make_builder()._parse_component_node(node)
+    assert result is None
+
+
+def test_parse_component_node_geopoint_parameter_input():
+    node = ComponentNode(
+        operator='within_distance',
+        field='gps_field',
+        field_type=FIELD_TYPE_GEOPOINT,
+        inputs={
+            'point': ParameterInput(value='my_point'),
+            'distance': ConstantInput(value='5'),
+            'unit': ConstantInput(value='miles'),
+        },
+    )
+    builder = _make_builder()
+    builder.param_values = {'my_point': '10.0 20.0'}
+    result = builder._parse_component_node(node)
+    assert result is not None
+
+
+def test_parse_component_node_geopoint_missing_parameter_value_returns_none():
+    node = ComponentNode(
+        operator='within_distance',
+        field='gps_field',
+        field_type=FIELD_TYPE_GEOPOINT,
+        inputs={
+            'point': ParameterInput(value='my_point'),
+            'distance': ConstantInput(value='5'),
+            'unit': ConstantInput(value='miles'),
+        },
+    )
+    builder = _make_builder()
+    builder.param_values = {}  # parameter not supplied
+    result = builder._parse_component_node(node)
+    assert result is None

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -46,7 +46,7 @@ from corehq.apps.case_search.models import (
     CaseSearchEndpoint,
     extract_search_request_config,
 )
-from corehq.apps.case_search.endpoint_query_spec import parse_query_spec
+from corehq.apps.case_search.endpoint_query_spec import ParameterInput, parse_parameter_spec, parse_query_spec
 from corehq.apps.es import HQESQuery, case_search
 from corehq.apps.es import cases as case_es
 from corehq.apps.es import filters, queries
@@ -410,6 +410,7 @@ class CaseSearchEndpointQueryBuilder:
         self.config = helper.config
 
     def build_query(self, search_criteria):
+        self.param_values = {c.key: c.value for c in search_criteria}
         search_es = self._get_initial_search_es()
         return search_es.add_query(self._parse_query(self.query_root), queries.MUST)
 
@@ -423,31 +424,42 @@ class CaseSearchEndpointQueryBuilder:
                 .is_closed(False)
                 .size(max_results))
 
+    def _non_none_child_query(self, node):
+        child_queries = [self._parse_query(child) for child in node.children]
+        return [q for q in child_queries if q is not None]
+
     def _parse_query(self, node):
         if node.type == 'all':
             return filters.AND(
-                *[self._parse_query(child) for child in node.children]
+                *self._non_none_child_query(node)
             )
         elif node.type == 'any':
             return filters.OR(
-                *[self._parse_query(child) for child in node.children]
+                *self._non_none_child_query(node)
             )
         elif node.type == 'none':
             return filters.NOT(
-                filters.OR(*[self._parse_query(child) for child in node.children])
+                filters.OR(*self._non_none_child_query(node))
             )
         elif node.type == 'component':
             return self._parse_component_node(node)
         else:
             return None
 
+    def _input_value(self, input_):
+        if isinstance(input_, ParameterInput):
+            return self.param_values.get(input_.value)
+        return input_.value
+
     def _parse_component_node(self, node):
         field = node.field
-        value = node.inputs['value'].value
+        value = self._input_value(node.inputs['value'])
+        if value is None:
+            return None # ignore component if value is not given
+
         operator = node.operator
 
         if node.field_type in (FIELD_TYPE_DATE, FIELD_TYPE_DATETIME):
-            value = node.inputs['value'].value
             if operator == 'equals':
                 return case_property_query(field, value)
             elif operator == 'lt':
@@ -455,7 +467,6 @@ class CaseSearchEndpointQueryBuilder:
             elif operator == 'gt':
                 return case_property_date_range(field, gt=value)
         elif node.field_type == FIELD_TYPE_NUMBER:
-            value = node.inputs['value'].value
             if operator == 'equals':
                 return case_property_query(field, value)
             elif operator == 'not_equals':
@@ -464,13 +475,12 @@ class CaseSearchEndpointQueryBuilder:
                 return case_property_numeric_range(field, **{operator: value})
         elif node.field_type == FIELD_TYPE_SELECT:
             if operator == 'selected_any':
-                return case_property_query(field, node.inputs['value'].value, multivalue_mode='or')
+                return case_property_query(field, value, multivalue_mode='or')
             elif operator == 'selected_all':
-                return case_property_query(field, node.inputs['value'].value, multivalue_mode='and')
+                return case_property_query(field, value, multivalue_mode='and')
             elif operator == 'is_empty':
                 return case_property_missing(field)
         else:
-            value = node.inputs['value'].value
             if operator == 'equals':
                 return case_property_query(field, value)
             elif operator == 'not_equals':

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -424,22 +424,22 @@ class CaseSearchEndpointQueryBuilder:
                 .is_closed(False)
                 .size(max_results))
 
-    def _non_none_child_query(self, node):
+    def _get_child_queries(self, node):
         child_queries = [self._parse_query(child) for child in node.children]
         return [q for q in child_queries if q is not None]
 
     def _parse_query(self, node):
         if node.type == 'all':
             return filters.AND(
-                *self._non_none_child_query(node)
+                *self._get_child_queries(node)
             )
         elif node.type == 'any':
             return filters.OR(
-                *self._non_none_child_query(node)
+                *self._get_child_queries(node)
             )
         elif node.type == 'none':
             return filters.NOT(
-                filters.OR(*self._non_none_child_query(node))
+                filters.OR(*self._get_child_queries(node))
             )
         elif node.type == 'component':
             return self._parse_component_node(node)

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -129,8 +129,11 @@ def get_endpoint_results(helper, config):
     if not endpoint.is_active:
         raise CaseSearchUserError(_("Endpoint '{}' not found").format(config.endpoint_id))
 
+    parameters, errors = parse_parameter_spec(endpoint.current_version.parameters)
+
     query_root, errors = parse_query_spec(
         endpoint.current_version.query,
+        parameters,
         endpoint.case_type,
         get_capability(helper.domain)
     )

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -8,6 +8,9 @@ from django.conf import settings
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
+from couchforms.geopoint import GeoPoint
+from jsonobject.exceptions import BadValueError
+
 from casexml.apps.case.fixtures import CaseDBFixture
 from casexml.apps.phone.data_providers.case.livequery import (
     get_all_related_live_cases,
@@ -25,6 +28,7 @@ from corehq.apps.case_search.const import (
 from corehq.apps.case_search.endpoint_capability import (
     FIELD_TYPE_DATE,
     FIELD_TYPE_DATETIME,
+    FIELD_TYPE_GEOPOINT,
     FIELD_TYPE_NUMBER,
     FIELD_TYPE_SELECT,
     get_capability,
@@ -53,6 +57,7 @@ from corehq.apps.es import filters, queries
 from corehq.apps.es.case_search import (
     CaseSearchES,
     case_property_date_range,
+    case_property_geo_distance,
     case_property_missing,
     case_property_numeric_range,
     case_property_query,
@@ -448,17 +453,36 @@ class CaseSearchEndpointQueryBuilder:
             return None
 
     def _input_value(self, input_):
+        if input_ is None:
+            return None
         if isinstance(input_, ParameterInput):
             return self.param_values.get(input_.value)
         return input_.value
 
     def _parse_component_node(self, node):
+        operator = node.operator
+
+        if node.field_type == FIELD_TYPE_GEOPOINT:
+            if operator == 'within_distance':
+                point = self._input_value(node.inputs.get('point'))
+                distance = self._input_value(node.inputs.get('distance'))
+                unit = self._input_value(node.inputs.get('unit'))
+                if None in (point, distance, unit):
+                    return None
+                try:
+                    geo_point = GeoPoint.from_string(point, flexible=True)
+                    distance = float(distance)
+                except (BadValueError, ValueError):
+                    return None
+                if unit not in queries.DISTANCE_UNITS:
+                    return None
+                return case_property_geo_distance(node.field, geo_point, **{unit: distance})
+            return None
+
         field = node.field
         value = self._input_value(node.inputs['value'])
         if value is None:
-            return None # ignore component if value is not given
-
-        operator = node.operator
+            return None  # ignore component if value is not given
 
         if node.field_type in (FIELD_TYPE_DATE, FIELD_TYPE_DATETIME):
             if operator == 'equals':

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -130,13 +130,14 @@ def get_endpoint_results(helper, config):
         raise CaseSearchUserError(_("Endpoint '{}' not found").format(config.endpoint_id))
 
     parameters, errors = parse_parameter_spec(endpoint.current_version.parameters)
-
-    query_root, errors = parse_query_spec(
-        endpoint.current_version.query,
-        parameters,
-        endpoint.case_type,
-        get_capability(helper.domain)
-    )
+    query_root = None
+    if not errors:
+        query_root, errors = parse_query_spec(
+            endpoint.current_version.query,
+            parameters,
+            endpoint.case_type,
+            get_capability(helper.domain)
+        )
     if errors:
         notify_exception(None, "Stored endpoint query failed validation", details={
             'endpoint': endpoint.id, 'errors': errors,


### PR DESCRIPTION
## Product Description

Add parameters to case search endpoints:
* Configure parameters
* Use them in query builder
* Use them in query tester
* Use them to pull values from search fields in case lists

<img width="851" height="526" alt="image" src="https://github.com/user-attachments/assets/f91db0a4-ecdb-45a1-9bef-08bb6ada37a1" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag

CASE_SEARCH_ENDPOINTS

## Safety Assurance

behind a feature flag. Will QA when feature is ready.

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
