### PR TITLE
Speed up S3 blob reads by using the botocore client directly

### DIFF
--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -95,8 +95,11 @@ class S3BlobDB(AbstractBlobDB):
     def get(self, key=None, type_code=None, meta=None):
         key = self._validate_get_args(key, type_code, meta)
         check_safe_key(key)
+        # Use the botocore client directly rather than the boto3 resource API
+        # (``bucket.Object(key).get()``): the resource layer rebuilds resource
+        # objects per call, which dominates CPU when fetching many blobs.
         with maybe_not_found(throw=NotFound(key)), self.report_timing('get', key):
-            resp = self._s3_bucket().Object(key).get()
+            resp = self.db.meta.client.get_object(Bucket=self.s3_bucket_name, Key=key)
         reported_content_length = resp['ContentLength']
 
         body = resp["Body"]


### PR DESCRIPTION
## Product Description
No user-facing change. Speeds up reads from the S3 blob db (used for form attachments, multimedia, exports, restores, etc.).

## Technical Summary

Optimize CPU usage by using botocore client directly, rather than the boto resource factory, when fetching an S3 object.

This was found while profiling `run_blob_export` (which reads every blob in a domain). With S3 fetches parallelized, the process was pinned at 100% on a single core, and `py-spy` showed the CPU dominated by the boto3 resource factory, not gzip or the network.

`S3BlobDB.get()` fetched each blob through the boto3 **resource** API — `bucket.Object(key).get()`. The resource layer rebuilds resource objects (and their dynamically generated classes/docstrings) on every call, which is surprisingly expensive when reading many blobs.

The fix is to use the botocore **client** directly:

```python
resp = self.db.meta.client.get_object(Bucket=self.s3_bucket_name, Key=key)
```

`resource.Object(key).get()` is a thin wrapper over `client.get_object(...)`, so the response is identical (`Body`, `ContentLength`) and the `NoSuchKey → NotFound` handling is unchanged — but it skips the entire resource factory. In the profile, re-running after this change made the resource-factory frames disappear entirely.

This benefits **every** S3 blob read in HQ, not just the exporter — it was split out of the export work (#37856) because of that broader impact. I honestly don't know how much of an impact outside of `run_blob_export`, but given how much it lowered CPU contention, we could possibly see a drop in CPU on `mobile_webworkers` after deploying this.

## Feature Flag
N/A

## Safety Assurance

### Safety story
The change is confined to the read path of one method. `client.get_object()` returns the same response object the resource wrapper returned, so callers (which consume `Body`/`ContentLength` via `BlobStream`) are unaffected, and missing-key handling still raises `NotFound` through the existing `maybe_not_found` path. No data is written or migrated.

### Automated test coverage
- `corehq/blobs/tests/test_s3db.py` — 70 tests against the local S3 backend, exercising `get`/`put`/round-trips, all pass.
- `test_mixin.py`, `test_blob_import.py`, `test_migratingdb.py` — 195 further blob tests that read via `get`, all pass.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
