### PR TITLE
ProjectDB: Fix collision on sync for long index names

### DIFF
--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -157,7 +157,10 @@ def update_table(conn, table):
     existing_indexes = {
         idx['name'] for idx in inspector.get_indexes(table.name, schema=schema)
     }
-    new_indexes = [idx for idx in table.indexes if idx.name not in existing_indexes]
+    new_indexes = [
+        idx for idx in table.indexes
+        if _index_name(idx, conn.dialect) not in existing_indexes
+    ]
 
     if not new_columns and not new_indexes:
         return
@@ -170,3 +173,9 @@ def update_table(conn, table):
         op.add_column(table.name, detached_col, schema=schema)
     for index in new_indexes:
         index.create(bind=conn)
+
+
+def _index_name(index, dialect):
+    """Return the index name as it is actually stored in the database."""
+    preparer = dialect.identifier_preparer
+    return preparer.unformat_identifiers(preparer.format_index(index))[0]

--- a/corehq/apps/project_db/tests/test_table_ddl.py
+++ b/corehq/apps/project_db/tests/test_table_ddl.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 import sqlalchemy
+from sqlalchemy import Table
 from unmagic import use
 
 from corehq.apps.project_db.table_ddl import (
@@ -10,6 +11,7 @@ from corehq.apps.project_db.table_ddl import (
     DomainSchema,
     create_or_update_project_db,
     get_project_db_engine,
+    update_table,
 )
 
 from .util import project_db_table
@@ -82,6 +84,25 @@ def _project_db_schema(domain):
     finally:
         with get_project_db_engine().begin() as conn:
             schema.drop(conn)
+
+
+@use('db', _project_db_schema('this-is-my-really-really-long-domain-name'))
+def test_truncated_index_name():
+    domain_schema = DomainSchema('this-is-my-really-really-long-domain-name')
+    table = Table(
+        'fairly-long-table-name',
+        sqlalchemy.MetaData(),
+        sqlalchemy.Column('case_id', sqlalchemy.Text, primary_key=True),
+        sqlalchemy.Column('owner_id', sqlalchemy.Text, index=True),
+        schema=domain_schema.name,
+    )
+    # char limit is 64, this is 86
+    assert list(table.indexes)[0].name == \
+        'ix_projectdb_this-is-my-really-really-long-domain-name_fairly-long-table-name_owner_id'
+    with get_project_db_engine().begin() as conn:
+        domain_schema.create(conn)
+        table.create(bind=conn)
+        update_table(conn, table)  # this should no-op, not fail
 
 
 @use('db', _project_db_schema('test_create_project_db'))


### PR DESCRIPTION
## Product Description
no user-facing change

## Technical Summary
Compare index names against the truncated name Postgres actually stores, not the full logical name.  Addresses a bug I encountered running this on staging with longer names than I'd used in testing

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
