### PR TITLE
Pass message as kwarg to InvalidParentId

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -573,12 +573,20 @@ class _CaseImportRow(object):
             return
         elif self.parent_relationship_type == 'extension':
             if not self.parent_identifier:
-                raise InvalidParentId(_(
-                    "'parent_identifier' column must be provided "
-                    "when 'parent_relationship_type' column is set to 'extension'"
-                ))
+                raise InvalidParentId(
+                    column_name='parent_identifier',
+                    message=_(
+                        "'parent_identifier' column must be provided "
+                        "when 'parent_relationship_type' column is set to 'extension'"
+                    ),
+                )
         else:
-            raise InvalidParentId(_("Invalid value for 'parent_relationship_type' column"))
+            raise InvalidParentId(
+                column_name='parent_relationship_type',
+                message=_(
+                    "Invalid value for 'parent_relationship_type' column"
+                ),
+            )
 
     def relies_on_uncreated_case(self, uncreated_external_ids):
         return any(lookup_id and lookup_id in uncreated_external_ids


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19947

The commit message explains it, but `InvalidParentId` inherits from `CaseRowError`, which has [this constructor](https://github.com/dimagi/commcare-hq/blob/fb2a7bea543071f58b8e50730af2e7ea2a387331/corehq/apps/case_importer/exceptions.py#L73-L84). We were previously passing the error message into `InvalidParentId` without specifying the kwarg, which meant it was being treated as the column_name. This was especially an issue because this text was a lazy translation, so it wasn't even a string, and caused issues later in the chain when json object got involved.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Very straightforward change. These are clearly error messages, not column names, and therefore belong as the `message` kwarg into `InvalidParentId`. These are the only two instances of `InvalidParentId` instantiation. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None that I'm aware of.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
