### PR TITLE
Dispatch blob fetch results with match-case

### DIFF
--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -110,12 +110,14 @@ class BlobDbBackendExporter(object):
         callers must invoke it serially. Interleaved calls (e.g. from multiple
         greenlets) would corrupt the archive.
         """
-        if isinstance(result, _Fetched):
-            with result.fileobj as fileobj:
-                self.db.copy_blob(fileobj, result.key, result.content_length)
-        elif isinstance(result, _Missing):
-            self.missing_ids.append(result.key)
-        # _Skipped: already in another dump; counted but not written.
+        match result:
+            case _Fetched(key, fileobj, content_length):
+                with fileobj:
+                    self.db.copy_blob(fileobj, key, content_length)
+            case _Missing(key):
+                self.missing_ids.append(key)
+            case _Skipped():
+                pass  # already in another dump; counted but not written
 
     def _write_missing_ids(self):
         if os.path.exists(self.missing_ids_filename):


### PR DESCRIPTION
## Product Description
No user-facing change — readability refactor of one method.

## Technical Summary
This is a followup to #37856.

Replaces the `if/elif isinstance(...)` chain in `BlobDbBackendExporter._write_object` with a `match` over the `_Fetched`/`_Missing`/`_Skipped` result types. The `_Skipped` no-op becomes an explicit `case` instead of a trailing comment, and each result is destructured in the pattern. Behavior-preserving.

## Safety Assurance
Behavior-preserving refactor of one method; the existing `TestExportRun` suite exercises every arm through the full export path.

- [x] This PR can be reverted after deploy with no further considerations
