### PR TITLE
Write the missing-blob-ids export log under --dir

### DIFF
--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -42,7 +42,7 @@ class BlobDbBackendExporter(object):
         self._spill_dir = os.path.dirname(os.path.abspath(filename))
         self.total_blobs = 0
         self.missing_ids = []
-        self.missing_ids_filename = "missing_blob_ids.txt"
+        self.missing_ids_filename = missing_ids_filename_for(filename)
 
     def __enter__(self):
         self.db.open('w:gz', compresslevel=COMPRESS_LEVEL)
@@ -126,6 +126,17 @@ class BlobDbBackendExporter(object):
         with open(self.missing_ids_filename, 'w') as f:
             for missing_id in self.missing_ids:
                 f.write(f"{missing_id}\n")
+
+
+def missing_ids_filename_for(export_filename):
+    """Derive the missing-blob-ids log path from the export archive path.
+
+    Placing the log beside the archive -- same directory and filename prefix --
+    keeps a run's two outputs together, honors the ``--dir`` chosen by the
+    operator, and disambiguates the logs of repeated or concurrent runs that
+    would otherwise all clobber a single ``missing_blob_ids.txt`` in the cwd.
+    """
+    return f"{export_filename.removesuffix('.tar.gz')}-missing_blob_ids.txt"
 
 
 class BlobExporter:

--- a/corehq/blobs/tests/test_export.py
+++ b/corehq/blobs/tests/test_export.py
@@ -3,24 +3,53 @@ import io
 import os
 import tarfile
 from collections import namedtuple
-from contextlib import chdir, redirect_stdout
+from contextlib import redirect_stdout
 from io import BytesIO, RawIOBase
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import mock
 
 import gevent
+import pytest
 from django.test import SimpleTestCase, TestCase
 
 from corehq.blobs import CODES, get_blob_db
 from corehq.blobs import export as export_module
 from corehq.blobs.exceptions import NotFound
-from corehq.blobs.export import BlobDbBackendExporter, BlobExporter
+from corehq.blobs.export import (
+    BlobDbBackendExporter,
+    BlobExporter,
+    missing_ids_filename_for,
+)
 from corehq.blobs.management.commands.run_blob_import import Command as ImportCommand
 from corehq.blobs.targzipdb import TarGzipBlobDB
 from corehq.blobs.tests.fixtures import blob_db
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB, new_meta
 
 _Meta = namedtuple('_Meta', 'key')
+
+
+@pytest.mark.parametrize("export_filename, expected", [
+    # full archive path: same dir and prefix, .tar.gz stripped
+    ("/data/2026-06-25_14.32-mydomain-blobs.tar.gz",
+     "/data/2026-06-25_14.32-mydomain-blobs-missing_blob_ids.txt"),
+    # -part / -db suffixes are part of the prefix and carried through
+    ("/data/2026-06-25_14.32-mydomain-blobs-part-p0.tar.gz",
+     "/data/2026-06-25_14.32-mydomain-blobs-part-p0-missing_blob_ids.txt"),
+    # no directory -> sits beside the archive in the cwd
+    ("export.tar.gz", "export-missing_blob_ids.txt"),
+    # no .tar.gz suffix (e.g. a bare temp file in tests) -> append as-is
+    ("/data/export", "/data/export-missing_blob_ids.txt"),
+])
+def test_missing_ids_filename_for(export_filename, expected):
+    assert missing_ids_filename_for(export_filename) == expected
+
+
+def test_exporter_derives_missing_ids_path_from_export_file():
+    with mock.patch.object(export_module, 'get_blob_db'):
+        migrator = BlobDbBackendExporter(
+            "/data/2026-06-25_14.32-mydomain-blobs.tar.gz", None)
+    assert migrator.missing_ids_filename == (
+        "/data/2026-06-25_14.32-mydomain-blobs-missing_blob_ids.txt")
 
 
 class _YieldingStream(io.BytesIO):
@@ -206,12 +235,13 @@ class TestBlobExporter(TestCase):
         orphaned_meta = new_meta(domain=self.domain, type_code=CODES.form_xml, content_length=42)
         orphaned_meta.save()
 
-        # migrate() writes missing_blob_ids.txt to the cwd for the orphaned
-        # meta; run in a temp dir so the test stays idempotent and does not
-        # pollute the repo root.
-        with TemporaryDirectory() as tmpdir, chdir(tmpdir), NamedTemporaryFile() as out:
-            self.exporter.migrate(out.name, force=True)
-            with tarfile.open(out.name, 'r:gz') as tgzfile:
+        # migrate() writes a missing-blob-ids log beside the export archive for
+        # the orphaned meta; export into a temp dir so both files are cleaned up
+        # and the test does not pollute the repo root.
+        with TemporaryDirectory() as tmpdir:
+            out = os.path.join(tmpdir, 'export.tar.gz')
+            self.exporter.migrate(out, force=True)
+            with tarfile.open(out, 'r:gz') as tgzfile:
                 self.assertEqual([expected_meta.key], tgzfile.getnames())
 
     def test_exported_blobs_can_be_imported_successfully(self):


### PR DESCRIPTION
## Product Description

Operational tool (`run_blob_export`), so no end-user-facing effect.

## Technical Summary

The list of referenced-but-missing blob ids was always logged to `missing_blob_ids.txt` in the cwd — ignoring the operator's `--dir`, and letting repeated/concurrent runs clobber each other's logs. The new `missing_ids_filename_for()` helper derives the path from the export archive instead (same directory and timestamped prefix), so the log lands next to the archive it describes.
## Feature Flag

N/A

## Safety Assurance

### Safety story

Low risk: only changes where one diagnostic log file is written — not the archive, the import path, or any stored data.

### Automated test coverage

- `test_missing_ids_filename_for` — parametrized over the derivation (`--dir` path, `-part`/`-db` suffixes, no directory, `.tgz`, no recognized extension).
- `test_exporter_derives_missing_ids_path_from_export_file` — confirms the exporter wires the derived path through.

### QA Plan

N/A — covered by automated tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
