### PR TITLE
Skip user migration on fresh install

### DIFF
--- a/corehq/apps/users/migrations/0083_reset_ccu_dm_is_active.py
+++ b/corehq/apps/users/migrations/0083_reset_ccu_dm_is_active.py
@@ -3,6 +3,7 @@ from django.db import migrations
 from corehq.apps.es import UserES, filters
 from corehq.apps.users.models import CommCareUser
 from corehq.util.couch import DocUpdate, iter_update
+from corehq.util.django_migrations import skip_on_fresh_install
 from corehq.util.log import with_progress_bar
 
 
@@ -19,6 +20,7 @@ def fix_user(user_doc):
         return DocUpdate(user_doc)
 
 
+@skip_on_fresh_install
 def reset_is_active(apps, schema_editor):
     iter_update(
         CommCareUser.get_db(),

--- a/corehq/apps/users/migrations/0083_reset_ccu_dm_is_active.py
+++ b/corehq/apps/users/migrations/0083_reset_ccu_dm_is_active.py
@@ -1,40 +1,14 @@
 from django.db import migrations
 
-from corehq.apps.es import UserES, filters
-from corehq.apps.users.models import CommCareUser
-from corehq.util.couch import DocUpdate, iter_update
-from corehq.util.django_migrations import skip_on_fresh_install
-from corehq.util.log import with_progress_bar
-
-
-def affected_ids():
-    return UserES().mobile_users().nested(
-        'user_domain_memberships',
-        filters.term('user_domain_memberships.is_active', False),
-    ).scroll_ids()
-
-
-def fix_user(user_doc):
-    if user_doc['domain_membership'].get('is_active', True) is False:
-        user_doc['domain_membership']['is_active'] = True
-        return DocUpdate(user_doc)
-
-
-@skip_on_fresh_install
-def reset_is_active(apps, schema_editor):
-    iter_update(
-        CommCareUser.get_db(),
-        fix_user,
-        with_progress_bar(list(affected_ids())),
-    )
-
 
 class Migration(migrations.Migration):
+    # This migration is now a no-op. It originally reset the `is_active` flag on
+    # existing CommCareUser domain memberships, but it is no longer possible to
+    # get users into that state in-product, so the one-time correction is no
+    # longer needed. See https://github.com/dimagi/commcare-hq/pull/36722.
 
     dependencies = [
         ('users', '0082_connectidmessagingkey_unique_active_messaging_key_per_user_and_domain'),
     ]
 
-    operations = [
-        migrations.RunPython(reset_is_active),
-    ]
+    operations = []


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
From what I can tell, this migration is only relevant for existing users, and on a fresh install we should not need to reset the `is_active` field on any user, so added that decorator accordingly.

For context, I ran into a [test failure](https://github.com/dimagi/commcare-hq/actions/runs/28129054340/job/83307655788) after changing a dependency on a different migration that led to this being run earlier in django's migration tree. Unclear if I'm going to move forward with that same change that led to the failure, but still seems good to just fix this now before someone else runs into it.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This migration resets the `is_active` flag on existing users that meet certain criteria. This does not need to be run on fresh install, and was causing test failures on another branch due to a change in django's migration tree order.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Given our tests weren't failing prior to this change, there isn't really any test that would catch this. It was only because I made a change to migration dependencies that django changed the migration order and this caused a test failure.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Migrations
It edits an existing migration, but doesn't result in any migration being run, so functionally there are no migrations in this PR.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
