### PR TITLE
Remove the unused use_fk_index_hint pagination machinery

### DIFF
--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -195,9 +195,8 @@ class UnfilteredModelIteratorBuilder(object):
         self.model_label = model_label
         self.domain = self.model_class = self.db_alias = None
         self.use_all_objects = use_all_objects
-        # defaults so iterators() works for subclasses that set these
+        # default so iterators() works for subclasses that set this
         self.pagination_key = ('pk',)
-        self.use_fk_index_hint = False
 
     def prepare(self, domain, model_class, db_alias):
         self.domain = domain
@@ -223,7 +222,6 @@ class UnfilteredModelIteratorBuilder(object):
             yield queryset_to_iterator(
                 queryset, self.model_class, limit=chunk_size,
                 ignore_ordering=True, pagination_key=self.pagination_key,
-                use_fk_index_hint=self.use_fk_index_hint,
             )
 
     def build(self, domain, model_class, db_alias):
@@ -231,17 +229,14 @@ class UnfilteredModelIteratorBuilder(object):
 
 
 class FilteredModelIteratorBuilder(UnfilteredModelIteratorBuilder):
-    def __init__(self, model_label, filter, use_all_objects=False, pagination_key=('pk',),
-                 use_fk_index_hint=False):
+    def __init__(self, model_label, filter, use_all_objects=False, pagination_key=('pk',)):
         super(FilteredModelIteratorBuilder, self).__init__(model_label, use_all_objects)
         self.filter = filter
         self.pagination_key = pagination_key
-        self.use_fk_index_hint = use_fk_index_hint
 
     def build(self, domain, model_class, db_alias):
         return self.__class__(
             self.model_label, self.filter, self.use_all_objects, self.pagination_key,
-            self.use_fk_index_hint,
         ).prepare(domain, model_class, db_alias)
 
     def count(self):

--- a/corehq/apps/dump_reload/tests/test_dump_domain_data.py
+++ b/corehq/apps/dump_reload/tests/test_dump_domain_data.py
@@ -65,7 +65,7 @@ class TestSqlChunkSizeFlag:
         limits = []
 
         def capture_limit(queryset, model_class, limit, ignore_ordering=False,
-                          pagination_key=('pk',), use_fk_index_hint=False):
+                          pagination_key=('pk',)):
             limits.append(limit)
             return iter([])
 

--- a/corehq/apps/dump_reload/tests/test_sql_filters.py
+++ b/corehq/apps/dump_reload/tests/test_sql_filters.py
@@ -117,11 +117,11 @@ class TestMultimediaBlobMetaFilter(TestCase):
 
 
 @sharded
-class TestPagingChildModelByParentId(TestCase):
-    """Page a case child model over the case__domain join with the seek aimed at
-    the parent's case_id (use_fk_index_hint=True), and check the keyset returns
-    every transaction exactly once across pages and shards."""
-    domain = 'test-paging-child-by-parent-id'
+class TestPagingChildModelByCompoundKey(TestCase):
+    """Page a case child model over the case__domain join with a compound
+    (case_id, pk) keyset, and check it returns every transaction exactly once
+    across pages and shards."""
+    domain = 'test-paging-child-by-compound-key'
 
     @classmethod
     def setUpClass(cls):
@@ -134,7 +134,6 @@ class TestPagingChildModelByParentId(TestCase):
             'form_processor.CaseTransaction',
             SimpleFilter('case__domain'),
             pagination_key=('case_id', 'pk'),
-            use_fk_index_hint=True,
         )
         # chunk_size=2 with 3 cases forces paging across the seek boundary
         transactions = [
@@ -266,24 +265,3 @@ class TestLedgerTransactionDumpViaCaseIDFilter(TestCase):
         assert self.other_case.case_id not in {txn.case_id for txn in transactions}
         # no dupes; (case_id, id) is the unique key -- id (pk) repeats across shards
         assert len({(txn.case_id, txn.id) for txn in transactions}) == len(transactions)
-
-
-def test_dump_builders_with_fk_index_hint_have_a_foreign_key_leading_key():
-    """Guard the dump config: every builder that sets use_fk_index_hint must have a
-    leading pagination key backed by a foreign key (so the parent column can be
-    derived). Otherwise it would raise at dump time."""
-    from corehq.apps.dump_reload.sql.dump import APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP
-    from corehq.apps.dump_reload.util import get_model_class
-    from corehq.util.queries import _fk_index_column
-
-    builders = [
-        builder
-        for builders in APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP.values()
-        for builder in builders
-        if builder.use_fk_index_hint
-    ]
-    # No builders currently set use_fk_index_hint; this guards any that are added.
-    for builder in builders:
-        _, model_cls = get_model_class(builder.model_label)
-        # raises ValueError unless pagination_key[0] is a foreign key's column
-        _fk_index_column(model_cls, builder.pagination_key)

--- a/corehq/util/queries.py
+++ b/corehq/util/queries.py
@@ -111,7 +111,7 @@ def paginated_queryset(queryset, chunk_size):
 
 
 def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
-                         pagination_key=('pk',), use_fk_index_hint=False):
+                         pagination_key=('pk',)):
     """
     Pull from queryset in chunks. This is suitable for deep pagination, but
     cannot be used with ordered querysets (results will be sorted by the
@@ -123,24 +123,13 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
     ``('pk',)`` or ``('owner_id', 'pk')`` is okay, but ``('owner_id',)`` is not,
     assuming multiple rows can share an ``owner_id``.
 
-    ``use_fk_index_hint``: when the leading pagination key is a foreign key's
-    stored column (e.g. ``case_id`` backs the ``case`` FK), bound the parent's
-    column each page so Postgres seeks the parent's index -- which it otherwise
-    won't, since it won't carry the keyset's inequality across the join [1][2].
-    Example: ``pagination_key=('case_id', 'pk'), use_fk_index_hint=True``.
-
     Retries on transient database connection failures (bounded at ~31
     minutes total) so long-running iterations survive brief outages.
-
-    [1] https://postgrespro.com/list/thread-id/2550799
-    [2] https://github.com/postgres/postgres/blob/REL_18_4/src/backend/optimizer/README
-        (the EquivalenceClasses section, on how the planner propagates equalities across joins)
     """
     if queryset.ordered and not ignore_ordering:
         raise AssertionError("queryset_to_iterator does not respect ordering.  "
                              "Pass ignore_ordering=True to continue.")
 
-    parent_column = _fk_index_column(model_cls, pagination_key) if use_fk_index_hint else None
     queryset = queryset.order_by(*pagination_key)
     last_doc_values = None
     while True:
@@ -148,12 +137,6 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
             chunk_qs = queryset
         else:
             chunk_qs = queryset.filter(_lexicographic_greater_than(pagination_key, last_doc_values))
-            if parent_column is not None:
-                # The parent bound must be raw SQL: the ORM collapses
-                # ``case__case_id`` to the child's own column, which Postgres can't
-                # use to seek the parent. Safe: the column comes from model metadata
-                # and the value is a bound parameter.
-                chunk_qs = chunk_qs.extra(where=[f'{parent_column} >= %s'], params=[last_doc_values[0]])
         chunk = _fetch_chunk_with_retry(chunk_qs, limit, model_cls, last_doc_values)
         if not chunk:
             return
@@ -161,29 +144,6 @@ def queryset_to_iterator(queryset, model_cls, limit=500, ignore_ordering=False,
             yield doc
 
         last_doc_values = tuple(getattr(doc, key) for key in pagination_key)
-
-
-def _fk_index_column(model_cls, pagination_key):
-    """Return the parent column for the foreign key backing the leading pagination
-    key, as a quoted ``"table"."column"`` SQL fragment (see ``queryset_to_iterator``).
-
-    The leading key must be a foreign key's stored column (e.g. ``case_id`` backs
-    the ``case`` FK). A foreign key with ``to_field`` guarantees the child's stored
-    ``<fk>_id`` column equals the parent's ``to_field`` on every row, so a bound on
-    the parent column is value-equivalent to the keyset's leading bound -- and,
-    unlike the child column, one Postgres can seek the parent's index with.
-    """
-    leading_key = pagination_key[0]
-    foreign_key = next(
-        (f for f in model_cls._meta.fields if f.many_to_one and f.get_attname() == leading_key),
-        None,
-    )
-    if foreign_key is None:
-        raise ValueError(
-            f"use_fk_index_hint requires pagination_key[0]={leading_key!r} to be a foreign "
-            f"key's column on {model_cls.__name__}, but none is"
-        )
-    return f'"{foreign_key.related_model._meta.db_table}"."{foreign_key.target_field.column}"'
 
 
 def _lexicographic_greater_than(fields, values):

--- a/corehq/util/tests/test_queries.py
+++ b/corehq/util/tests/test_queries.py
@@ -1,7 +1,6 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import pytest
 from django.contrib.auth.models import User
 from django.db import connections
 from django.db.utils import InterfaceError, OperationalError
@@ -9,7 +8,6 @@ from django.test.testcases import TestCase
 
 from corehq.util import queries
 from corehq.util.queries import (
-    _fk_index_column,
     _lexicographic_greater_than,
     queryset_to_iterator,
 )
@@ -23,49 +21,6 @@ def test_lexicographic_greater_than_single_field():
 def test_lexicographic_greater_than_multiple_fields():
     qs = User.objects.filter(_lexicographic_greater_than(('last_name', 'pk'), ('Tenenbaum', 5)))
     assert '("auth_user"."last_name", "auth_user"."id") > (' in str(qs.query)
-
-
-def test_fk_index_column_returns_the_parent_column():
-    from corehq.form_processor.models import CaseTransaction
-    # case_id is the stored column of CaseTransaction.case; case__case_id is its target
-    assert (_fk_index_column(CaseTransaction, ('case_id', 'pk'))
-            == '"form_processor_commcarecasesql"."case_id"')
-
-
-@pytest.mark.parametrize("pagination_key", [
-    ('pk', 'case_id'),       # pk is not a foreign key's column
-    ('server_date', 'pk'),   # nor is a plain field
-])
-def test_fk_index_column_rejects_a_leading_key_with_no_foreign_key(pagination_key):
-    from corehq.form_processor.models import CaseTransaction
-    with pytest.raises(ValueError):
-        _fk_index_column(CaseTransaction, pagination_key)
-
-
-def test_use_fk_index_hint_seeks_the_parent_column_while_keyset_stays_on_the_child():
-    # The keyset is built on the child's own column (pagination_key); the hint adds
-    # a raw bound on the parent column so Postgres can seek the parent's index.
-    from corehq.form_processor.models import CaseTransaction
-    pages = []
-
-    def capture(queryset, limit):
-        pages.append(str(queryset.query))   # compiles SQL; no db access
-        return [SimpleNamespace(case_id='abc', pk=5)] if len(pages) == 1 else []
-
-    with patch.object(queries, '_fetch_chunk', side_effect=capture):
-        list(queryset_to_iterator(
-            CaseTransaction.objects.using('default'), CaseTransaction, limit=1,
-            ignore_ordering=True, pagination_key=('case_id', 'pk'),
-            use_fk_index_hint=True,
-        ))
-
-    assert len(pages) == 2  # first page, then the seeked page
-    seeked_page = pages[1]
-    # raw bound on the parent column -- the planner hint
-    assert '"form_processor_commcarecasesql"."case_id" >= ' in seeked_page
-    # keyset still on the child's own column, as a row-value comparison
-    assert ('("form_processor_casetransaction"."case_id", '
-            '"form_processor_casetransaction"."id") > (' in seeked_page)
 
 
 def test_keyset_seek_emits_a_row_value_comparison_in_the_query():


### PR DESCRIPTION
## Product Description
None. Internal cleanup of domain-dump pagination internals; no user- or operator-facing behavior changes.

## Technical Summary
[#37788](https://github.com/dimagi/commcare-hq/pull/37788) added `use_fk_index_hint` to `queryset_to_iterator`: when the leading pagination key was a foreign key's stored column, it bound the parent's column each page with a raw `>= %s` so Postgres would seek the parent's index rather than ignore the keyset inequality across the join.

That optimization didn't pan out (#37788's own title: *"it was not actually faster"*), and [#37851](https://github.com/dimagi/commcare-hq/pull/37851) rerouted the affected models — `CaseTransaction` and `LedgerTransaction` — to `CaseIDFilter`, and dropped the rest back to a plain `pk` keyset. That left **no production caller** setting the hint; only tests exercised it. #37851's description flagged this plumbing for removal "for then" — this is that cleanup.

Removed: the `use_fk_index_hint` parameter and all the plumbing, tests, and so on that supported it.

The `pagination_key` parameter, which _was_ very useful in the final optimization, is untouched.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Behavior-preserving removal of a code path that no production caller reached. Verified by grep that the codebase no longer has any occurrence of the string "use_fk_index_hint".

### Automated test coverage
- `test_queries.py` retains the keyset coverage: `test_keyset_seek_emits_a_row_value_comparison_in_the_query` (compound-key SQL form) and the `TestQuerysetToIterator` paging/retry suite.
- `test_sql_filters.py`'s real-DB sharded test for paging a case child model by a compound `(case_id, pk)` key over the `case__domain` join is retained (retargeted from the now-removed hint framing) and passes, proving compound-key pagination still returns every row exactly once across shards.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
