### PR TITLE
Fix codecov-action after v5 rewrite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,7 @@ jobs:
         files: ${{ github.workspace }}/coverage.xml
         fail_ci_if_error: true
         working-directory: /tmp
+        root_dir: ${{ github.workspace }}
     - name: Stop containers
       if: always()
       run: scripts/docker down

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,8 +66,9 @@ jobs:
       uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: coverage.xml
+        files: ${{ github.workspace }}/coverage.xml
         fail_ci_if_error: true
+        working-directory: /tmp
     - name: Stop containers
       if: always()
       run: scripts/docker down


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

### Error

After #37835 bumped codecov/codecov-action from v4 to v7, the upload step fails on every CI run with:
```
 -> Downloading https://cli.codecov.io/latest/linux/codecov
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to create the file codecov: Permission denied

  0 10.6M    0  1360    0     0  10064      0  0:18:29 --:--:--  0:18:29 10149
curl: (23) Failure writing output to destination
==> Finishing downloading linux:latest
      Version: v11.2.8
 
gpg: directory '/home/runner/.gnupg' created
gpg: keybox '/home/runner/.gnupg/pubring.kbx' created
gpg: /home/runner/.gnupg/trustdb.gpg: trustdb created
gpg: key 806BB28AED779869: public key "Codecov Uploader (Codecov Uploader Verification Key) <security@codecov.io>" imported
gpg: Total number processed: 1
gpg:               imported: 1
==> Verifying GPG signature integrity
 -> Downloading https://cli.codecov.io/latest/linux/codecov.SHA256SUM
 -> Downloading https://cli.codecov.io/latest/linux/codecov.SHA256SUM.sig
 
gpg: can't open 'codecov.SHA256SUM.sig': No such file or directory
gpg: verify signatures failed: No such file or directory
==> Could not verify signature. Please contact Codecov if problem continues
    Exiting...
Error: Process completed with exit code 1.
```
**Notably, you can see that the first error is a permission error when attempting to download the binary saying "failed to create file codecov".**

The build on dependabot's PR upgrading to v7 succeeded because the codecov upload step is skipped. This is because dependabot does not have access to the `CODECOV_TOKEN`, and if the token is empty we [skip the upload step](https://github.com/dimagi/commcare-hq/blob/c681890994824c9a084e2bb067d64be15988307e/.github/workflows/tests.yml#L65). **Sidenote:** we can add the `CODECOV_TOKEN` to dependabot's secrets in the repo settings, but need someone with access to do so. Once that is done, we should avoid any issues like this in the future where codecov is upgraded but not working correctly.

### Cause

v5 of codecov-action was a rewrite that changed how the action installs and runs codecov, but not what it uploads. It did this by delegating the download of the CLI binary to `codecov/wrapper` instead of writing the download into a default directory the action has access to. The problem is it fetches/writes it into [the current directory](https://github.com/codecov/wrapper/blob/bad8df56cd845fa9c6115a924bbd3215e1926ec8/scripts/download.sh#L51), which the github action runner does not have access to write to. This is because we mount the $GITHUB_WORKSPACE directory to  /mnt/commcare-hq-ro, effectively sharing this filesystem between the github action runner and the test container. Inside the test container, [docker/run.sh](https://github.com/dimagi/commcare-hq/blob/9134ec52cdbc84ec7e818d20120a7e49eb3b9dcc/docker/run.sh#L277) changes the owner to the container's internal `cchq` user. Becuase that path is bind-mounted from `$GITHUB_WORKSPACE`, the chown is reflected in the github action runner, and when the codecov upload step runs, the runner does not have write access to its own workspace.

### Fix

I chose a relatively straightforward option with minimal changes, which was to ensure the file was downloaded into a directory that the github action `runner` user has access to. To make this change, I specified the directory to download the binary to (/tmp, which the runner has access to), and used a full path for where to read the coverage.xml file from instead of a relative path since the runner would now be reading that file from a different location.

### Update

Needed to also add `root_dir` to tell codecov what the project root was since we are running codecov in a different directory.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This is just used for our build pipeline/internal code coverage metrics. The failure is blocking our builds from passing, and given they are already failing at the moment, this doesn't introduce any additional risk on that front.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
The codecov upload path will be executed in the build on this PR.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
