### PR TITLE
Dispatch blob fetch results with a single result type

### DIFF
--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -1,9 +1,9 @@
 import os
 import shutil
 import time
-from collections import namedtuple
 from tempfile import SpooledTemporaryFile
 
+from attrs import define, field
 from gevent.pool import Pool
 
 from corehq.apps.dump_reload.sql.dump import (
@@ -25,9 +25,31 @@ PROGRESS_INTERVAL = 10_000  # print a progress line every N objects processed
 # .tar.gz format (readable by run_blob_import) at a fraction of the CPU.
 COMPRESS_LEVEL = 1
 
-_Fetched = namedtuple('_Fetched', 'key fileobj content_length')
-_Missing = namedtuple('_Missing', 'key')
-_Skipped = namedtuple('_Skipped', 'key')
+@define
+class _Result:
+    """A blob fetch outcome: exactly one of fetched / missing / skipped.
+
+    - fetched: ``key`` set, ``fileobj`` and ``content_length`` present
+    - missing: ``key`` set, ``missing`` is True
+    - skipped: ``key`` is None (already in another dump)
+    """
+    key = field()
+    fileobj = field(default=None)
+    content_length = field(default=None)
+    missing = field(default=False)
+
+    def __attrs_post_init__(self):
+        states = (
+            self.key is None,                                              # skipped
+            self.fileobj is not None and self.content_length is not None,  # fetched
+            self.missing,                                                  # missing
+        )
+        assert sum(states) == 1, f"invalid _Result state: {self}"
+
+
+# Already in another dump: counted but not written. Shared because it carries no
+# per-blob state and is only ever read, so it's safe to return from any greenlet.
+_SKIPPED = _Result(None)
 
 
 class BlobDbBackendExporter(object):
@@ -84,24 +106,24 @@ class BlobDbBackendExporter(object):
         print(f"Processed {self.total_blobs} objects in {elapsed:.1f}s ({rate})")
 
     def _fetch_object(self, meta):
-        """Fetch and fully buffer one blob, returning a _Fetched/_Missing/_Skipped result.
+        """Fetch and fully buffer one blob, returning a fetched/missing/skipped _Result.
 
         Safe for concurrent use -- it only reads shared state and buffers into
         its own file, never touching the tar, so many fetches can run in
         parallel.
         """
         if meta.key in self._already_exported:
-            return _Skipped(meta.key)
+            return _SKIPPED
         try:
             content = self.src_db.get(meta.key, CODES.maybe_compressed)
         except NotFound:
-            return _Missing(meta.key)
+            return _Result(meta.key, missing=True)
         spool = SpooledTemporaryFile(max_size=SPILL_THRESHOLD, dir=self._spill_dir)
         with content:
             content_length = content.content_length
             shutil.copyfileobj(content, spool)
         spool.seek(0)
-        return _Fetched(meta.key, spool, content_length)
+        return _Result(meta.key, spool, content_length)
 
     def _write_object(self, result):
         """Apply one fetched result: write it to the tar, or record it missing.
@@ -110,12 +132,12 @@ class BlobDbBackendExporter(object):
         callers must invoke it serially. Interleaved calls (e.g. from multiple
         greenlets) would corrupt the archive.
         """
-        if isinstance(result, _Fetched):
+        if result.fileobj is not None:
             with result.fileobj as fileobj:
                 self.db.copy_blob(fileobj, result.key, result.content_length)
-        elif isinstance(result, _Missing):
+        elif result.missing:
             self.missing_ids.append(result.key)
-        # _Skipped: already in another dump; counted but not written.
+        # else skipped: already in another dump; counted but not written.
 
     def _write_missing_ids(self):
         if os.path.exists(self.missing_ids_filename):

--- a/corehq/blobs/tests/test_export.py
+++ b/corehq/blobs/tests/test_export.py
@@ -18,6 +18,8 @@ from corehq.blobs.exceptions import NotFound
 from corehq.blobs.export import (
     BlobDbBackendExporter,
     BlobExporter,
+    _Result,
+    _SKIPPED,
     missing_ids_filename_for,
 )
 from corehq.blobs.management.commands.run_blob_import import Command as ImportCommand
@@ -91,6 +93,40 @@ def _export_with_fake_src(blobs, metas, already_exported=None, concurrency=8, sr
         with tarfile.open(out.name, 'r:gz') as tgz:
             extracted = {n: tgz.extractfile(n).read() for n in tgz.getnames()}
         return extracted, migrator.missing_ids, migrator.total_blobs
+
+
+@pytest.mark.parametrize("kwargs", [
+    {},  # fetched: key + fileobj + content_length
+    {"missing": True},  # missing: key + missing flag
+])
+def test_result_valid_states(kwargs):
+    # fetched/missing both carry a key; the only difference is the payload
+    if kwargs:
+        _Result("k", **kwargs)
+    else:
+        _Result("k", fileobj=io.BytesIO(b'data'), content_length=4)
+
+
+def test_result_skipped_constant_is_valid():
+    assert _SKIPPED.key is None
+    assert _SKIPPED.fileobj is None
+    assert not _SKIPPED.missing
+
+
+@pytest.mark.parametrize("args, kwargs", [
+    # fetched without a content_length is not a complete fetched result, and
+    # has no other state set, so it is not any valid state
+    (("k",), {"fileobj": io.BytesIO(b'data')}),
+    # fetched payload on a keyless (skipped) result -> two states at once
+    ((None,), {"fileobj": io.BytesIO(b'data'), "content_length": 4}),
+    # keyless and flagged missing -> skipped and missing at once
+    ((None,), {"missing": True}),
+    # fetched payload and flagged missing -> two states at once
+    (("k",), {"fileobj": io.BytesIO(b'data'), "content_length": 4, "missing": True}),
+])
+def test_result_invalid_states_raise(args, kwargs):
+    with pytest.raises(AssertionError):
+        _Result(*args, **kwargs)
 
 
 class TestExportRun(SimpleTestCase):


### PR DESCRIPTION
## Product Description
No user-facing change — readability/safety refactor of the blob export fetch-result type.

## Technical Summary
Follow-up to the review discussion on #37856 (and the now-closed #37871).

`BlobDbBackendExporter` previously modeled a blob fetch outcome as one of three namedtuples (`_Fetched` / `_Missing` / `_Skipped`) and dispatched on them with `isinstance` in `_write_object`. Reviewers found the `isinstance`-on-tuple-types dispatch messy, and preferred a single result type distinguished by duck typing over a set of one-off type definitions.

This replaces the three types with a single `attrs` `_Result`.

Behavior-preserving.

## Safety Assurance

### Safety story
Behavior-preserving refactor of one internal export command. The dispatch logic is unchanged in effect; only its representation changed. The new invariant assertion can only fire on a construction that the old code couldn't have generated anyway.

### Automated test coverage
- The existing `test_export.py::TestExportRun` suite drives `BlobDbBackendExporter.run()` end to end and exercises all three result arms (fetched, missing, already-exported/skipped), so it pins the preserved behavior.
- Added parametrized tests for `_Result` directly: the valid fetched/missing states and the `_SKIPPED` constant pass; four malformed combinations (e.g. fetched without a `content_length`, a keyless result also flagged `missing`) raise `AssertionError`.

### QA Plan
Covered by automated tests; no QA ticket needed for an internal refactor.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
