### PR TITLE
When updating migrations.lock, fetch migrations prior to writing to file

### DIFF
--- a/hqscripts/management/commands/makemigrations.py
+++ b/hqscripts/management/commands/makemigrations.py
@@ -102,9 +102,15 @@ class Command(makemigrations.Command):
         return lines
 
     def write_migrations_lock(self):
-        """Write a new migrations.lock file."""
+        """Write a new migrations.lock file.
+
+        The migrations list is generated *before* the lock file is opened so
+        that a failure during generation (e.g. the database is unavailable)
+        does not clobber the existing lock file by truncating it.
+        """
+        content = "".join(self.get_migrations_list())
         with open(self.lock_path, "w") as file:
-            file.write("".join(self.get_migrations_list()))
+            file.write(content)
 
     def check_migrations_lock(self):
         """Check if the current migrations list matches the migrations.lock."""


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
If postgres is not running locally and you run `./manage.py makemigrations --lock-update`, it will overwrite the migrations.lock file, leaving it empty since the command ultimately fails. I find this annoying.

The change is to fetch the contents first to hit any errors related to service availability prior to opening the file to write to.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
The build runs `./manage.py makemigrations --lock-update` to verify no changes so it would surface any issues in this build if they were introduced.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
