### PR TITLE
Designate one permission migration to run Permission.create_all() on fresh install

### DIFF
--- a/corehq/apps/users/migrations/0043_add_release_management_permission.py
+++ b/corehq/apps/users/migrations/0043_add_release_management_permission.py
@@ -1,11 +1,16 @@
 from django.db import migrations
 
 from corehq.apps.users.models_role import Permission
-from corehq.util.django_migrations import skip_on_fresh_install
 
 
-@skip_on_fresh_install
 def create_release_management_permission(apps, schema_editor):
+    """
+    This is the only permission-related migration that intentionally does not
+    get skipped on fresh install  (no @skip_on_fresh_install decorator). This
+    is to ensure that we have a migration that will run Permission.create_all()
+    on a fresh install to eagerly populate all HqPermissions in the postgres
+    table.
+    """
     Permission.create_all()
 
 
@@ -13,6 +18,8 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('users', '0042_deactivatemobileworkertrigger'),
+        # Permission is an audited table that will create audit events
+        ('field_audit', '0002_add_is_bootstrap_column'),
     ]
 
     operations = [

--- a/corehq/apps/users/migrations/0043_add_release_management_permission.py
+++ b/corehq/apps/users/migrations/0043_add_release_management_permission.py
@@ -1,8 +1,10 @@
 from django.db import migrations
 
 from corehq.apps.users.models_role import Permission
+from corehq.util.django_migrations import skip_on_fresh_install
 
 
+@skip_on_fresh_install
 def create_release_management_permission(apps, schema_editor):
     Permission.create_all()
 

--- a/corehq/apps/users/migrations/0045_add_view_tableau_permission.py
+++ b/corehq/apps/users/migrations/0045_add_view_tableau_permission.py
@@ -1,8 +1,10 @@
 from django.db import migrations
 
 from corehq.apps.users.models_role import Permission
+from corehq.util.django_migrations import skip_on_fresh_install
 
 
+@skip_on_fresh_install
 def create_view_tableau_permission(apps, schema_editor):
     Permission.create_all()
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
I was running into an issue after making a change that reordered django's migration tree which resulted in 0043_add_release_management_permission.py failing. This was because it runs `Permission.create_all()`, and Permission is an audited model, so django field audit was attempting to create AuditEvents. The issue is that the django field audit migrations hadn't yet run, so there is effectively a dependency on a django field audit migration in any migration where we introduce a new permission/call Permission.create_all().

In looking into this, it became clear that we don't have any way to guarantee that `Permission.create_all()` is run on a fresh environment other than these types of migrations. So the outcome was to designate the first migration that runs `Permission.create_all()` as the one responsible for bootstrapping fresh environments, and any similar migrations after that that also run `Permission.create_all()` can be skipped on fresh installs.

This means that we also need to declare the explicit dependency on a django-field-audit migration in this permission migration.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
[HqPermissions](https://github.com/dimagi/commcare-hq/blob/74abb896d8e3afcb18877ca4912be972670a1f09/corehq/apps/users/models.py#L180) is the source of truth for permissions in commcare-hq.

The `Permission` postgres table is effectively a wrapper around `HqPermissions`, with one row per permission. The `Permission` rows are created lazily if needed, but it seems there is a precedent for ensuring they are eagerly created, which is why I'm preserving that behavior, but more explicitly defining that behavior.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
This edits existing migrations only.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
