### PR TITLE
Truncate overly long ProjectDB identifiers

### DIFF
--- a/corehq/apps/project_db/README.rst
+++ b/corehq/apps/project_db/README.rst
@@ -50,9 +50,10 @@ TODOs
   Postgres schema rather than a Django model, the standard model-based
   registration won't catch it; deleting a domain would orphan its
   ``projectdb_<domain>`` schema and data.
-- Store raw case prop name as a comment. This could then be used to know how
-  to insert a case based on inspecting the table.  It'd change ``case_to_row``
-  to iterate through columns instead of properties
+- Use the stored property-name comments when populating. Each property column
+  stores its raw case property name as a Postgres comment, which lets the
+  source property be recovered by inspecting the table. ``case_to_row`` could
+  use this to iterate through columns instead of properties.
 - Date vs Datetime. Looks like the DD only supports date
   properties, not datetime - does it intend the latter? Should we
   support both?

--- a/corehq/apps/project_db/README.rst
+++ b/corehq/apps/project_db/README.rst
@@ -17,6 +17,10 @@ Layout
   properties (date, number) get an additional typed column, e.g.
   ``date_prop__<name>``.
 
+Postgres truncates identifiers at 63 bytes, so schema, table, and column names
+are truncated with a hash suffix for uniqueness, with the raw values stored as
+postgresql comments so they can be recovered on inspection.
+
 Definitions are built with `SQLAlchemy Core
 <https://docs.sqlalchemy.org/en/13/core/>`_ and live in the database configured
 for the ``project_db`` engine (the default database unless
@@ -39,10 +43,6 @@ Populating the tables with case data and querying them are not yet implemented.
 TODOs
 ----
 
-- Identifier length & collisions. Postgres silently truncates identifiers at
-  63 bytes. Property column names are now run through ``truncate_identifier``,
-  but ``domain`` and ``case_type`` are still used directly as the schema and
-  table names. Long domain names can collide. Truncate-and-hash these too.
 - Wire schema cleanup to domain deletion. ``DomainSchema.drop`` exists but
   is not registered in ``corehq/apps/domain/deletion.py``. Because this is a raw
   Postgres schema rather than a Django model, the standard model-based

--- a/corehq/apps/project_db/README.rst
+++ b/corehq/apps/project_db/README.rst
@@ -39,12 +39,10 @@ Populating the tables with case data and querying them are not yet implemented.
 TODOs
 ----
 
-- Identifier length & collisions. ``domain`` and ``case_type`` are used
-  directly as Postgres identifiers, which are silently truncated at 63 bytes.
-  ``CaseProperty.name`` allows up to 255 chars, so generated ``prop__<name>``
-  columns can truncate and collide; long domain names can collide on schema
-  name, where ``DROP SCHEMA ... CASCADE`` could affect another domain's data.
-  Truncate-and-hash before use (see the ``# TODO`` in ``table_ddl.py``).
+- Identifier length & collisions. Postgres silently truncates identifiers at
+  63 bytes. Property column names are now run through ``truncate_identifier``,
+  but ``domain`` and ``case_type`` are still used directly as the schema and
+  table names. Long domain names can collide. Truncate-and-hash these too.
 - Wire schema cleanup to domain deletion. ``DomainSchema.drop`` exists but
   is not registered in ``corehq/apps/domain/deletion.py``. Because this is a raw
   Postgres schema rather than a Django model, the standard model-based

--- a/corehq/apps/project_db/management/commands/manage_project_db.py
+++ b/corehq/apps/project_db/management/commands/manage_project_db.py
@@ -10,6 +10,7 @@ from corehq.apps.project_db.table_ddl import (
     DomainSchema,
     create_or_update_project_db,
     get_project_db_engine,
+    preview_drop,
 )
 from corehq.form_processor.backends.sql.dbaccessors import (
     CaseReindexAccessor,
@@ -65,11 +66,28 @@ class Command(BaseCommand):
             _populate(domain, since)
             self.stdout.write("Populated ProjectDB")
         if drop:
-            with get_project_db_engine().begin() as conn:
-                DomainSchema(domain).drop(conn)
-            self.stdout.write("Deleted ProjectDB table")
+            _drop(domain, self.stdout)
         if describe:
             _describe(domain)
+
+
+def _drop(domain, stdout):
+    schema = DomainSchema(domain)
+    engine = get_project_db_engine()
+    if schema.name not in sqlalchemy.inspect(engine).get_schema_names():
+        stdout.write(f"No ProjectDB schema found for domain '{domain}'")
+        return
+
+    stdout.write("The following objects will be dropped:")
+    for notice in preview_drop(domain):
+        stdout.write(notice.rstrip())
+
+    if input("confirm (y/N): ").strip().lower() in ('y', 'yes'):
+        with engine.begin() as conn:
+            schema.drop(conn)
+        stdout.write("Dropped ProjectDB schema")
+    else:
+        stdout.write("Aborted; nothing was dropped")
 
 
 def _populate(domain, start_date):

--- a/corehq/apps/project_db/populate.py
+++ b/corehq/apps/project_db/populate.py
@@ -8,7 +8,7 @@ from dimagi.utils.chunked import chunked
 
 from corehq.apps.data_dictionary.models import CaseProperty
 
-from .table_ddl import CaseTable, get_project_db_engine
+from .table_ddl import CaseTable, get_project_db_engine, property_column
 
 
 def send_to_project_db(domain, case_type, cases):
@@ -64,11 +64,11 @@ def case_to_row(case, table_columns):
         'host_id': ids_by_identifier.get('host'),
     }
     for key, value in case.case_json.items():
-        col_name = f'prop__{key}'
+        col_name = property_column(key)
         if col_name in table_columns:
             row[col_name] = str(value)
             for data_type, coerce_fn in _TYPED_COERCIONS:
-                typed_col = f'{data_type}_prop__{key}'
+                typed_col = property_column(key, data_type)
                 if typed_col in table_columns:
                     row[typed_col] = coerce_fn(value)
     return row

--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -70,13 +70,15 @@ class CaseTable:
 
         Every property gets a raw Text column named ``prop__<name>``. Some
         typed properties get an additional typed column named
-        ``<data_type>_prop__<name>``.
+        ``<data_type>_prop__<name>``. The raw property name is stored as a
+        postgres comment.
         """
         for name, data_type in self._get_dd_properties():
-            yield Column(f'prop__{name}', Text, nullable=False, server_default='')
+            yield Column(f'prop__{name}', Text, nullable=False, server_default='',
+                         comment=name)
 
             if col_type := self.COERCED_PROPERTY_TYPES.get(data_type):
-                yield Column(f'{data_type}_prop__{name}', col_type)
+                yield Column(f'{data_type}_prop__{name}', col_type, comment=name)
 
     def _get_dd_properties(self):
         return CaseProperty.objects.filter(

--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -1,3 +1,5 @@
+import hashlib
+
 import sqlalchemy
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
@@ -6,6 +8,26 @@ from sqlalchemy.dialects import postgresql
 
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.sql_db.connections import PROJECT_DB_ENGINE_ID, connection_manager
+
+MAX_IDENTIFIER_LENGTH = 63
+_HASH_LENGTH = 8
+
+
+def truncate_identifier(identifier):
+    """Return a Postgres-safe identifier no longer than 63 bytes"""
+    encoded = identifier.encode('utf-8')
+    if len(encoded) <= MAX_IDENTIFIER_LENGTH:
+        return identifier
+    suffix = '_' + hashlib.sha256(encoded).hexdigest()[:_HASH_LENGTH]
+    # Decode may drop a trailing partial character; that only shortens the result
+    kept = encoded[:MAX_IDENTIFIER_LENGTH - len(suffix)].decode('utf-8', errors='ignore')
+    return kept + suffix
+
+
+def property_column(name, data_type=None):
+    if data_type is None:
+        return truncate_identifier(f'prop__{name}')
+    return truncate_identifier(f'{data_type}_prop__{name}')
 
 
 def get_project_db_engine():
@@ -74,11 +96,10 @@ class CaseTable:
         postgres comment.
         """
         for name, data_type in self._get_dd_properties():
-            yield Column(f'prop__{name}', Text, nullable=False, server_default='',
-                         comment=name)
+            yield Column(property_column(name), Text, nullable=False, server_default='', comment=name)
 
             if col_type := self.COERCED_PROPERTY_TYPES.get(data_type):
-                yield Column(f'{data_type}_prop__{name}', col_type, comment=name)
+                yield Column(property_column(name, data_type), col_type, comment=name)
 
     def _get_dd_properties(self):
         return CaseProperty.objects.filter(

--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -74,17 +74,22 @@ class CaseTable:
 
     def __init__(self, domain, case_type):
         self.domain = domain
-        self.case_type = case_type  # TODO truncate and append hash if needed
+        self.case_type = case_type
         self.domain_schema = DomainSchema(domain)
+
+    @property
+    def table_name(self):
+        return truncate_identifier(self.case_type)
 
     def build_definition(self, metadata):
         """Build a SQLAlchemy Table object defining the case type table"""
         return Table(
-            self.case_type,
+            self.table_name,
             metadata,  # The table is also attached to the provided metadata
             *self._build_property_columns(),
             *self._static_columns(),
             schema=self.domain_schema.name,
+            comment=self.case_type,  # raw case type, recoverable if truncated
         )
 
     def _build_property_columns(self):
@@ -129,7 +134,7 @@ class CaseTable:
         """Reflect a SQLAlchemy ``Table`` from the database by inspection"""
         try:
             return Table(
-                self.case_type,
+                self.table_name,
                 sqlalchemy.MetaData(),
                 schema=self.domain_schema.name,
                 autoload=True,

--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -42,7 +42,7 @@ class DomainSchema:
 
     @property
     def name(self):
-        return f'projectdb_{self.domain}'
+        return truncate_identifier(f'projectdb_{self.domain}')
 
     @property
     def _quoted_name(self):
@@ -52,6 +52,21 @@ class DomainSchema:
         conn.execute(sqlalchemy.text(
             f'CREATE SCHEMA IF NOT EXISTS {self._quoted_name}'
         ))
+        # Store the raw, not-truncated domain name as a comment
+        conn.execute(
+            sqlalchemy.text(f'COMMENT ON SCHEMA {self._quoted_name} IS :comment'),
+            {'comment': self.domain},
+        )
+
+    def get_comment(self, conn):
+        """Return the raw domain stored as this schema's Postgres comment"""
+        return conn.execute(
+            sqlalchemy.text(
+                "SELECT obj_description(oid, 'pg_namespace') "
+                "FROM pg_namespace WHERE nspname = :name"
+            ),
+            {'name': self.name},
+        ).scalar()
 
     def set_local_search_path(self, conn):
         """Scope the connection's search_path to a domain's project DB schema"""

--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -135,6 +135,21 @@ def create_or_update_project_db(domain):
             update_table(conn, table)
 
 
+def preview_drop(domain):
+    """Return the PostgreSQL CASCADE notices for dropping a domain's schema"""
+    schema = DomainSchema(domain)
+    raw = get_project_db_engine().raw_connection()
+    try:
+        cursor = raw.cursor()
+        del raw.connection.notices[:]
+        cursor.execute(f'DROP SCHEMA {schema._quoted_name} CASCADE')
+        notices = list(raw.connection.notices)
+        raw.rollback()
+        return notices
+    finally:
+        raw.close()
+
+
 def _get_case_types(domain):
     return list(CaseType.objects.filter(
         domain=domain, is_deprecated=False,

--- a/corehq/apps/project_db/tests/test_populate.py
+++ b/corehq/apps/project_db/tests/test_populate.py
@@ -12,7 +12,11 @@ from corehq.apps.project_db.populate import (
     send_to_project_db,
     upsert_cases,
 )
-from corehq.apps.project_db.table_ddl import CaseTable, get_project_db_engine
+from corehq.apps.project_db.table_ddl import (
+    CaseTable,
+    get_project_db_engine,
+    truncate_identifier,
+)
 from corehq.form_processor.models import CommCareCase
 
 from .util import project_db_table
@@ -164,6 +168,24 @@ def test_send_to_project_db():
         rows = conn.execute(table.select()).fetchall()
     assert [r[0] for r in rows] == ['Alice', 'Bob', '']
     assert CaseTable('test-upsert', 'clinic').reflect() is None
+
+
+@use('db', project_db_table('test-long-prop', 'patient', {'x' * 100: 'date'}))
+def test_send_long_property_name_round_trip():
+    # A property whose column name exceeds Postgres's 63-byte limit must survive
+    # create -> reflect -> upsert with the DDL and populate sides agreeing.
+    long_name = 'x' * 100
+    send_to_project_db('test-long-prop', 'patient', [
+        _make_case({long_name: '1990-05-20'}, type='patient'),
+    ])
+
+    table = CaseTable('test-long-prop', 'patient').reflect()
+    plain_col = truncate_identifier(f'prop__{long_name}')
+    typed_col = truncate_identifier(f'date_prop__{long_name}')
+    with get_project_db_engine().begin() as conn:
+        rows = conn.execute(table.select()).fetchall()
+    assert rows[0][plain_col] == '1990-05-20'
+    assert rows[0][typed_col] == datetime.date(1990, 5, 20)
 
 
 @use('db', project_db_table('test-send', 'patient', {'first_name': 'plain'}))

--- a/corehq/apps/project_db/tests/test_table_ddl.py
+++ b/corehq/apps/project_db/tests/test_table_ddl.py
@@ -11,6 +11,7 @@ from corehq.apps.project_db.table_ddl import (
     create_or_update_project_db,
     get_project_db_engine,
     preview_drop,
+    truncate_identifier,
     update_table,
 )
 
@@ -19,6 +20,22 @@ from .util import project_db_table
 
 def test_schema_name():
     assert DomainSchema('my-domain').name == 'projectdb_my-domain'
+
+
+@pytest.mark.parametrize('identifier, expected', [
+    ('prop__short', 'prop__short'),  # unchanged
+    ('p' * 63, 'p' * 63),  # exactly at the limit
+    ('p' * 64, 'p' * 54 + '_153ac90a'),  # over the limit
+    ('prop__how_many_pecks_of_pickled_peppers_did_peter_piper_pick__a_peck',
+     'prop__how_many_pecks_of_pickled_peppers_did_peter_pipe_aebfc91f'),
+    ('prop__how_many_pecks_of_pickled_peppers_did_peter_piper_pick__enough',  # Same prefix as above
+     'prop__how_many_pecks_of_pickled_peppers_did_peter_pipe_6e49f8dc'),
+    ("A son dotà ‘d sust e ‘d consiensa e a dëvo agì j’un con j’àutri ant n’ëspìrit ëd fradlansa",
+     "A son dotà ‘d sust e ‘d consiensa e a dëvo agì _47f54a51"),  # multi-byte chars > shorter result
+])
+def test_truncate_identifier(identifier, expected):
+    assert len(expected.encode('utf-8')) <= 63
+    assert truncate_identifier(identifier) == expected
 
 
 @pytest.mark.parametrize('domain, expected', [
@@ -80,6 +97,20 @@ def test_case_table_basics():
     assert table.c['date_prop__dob'].comment == 'dob'
     assert table.c['prop__children_count'].comment == 'children_count'
     assert table.c['number_prop__children_count'].comment == 'children_count'
+
+
+def test_long_property_names_are_truncated():
+    long_name = 'this_is_a_really_really_frankly_unreasonably_long_property_name'
+    with patch.object(CaseTable, '_get_dd_properties', return_value=[(long_name, 'date')]):
+        table = (CaseTable('test-domain', 'person').build_definition(sqlalchemy.MetaData()))
+
+    plain_col = 'prop__this_is_a_really_really_frankly_unreasonably_lon_37418cd6'
+    typed_col = 'date_prop__this_is_a_really_really_frankly_unreasonabl_2fd77f90'
+    assert plain_col in table.c
+    assert typed_col in table.c
+    # The full property name remains recoverable via the column comment
+    assert table.c[plain_col].comment == long_name
+    assert table.c[typed_col].comment == long_name
 
 
 def _project_db_schema(domain):

--- a/corehq/apps/project_db/tests/test_table_ddl.py
+++ b/corehq/apps/project_db/tests/test_table_ddl.py
@@ -10,6 +10,7 @@ from corehq.apps.project_db.table_ddl import (
     DomainSchema,
     create_or_update_project_db,
     get_project_db_engine,
+    preview_drop,
     update_table,
 )
 
@@ -104,6 +105,15 @@ def test_truncated_index_name():
         domain_schema.create(conn)
         table.create(bind=conn)
         update_table(conn, table)  # this should no-op, not fail
+
+
+@use('db', project_db_table('test-preview-drop', 'patient', {'first_name': 'plain'}))
+def test_preview_drop_lists_tables_without_dropping():
+    domain = 'test-preview-drop'
+    notices = '\n'.join(preview_drop(domain))
+    assert 'drop cascades to table "projectdb_test-preview-drop".patient' in notices
+    with get_project_db_engine().begin() as conn:
+        assert DomainSchema(domain).name in sqlalchemy.inspect(conn).get_schema_names()
 
 
 @use('db')

--- a/corehq/apps/project_db/tests/test_table_ddl.py
+++ b/corehq/apps/project_db/tests/test_table_ddl.py
@@ -22,6 +22,13 @@ def test_schema_name():
     assert DomainSchema('my-domain').name == 'projectdb_my-domain'
 
 
+def test_schema_name_truncation():
+    long_domain = 'd' * 100
+    schema = DomainSchema(long_domain)
+    assert schema.name == f'projectdb_{"d" * 44}_954c9921'
+    assert len(schema.name.encode('utf-8')) <= 63
+
+
 @pytest.mark.parametrize('identifier, expected', [
     ('prop__short', 'prop__short'),  # unchanged
     ('p' * 63, 'p' * 63),  # exactly at the limit
@@ -60,6 +67,22 @@ def test_schema_lifecycle():
         assert search_path == schema.name
 
         schema.drop(conn)
+        assert schema.name not in sqlalchemy.inspect(conn).get_schema_names()
+
+
+@use('db')
+def test_long_domain_schema_lifecycle():
+    # A domain whose schema name exceeds Postgres's 63-byte limit round-trips
+    # through create -> lookup -> drop under its truncated name.
+    engine = get_project_db_engine()
+    schema = DomainSchema('d' * 100)
+    with engine.begin() as conn:
+        schema.create(conn)
+        try:
+            assert schema.name in sqlalchemy.inspect(conn).get_schema_names()
+            assert schema.get_comment(conn) == 'd' * 100
+        finally:
+            schema.drop(conn)
         assert schema.name not in sqlalchemy.inspect(conn).get_schema_names()
 
 

--- a/corehq/apps/project_db/tests/test_table_ddl.py
+++ b/corehq/apps/project_db/tests/test_table_ddl.py
@@ -1,10 +1,9 @@
-from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
 import sqlalchemy
 from sqlalchemy import Table
-from unmagic import use
+from unmagic import fixture, use
 
 from corehq.apps.project_db.table_ddl import (
     CaseTable,
@@ -76,19 +75,21 @@ def test_case_table_basics():
     assert table.c['number_prop__children_count'].nullable is True
 
 
-@contextmanager
 def _project_db_schema(domain):
-    schema = DomainSchema(domain)
-    try:
-        yield schema
-    finally:
-        with get_project_db_engine().begin() as conn:
-            schema.drop(conn)
+    @fixture
+    def inner():
+        schema = DomainSchema(domain)
+        try:
+            yield schema
+        finally:
+            with get_project_db_engine().begin() as conn:
+                schema.drop(conn)
+    return inner()
 
 
-@use('db', _project_db_schema('this-is-my-really-really-long-domain-name'))
+@use('db')
 def test_truncated_index_name():
-    domain_schema = DomainSchema('this-is-my-really-really-long-domain-name')
+    domain_schema = _project_db_schema('this-is-my-really-really-long-domain-name')
     table = Table(
         'fairly-long-table-name',
         sqlalchemy.MetaData(),
@@ -105,23 +106,23 @@ def test_truncated_index_name():
         update_table(conn, table)  # this should no-op, not fail
 
 
-@use('db', _project_db_schema('test_create_project_db'))
+@use('db')
 @patch('corehq.apps.project_db.table_ddl._get_case_types')
 @patch.object(CaseTable, '_get_dd_properties')
 def test_create_project_db(get_dd_properties, get_case_types):
     # Actually commit the project_db definition to postgres and spot check results
     domain = 'test_create_project_db'
-    schema_name = DomainSchema(domain).name
+    schema = _project_db_schema('test_create_project_db')
 
     get_case_types.return_value = ['patient']
     get_dd_properties.return_value = [('nickname', 'plain'), ('dob', 'plain')]
     create_or_update_project_db(domain)
-    _assert_db_created_as_expected(schema_name)
+    _assert_db_created_as_expected(schema.name)
 
     # Drop nickname, make dob a date, add a new prop
     get_dd_properties.return_value = [('favorite_color', 'plain'), ('dob', 'date')]
     create_or_update_project_db(domain)
-    _assert_db_updated_as_expected(schema_name)
+    _assert_db_updated_as_expected(schema.name)
 
 
 def _assert_db_created_as_expected(schema):

--- a/corehq/apps/project_db/tests/test_table_ddl.py
+++ b/corehq/apps/project_db/tests/test_table_ddl.py
@@ -75,6 +75,7 @@ def test_case_table_basics():
 
     assert table.name == 'person'
     assert table.schema == 'projectdb_test-domain'
+    assert table.comment == 'person'  # raw case type, recoverable if truncated
 
     for column in CaseTable._static_columns():
         assert column.name in table.c
@@ -111,6 +112,19 @@ def test_long_property_names_are_truncated():
     # The full property name remains recoverable via the column comment
     assert table.c[plain_col].comment == long_name
     assert table.c[typed_col].comment == long_name
+
+
+def test_long_case_type_is_truncated():
+    long_type = 'x' * 100
+    case_table = CaseTable('test-domain', long_type)
+    assert case_table.case_type == long_type
+    assert case_table.table_name == truncate_identifier(long_type)
+
+    with patch.object(CaseTable, '_get_dd_properties', return_value=[]):
+        table = case_table.build_definition(sqlalchemy.MetaData())
+    assert table.name == truncate_identifier(long_type)
+    assert len(table.name.encode('utf-8')) <= 63
+    assert table.comment == long_type
 
 
 def _project_db_schema(domain):
@@ -177,6 +191,8 @@ def _assert_db_created_as_expected(schema):
         inspector = sqlalchemy.inspect(conn)
         assert schema in inspector.get_schema_names()
         assert ['patient'] == inspector.get_table_names(schema=schema)
+        # The table stores the raw case type as a comment
+        assert inspector.get_table_comment('patient', schema=schema) == {'text': 'patient'}
 
         cols = {col['name']: col for col in inspector.get_columns('patient', schema=schema)}
         col_types = {name: col['type'] for name, col in cols.items()}

--- a/corehq/apps/project_db/tests/test_table_ddl.py
+++ b/corehq/apps/project_db/tests/test_table_ddl.py
@@ -75,6 +75,12 @@ def test_case_table_basics():
     assert table.c['date_prop__dob'].nullable is True
     assert table.c['number_prop__children_count'].nullable is True
 
+    # Both plain and typed columns carry the raw property name as a comment
+    assert table.c['prop__dob'].comment == 'dob'
+    assert table.c['date_prop__dob'].comment == 'dob'
+    assert table.c['prop__children_count'].comment == 'children_count'
+    assert table.c['number_prop__children_count'].comment == 'children_count'
+
 
 def _project_db_schema(domain):
     @fixture
@@ -149,6 +155,10 @@ def _assert_db_created_as_expected(schema):
         assert isinstance(col_types['prop__dob'], sqlalchemy.Text)
         assert 'date_prop__dob' not in cols
 
+        # Property columns store the raw case property name as a comment
+        assert cols['prop__nickname']['comment'] == 'nickname'
+        assert cols['prop__dob']['comment'] == 'dob'
+
         # Text property columns and external_id are NOT NULL, defaulting to ''
         for name in ['prop__nickname', 'prop__dob', 'external_id']:
             assert cols[name]['nullable'] is False, name
@@ -168,17 +178,15 @@ def _assert_db_updated_as_expected(schema):
         # still only the one table
         assert ['patient'] == inspector.get_table_names(schema=schema)
 
-        columns = {
-            col['name']: col['type']
-            for col in inspector.get_columns('patient', schema=schema)
-        }
-        # New column added
-        assert isinstance(columns['prop__favorite_color'], sqlalchemy.Text)
+        columns = {col['name']: col for col in inspector.get_columns('patient', schema=schema)}
+        # New column added, with its raw property name as a comment
+        assert isinstance(columns['prop__favorite_color']['type'], sqlalchemy.Text)
+        assert columns['prop__favorite_color']['comment'] == 'favorite_color'
         # Column for deleted case property is still present
-        assert isinstance(columns['prop__nickname'], sqlalchemy.Text)
+        assert isinstance(columns['prop__nickname']['type'], sqlalchemy.Text)
         # Both a plain and a date column for dob
-        assert isinstance(columns['prop__dob'], sqlalchemy.Text)
-        assert isinstance(columns['date_prop__dob'], sqlalchemy.Date)
+        assert isinstance(columns['prop__dob']['type'], sqlalchemy.Text)
+        assert isinstance(columns['date_prop__dob']['type'], sqlalchemy.Date)
 
 
 @use('db', project_db_table('test-reflect', 'patient', {


### PR DESCRIPTION
## Product Description


## Technical Summary
Any identifiers longer than 63 characters will be truncated by postgres, potentially causing conflicts if two have the same beginning.  This PR introduces a typical truncate-and-hash pattern for domain schema names, case type table names, and case property column names.

Since this truncation loses information, I've also added the original values as a postgresql comment, so it can be retrieved by inspection later if needed.  I may later modify the code that turns a case into a table row to only use information stored in the table metadata, but I haven't yet done that here.

Couple other minor fixes here too - a followup from @millerdev 's comment in a previous PR, and a QoL improvement fro my own testing.  See commit messages for details.

## Feature Flag


## Safety Assurance
Unborn feature, not actually in use anywhere yet.

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
