### PR TITLE
Switch offboard user UI check to 'is_dimagi'

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -59,7 +59,7 @@
         href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}"
         >{% trans "Reset Two-Factor Authentication" %}</a
       >
-      {% if web_user.is_staff %}
+      {% if web_user.is_dimagi %}
         <button
           class="btn btn-danger"
           data-toggle="modal"
@@ -108,7 +108,7 @@
 
 {% block modals %}
   {{ block.super }}
-  {% if web_user.is_staff %}
+  {% if web_user.is_dimagi %}
     <div
       class="modal fade"
       id="offboard-staff-user-modal"


### PR DESCRIPTION
## Product Description
Changes the condition under which "Offboard Staff User" will appear on the admin-facing web user lookup
<img width="702" height="145" alt="image" src="https://github.com/user-attachments/assets/c9ba647d-c652-41b1-9828-c2e75e55b599" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19995
Uses `is_dimagi` to determine whether to show the "Offboard Staff User" option. As opposed to `is_staff`, which is only assigned in practice for superusers.

## Safety Assurance

### Safety story
This just changes a single UI condition and is quite safe.

### Automated test coverage
n/a

### QA Plan
n/a


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
