### PR TITLE
Small fixes for case search endpoint query builder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,6 +36,7 @@ module.exports = function (grunt) {
         'locations',
         'userreports/bootstrap3',
         'userreports/bootstrap5',
+        'case_search',
         'cloudcare',
         'cloudcare/form_entry',
         'hqwebapp/bootstrap3',

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -8,6 +8,7 @@ import {
     subtreeGroupHeight,
     cloneWithNewIds,
     normalizeRoot,
+    removeChild,
 } from "case_search/js/endpoint_tree";
 
 // Input-slot type sentinels. These MUST stay in sync with the constants in
@@ -133,8 +134,8 @@ Alpine.data("endpointForm", () => {
             });
         },
 
-        removeNode(parentGroup, idx) {
-            parentGroup.children.splice(idx, 1);
+        removeNode(parentGroup, node) {
+            removeChild(parentGroup, node);
         },
 
         copyNode(node) {

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -23,6 +23,10 @@ Alpine.data("endpointForm", () => {
         query: initialPageData.get("initial_query"),
         capability: initialPageData.get("capability"),
         _nextId: 1,
+        // Holds a snapshot of a copied condition/group, or null. Shared across
+        // the whole builder so a node copied in one group can be pasted into
+        // another.
+        copiedNode: null,
         // Exposed so condition_row.html can compare against the sentinel rather
         // than re-typing the "choice" literal.
         slotTypeChoice: SLOT_TYPE_CHOICE,
@@ -140,6 +144,39 @@ Alpine.data("endpointForm", () => {
 
         removeNode(parentGroup, idx) {
             parentGroup.children.splice(idx, 1);
+        },
+
+        copyNode(node) {
+            this.copiedNode = JSON.parse(JSON.stringify(node));
+        },
+
+        _subtreeGroupHeight(node) {
+            if (node.type === "component") {
+                return 0;
+            }
+            const heights = (node.children || []).map((c) =>
+                this._subtreeGroupHeight(c),
+            );
+            return 1 + Math.max(0, ...heights);
+        },
+
+        canPasteInto(depth) {
+            return (
+                !!this.copiedNode &&
+                this._subtreeGroupHeight(this.copiedNode) <= depth
+            );
+        },
+
+        pasteInto(group) {
+            if (!this.copiedNode) {
+                return;
+            }
+            const clone = JSON.parse(JSON.stringify(this.copiedNode));
+            this.initializeIds(clone);
+            if (!group.children) {
+                group.children = [];
+            }
+            group.children.push(clone);
         },
 
         onFieldChange(node) {

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -1,6 +1,7 @@
 import "commcarehq";
 import "hqwebapp/js/htmx_base";
 import Alpine from "alpinejs";
+import "hqwebapp/js/alpinejs/directives/datepicker";
 import initialPageData from "hqwebapp/js/initial_page_data";
 
 // Input-slot type sentinels. These MUST stay in sync with the constants in

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -2,6 +2,7 @@ import "commcarehq";
 import "hqwebapp/js/htmx_base";
 import Alpine from "alpinejs";
 import "hqwebapp/js/alpinejs/directives/datepicker";
+import "hqwebapp/js/alpinejs/directives/select2";
 import initialPageData from "hqwebapp/js/initial_page_data";
 
 // Input-slot type sentinels. These MUST stay in sync with the constants in
@@ -171,6 +172,18 @@ Alpine.data("endpointForm", () => {
                 node.inputs[slotName] = { type: "constant", value: "" };
             }
             return node.inputs[slotName];
+        },
+
+        slotStretches(node, slot) {
+            // Only free-text constant inputs grow to fill the row; choice,
+            // date/datetime, and parameter selects stay at their content width.
+            if (slot.type === this.slotTypeChoice) {
+                return false;
+            }
+            if (slot.type === "date" || slot.type === "datetime") {
+                return false;
+            }
+            return this.getInputValue(node, slot.name).type === "constant";
         },
 
         setInputType(node, slotName, valueType) {

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -4,6 +4,11 @@ import Alpine from "alpinejs";
 import "hqwebapp/js/alpinejs/directives/datepicker";
 import "hqwebapp/js/alpinejs/directives/select2";
 import initialPageData from "hqwebapp/js/initial_page_data";
+import {
+    subtreeGroupHeight,
+    cloneWithNewIds,
+    normalizeRoot,
+} from "case_search/js/endpoint_tree";
 
 // Input-slot type sentinels. These MUST stay in sync with the constants in
 // corehq/apps/case_search/endpoint_capability.py (INPUT_TYPE_CHOICE,
@@ -79,22 +84,8 @@ Alpine.data("endpointForm", () => {
             }
         },
 
-        // The stored spec and builder state share the same shape, so the only
-        // adjustment needed is at the root: the builder always renders a
-        // group, so wrap a bare-component or empty/legacy root in an `all`
-        // group.
-        normalizeRoot(node) {
-            if (node && ["all", "any", "none"].includes(node.type)) {
-                return node;
-            }
-            if (node && node.type === "component") {
-                return { type: "all", children: [node] };
-            }
-            return { type: "all", children: (node && node.children) || [] };
-        },
-
         init() {
-            this.query = this.normalizeRoot(this.query);
+            this.query = normalizeRoot(this.query);
             this.initializeIds(this.query);
         },
 
@@ -150,20 +141,10 @@ Alpine.data("endpointForm", () => {
             this.copiedNode = JSON.parse(JSON.stringify(node));
         },
 
-        _subtreeGroupHeight(node) {
-            if (node.type === "component") {
-                return 0;
-            }
-            const heights = (node.children || []).map((c) =>
-                this._subtreeGroupHeight(c),
-            );
-            return 1 + Math.max(0, ...heights);
-        },
-
         canPasteInto(depth) {
             return (
                 !!this.copiedNode &&
-                this._subtreeGroupHeight(this.copiedNode) <= depth
+                subtreeGroupHeight(this.copiedNode) <= depth
             );
         },
 
@@ -171,8 +152,11 @@ Alpine.data("endpointForm", () => {
             if (!this.copiedNode) {
                 return;
             }
-            const clone = JSON.parse(JSON.stringify(this.copiedNode));
-            this.initializeIds(clone);
+            const { node: clone, nextId } = cloneWithNewIds(
+                this.copiedNode,
+                this._nextId,
+            );
+            this._nextId = nextId;
             if (!group.children) {
                 group.children = [];
             }

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -12,8 +12,6 @@ const SLOT_TYPE_CHOICE = "choice";
 const SLOT_TYPE_MATCH_FIELD = "match_field";
 
 Alpine.data("endpointForm", () => {
-    const mode = initialPageData.get("endpoint_mode");
-
     return {
         name: initialPageData.get("initial_name"),
         targetType: initialPageData.get("initial_target_type"),
@@ -22,7 +20,6 @@ Alpine.data("endpointForm", () => {
         testParamValues: {},
         query: initialPageData.get("initial_query"),
         capability: initialPageData.get("capability"),
-        mode: mode,
         _nextId: 1,
         // Exposed so condition_row.html can compare against the sentinel rather
         // than re-typing the "choice" literal.

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -5,7 +5,7 @@ import "hqwebapp/js/alpinejs/directives/datepicker";
 import "hqwebapp/js/alpinejs/directives/select2";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import {
-    subtreeGroupHeight,
+    subtreeGroupDepth,
     cloneWithNewIds,
     normalizeRoot,
     removeChild,
@@ -145,7 +145,7 @@ Alpine.data("endpointForm", () => {
         canPasteInto(depth) {
             return (
                 !!this.copiedNode &&
-                subtreeGroupHeight(this.copiedNode) <= depth
+                subtreeGroupDepth(this.copiedNode) <= depth
             );
         },
 

--- a/corehq/apps/case_search/static/case_search/js/endpoint_tree.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_tree.js
@@ -1,0 +1,33 @@
+// Pure tree operations for the endpoint query builder. Kept free of Alpine and
+// page-data dependencies so they can be unit-tested directly.
+
+export function subtreeGroupHeight(node) {
+    if (node.type === "component") {
+        return 0;
+    }
+    const heights = (node.children || []).map(subtreeGroupHeight);
+    return 1 + Math.max(0, ...heights);
+}
+
+export function cloneWithNewIds(node, nextId) {
+    const clone = JSON.parse(JSON.stringify(node));
+    const assign = (n) => {
+        n._id = nextId++;
+        (n.children || []).forEach(assign);
+    };
+    assign(clone);
+    return { node: clone, nextId };
+}
+
+// The stored spec and builder state share the same shape, so the only
+// adjustment needed is at the root: the builder always renders a group, so
+// wrap a bare-component or empty/legacy root in an `all` group.
+export function normalizeRoot(node) {
+    if (node && ["all", "any", "none"].includes(node.type)) {
+        return node;
+    }
+    if (node && node.type === "component") {
+        return { type: "all", children: [node] };
+    }
+    return { type: "all", children: (node && node.children) || [] };
+}

--- a/corehq/apps/case_search/static/case_search/js/endpoint_tree.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_tree.js
@@ -31,3 +31,16 @@ export function normalizeRoot(node) {
     }
     return { type: "all", children: (node && node.children) || [] };
 }
+
+// Remove `node` from `parent.children` by identity, returning true if found.
+// Identity rather than index because the builder's x-for is keyed by `_id` and
+// Alpine does not re-run a child's scope after the list mutates, so a captured
+// index goes stale and would delete the wrong sibling.
+export function removeChild(parent, node) {
+    const idx = (parent.children || []).indexOf(node);
+    if (idx === -1) {
+        return false;
+    }
+    parent.children.splice(idx, 1);
+    return true;
+}

--- a/corehq/apps/case_search/static/case_search/js/endpoint_tree.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_tree.js
@@ -1,11 +1,11 @@
 // Pure tree operations for the endpoint query builder. Kept free of Alpine and
 // page-data dependencies so they can be unit-tested directly.
 
-export function subtreeGroupHeight(node) {
+export function subtreeGroupDepth(node) {
     if (node.type === "component") {
         return 0;
     }
-    const heights = (node.children || []).map(subtreeGroupHeight);
+    const heights = (node.children || []).map(subtreeGroupDepth);
     return 1 + Math.max(0, ...heights);
 }
 

--- a/corehq/apps/case_search/static/case_search/scss/endpoint_edit.scss
+++ b/corehq/apps/case_search/static/case_search/scss/endpoint_edit.scss
@@ -3,3 +3,15 @@
   height: 24px;
   font-size: 11px;
 }
+
+// The global `.select2-container { width: 100% !important; }` rule
+// (hqwebapp/scss/commcarehq/_select2.scss) would stretch the field select2
+// across the whole condition row. Constrain just this one so it sits inline
+// before the operator dropdown.
+.ep-field-select + .select2-container {
+  width: 12rem !important;
+}
+
+.ep-date-input {
+  width: 12rem;
+}

--- a/corehq/apps/case_search/static/case_search/spec/endpoint_tree.spec.js
+++ b/corehq/apps/case_search/static/case_search/spec/endpoint_tree.spec.js
@@ -1,0 +1,117 @@
+import {
+    subtreeGroupHeight,
+    cloneWithNewIds,
+    normalizeRoot,
+} from "case_search/js/endpoint_tree";
+
+const component = (extra = {}) => ({ type: "component", ...extra });
+const group = (type, children) => ({ type, children });
+
+describe("endpoint_tree", function () {
+    describe("subtreeGroupHeight", function () {
+        it("is 0 for a component", function () {
+            assert.equal(subtreeGroupHeight(component()), 0);
+        });
+
+        it("is 1 for a group of only components", function () {
+            assert.equal(
+                subtreeGroupHeight(group("all", [component(), component()])),
+                1,
+            );
+        });
+
+        it("is 1 for an empty group", function () {
+            assert.equal(subtreeGroupHeight(group("any", [])), 1);
+        });
+
+        it("is 1 for a group with no children key", function () {
+            assert.equal(subtreeGroupHeight({ type: "all" }), 1);
+        });
+
+        it("counts the deepest nested group", function () {
+            const tree = group("all", [
+                component(),
+                group("any", [component()]),
+            ]);
+            assert.equal(subtreeGroupHeight(tree), 2);
+        });
+
+        it("follows the deepest branch, not the first", function () {
+            const tree = group("all", [
+                group("any", [component()]),
+                group("none", [group("all", [component()])]),
+            ]);
+            assert.equal(subtreeGroupHeight(tree), 3);
+        });
+    });
+
+    describe("cloneWithNewIds", function () {
+        it("deep-clones so the source is not shared", function () {
+            const source = group("all", [component({ field: "name" })]);
+            const { node: clone } = cloneWithNewIds(source, 1);
+            clone.children[0].field = "changed";
+            assert.equal(source.children[0].field, "name");
+        });
+
+        it("assigns sequential ids pre-order starting at nextId", function () {
+            const source = group("all", [
+                component(),
+                group("any", [component()]),
+            ]);
+            const { node: clone } = cloneWithNewIds(source, 10);
+            assert.equal(clone._id, 10);
+            assert.equal(clone.children[0]._id, 11);
+            assert.equal(clone.children[1]._id, 12);
+            assert.equal(clone.children[1].children[0]._id, 13);
+        });
+
+        it("returns the next unused id", function () {
+            const source = group("all", [component(), component()]);
+            const { nextId } = cloneWithNewIds(source, 5);
+            assert.equal(nextId, 8);
+        });
+
+        it("returns nextId + 1 for a lone component", function () {
+            const { node: clone, nextId } = cloneWithNewIds(component(), 42);
+            assert.equal(clone._id, 42);
+            assert.equal(nextId, 43);
+        });
+
+        it("does not mutate the source ids", function () {
+            const source = group("all", [component()]);
+            source._id = 99;
+            source.children[0]._id = 100;
+            cloneWithNewIds(source, 1);
+            assert.equal(source._id, 99);
+            assert.equal(source.children[0]._id, 100);
+        });
+    });
+
+    describe("normalizeRoot", function () {
+        it("passes an all/any/none group through unchanged", function () {
+            const g = group("any", [component()]);
+            assert.strictEqual(normalizeRoot(g), g);
+        });
+
+        it("wraps a bare component in an all group", function () {
+            const c = component({ field: "name" });
+            const result = normalizeRoot(c);
+            assert.equal(result.type, "all");
+            assert.deepEqual(result.children, [c]);
+        });
+
+        it("returns an empty all group for null", function () {
+            assert.deepEqual(normalizeRoot(null), {
+                type: "all",
+                children: [],
+            });
+        });
+
+        it("keeps children of a legacy/unknown-type root", function () {
+            const children = [component()];
+            const result = normalizeRoot({ type: "legacy", children });
+            assert.equal(result.type, "all");
+            assert.deepEqual(result.children, children);
+        });
+    });
+});

--- a/corehq/apps/case_search/static/case_search/spec/endpoint_tree.spec.js
+++ b/corehq/apps/case_search/static/case_search/spec/endpoint_tree.spec.js
@@ -2,6 +2,7 @@ import {
     subtreeGroupHeight,
     cloneWithNewIds,
     normalizeRoot,
+    removeChild,
 } from "case_search/js/endpoint_tree";
 
 const component = (extra = {}) => ({ type: "component", ...extra });
@@ -112,6 +113,44 @@ describe("endpoint_tree", function () {
             const result = normalizeRoot({ type: "legacy", children });
             assert.equal(result.type, "all");
             assert.deepEqual(result.children, children);
+        });
+    });
+
+    describe("removeChild", function () {
+        it("removes the node and returns true", function () {
+            const b = component({ field: "b" });
+            const parent = group("all", [component({ field: "a" }), b]);
+            assert.isTrue(removeChild(parent, b));
+            assert.deepEqual(parent.children, [component({ field: "a" })]);
+        });
+
+        it("removes by identity, not by matching value", function () {
+            // Two structurally identical siblings: only the referenced one goes.
+            const first = component({ field: "x" });
+            const second = component({ field: "x" });
+            const parent = group("all", [first, second]);
+            removeChild(parent, second);
+            assert.equal(parent.children.length, 1);
+            assert.strictEqual(parent.children[0], first);
+        });
+
+        it("removes the correct sibling regardless of position", function () {
+            const a = component({ field: "a" });
+            const b = component({ field: "b" });
+            const c = component({ field: "c" });
+            const parent = group("all", [a, b, c]);
+            removeChild(parent, b);
+            assert.deepEqual(parent.children, [a, c]);
+        });
+
+        it("returns false and does not mutate when node is absent", function () {
+            const parent = group("all", [component({ field: "a" })]);
+            assert.isFalse(removeChild(parent, component({ field: "a" })));
+            assert.equal(parent.children.length, 1);
+        });
+
+        it("returns false when the parent has no children", function () {
+            assert.isFalse(removeChild({ type: "all" }, component()));
         });
     });
 });

--- a/corehq/apps/case_search/static/case_search/spec/endpoint_tree.spec.js
+++ b/corehq/apps/case_search/static/case_search/spec/endpoint_tree.spec.js
@@ -1,5 +1,5 @@
 import {
-    subtreeGroupHeight,
+    subtreeGroupDepth,
     cloneWithNewIds,
     normalizeRoot,
     removeChild,
@@ -9,24 +9,24 @@ const component = (extra = {}) => ({ type: "component", ...extra });
 const group = (type, children) => ({ type, children });
 
 describe("endpoint_tree", function () {
-    describe("subtreeGroupHeight", function () {
+    describe("subtreeGroupDepth", function () {
         it("is 0 for a component", function () {
-            assert.equal(subtreeGroupHeight(component()), 0);
+            assert.equal(subtreeGroupDepth(component()), 0);
         });
 
         it("is 1 for a group of only components", function () {
             assert.equal(
-                subtreeGroupHeight(group("all", [component(), component()])),
+                subtreeGroupDepth(group("all", [component(), component()])),
                 1,
             );
         });
 
         it("is 1 for an empty group", function () {
-            assert.equal(subtreeGroupHeight(group("any", [])), 1);
+            assert.equal(subtreeGroupDepth(group("any", [])), 1);
         });
 
         it("is 1 for a group with no children key", function () {
-            assert.equal(subtreeGroupHeight({ type: "all" }), 1);
+            assert.equal(subtreeGroupDepth({ type: "all" }), 1);
         });
 
         it("counts the deepest nested group", function () {
@@ -34,7 +34,7 @@ describe("endpoint_tree", function () {
                 component(),
                 group("any", [component()]),
             ]);
-            assert.equal(subtreeGroupHeight(tree), 2);
+            assert.equal(subtreeGroupDepth(tree), 2);
         });
 
         it("follows the deepest branch, not the first", function () {
@@ -42,7 +42,7 @@ describe("endpoint_tree", function () {
                 group("any", [component()]),
                 group("none", [group("all", [component()])]),
             ]);
-            assert.equal(subtreeGroupHeight(tree), 3);
+            assert.equal(subtreeGroupDepth(tree), 3);
         });
     });
 

--- a/corehq/apps/case_search/static/case_search/spec/main.js
+++ b/corehq/apps/case_search/static/case_search/spec/main.js
@@ -1,0 +1,5 @@
+import hqMocha from "mocha/js/main";
+
+import "case_search/spec/endpoint_tree.spec";
+
+hqMocha.run();

--- a/corehq/apps/case_search/templates/case_search/endpoint_edit.html
+++ b/corehq/apps/case_search/templates/case_search/endpoint_edit.html
@@ -143,7 +143,7 @@
             </span>
             <input
               type="text"
-              class="form-control form-control-sm font-monospace flex-grow-1"
+              class="form-control font-monospace flex-grow-1"
               x-model="param.name"
               :id="'param-name-' + idx"
               required
@@ -151,10 +151,7 @@
               title="{% trans "Name cannot be empty or only whitespace" %}"
               placeholder="{% trans "parameter name" %}"
             />
-            <select
-              class="form-select form-select-sm w-auto"
-              x-model="param.type"
-            >
+            <select class="form-select w-auto" x-model="param.type">
               <option value="text">{% trans "text" %}</option>
               <option value="number">{% trans "number" %}</option>
               <option value="date">{% trans "date" %}</option>
@@ -162,7 +159,7 @@
             </select>
             <button
               type="button"
-              class="btn btn-sm text-secondary border-0 p-1"
+              class="btn text-secondary border-0 p-1"
               @click="removeParameter(idx)"
               :aria-label="'{% trans "Remove parameter" %}'"
             >
@@ -173,7 +170,7 @@
 
         <button
           type="button"
-          class="btn btn-outline-primary btn-sm"
+          class="btn btn-outline-primary"
           @click="addParameter()"
         >
           <i class="fa-solid fa-plus me-1"></i>{% trans "Add Parameter" %}
@@ -220,12 +217,12 @@
 
     {# Actions #}
     <div class="mt-3 d-flex gap-2">
-      <button type="submit" class="btn btn-primary btn-sm">
+      <button type="submit" class="btn btn-primary">
         {% if endpoint_mode == 'new' %}{% trans "Create Endpoint" %}{% else %}{% trans "Save" %}{% endif %}
       </button>
       <a
         href="{% url 'case_search_endpoints' domain %}"
-        class="btn btn-outline-primary btn-sm"
+        class="btn btn-outline-primary"
         >{% trans "Cancel" %}</a
       >
     </div>

--- a/corehq/apps/case_search/templates/case_search/endpoint_list.html
+++ b/corehq/apps/case_search/templates/case_search/endpoint_list.html
@@ -57,13 +57,13 @@
             <td>
               <a
                 href="{% url 'case_search_endpoint_edit' domain endpoint.id %}"
-                class="btn btn-sm btn-outline-primary"
+                class="btn btn-outline-primary"
               >
                 {% trans "Edit" %}
               </a>
               <button
                 type="button"
-                class="btn btn-sm btn-outline-danger"
+                class="btn btn-outline-danger"
                 data-bs-toggle="modal"
                 data-bs-target="#deactivate-modal"
                 data-endpoint-name="{{ endpoint.name }}"

--- a/corehq/apps/case_search/templates/case_search/partials/condition_row.html
+++ b/corehq/apps/case_search/templates/case_search/partials/condition_row.html
@@ -82,14 +82,21 @@
             >
               <select
                 class="form-select form-select-sm w-auto"
-                :value="getInputValue(node, slot.name).value"
                 @change="node.inputs[slot.name].value = $event.target.value"
               >
-                <option value="" disabled selected>
+                <option
+                  value=""
+                  disabled
+                  :selected="!getInputValue(node, slot.name).value"
+                >
                   {% trans "-- Parameter --" %}
                 </option>
                 <template x-for="parameter in getParametersOfType(slot.type)">
-                  <option :value="parameter" x-text="parameter"></option>
+                  <option
+                    :value="parameter"
+                    x-text="parameter"
+                    :selected="parameter === getInputValue(node, slot.name).value"
+                  ></option>
                 </template>
               </select>
             </template>

--- a/corehq/apps/case_search/templates/case_search/partials/condition_row.html
+++ b/corehq/apps/case_search/templates/case_search/partials/condition_row.html
@@ -10,10 +10,11 @@
     <i :class="typeIconClass(getFieldType(node.field))"></i>
   </span>
   <select
-    class="form-select form-select-sm w-auto"
-    @change="node.field = $event.target.value; onFieldChange(node)"
+    class="form-select w-auto ep-field-select"
+    x-select2='{"placeholder": "{% trans "Field" %}", "allowClear": true}'
+    @select2change="node.field = $event.detail; onFieldChange(node)"
   >
-    <option value="" :selected="!node.field">{% trans "-- Field --" %}</option>
+    <option value=""></option>
     <template x-for="field in Object.values(currentFields)" :key="field.name">
       <option
         :value="field.name"
@@ -24,7 +25,7 @@
   </select>
   <template x-if="node.field">
     <select
-      class="form-select form-select-sm w-auto"
+      class="form-select w-auto"
       @change="node.operator = $event.target.value; onOperatorChange(node)"
     >
       <option value="" :selected="!node.operator">
@@ -41,12 +42,15 @@
   </template>
   <template x-if="node.operator">
     <template x-for="slot in getInputSchemaForOperation(node)" :key="slot.name">
-      <div class="d-flex gap-1 flex-grow-1">
+      <div
+        class="d-flex gap-1"
+        :class="{ 'flex-grow-1': slotStretches(node, slot) }"
+      >
         {# Choice slots are constant-only: a dropdown of fixed options, no type #}
         {# selector. `slotTypeChoice` mirrors endpoint_capability.INPUT_TYPE_CHOICE. #}
         <template x-if="slot.type === slotTypeChoice">
           <select
-            class="form-select form-select-sm"
+            class="form-select w-auto"
             x-model="getInputValue(node, slot.name).value"
             :aria-label="slot.name"
           >
@@ -58,7 +62,7 @@
         <template x-if="slot.type !== slotTypeChoice">
           <div class="d-flex gap-1 flex-grow-1">
             <select
-              class="form-select form-select-sm w-auto"
+              class="form-select w-auto"
               :value="getInputValue(node, slot.name).type"
               @change="setInputType(node, slot.name, $event.target.value)"
             >
@@ -69,13 +73,13 @@
               <div class="flex-grow-1">
                 <template x-if="slot.type === 'date'">
                   <div
-                    class="input-group input-group-sm"
+                    class="input-group ep-date-input"
                     data-td-target-input="nearest"
                     data-td-target-toggle="nearest"
                   >
                     <input
                       type="text"
-                      class="form-control form-control-sm"
+                      class="form-control"
                       :id="'cond-' + node._id + '-' + slot.name"
                       x-model="getInputValue(node, slot.name).value"
                       x-datepicker='{"useInputGroup": true}'
@@ -93,13 +97,13 @@
                 </template>
                 <template x-if="slot.type === 'datetime'">
                   <div
-                    class="input-group input-group-sm"
+                    class="input-group ep-date-input"
                     data-td-target-input="nearest"
                     data-td-target-toggle="nearest"
                   >
                     <input
                       type="text"
-                      class="form-control form-control-sm"
+                      class="form-control"
                       :id="'cond-' + node._id + '-' + slot.name"
                       x-model="getInputValue(node, slot.name).value"
                       x-datepicker='{"datetime": true, "useInputGroup": true}'
@@ -120,7 +124,7 @@
                 >
                   <input
                     type="text"
-                    class="form-control form-control-sm"
+                    class="form-control"
                     x-model="getInputValue(node, slot.name).value"
                     :placeholder="slot.name"
                   />
@@ -131,7 +135,7 @@
               x-if="getInputValue(node, slot.name).type === 'parameter'"
             >
               <select
-                class="form-select form-select-sm w-auto"
+                class="form-select w-auto"
                 @change="node.inputs[slot.name].value = $event.target.value"
               >
                 <option
@@ -157,7 +161,7 @@
   </template>
   <button
     type="button"
-    class="btn btn-sm text-secondary border-0 p-1 ms-auto flex-shrink-0"
+    class="btn text-secondary border-0 p-1 ms-auto flex-shrink-0"
     @click="removeNode(_removeParent, _removeIdx)"
     aria-label="{% trans "Remove condition" %}"
   >

--- a/corehq/apps/case_search/templates/case_search/partials/condition_row.html
+++ b/corehq/apps/case_search/templates/case_search/partials/condition_row.html
@@ -66,12 +66,66 @@
               <option value="parameter">{% trans "Parameter" %}</option>
             </select>
             <template x-if="getInputValue(node, slot.name).type === 'constant'">
-              <input
-                type="text"
-                class="form-control form-control-sm"
-                x-model="getInputValue(node, slot.name).value"
-                :placeholder="slot.name"
-              />
+              <div class="flex-grow-1">
+                <template x-if="slot.type === 'date'">
+                  <div
+                    class="input-group input-group-sm"
+                    data-td-target-input="nearest"
+                    data-td-target-toggle="nearest"
+                  >
+                    <input
+                      type="text"
+                      class="form-control form-control-sm"
+                      :id="'cond-' + node._id + '-' + slot.name"
+                      x-model="getInputValue(node, slot.name).value"
+                      x-datepicker='{"useInputGroup": true}'
+                      :placeholder="slot.name"
+                      autocomplete="off"
+                    />
+                    <button
+                      class="btn btn-outline-secondary"
+                      type="button"
+                      data-td-toggle="datetimepicker"
+                    >
+                      <i class="fa-solid fa-calendar-days"></i>
+                    </button>
+                  </div>
+                </template>
+                <template x-if="slot.type === 'datetime'">
+                  <div
+                    class="input-group input-group-sm"
+                    data-td-target-input="nearest"
+                    data-td-target-toggle="nearest"
+                  >
+                    <input
+                      type="text"
+                      class="form-control form-control-sm"
+                      :id="'cond-' + node._id + '-' + slot.name"
+                      x-model="getInputValue(node, slot.name).value"
+                      x-datepicker='{"datetime": true, "useInputGroup": true}'
+                      :placeholder="slot.name"
+                      autocomplete="off"
+                    />
+                    <button
+                      class="btn btn-outline-secondary"
+                      type="button"
+                      data-td-toggle="datetimepicker"
+                    >
+                      <i class="fa-solid fa-calendar-days"></i>
+                    </button>
+                  </div>
+                </template>
+                <template
+                  x-if="slot.type !== 'date' && slot.type !== 'datetime'"
+                >
+                  <input
+                    type="text"
+                    class="form-control form-control-sm"
+                    x-model="getInputValue(node, slot.name).value"
+                    :placeholder="slot.name"
+                  />
+                </template>
+              </div>
             </template>
             <template
               x-if="getInputValue(node, slot.name).type === 'parameter'"

--- a/corehq/apps/case_search/templates/case_search/partials/condition_row.html
+++ b/corehq/apps/case_search/templates/case_search/partials/condition_row.html
@@ -162,6 +162,14 @@
   <button
     type="button"
     class="btn text-secondary border-0 p-1 ms-auto flex-shrink-0"
+    @click="copyNode(node)"
+    aria-label="{% trans "Copy condition" %}"
+  >
+    <i class="fa-regular fa-clone"></i>
+  </button>
+  <button
+    type="button"
+    class="btn text-secondary border-0 p-1 flex-shrink-0"
     @click="removeNode(_removeParent, _removeIdx)"
     aria-label="{% trans "Remove condition" %}"
   >

--- a/corehq/apps/case_search/templates/case_search/partials/condition_row.html
+++ b/corehq/apps/case_search/templates/case_search/partials/condition_row.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{# Condition row partial — expects Alpine scope with: node, _removeParent, _removeIdx #}
+{# Condition row partial — expects Alpine scope with: node, _removeParent #}
 {# All other bindings (mode, currentFields, capability, helper functions) #}
 {# are inherited from the enclosing endpointForm() Alpine context.        #}
 
@@ -170,7 +170,7 @@
   <button
     type="button"
     class="btn text-secondary border-0 p-1 flex-shrink-0"
-    @click="removeNode(_removeParent, _removeIdx)"
+    @click="removeNode(_removeParent, node)"
     aria-label="{% trans "Remove condition" %}"
   >
     <i class="fa-regular fa-trash-can"></i>

--- a/corehq/apps/case_search/templates/case_search/partials/condition_row.html
+++ b/corehq/apps/case_search/templates/case_search/partials/condition_row.html
@@ -26,7 +26,6 @@
     <select
       class="form-select form-select-sm w-auto"
       @change="node.operator = $event.target.value; onOperatorChange(node)"
-      :disabled="mode === 'readonly'"
     >
       <option value="" :selected="!node.operator">
         {% trans "-- Operation --" %}
@@ -49,7 +48,6 @@
           <select
             class="form-select form-select-sm"
             x-model="getInputValue(node, slot.name).value"
-            :disabled="mode === 'readonly'"
             :aria-label="slot.name"
           >
             <template x-for="option in slot.options" :key="option">
@@ -63,7 +61,6 @@
               class="form-select form-select-sm w-auto"
               :value="getInputValue(node, slot.name).type"
               @change="setInputType(node, slot.name, $event.target.value)"
-              :disabled="mode === 'readonly'"
             >
               <option value="constant">{% trans "Value" %}</option>
               <option value="parameter">{% trans "Parameter" %}</option>
@@ -73,7 +70,6 @@
                 type="text"
                 class="form-control form-control-sm"
                 x-model="getInputValue(node, slot.name).value"
-                :disabled="mode === 'readonly'"
                 :placeholder="slot.name"
               />
             </template>
@@ -105,14 +101,12 @@
       </div>
     </template>
   </template>
-  <template x-if="mode !== 'readonly'">
-    <button
-      type="button"
-      class="btn btn-sm text-secondary border-0 p-1 ms-auto flex-shrink-0"
-      @click="removeNode(_removeParent, _removeIdx)"
-      aria-label="{% trans "Remove condition" %}"
-    >
-      <i class="fa-regular fa-trash-can"></i>
-    </button>
-  </template>
+  <button
+    type="button"
+    class="btn btn-sm text-secondary border-0 p-1 ms-auto flex-shrink-0"
+    @click="removeNode(_removeParent, _removeIdx)"
+    aria-label="{% trans "Remove condition" %}"
+  >
+    <i class="fa-regular fa-trash-can"></i>
+  </button>
 </div>

--- a/corehq/apps/case_search/templates/case_search/partials/condition_row.html
+++ b/corehq/apps/case_search/templates/case_search/partials/condition_row.html
@@ -95,33 +95,7 @@
                     </button>
                   </div>
                 </template>
-                <template x-if="slot.type === 'datetime'">
-                  <div
-                    class="input-group ep-date-input"
-                    data-td-target-input="nearest"
-                    data-td-target-toggle="nearest"
-                  >
-                    <input
-                      type="text"
-                      class="form-control"
-                      :id="'cond-' + node._id + '-' + slot.name"
-                      x-model="getInputValue(node, slot.name).value"
-                      x-datepicker='{"datetime": true, "useInputGroup": true}'
-                      :placeholder="slot.name"
-                      autocomplete="off"
-                    />
-                    <button
-                      class="btn btn-outline-secondary"
-                      type="button"
-                      data-td-toggle="datetimepicker"
-                    >
-                      <i class="fa-solid fa-calendar-days"></i>
-                    </button>
-                  </div>
-                </template>
-                <template
-                  x-if="slot.type !== 'date' && slot.type !== 'datetime'"
-                >
+                <template x-if="slot.type !== 'date'">
                   <input
                     type="text"
                     class="form-control"

--- a/corehq/apps/case_search/templates/case_search/partials/group_header.html
+++ b/corehq/apps/case_search/templates/case_search/partials/group_header.html
@@ -11,8 +11,7 @@
       type="button"
       class="btn"
       :class="node.type === 'all' ? 'btn-primary' : 'btn-outline-secondary'"
-      @click="if (mode !== 'readonly') node.type = 'all'"
-      :disabled="mode === 'readonly'"
+      @click="node.type = 'all'"
     >
       {% trans "ALL" %}
     </button>
@@ -20,8 +19,7 @@
       type="button"
       class="btn"
       :class="node.type === 'any' ? 'btn-primary' : 'btn-outline-secondary'"
-      @click="if (mode !== 'readonly') node.type = 'any'"
-      :disabled="mode === 'readonly'"
+      @click="node.type = 'any'"
     >
       {% trans "ANY" %}
     </button>
@@ -29,8 +27,7 @@
       type="button"
       class="btn"
       :class="node.type === 'none' ? 'btn-primary' : 'btn-outline-secondary'"
-      @click="if (mode !== 'readonly') node.type = 'none'"
-      :disabled="mode === 'readonly'"
+      @click="node.type = 'none'"
     >
       {% trans "NONE" %}
     </button>
@@ -46,7 +43,7 @@
       >{% trans "match none of the following" %}</span
     >
   </span>
-  <template x-if="mode !== 'readonly' && _removeParent !== null">
+  <template x-if="_removeParent !== null">
     <button
       type="button"
       class="btn btn-sm text-secondary border-0 p-1 ms-auto"

--- a/corehq/apps/case_search/templates/case_search/partials/group_header.html
+++ b/corehq/apps/case_search/templates/case_search/partials/group_header.html
@@ -6,7 +6,7 @@
   >
     <i class="fa-solid fa-code-branch"></i>
   </span>
-  <div class="btn-group btn-group-sm" role="group">
+  <div class="btn-group" role="group">
     <button
       type="button"
       class="btn"
@@ -46,7 +46,7 @@
   <template x-if="_removeParent !== null">
     <button
       type="button"
-      class="btn btn-sm text-secondary border-0 p-1 ms-auto"
+      class="btn text-secondary border-0 p-1 ms-auto"
       @click="removeNode(_removeParent, _removeIdx)"
       aria-label="{% trans "Remove group" %}"
     >

--- a/corehq/apps/case_search/templates/case_search/partials/group_header.html
+++ b/corehq/apps/case_search/templates/case_search/partials/group_header.html
@@ -43,10 +43,18 @@
       >{% trans "match none of the following" %}</span
     >
   </span>
+  <button
+    type="button"
+    class="btn text-secondary border-0 p-1 ms-auto"
+    @click="copyNode(node)"
+    aria-label="{% trans "Copy group" %}"
+  >
+    <i class="fa-regular fa-clone"></i>
+  </button>
   <template x-if="_removeParent !== null">
     <button
       type="button"
-      class="btn text-secondary border-0 p-1 ms-auto"
+      class="btn text-secondary border-0 p-1"
       @click="removeNode(_removeParent, _removeIdx)"
       aria-label="{% trans "Remove group" %}"
     >

--- a/corehq/apps/case_search/templates/case_search/partials/group_header.html
+++ b/corehq/apps/case_search/templates/case_search/partials/group_header.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{# Expects Alpine scope: node, _removeParent (null = no remove button), _removeIdx #}
+{# Expects Alpine scope: node, _removeParent (null = no remove button) #}
 <div class="d-flex align-items-center gap-2 mb-2">
   <span
     class="ep-type-badge d-inline-flex align-items-center justify-content-center flex-shrink-0 rounded-1 bg-secondary text-white"
@@ -55,7 +55,7 @@
     <button
       type="button"
       class="btn text-secondary border-0 p-1"
-      @click="removeNode(_removeParent, _removeIdx)"
+      @click="removeNode(_removeParent, node)"
       aria-label="{% trans "Remove group" %}"
     >
       <i class="fa-regular fa-trash-can"></i>

--- a/corehq/apps/case_search/templates/case_search/partials/group_node.html
+++ b/corehq/apps/case_search/templates/case_search/partials/group_node.html
@@ -40,7 +40,7 @@
   <div class="d-flex gap-2 mt-2 flex-wrap">
     <button
       type="button"
-      class="btn btn-outline-primary btn-sm"
+      class="btn btn-outline-primary"
       @click="addCondition(node)"
     >
       <i class="fa-solid fa-plus me-1"></i>{% trans "Add Condition" %}
@@ -48,7 +48,7 @@
     {% if depth > 0 %}
       <button
         type="button"
-        class="btn btn-outline-primary btn-sm"
+        class="btn btn-outline-primary"
         @click="addGroup(node, 'all')"
       >
         <i class="fa-solid fa-code-branch me-1"></i>{% trans "Add Group" %}

--- a/corehq/apps/case_search/templates/case_search/partials/group_node.html
+++ b/corehq/apps/case_search/templates/case_search/partials/group_node.html
@@ -1,17 +1,15 @@
 {% load i18n %}
 {# Recursive all/any/none group renderer.                                    #}
-{# Expects Alpine scope: node, _removeParent (null = no remove), _removeIdx. #}
+{# Expects Alpine scope: node, _removeParent (null = no remove button).      #}
 {# Expects template context: depth = remaining nesting levels below this     #}
 {# group; the template includes itself until depth runs out.                 #}
 {% include 'case_search/partials/group_header.html' %}
 <div class="ps-4 border-start border-2">
-  <template x-for="(child, childIdx) in node.children" :key="child._id">
+  <template x-for="child in node.children" :key="child._id">
     <div class="mb-2">
       {# Component condition #}
       <template x-if="child.type === 'component'">
-        <div
-          x-data="{ node: child, _removeParent: node, _removeIdx: childIdx }"
-        >
+        <div x-data="{ node: child, _removeParent: node }">
           {% include 'case_search/partials/condition_row.html' %}
         </div>
       </template>
@@ -19,9 +17,7 @@
       {# Nested all/any/none group #}
       {% if depth > 0 %}
         <template x-if="['all', 'any', 'none'].includes(child.type)">
-          <div
-            x-data="{ node: child, _removeParent: node, _removeIdx: childIdx }"
-          >
+          <div x-data="{ node: child, _removeParent: node }">
             {% include 'case_search/partials/group_node.html' with depth=depth|add:"-1" %}
           </div>
         </template>

--- a/corehq/apps/case_search/templates/case_search/partials/group_node.html
+++ b/corehq/apps/case_search/templates/case_search/partials/group_node.html
@@ -37,24 +37,22 @@
   </template>
 
   {# Add buttons #}
-  <template x-if="mode !== 'readonly'">
-    <div class="d-flex gap-2 mt-2 flex-wrap">
+  <div class="d-flex gap-2 mt-2 flex-wrap">
+    <button
+      type="button"
+      class="btn btn-outline-primary btn-sm"
+      @click="addCondition(node)"
+    >
+      <i class="fa-solid fa-plus me-1"></i>{% trans "Add Condition" %}
+    </button>
+    {% if depth > 0 %}
       <button
         type="button"
         class="btn btn-outline-primary btn-sm"
-        @click="addCondition(node)"
+        @click="addGroup(node, 'all')"
       >
-        <i class="fa-solid fa-plus me-1"></i>{% trans "Add Condition" %}
+        <i class="fa-solid fa-code-branch me-1"></i>{% trans "Add Group" %}
       </button>
-      {% if depth > 0 %}
-        <button
-          type="button"
-          class="btn btn-outline-primary btn-sm"
-          @click="addGroup(node, 'all')"
-        >
-          <i class="fa-solid fa-code-branch me-1"></i>{% trans "Add Group" %}
-        </button>
-      {% endif %}
-    </div>
-  </template>
+    {% endif %}
+  </div>
 </div>

--- a/corehq/apps/case_search/templates/case_search/partials/group_node.html
+++ b/corehq/apps/case_search/templates/case_search/partials/group_node.html
@@ -54,5 +54,26 @@
         <i class="fa-solid fa-code-branch me-1"></i>{% trans "Add Group" %}
       </button>
     {% endif %}
+    <template x-if="copiedNode">
+      <button
+        type="button"
+        class="btn btn-outline-primary"
+        :disabled="!canPasteInto({{ depth }})"
+        @click="pasteInto(node)"
+      >
+        <i class="fa-regular fa-clipboard me-1"></i>
+        <span x-show="copiedNode.type === 'component'"
+          >{% trans "Paste Condition" %}</span
+        >
+        <span x-show="copiedNode.type !== 'component'"
+          >{% trans "Paste Group" %}</span
+        >
+      </button>
+    </template>
+    <template x-if="copiedNode && !canPasteInto({{ depth }})">
+      <span class="text-muted small fst-italic align-self-center">
+        {% trans "Copied group is nested too deeply to paste here" %}
+      </span>
+    </template>
   </div>
 </div>

--- a/corehq/apps/case_search/templates/case_search/partials/query_builder.html
+++ b/corehq/apps/case_search/templates/case_search/partials/query_builder.html
@@ -5,7 +5,7 @@
 {# the Alpine-only `_id` keys (see strippedQuery() in the JS).              #}
 
 <div class="filter-tree">
-  <div x-data="{ node: query, _removeParent: null, _removeIdx: null }">
+  <div x-data="{ node: query, _removeParent: null }">
     {% include 'case_search/partials/group_node.html' with depth=max_group_depth %}
   </div>
 

--- a/corehq/apps/case_search/templates/case_search/partials/query_tester.html
+++ b/corehq/apps/case_search/templates/case_search/partials/query_tester.html
@@ -12,12 +12,37 @@
       x-text="param.name"
     ></label>
     <div class="col-sm-10 ">
-      <input
-        type="text"
-        class="form-control form-control-sm font-monospace flex-grow-1"
-        :id="'param-value-' + idx"
-        x-model="testParamValues[param.name]"
-      />
+      <template x-if="param.type === 'date'">
+        <div
+          class="input-group input-group-sm"
+          data-td-target-input="nearest"
+          data-td-target-toggle="nearest"
+        >
+          <input
+            type="text"
+            class="form-control form-control-sm font-monospace"
+            :id="'param-value-' + idx"
+            x-model="testParamValues[param.name]"
+            x-datepicker='{"useInputGroup": true}'
+            autocomplete="off"
+          />
+          <button
+            class="btn btn-outline-secondary"
+            type="button"
+            data-td-toggle="datetimepicker"
+          >
+            <i class="fa-solid fa-calendar-days"></i>
+          </button>
+        </div>
+      </template>
+      <template x-if="param.type !== 'date'">
+        <input
+          type="text"
+          class="form-control form-control-sm font-monospace flex-grow-1"
+          :id="'param-value-' + idx"
+          x-model="testParamValues[param.name]"
+        />
+      </template>
     </div>
   </div>
 </template>

--- a/corehq/apps/case_search/templates/case_search/partials/query_tester.html
+++ b/corehq/apps/case_search/templates/case_search/partials/query_tester.html
@@ -14,13 +14,13 @@
     <div class="col-sm-10 ">
       <template x-if="param.type === 'date'">
         <div
-          class="input-group input-group-sm"
+          class="input-group"
           data-td-target-input="nearest"
           data-td-target-toggle="nearest"
         >
           <input
             type="text"
-            class="form-control form-control-sm font-monospace"
+            class="form-control font-monospace"
             :id="'param-value-' + idx"
             x-model="testParamValues[param.name]"
             x-datepicker='{"useInputGroup": true}'
@@ -38,7 +38,7 @@
       <template x-if="param.type !== 'date'">
         <input
           type="text"
-          class="form-control form-control-sm font-monospace flex-grow-1"
+          class="form-control font-monospace flex-grow-1"
           :id="'param-value-' + idx"
           x-model="testParamValues[param.name]"
         />
@@ -49,7 +49,7 @@
 
 <button
   type="button"
-  class="btn btn-secondary btn-sm"
+  class="btn btn-secondary"
   hx-post="{% url 'case_search_endpoint_test' domain %}"
   hx-include="closest form"
   :hx-vals="JSON.stringify({test_param_values: testParamValues})"

--- a/corehq/apps/case_search/templates/case_search/spec/mocha.html
+++ b/corehq/apps/case_search/templates/case_search/spec/mocha.html
@@ -1,0 +1,3 @@
+{% extends "mocha/base.html" %}
+{% load hq_shared_tags %}
+{% js_entry "case_search/spec/main" %}

--- a/corehq/apps/case_search/templates/case_search/spec/mocha.html
+++ b/corehq/apps/case_search/templates/case_search/spec/mocha.html
@@ -1,3 +1,3 @@
 {% extends "mocha/base.html" %}
 {% load hq_shared_tags %}
-{% js_entry "case_search/spec/main" %}
+{% js_entry_b3 "case_search/spec/main" %}


### PR DESCRIPTION
## Product Description

A couple of smaller fixes/additions to the case search endpoint query builder.

<img width="825" height="431" alt="image" src="https://github.com/user-attachments/assets/7ad4c827-8eb6-4d4f-8817-dedfd11d0ccd" />

- Use select 2 for field selection
- Add copy paste functionality to assist with building out queries
- Use a date picker for date fields in query builder
- Remove some dead code
- Fix the delete node functionality

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag

CASE_SEARCH_ENDPOINTS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

Added test

### QA Plan

With complete feature

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
