### PR TITLE
Avoid false positives from form icons

### DIFF
--- a/corehq/form_processor/submission_validation.py
+++ b/corehq/form_processor/submission_validation.py
@@ -64,5 +64,20 @@ def _walk(node, found):
         for value in node:
             _walk(value, found)
     elif isinstance(node, str):
-        if node.lower().endswith(IMAGE_EXTENSIONS):
+        if _is_image_answer(node):
             found.add(node)
+
+
+def _is_image_answer(form_answer):
+    """
+    Returns True if ``form_answer`` is an image answer. Excludes form
+    images like icons.
+
+    >>> _is_image_answer('https://www.commcarehq.org/a/domain/api/form/attachment/abc/123.jpg')
+    True
+    >>> _is_image_answer('jr://file/commcare/image/data/green_increased.png')
+    False
+
+    """
+    lower = form_answer.lower()
+    return lower.endswith(IMAGE_EXTENSIONS) and not lower.startswith('jr://')

--- a/corehq/form_processor/tests/test_submission_validation.py
+++ b/corehq/form_processor/tests/test_submission_validation.py
@@ -1,3 +1,4 @@
+import doctest
 import uuid
 from io import BytesIO
 from types import SimpleNamespace
@@ -257,3 +258,10 @@ class TestCheckImageAttachmentsCachingFootprint(TestCase):
         assert handler_form_xml_fetches == 0, (
             'handler must not trigger an additional form.xml blob fetch'
         )
+
+
+def test_doctests():
+    import corehq.form_processor.submission_validation as module
+
+    results = doctest.testmod(module)
+    assert results.failed == 0


### PR DESCRIPTION
## Technical Summary

This tweaks the method used for determining whether a form is missing an image attachment. The current method results in false positives by identifying icons inside a form as image question answers. This tweak excludes them.

Context:
* Jira: [SAAS-19082](https://dimagi.atlassian.net/browse/SAAS-19082)
* PR https://github.com/dimagi/commcare-hq/pull/37710

## Safety Assurance

### Safety story

Tiny change

### Automated test coverage

Yes

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19082]: https://dimagi.atlassian.net/browse/SAAS-19082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ