### PR TITLE
Collect Form Designer Error Context

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -29,6 +29,7 @@ function buildSelectedQuestion(mug) {
     const parent = mug.parentMug;
     const belongsToQuestion = parent && {
         type: parent.options.typeName,
+        label: parent.form.vellum.getMugDisplayName(parent),
         question_id: parent.p.nodeID,
         path: parent.hashtagPath,
     };
@@ -36,6 +37,7 @@ function buildSelectedQuestion(mug) {
     if (mug.__className === "Choice") {
         return {
             type: mug.options.typeName,
+            label: mug.form.vellum.getMugDisplayName(mug),
             value: mug.p.nodeID,
             belongs_to_question: belongsToQuestion,
         };
@@ -43,11 +45,13 @@ function buildSelectedQuestion(mug) {
     if (mug.__className === "Itemset") {
         return {
             type: mug.options.typeName,
+            label: mug.form.vellum.getMugDisplayName(mug),
             belongs_to_question: belongsToQuestion,
         };
     }
     return {
         type: mug.options.typeName,
+        label: mug.form.vellum.getMugDisplayName(mug),
         question_id: mug.p.nodeID,
         path: mug.hashtagPath,
     };

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -3,7 +3,6 @@ import initialPageData from "hqwebapp/js/initial_page_data";
 import ocsContext, {WIDGET_SELECTOR} from "hqwebapp/js/ocs_page_context";
 
 const FORMDESIGNER = '#formdesigner';
-let fd;
 
 function _vellum() {
     return $(FORMDESIGNER).vellum("get");
@@ -87,7 +86,7 @@ function _collectMugErrors(mug) {
     return result;
 }
 
-function _cardListFieldErrors(mug) {
+function _cardListFieldErrors(mug, fd) {
     // `.fd-field-error` is cardList-only and lives only in the DOM.
     const out = [];
     fd.querySelectorAll('.fd-card-list .has-error').forEach(row => {
@@ -111,7 +110,7 @@ function _cardListFieldErrors(mug) {
     return out;
 }
 
-function _xpathEditorError(mug) {
+function _xpathEditorError(mug, fd) {
     const el = fd.querySelector('.fd-xpath-validation-summary');
     if (!_isVisible(el)) {return [];}
     const editedProp = mug.form.vellum.data.core.currentlyEditedProperty;
@@ -128,11 +127,11 @@ function _xpathEditorError(mug) {
     }];
 }
 
-function _selectedQuestionWarnings(mug) {
+function _selectedQuestionWarnings(mug, fd) {
     return [
         ..._collectMugErrors(mug),
-        ..._cardListFieldErrors(mug),
-        ..._xpathEditorError(mug),
+        ..._cardListFieldErrors(mug, fd),
+        ..._xpathEditorError(mug, fd),
     ];
 }
 
@@ -168,15 +167,15 @@ function _formWarnings(form) {
     return formWarnings.map(err => err.message.trim());
 }
 
-function _dataSourceWarnings() {
+function _dataSourceWarnings(fd) {
     // External data source load failures only exist as a DOM banner.
     const banner = fd.querySelector('.fd-external-sources-error');
     if (!_isVisible(banner)) {return [];}
     return [banner.querySelector('.help-block').textContent.trim()];
 }
 
-function _formLoadWarnings(form) {
-    return [..._formWarnings(form), ..._dataSourceWarnings()];
+function _formLoadWarnings(form, fd) {
+    return [..._formWarnings(form), ..._dataSourceWarnings(fd)];
 }
 
 function _collectFormContext() {
@@ -185,17 +184,18 @@ function _collectFormContext() {
     if (!form) {
         return {};
     }
+    const fd = document.querySelector(FORMDESIGNER);
     const selectedMug = vellum.getCurrentlySelectedMug();
     const currentSelectedQuestion = buildSelectedQuestion(selectedMug);
     if (currentSelectedQuestion) {
-        currentSelectedQuestion.warnings = _selectedQuestionWarnings(selectedMug);
+        currentSelectedQuestion.warnings = _selectedQuestionWarnings(selectedMug, fd);
     }
     return {
         form_context: {
             form_xml: extractFormXml(vellum),
             question_types: extractQuestionTypes(form),
             unselected_question_warnings: _unselectedQuestionWarnings(form, selectedMug?.ufid),
-            form_load_warnings: _formLoadWarnings(form),
+            form_load_warnings: _formLoadWarnings(form, fd),
             current_selected_question: currentSelectedQuestion,
             module_name: initialPageData.get('module_name'),
         },
@@ -206,7 +206,6 @@ $(function () {
     if (!document.querySelector(WIDGET_SELECTOR)) {
         return;
     }
-    fd = document.querySelector(FORMDESIGNER);
     ocsContext.registerContextCollector(_collectFormContext);
 });
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -213,8 +213,11 @@ export {
     extractFormXml,
     extractQuestionTypes,
     extractSelectedQuestion,
-    _collectMugErrors,
     unselectedQuestionWarnings,
+};
+
+export const exportedForTesting = {
+    _collectMugErrors,
     _formWarnings,
     _cardListFieldErrors,
     _xpathEditorError,

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -61,8 +61,8 @@ function extractSelectedQuestion(vellum) {
     return buildSelectedQuestion(vellum?.getCurrentlySelectedMug());
 }
 
-function _isVisible(el) {
-    return el && el.offsetParent !== null;
+function _isVisible(elem) {
+    return elem && elem.offsetParent !== null;
 }
 
 function _toSingleLine(text) {
@@ -111,14 +111,14 @@ function _cardListFieldErrors(mug, fd) {
 }
 
 function _xpathEditorError(mug, fd) {
-    const el = fd.querySelector('.fd-xpath-validation-summary');
-    if (!_isVisible(el)) {return [];}
+    const elem = fd.querySelector('.fd-xpath-validation-summary');
+    if (!_isVisible(elem)) {return [];}
     const editedProp = mug.form.vellum.data.core.currentlyEditedProperty;
 
     const input = fd.querySelector('.fd-xpath-editor-text');
     const expression = _toSingleLine(input.value || input.textContent);
 
-    const error = _toSingleLine(el.querySelector('pre').textContent);
+    const error = _toSingleLine(elem.querySelector('pre').textContent);
 
     return [{
         field: `${mug.spec[editedProp].lstring} - XPath Editor`,

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -3,6 +3,7 @@ import initialPageData from "hqwebapp/js/initial_page_data";
 import ocsContext, {WIDGET_SELECTOR} from "hqwebapp/js/ocs_page_context";
 
 const FORMDESIGNER = '#formdesigner';
+let fd;
 
 function _vellum() {
     return $(FORMDESIGNER).vellum("get");
@@ -61,17 +62,141 @@ function extractSelectedQuestion(vellum) {
     return buildSelectedQuestion(vellum?.getCurrentlySelectedMug());
 }
 
+function _isVisible(el) {
+    return el && el.offsetParent !== null;
+}
+
+function _toSingleLine(text) {
+    return text ? text.replace(/\s+/g, ' ').trim() : '';
+}
+
+function _collectMugErrors(mug) {
+    const spec = mug.spec;
+    const result = [];
+    mug.messages.each((msg, attr) => {
+        if (msg.level === 'info') {return;}
+        const field = attr ? (spec[attr]?.lstring || attr) : '';
+        // mug.p[attr] isn't always a string (booleans, itext objects)
+        const value = attr && typeof mug.p[attr] === 'string' ? mug.p[attr] : '';
+        result.push({
+            ...(field && {field}),
+            ...(value && {value}),
+            error: mug.messages.getMessageText(msg.message),
+        });
+    });
+    return result;
+}
+
+function _cardListFieldErrors(mug) {
+    // `.fd-field-error` is cardList-only and lives only in the DOM.
+    const out = [];
+    fd.querySelectorAll('.fd-card-list .has-error').forEach(row => {
+        const attr = row.closest('[name^="property-"]').getAttribute('name').slice('property-'.length);
+        const field = mug.spec[attr].lstring;
+
+        const subfield = row.querySelector('label')?.textContent;
+
+        const input = row.querySelector('.form-control');
+        const value = input.value || input.textContent || '';
+
+        const error = row.querySelector('.fd-field-error').textContent;
+
+        out.push({
+            ...(field && {field}),
+            ...(subfield && {subfield}),
+            ...(value && {value}),
+            error,
+        });
+    });
+    return out;
+}
+
+function _xpathEditorError(mug) {
+    const el = fd.querySelector('.fd-xpath-validation-summary');
+    if (!_isVisible(el)) {return [];}
+    const editedProp = mug.form.vellum.data.core.currentlyEditedProperty;
+
+    const input = fd.querySelector('.fd-xpath-editor-text');
+    const expression = _toSingleLine(input.value || input.textContent);
+
+    const error = _toSingleLine(el.querySelector('pre').textContent);
+
+    return [{
+        field: `${mug.spec[editedProp].lstring} - XPath Editor`,
+        value: expression,
+        error,
+    }];
+}
+
+function _selectedQuestionWarnings(mug) {
+    return [
+        ..._collectMugErrors(mug),
+        ..._cardListFieldErrors(mug),
+        ..._xpathEditorError(mug),
+    ];
+}
+
+function _unselectedQuestionWarnings(form, selectedUfid) {
+    const warnings = {};
+    form.walkMugs(mug => {
+        if (mug.ufid === selectedUfid) {return;}
+        const mugWarnings = _collectMugErrors(mug);
+        if (!mugWarnings.length) {return;}
+
+        if (mug.absolutePath) {
+            warnings[mug.absolutePath] = mugWarnings;
+            return;
+        }
+
+        // Choices/Lookup tables have no path of their own
+        const parent = mug.parentMug;
+        if (!parent?.absolutePath) {return;}
+        const key = `${parent.absolutePath}/${mug.p.nodeID || mug.options.typeName}`;
+        warnings[key] = mugWarnings;
+    });
+    return warnings;
+}
+
+function _formWarnings(form) {
+    const errors = form.errors.filter(err => err.level === 'error');
+    const formWarnings = [...errors];
+    const parseWarnings = form.errors.filter(err => err.level === 'parse-warning');
+    // Only the latest parse warning is displayed in the UI
+    if (parseWarnings.length) {
+        formWarnings.push(parseWarnings[parseWarnings.length - 1]);
+    }
+    return formWarnings.map(err => err.message.trim());
+}
+
+function _dataSourceWarnings() {
+    // External data source load failures only exist as a DOM banner.
+    const banner = fd.querySelector('.fd-external-sources-error');
+    if (!_isVisible(banner)) {return [];}
+    return [banner.querySelector('.help-block').textContent.trim()];
+}
+
+function _formLoadWarnings(form) {
+    return [..._formWarnings(form), ..._dataSourceWarnings()];
+}
+
 function _collectFormContext() {
     const vellum = _vellum();
     const form = vellum?.data.core.form;
     if (!form) {
         return {};
     }
+    const selectedMug = vellum.getCurrentlySelectedMug();
+    const currentSelectedQuestion = buildSelectedQuestion(selectedMug);
+    if (currentSelectedQuestion) {
+        currentSelectedQuestion.warnings = _selectedQuestionWarnings(selectedMug);
+    }
     return {
         form_context: {
             form_xml: extractFormXml(vellum),
             question_types: extractQuestionTypes(form),
-            current_selected_question: extractSelectedQuestion(vellum),
+            unselected_question_warnings: _unselectedQuestionWarnings(form, selectedMug?.ufid),
+            form_load_warnings: _formLoadWarnings(form),
+            current_selected_question: currentSelectedQuestion,
             module_name: initialPageData.get('module_name'),
         },
     };
@@ -81,6 +206,7 @@ $(function () {
     if (!document.querySelector(WIDGET_SELECTOR)) {
         return;
     }
+    fd = document.querySelector(FORMDESIGNER);
     ocsContext.registerContextCollector(_collectFormContext);
 });
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -209,4 +209,14 @@ $(function () {
     ocsContext.registerContextCollector(_collectFormContext);
 });
 
-export {extractFormXml, extractQuestionTypes, extractSelectedQuestion};
+export {
+    extractFormXml,
+    extractQuestionTypes,
+    extractSelectedQuestion,
+    _collectMugErrors,
+    _unselectedQuestionWarnings,
+    _formWarnings,
+    _cardListFieldErrors,
+    _xpathEditorError,
+    _dataSourceWarnings,
+};

--- a/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/ocs_widget_form_designer_context.js
@@ -127,7 +127,7 @@ function _xpathEditorError(mug, fd) {
     }];
 }
 
-function _selectedQuestionWarnings(mug, fd) {
+function selectedQuestionWarnings(mug, fd) {
     return [
         ..._collectMugErrors(mug),
         ..._cardListFieldErrors(mug, fd),
@@ -135,7 +135,7 @@ function _selectedQuestionWarnings(mug, fd) {
     ];
 }
 
-function _unselectedQuestionWarnings(form, selectedUfid) {
+function unselectedQuestionWarnings(form, selectedUfid) {
     const warnings = {};
     form.walkMugs(mug => {
         if (mug.ufid === selectedUfid) {return;}
@@ -174,7 +174,7 @@ function _dataSourceWarnings(fd) {
     return [banner.querySelector('.help-block').textContent.trim()];
 }
 
-function _formLoadWarnings(form, fd) {
+function formLoadWarnings(form, fd) {
     return [..._formWarnings(form), ..._dataSourceWarnings(fd)];
 }
 
@@ -188,14 +188,14 @@ function _collectFormContext() {
     const selectedMug = vellum.getCurrentlySelectedMug();
     const currentSelectedQuestion = buildSelectedQuestion(selectedMug);
     if (currentSelectedQuestion) {
-        currentSelectedQuestion.warnings = _selectedQuestionWarnings(selectedMug, fd);
+        currentSelectedQuestion.warnings = selectedQuestionWarnings(selectedMug, fd);
     }
     return {
         form_context: {
             form_xml: extractFormXml(vellum),
             question_types: extractQuestionTypes(form),
-            unselected_question_warnings: _unselectedQuestionWarnings(form, selectedMug?.ufid),
-            form_load_warnings: _formLoadWarnings(form, fd),
+            unselected_question_warnings: unselectedQuestionWarnings(form, selectedMug?.ufid),
+            form_load_warnings: formLoadWarnings(form, fd),
             current_selected_question: currentSelectedQuestion,
             module_name: initialPageData.get('module_name'),
         },
@@ -214,7 +214,7 @@ export {
     extractQuestionTypes,
     extractSelectedQuestion,
     _collectMugErrors,
-    _unselectedQuestionWarnings,
+    unselectedQuestionWarnings,
     _formWarnings,
     _cardListFieldErrors,
     _xpathEditorError,

--- a/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/main.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/main.js
@@ -1,6 +1,7 @@
 import hqMocha from "mocha/js/main";
 
 import "bootstrap";
+import "select2/dist/js/select2.full.min";
 import "jquery.vellum.dev";
 
 import "app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec";

--- a/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
@@ -6,13 +6,17 @@ import {
     extractFormXml,
     extractQuestionTypes,
     extractSelectedQuestion,
-    _collectMugErrors,
+    exportedForTesting,
     unselectedQuestionWarnings,
+} from "app_manager/js/forms/ocs_widget_form_designer_context";
+
+const {
+    _collectMugErrors,
     _formWarnings,
     _cardListFieldErrors,
     _xpathEditorError,
     _dataSourceWarnings,
-} from "app_manager/js/forms/ocs_widget_form_designer_context";
+} = exportedForTesting;
 
 
 function bootVellum() {

--- a/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
@@ -114,6 +114,7 @@ describe("OCS form designer context extractors", function () {
 
             assert.deepEqual(extractSelectedQuestion(vellum), {
                 type: "Text",
+                label: vellum.getMugDisplayName(mug),
                 question_id: "patient_name",
                 path: mug.hashtagPath,
             });
@@ -126,9 +127,11 @@ describe("OCS form designer context extractors", function () {
 
             assert.deepEqual(extractSelectedQuestion(vellum), {
                 type: "Choice",
+                label: vellum.getMugDisplayName(choice),
                 value: "red",
                 belongs_to_question: {
                     type: "Multiple Choice",
+                    label: vellum.getMugDisplayName(select),
                     question_id: "color",
                     path: select.hashtagPath,
                 },

--- a/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
@@ -7,7 +7,7 @@ import {
     extractQuestionTypes,
     extractSelectedQuestion,
     _collectMugErrors,
-    _unselectedQuestionWarnings,
+    unselectedQuestionWarnings,
     _formWarnings,
     _cardListFieldErrors,
     _xpathEditorError,
@@ -164,7 +164,7 @@ describe("OCS form designer context extractors", function () {
             }]);
         });
 
-        it("_unselectedQuestionWarnings walks mugs and collects errors from unselected questions", function () {
+        it("unselectedQuestionWarnings walks mugs and collects errors from unselected questions", function () {
             const first = addQuestion("Text", "first");
             first.p.nodeID = "invalid id";
             first.validate();
@@ -179,7 +179,7 @@ describe("OCS form designer context extractors", function () {
             assert.isNull(dupRed.absolutePath);
             assert.equal(dupRed.parentMug, select);
 
-            const result = _unselectedQuestionWarnings(vellum.data.core.form, second.ufid);
+            const result = unselectedQuestionWarnings(vellum.data.core.form, second.ufid);
 
             const invalidIdError = "invalid id is not a valid Question ID. " +
                 "It must start with a letter and contain only " +

--- a/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
@@ -1,10 +1,17 @@
 import $ from "jquery";
 
 import VELLUM_OPTIONS from "app_manager/spec/form_designer_context/vellum_options";
+import ORPHAN_BIND_XML from "app_manager/spec/form_designer_context/orphan_bind_xml";
 import {
     extractFormXml,
     extractQuestionTypes,
     extractSelectedQuestion,
+    _collectMugErrors,
+    _unselectedQuestionWarnings,
+    _formWarnings,
+    _cardListFieldErrors,
+    _xpathEditorError,
+    _dataSourceWarnings,
 } from "app_manager/js/forms/ocs_widget_form_designer_context";
 
 
@@ -30,8 +37,29 @@ describe("OCS form designer context extractors", function () {
     function addQuestion(type, nodeID) {
         const mug = $fd.vellum("addQuestion", type);
         if (nodeID) {
+            // Match Vellum's test util
+            if (mug.p.labelItext) {
+                mug.p.labelItext.set(mug.getLabelValue());
+            }
+            if (type === "Choice" && mug.p.labelItext) {
+                mug.p.labelItext.set(nodeID);
+            }
             mug.p.nodeID = nodeID;
         }
+        return mug;
+    }
+
+    function loadForm(xml) {
+        vellum.data.core.parseWarnings = [];
+        vellum.loadXML(xml, {});
+        delete vellum.data.core.parseWarnings;
+        return vellum.data.core.form;
+    }
+
+    function clickQuestion(mug) {
+        vellum.jstree("deselect_all", true);
+        vellum.jstree("select_node", mug.ufid);
+        $fd.find(".collapse-toggle.collapsed").click();
         return mug;
     }
 
@@ -57,7 +85,7 @@ describe("OCS form designer context extractors", function () {
             const xml = extractFormXml(vellum);
 
             assert.isString(xml);
-            assert.include(xml, '<bind nodeset="/data/village_name" type="xsd:string" />');
+            assert.include(xml, 'nodeset="/data/village_name"');
         });
     });
 
@@ -118,6 +146,126 @@ describe("OCS form designer context extractors", function () {
                     path: select.hashtagPath,
                 },
             });
+        });
+    });
+
+    describe("Form designer's error context", function () {
+        it("_collectMugErrors reads mug.messages", function () {
+            const mug = addQuestion("Text", "age");
+            mug.p.nodeID = "invalid id";
+            mug.validate();
+
+            assert.deepEqual(_collectMugErrors(mug), [{
+                field: mug.spec.nodeID.lstring,
+                value: "invalid id",
+                error: "invalid id is not a valid Question ID. " +
+                    "It must start with a letter and contain only " +
+                    "letters, numbers, and '-' or '_' characters.",
+            }]);
+        });
+
+        it("_unselectedQuestionWarnings walks mugs and collects errors from unselected questions", function () {
+            const first = addQuestion("Text", "first");
+            first.p.nodeID = "invalid id";
+            first.validate();
+            const second = addQuestion("Text", "second");
+
+            const select = addQuestion("Select", "color");
+            addQuestion("Choice", "red");
+            const dupRed = addQuestion("Choice", "red");
+            dupRed.validate();
+
+            assert.equal(dupRed.__className, "Choice");
+            assert.isNull(dupRed.absolutePath);
+            assert.equal(dupRed.parentMug, select);
+
+            const result = _unselectedQuestionWarnings(vellum.data.core.form, second.ufid);
+
+            const invalidIdError = "invalid id is not a valid Question ID. " +
+                "It must start with a letter and contain only " +
+                "letters, numbers, and '-' or '_' characters.";
+
+            assert.property(result, first.absolutePath);
+            assert.equal(result[first.absolutePath][0].error, invalidIdError);
+            assert.notProperty(result, second.absolutePath);
+
+            const choiceKey = `${select.absolutePath}/${dupRed.p.nodeID}`;
+            assert.property(result, choiceKey);
+            assert.deepEqual(result[choiceKey], [{
+                field: dupRed.spec.nodeID.lstring,
+                value: "red",
+                error: "This choice value has been used in the same question",
+            }]);
+        });
+
+        it("_formWarnings reads form.errors", function () {
+            const form = loadForm(ORPHAN_BIND_XML);
+            assert.deepEqual(_formWarnings(form), [
+                "Bind Node [/data/ghost] found but has no associated Data node. " +
+                "This bind node will be discarded!",
+            ]);
+        });
+
+        it("_xpathEditorError captures the open xpath editor's validation error", async function () {
+            const mug = addQuestion("Text", "q");
+            clickQuestion(mug);
+
+            vellum.data.core.currentlyEditedProperty = "relevantAttr";
+            vellum.displayXPathEditor({
+                mug: mug,
+                xpathType: "bool",
+                value: "this is not valid!!!",
+                change: function () {},
+                done: function () {},
+            });
+            // displayXPathEditor dynamically imports expressionEditor
+            // so the save button isn't in the DOM immediately.
+            for (let i = 0; i < 100 && !$fd.find(".fd-xpath-save-button").length; i++) {
+                await new Promise(r => setTimeout(r, 50));
+            }
+
+            $fd.find(".fd-xpath-save-button").first().click();
+
+            const result = _xpathEditorError(mug, $fd[0]);
+            assert.equal(result.length, 1);
+            assert.equal(result[0].field, "Display Condition - XPath Editor");
+            assert.include(result[0].error, "Lexical error");
+            assert.include(result[0].value, "this is not valid");
+        });
+
+        it("_cardListFieldErrors collects a cardList row error", function () {
+            const stc = addQuestion("SaveToCase", "stc");
+            stc.p.case_id = "uuid()";
+            stc.p.useCreate = true;
+            stc.p.case_type = "patient";
+            stc.p.caseName = "/data/name";
+            stc.p.createProperty = {
+                "bad name!": {calculate: "'x'"},
+            };
+            clickQuestion(stc);
+
+            const result = _cardListFieldErrors(stc, $fd[0]);
+            assert.equal(result.length, 1);
+            assert.equal(result[0].field, stc.spec.createProperty.lstring);
+            assert.equal(result[0].subfield, "Property Name");
+            assert.equal(result[0].value, "bad name!");
+            assert.include(result[0].error, "letters, numbers, '-' and '_'");
+        });
+
+        it("_dataSourceWarnings reads the databrowser banner after a datasources load failure", function () {
+            const $banner = $fd.find(".fd-external-sources-error");
+            assert.isTrue($banner.hasClass("hide"));
+
+            vellum.datasources.fire({
+                type: "error",
+                xhr: {status: 400, responseText: "boom"},
+            });
+
+            assert.isFalse($banner.hasClass("hide"));
+            const warnings = _dataSourceWarnings($fd[0]);
+            assert.equal(warnings.length, 1);
+            assert.include(warnings[0], "Could not load app properties");
+            assert.include(warnings[0], "boom");
         });
     });
 });

--- a/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/ocs_widget_form_designer_context_spec.js
@@ -1,30 +1,12 @@
 import $ from "jquery";
 
+import VELLUM_OPTIONS from "app_manager/spec/form_designer_context/vellum_options";
 import {
     extractFormXml,
     extractQuestionTypes,
     extractSelectedQuestion,
 } from "app_manager/js/forms/ocs_widget_form_designer_context";
 
-// Minimum options to boot the bundled Vellum
-const VELLUM_OPTIONS = {
-    core: {
-        loadDelay: 0,
-        formName: "Test Form",
-        dataSourcesEndpoint: function (callback) { callback([]); },
-        saveUrl: function () {},
-    },
-    javaRosa: {
-        langs: ["en"],
-        displayLanguage: "en",
-    },
-    features: {
-        disable_popovers: true,
-    },
-    intents: {
-        templates: [{id: "intent", name: "Intent", mime: "text/plain"}],
-    },
-};
 
 function bootVellum() {
     return new Promise(function (resolve) {

--- a/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/orphan_bind_xml.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/orphan_bind_xml.js
@@ -1,0 +1,40 @@
+// A bind with no matching data node — Vellum records this as a parse warning
+// in form.errors on load.
+const ORPHAN_BIND_XML = `<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:orx="http://openrosa.org/jr/xforms"
+    xmlns="http://www.w3.org/2002/xforms"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:vellum="http://commcarehq.org/xforms/vellum">
+    <h:head>
+        <h:title>T</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
+                    xmlns="http://openrosa.org/formdesigner/ABC"
+                    uiVersion="1"
+                    version="1"
+                    name="T">
+                    <text />
+                </data>
+            </instance>
+            <bind nodeset="/data/text" type="xsd:string" />
+            <bind nodeset="/data/ghost" type="xsd:string" />
+            <itext>
+                <translation lang="en" default="">
+                    <text id="text-label">
+                        <value>text</value>
+                    </text>
+                </translation>
+            </itext>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/text">
+            <label ref="jr:itext('text-label')" />
+        </input>
+    </h:body>
+</h:html>`;
+
+export default ORPHAN_BIND_XML;

--- a/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/vellum_options.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/vellum_options.js
@@ -12,10 +12,15 @@ const VELLUM_OPTIONS = {
     },
     features: {
         disable_popovers: true,
+        rich_text: true,
     },
     intents: {
         templates: [{id: "intent", name: "Intent", mime: "text/plain"}],
     },
+    plugins: [
+        "databrowser",
+        "saveToCase",
+    ],
 };
 
 export default VELLUM_OPTIONS;

--- a/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/vellum_options.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/form_designer_context/vellum_options.js
@@ -1,0 +1,21 @@
+// Minimum options to boot the bundled Vellum
+const VELLUM_OPTIONS = {
+    core: {
+        loadDelay: 0,
+        formName: "Test Form",
+        dataSourcesEndpoint: function (callback) { callback([]); },
+        saveUrl: function () {},
+    },
+    javaRosa: {
+        langs: ["en"],
+        displayLanguage: "en",
+    },
+    features: {
+        disable_popovers: true,
+    },
+    intents: {
+        templates: [{id: "intent", name: "Intent", mime: "text/plain"}],
+    },
+};
+
+export default VELLUM_OPTIONS;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_context.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_context.js
@@ -47,12 +47,21 @@ function collectGlobalContext() {
     }, _roleContext);
 }
 
+function runCollector(collectContext) {
+    try {
+        return collectContext() || {};
+    } catch (error) {
+        console.error("OCS context collector failed");
+        return {};
+    }
+}
+
 function getClientPageContext() {
-    return Object.assign(
-        {},
-        collectGlobalContext(),
-        ..._contextCollectors.map((collectContext) => collectContext() || {}),
-    );
+    const context = collectGlobalContext();
+    for (const collectContext of _contextCollectors) {
+        Object.assign(context, runCollector(collectContext));
+    }
+    return context;
 }
 
 document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This PR adds Form Designer errors/warnings into `form_context`, since they're all collected from Vellum.

- `current_selected_question` — now includes `label` (Vellum's tree display name) and `warnings` (what the user can see for the open question: mug messages + cardList field errors + open XPath-editor error).
- `unselected_question_warnings` — `{path: [warning]}` for every other question; choices (which have no path) are keyed `parentPath/nodeID`.
- `form_load_warnings` — form-level parse warnings from `form.errors` (all errors + the latest parse-warning, matching what the UI shows) plus the external-data-source failure banner.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
All tests passed in https://github.com/dimagi/commcare-hq/actions/runs/28766110849

Five collector sources: mug validation messages, cardList field errors (DOM), open xpath-editor errors (DOM), form-level parse errors (form.errors), external-data-source banner (DOM). All have tests to guard it so if anything changed in Vellum the test will fail.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`OCT_CHATBOT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Frontend-only, read-only, and gated behind the `OCS_CHATBOT` feature preview 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
New tests added in `app_manager/form_designer_context`
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
