### PR TITLE
Collect app preview error context

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap3/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap3/preview_app.js
@@ -3,37 +3,16 @@ import $ from "jquery";
 import googleAnalytics from "analytix/js/google";
 import noopMetrics from "analytix/js/noopMetrics";
 import appManagerUtils from "app_manager/js/app_manager_utils";
+import {DATA, EVENTS, POSITION, SELECTORS} from "app_manager/js/preview_app_constants";
 import layoutController from "hqwebapp/js/layout";
 
 var module = {};
 var _private = {};
 
-module.SELECTORS = {
-    BTN_TOGGLE_PREVIEW: '.js-preview-toggle',
-    PREVIEW_WINDOW: '#js-appmanager-preview',
-    PREVIEW_WINDOW_IFRAME: '#js-appmanager-preview iframe',
-    APP_MANAGER_BODY: '#js-appmanager-body',
-    PREVIEW_ACTION_TEXT_SHOW: '.js-preview-action-show',
-    PREVIEW_ACTION_TEXT_HIDE: '.js-preview-action-hide',
-    BTN_REFRESH: '.js-preview-refresh',
-    OFFSET_FOR_PREVIEW: '.offset-for-preview',
-    FORMDESIGNER: '#formdesigner',
-};
-
-module.EVENTS = {
-    RESIZE: 'previewApp.resize',
-};
-
-module.POSITION = {
-    FIXED: 'fixed',
-    ABSOLUTE: 'absolute',
-};
-
-module.DATA = {
-    OPEN: 'preview-isopen',
-    POSITION: 'position',
-    TABLET: 'preview-tablet',   // also referenced in cloudcare/js/preview_app/preview_app
-};
+module.SELECTORS = SELECTORS;
+module.EVENTS = EVENTS;
+module.POSITION = POSITION;
+module.DATA = DATA;
 
 _private.isFormdesigner = false;
 

--- a/corehq/apps/app_manager/static/app_manager/js/bootstrap5/preview_app.js
+++ b/corehq/apps/app_manager/static/app_manager/js/bootstrap5/preview_app.js
@@ -3,37 +3,16 @@ import $ from "jquery";
 import googleAnalytics from "analytix/js/google";
 import noopMetrics from "analytix/js/noopMetrics";
 import appManagerUtils from "app_manager/js/app_manager_utils";
+import {DATA, EVENTS, POSITION, SELECTORS} from "app_manager/js/preview_app_constants";
 import layoutController from "hqwebapp/js/layout";
 
 var module = {};
 var _private = {};
 
-module.SELECTORS = {
-    BTN_TOGGLE_PREVIEW: '.js-preview-toggle',
-    PREVIEW_WINDOW: '#js-appmanager-preview',
-    PREVIEW_WINDOW_IFRAME: '#js-appmanager-preview iframe',
-    APP_MANAGER_BODY: '#js-appmanager-body',
-    PREVIEW_ACTION_TEXT_SHOW: '.js-preview-action-show',
-    PREVIEW_ACTION_TEXT_HIDE: '.js-preview-action-hide',
-    BTN_REFRESH: '.js-preview-refresh',
-    OFFSET_FOR_PREVIEW: '.offset-for-preview',
-    FORMDESIGNER: '#formdesigner',
-};
-
-module.EVENTS = {
-    RESIZE: 'previewApp.resize',
-};
-
-module.POSITION = {
-    FIXED: 'fixed',
-    ABSOLUTE: 'absolute',
-};
-
-module.DATA = {
-    OPEN: 'preview-isopen',
-    POSITION: 'position',
-    TABLET: 'preview-tablet',   // also referenced in cloudcare/js/preview_app/preview_app
-};
+module.SELECTORS = SELECTORS;
+module.EVENTS = EVENTS;
+module.POSITION = POSITION;
+module.DATA = DATA;
 
 _private.isFormdesigner = false;
 

--- a/corehq/apps/app_manager/static/app_manager/js/ocs_widget_app_manager_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/ocs_widget_app_manager_context.js
@@ -29,11 +29,10 @@ function _collectAppStructureContext() {
 }
 
 function _collectAppPreviewContext() {
-    const getErrors = document.querySelector(SELECTORS.PREVIEW_WINDOW_IFRAME)?.contentWindow.getAppPreviewErrors;
-    if (typeof getErrors !== 'function') {
-        return {};
-    }
-    const errors = getErrors();
+    const errors = (
+        document.querySelector(SELECTORS.PREVIEW_WINDOW_IFRAME)?.contentWindow
+        .getAppPreviewErrors?.()
+    ) || [];
     return errors.length ? {app_preview_errors: errors} : {};
 }
 

--- a/corehq/apps/app_manager/static/app_manager/js/ocs_widget_app_manager_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/ocs_widget_app_manager_context.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import initialPageData from "hqwebapp/js/initial_page_data";
+import {SELECTORS} from "app_manager/js/preview_app_constants";
 import ocsContext, {WIDGET_SELECTOR} from "hqwebapp/js/ocs_page_context";
 
 function _text(el) {
@@ -27,9 +28,19 @@ function _collectAppStructureContext() {
     return {app_structure: _readStructure()};
 }
 
+function _collectAppPreviewContext() {
+    const getErrors = document.querySelector(SELECTORS.PREVIEW_WINDOW_IFRAME)?.contentWindow.getAppPreviewErrors;
+    if (typeof getErrors !== 'function') {
+        return {};
+    }
+    const errors = getErrors();
+    return errors.length ? {app_preview_errors: errors} : {};
+}
+
 $(function () {
     if (!document.querySelector(WIDGET_SELECTOR)) {
         return;
     }
     ocsContext.registerContextCollector(_collectAppStructureContext);
+    ocsContext.registerContextCollector(_collectAppPreviewContext);
 });

--- a/corehq/apps/app_manager/static/app_manager/js/ocs_widget_app_manager_context.js
+++ b/corehq/apps/app_manager/static/app_manager/js/ocs_widget_app_manager_context.js
@@ -33,7 +33,7 @@ function _collectAppPreviewContext() {
         document.querySelector(SELECTORS.PREVIEW_WINDOW_IFRAME)?.contentWindow
         .getAppPreviewErrors?.()
     ) || [];
-    return errors.length ? {app_preview_errors: errors} : {};
+    return errors.length ? {app_preview_warnings: errors} : {};
 }
 
 $(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/preview_app_constants.js
+++ b/corehq/apps/app_manager/static/app_manager/js/preview_app_constants.js
@@ -1,0 +1,28 @@
+const PREVIEW_WINDOW = '#js-appmanager-preview';
+
+export const SELECTORS = {
+    BTN_TOGGLE_PREVIEW: '.js-preview-toggle',
+    PREVIEW_WINDOW: PREVIEW_WINDOW,
+    PREVIEW_WINDOW_IFRAME: `${PREVIEW_WINDOW} iframe`,
+    APP_MANAGER_BODY: '#js-appmanager-body',
+    PREVIEW_ACTION_TEXT_SHOW: '.js-preview-action-show',
+    PREVIEW_ACTION_TEXT_HIDE: '.js-preview-action-hide',
+    BTN_REFRESH: '.js-preview-refresh',
+    OFFSET_FOR_PREVIEW: '.offset-for-preview',
+    FORMDESIGNER: '#formdesigner',
+};
+
+export const EVENTS = {
+    RESIZE: 'previewApp.resize',
+};
+
+export const POSITION = {
+    FIXED: 'fixed',
+    ABSOLUTE: 'absolute',
+};
+
+export const DATA = {
+    OPEN: 'preview-isopen',
+    POSITION: 'position',
+    TABLET: 'preview-tablet',   // also referenced in cloudcare/js/preview_app/preview_app
+};

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -11,7 +11,7 @@ import {Modal} from "bootstrap5";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import GGAnalytics from "analytix/js/google";
 import noopMetrics from "analytix/js/noopMetrics";
-import CloudcareUtils, {NOTIFICATIONS_CONTAINER} from "cloudcare/js/utils";
+import CloudcareUtils from "cloudcare/js/utils";
 import AppsAPI from "cloudcare/js/formplayer/apps/api";
 import Const from "cloudcare/js/formplayer/constants";
 
@@ -141,23 +141,23 @@ $(document).on("ajaxStart", function () {
 });
 
 FormplayerFrontend.on('clearNotifications', function () {
-    $(NOTIFICATIONS_CONTAINER).empty();
+    $(Const.NOTIFICATIONS_CONTAINER).empty();
 });
 
 FormplayerFrontend.on('showError', function (errorMessage, isHTML, reportToHq, additionalData) {
     if (isHTML) {
-        CloudcareUtils.showHTMLError(errorMessage, $(NOTIFICATIONS_CONTAINER), null, reportToHq);
+        CloudcareUtils.showHTMLError(errorMessage, $(Const.NOTIFICATIONS_CONTAINER), null, reportToHq);
     } else {
-        CloudcareUtils.showError(errorMessage, $(NOTIFICATIONS_CONTAINER), reportToHq, additionalData);
+        CloudcareUtils.showError(errorMessage, $(Const.NOTIFICATIONS_CONTAINER), reportToHq, additionalData);
     }
 });
 
 FormplayerFrontend.on('showWarning', function (message) {
-    CloudcareUtils.showWarning(message, $(NOTIFICATIONS_CONTAINER));
+    CloudcareUtils.showWarning(message, $(Const.NOTIFICATIONS_CONTAINER));
 });
 
 FormplayerFrontend.on('showSuccess', function (successMessage) {
-    CloudcareUtils.showSuccess(successMessage, $(NOTIFICATIONS_CONTAINER), 10000);
+    CloudcareUtils.showSuccess(successMessage, $(Const.NOTIFICATIONS_CONTAINER), 10000);
 });
 
 FormplayerFrontend.on('handleNotification', function (notification) {
@@ -194,9 +194,9 @@ FormplayerFrontend.on('startForm', function (data) {
             message = resp.notification.message;
         }
         if (resp.is_html) {
-            CloudcareUtils.showHTMLError(message, $(NOTIFICATIONS_CONTAINER), null, resp.reportToHq);
+            CloudcareUtils.showHTMLError(message, $(Const.NOTIFICATIONS_CONTAINER), null, resp.reportToHq);
         } else {
-            CloudcareUtils.showError(message, $(NOTIFICATIONS_CONTAINER), resp.reportToHq);
+            CloudcareUtils.showError(message, $(Const.NOTIFICATIONS_CONTAINER), resp.reportToHq);
         }
     };
     noopMetrics.track.event('Viewed Form', {
@@ -226,10 +226,10 @@ FormplayerFrontend.on('startForm', function (data) {
                             });
                         }
                     };
-                $(NOTIFICATIONS_CONTAINER).off('click').on('click', dataFeedbackLoopAnalytics);
-                $alert = CloudcareUtils.showSuccess(markdowner().render(resp.submitResponseMessage), $(NOTIFICATIONS_CONTAINER), undefined, true);
+                $(Const.NOTIFICATIONS_CONTAINER).off('click').on('click', dataFeedbackLoopAnalytics);
+                $alert = CloudcareUtils.showSuccess(markdowner().render(resp.submitResponseMessage), $(Const.NOTIFICATIONS_CONTAINER), undefined, true);
             } else {
-                $alert = CloudcareUtils.showSuccess(gettext("Form successfully saved!"), $(NOTIFICATIONS_CONTAINER));
+                $alert = CloudcareUtils.showSuccess(gettext("Form successfully saved!"), $(Const.NOTIFICATIONS_CONTAINER));
             }
             if ($alert) {
                 // Clear the success notification the next time user changes screens
@@ -270,7 +270,7 @@ FormplayerFrontend.on('startForm', function (data) {
                 FormplayerUtils.navigate('/apps', { trigger: true });
             }
         } else {
-            CloudcareUtils.showError(resp.output, $(NOTIFICATIONS_CONTAINER));
+            CloudcareUtils.showError(resp.output, $(Const.NOTIFICATIONS_CONTAINER));
         }
     };
     data.debuggerEnabled = user.debuggerEnabled;
@@ -343,7 +343,7 @@ FormplayerFrontend.on("start", function (model, options) {
                 if (!navigator.onLine && (new Date() - offlineTime) > reconnectTimingWindow) {
                     CloudcareUtils.showError(gettext("You are now offline. Web Apps is not optimized " +
                         "for offline use. Please reconnect to the Internet before " +
-                        "continuing."), $(NOTIFICATIONS_CONTAINER));
+                        "continuing."), $(Const.NOTIFICATIONS_CONTAINER));
                     $('.submit').prop('disabled', 'disabled');
                     $('.form-control, .form-select').prop('disabled', 'disabled');
                 }
@@ -353,7 +353,7 @@ FormplayerFrontend.on("start", function (model, options) {
     window.addEventListener(
         'online', function () {
             if ((new Date() - offlineTime) > reconnectTimingWindow) {
-                CloudcareUtils.showSuccess(gettext("You are are back online."), $(NOTIFICATIONS_CONTAINER));
+                CloudcareUtils.showSuccess(gettext("You are are back online."), $(Const.NOTIFICATIONS_CONTAINER));
                 $('.submit').prop('disabled', false);
                 $('.form-control, .form-select').prop('disabled', false);
             }
@@ -641,7 +641,7 @@ FormplayerFrontend.on('refreshApplication', function (appId) {
         }
 
         CloudcareUtils.formplayerLoadingComplete();
-        $(NOTIFICATIONS_CONTAINER).empty();
+        $(Const.NOTIFICATIONS_CONTAINER).empty();
         FormplayerFrontend.trigger('navigateHome');
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -11,7 +11,7 @@ import {Modal} from "bootstrap5";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import GGAnalytics from "analytix/js/google";
 import noopMetrics from "analytix/js/noopMetrics";
-import CloudcareUtils from "cloudcare/js/utils";
+import CloudcareUtils, {NOTIFICATIONS_CONTAINER} from "cloudcare/js/utils";
 import AppsAPI from "cloudcare/js/formplayer/apps/api";
 import Const from "cloudcare/js/formplayer/constants";
 
@@ -141,23 +141,23 @@ $(document).on("ajaxStart", function () {
 });
 
 FormplayerFrontend.on('clearNotifications', function () {
-    $("#cloudcare-notifications").empty();
+    $(NOTIFICATIONS_CONTAINER).empty();
 });
 
 FormplayerFrontend.on('showError', function (errorMessage, isHTML, reportToHq, additionalData) {
     if (isHTML) {
-        CloudcareUtils.showHTMLError(errorMessage, $("#cloudcare-notifications"), null, reportToHq);
+        CloudcareUtils.showHTMLError(errorMessage, $(NOTIFICATIONS_CONTAINER), null, reportToHq);
     } else {
-        CloudcareUtils.showError(errorMessage, $("#cloudcare-notifications"), reportToHq, additionalData);
+        CloudcareUtils.showError(errorMessage, $(NOTIFICATIONS_CONTAINER), reportToHq, additionalData);
     }
 });
 
 FormplayerFrontend.on('showWarning', function (message) {
-    CloudcareUtils.showWarning(message, $("#cloudcare-notifications"));
+    CloudcareUtils.showWarning(message, $(NOTIFICATIONS_CONTAINER));
 });
 
 FormplayerFrontend.on('showSuccess', function (successMessage) {
-    CloudcareUtils.showSuccess(successMessage, $("#cloudcare-notifications"), 10000);
+    CloudcareUtils.showSuccess(successMessage, $(NOTIFICATIONS_CONTAINER), 10000);
 });
 
 FormplayerFrontend.on('handleNotification', function (notification) {
@@ -194,9 +194,9 @@ FormplayerFrontend.on('startForm', function (data) {
             message = resp.notification.message;
         }
         if (resp.is_html) {
-            CloudcareUtils.showHTMLError(message, $("#cloudcare-notifications"), null, resp.reportToHq);
+            CloudcareUtils.showHTMLError(message, $(NOTIFICATIONS_CONTAINER), null, resp.reportToHq);
         } else {
-            CloudcareUtils.showError(message, $("#cloudcare-notifications"), resp.reportToHq);
+            CloudcareUtils.showError(message, $(NOTIFICATIONS_CONTAINER), resp.reportToHq);
         }
     };
     noopMetrics.track.event('Viewed Form', {
@@ -226,10 +226,10 @@ FormplayerFrontend.on('startForm', function (data) {
                             });
                         }
                     };
-                $("#cloudcare-notifications").off('click').on('click', dataFeedbackLoopAnalytics);
-                $alert = CloudcareUtils.showSuccess(markdowner().render(resp.submitResponseMessage), $("#cloudcare-notifications"), undefined, true);
+                $(NOTIFICATIONS_CONTAINER).off('click').on('click', dataFeedbackLoopAnalytics);
+                $alert = CloudcareUtils.showSuccess(markdowner().render(resp.submitResponseMessage), $(NOTIFICATIONS_CONTAINER), undefined, true);
             } else {
-                $alert = CloudcareUtils.showSuccess(gettext("Form successfully saved!"), $("#cloudcare-notifications"));
+                $alert = CloudcareUtils.showSuccess(gettext("Form successfully saved!"), $(NOTIFICATIONS_CONTAINER));
             }
             if ($alert) {
                 // Clear the success notification the next time user changes screens
@@ -270,7 +270,7 @@ FormplayerFrontend.on('startForm', function (data) {
                 FormplayerUtils.navigate('/apps', { trigger: true });
             }
         } else {
-            CloudcareUtils.showError(resp.output, $("#cloudcare-notifications"));
+            CloudcareUtils.showError(resp.output, $(NOTIFICATIONS_CONTAINER));
         }
     };
     data.debuggerEnabled = user.debuggerEnabled;
@@ -343,7 +343,7 @@ FormplayerFrontend.on("start", function (model, options) {
                 if (!navigator.onLine && (new Date() - offlineTime) > reconnectTimingWindow) {
                     CloudcareUtils.showError(gettext("You are now offline. Web Apps is not optimized " +
                         "for offline use. Please reconnect to the Internet before " +
-                        "continuing."), $("#cloudcare-notifications"));
+                        "continuing."), $(NOTIFICATIONS_CONTAINER));
                     $('.submit').prop('disabled', 'disabled');
                     $('.form-control, .form-select').prop('disabled', 'disabled');
                 }
@@ -353,7 +353,7 @@ FormplayerFrontend.on("start", function (model, options) {
     window.addEventListener(
         'online', function () {
             if ((new Date() - offlineTime) > reconnectTimingWindow) {
-                CloudcareUtils.showSuccess(gettext("You are are back online."), $("#cloudcare-notifications"));
+                CloudcareUtils.showSuccess(gettext("You are are back online."), $(NOTIFICATIONS_CONTAINER));
                 $('.submit').prop('disabled', false);
                 $('.form-control, .form-select').prop('disabled', false);
             }
@@ -641,7 +641,7 @@ FormplayerFrontend.on('refreshApplication', function (appId) {
         }
 
         CloudcareUtils.formplayerLoadingComplete();
-        $("#cloudcare-notifications").empty();
+        $(NOTIFICATIONS_CONTAINER).empty();
         FormplayerFrontend.trigger('navigateHome');
     });
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/constants.js
@@ -50,4 +50,6 @@ export default {
     MILLIS_BEFORE_SHOW_LOADING: 1000,
 
     SCROLLABLE_CONTENT_CONTAINER: '#content-plus-version-info-container',
+
+    NOTIFICATIONS_CONTAINER: '#cloudcare-notifications',
 };

--- a/corehq/apps/cloudcare/static/cloudcare/js/preview_app/main.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/preview_app/main.js
@@ -3,6 +3,7 @@ import $ from "jquery";
 import _ from "underscore";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import sentry from "cloudcare/js/sentry";
+import utils from "cloudcare/js/utils";
 import * as previewApp from "cloudcare/js/preview_app/preview_app";
 import "cloudcare/js/preview_app/dragscroll";  // for .dragscroll elements
 
@@ -10,6 +11,11 @@ $(function () {
     sentry.initSentry();
 
     window.MAPBOX_ACCESS_TOKEN = initialPageData.get('mapbox_access_token'); // maps api is loaded on-demand
+
+    // OCS context collector reads this
+    window.getAppPreviewErrors = function () {
+        return utils.getErrorNotificationTexts();
+    };
     previewApp.start({
         apps: [initialPageData.get('app')],
         language: initialPageData.get('language'),

--- a/corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js
@@ -1,8 +1,17 @@
+import $ from "jquery";
 import sinon from "sinon";
 import constants from "cloudcare/js/formplayer/constants";
 import utils from "cloudcare/js/utils";
 
 describe("Cloudcare Utils", function () {
+    it("getErrorNotificationTexts reads errors shown via showError", function () {
+        utils.showError("Something went wrong", $(utils.NOTIFICATIONS_CONTAINER), false);
+
+        assert.deepEqual(utils.getErrorNotificationTexts(), ["Something went wrong"]);
+
+        $(utils.NOTIFICATIONS_CONTAINER).empty();
+    });
+
     describe('Small Screen Listener', function () {
         const callback = sinon.stub().callsFake(smallScreenEnabled => smallScreenEnabled);
         const smallScreenListener = utils.smallScreenListener(callback);

--- a/corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js
@@ -5,11 +5,11 @@ import utils from "cloudcare/js/utils";
 
 describe("Cloudcare Utils", function () {
     it("getErrorNotificationTexts reads errors shown via showError", function () {
-        utils.showError("Something went wrong", $(utils.NOTIFICATIONS_CONTAINER), false);
+        utils.showError("Something went wrong", $(constants.NOTIFICATIONS_CONTAINER), false);
 
         assert.deepEqual(utils.getErrorNotificationTexts(), ["Something went wrong"]);
 
-        $(utils.NOTIFICATIONS_CONTAINER).empty();
+        $(constants.NOTIFICATIONS_CONTAINER).empty();
     });
 
     describe('Small Screen Listener', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -22,8 +22,6 @@ NProgress.configure({
     showSpinner: false,
 });
 
-const NOTIFICATIONS_CONTAINER = '#cloudcare-notifications';
-
 var showError = function (message, $el, reportToHq, additionalData) {
     message = getErrorMessage(message);
     // Make message more user friendly since html isn't useful here
@@ -111,7 +109,7 @@ var _show = function (message, $el, autoHideTime, classes, isHTML) {
 
 const getErrorNotificationTexts = function () {
     const texts = [];
-    $(`${NOTIFICATIONS_CONTAINER} .alert-danger`).each(function () {
+    $(`${constants.NOTIFICATIONS_CONTAINER} .alert-danger`).each(function () {
         const text = $(this).text().replace(/\s+/g, ' ').trim();
         if (text) {
             texts.push(text);
@@ -192,7 +190,7 @@ var formplayerLoadingComplete = function (isError, message) {
     sessionStorage.formplayerQueryInProgress = false;
     hideLoading();
     if (isError) {
-        showError(message || gettext('Error saving!'), $(NOTIFICATIONS_CONTAINER));
+        showError(message || gettext('Error saving!'), $(constants.NOTIFICATIONS_CONTAINER));
     }
 };
 
@@ -204,11 +202,11 @@ var formplayerSyncComplete = function (isError) {
     hideLoading();
     if (isError) {
         const notificationText = gettext('Could not sync user data. Please report an issue if this persists.');
-        showError(notificationText, $(NOTIFICATIONS_CONTAINER));
+        showError(notificationText, $(constants.NOTIFICATIONS_CONTAINER));
         updateScreenReaderNotification(notificationText);
     } else {
         const notificationText = gettext('User Data successfully synced.');
-        showSuccess(notificationText, $(NOTIFICATIONS_CONTAINER), 5000);
+        showSuccess(notificationText, $(constants.NOTIFICATIONS_CONTAINER), 5000);
         updateScreenReaderNotification(notificationText);
     }
 };
@@ -218,10 +216,10 @@ var clearUserDataComplete = function (isError) {
     if (isError) {
         showError(
             gettext('Could not clear user data. Please report an issue if this persists.'),
-            $(NOTIFICATIONS_CONTAINER),
+            $(constants.NOTIFICATIONS_CONTAINER),
         );
     } else {
-        showSuccess(gettext('User data successfully cleared.'), $(NOTIFICATIONS_CONTAINER), 5000);
+        showSuccess(gettext('User data successfully cleared.'), $(constants.NOTIFICATIONS_CONTAINER), 5000);
     }
 };
 
@@ -230,10 +228,10 @@ var breakLocksComplete = function (isError, message) {
     if (isError) {
         showError(
             gettext('Error breaking locks. Please report an issue if this persists.'),
-            $(NOTIFICATIONS_CONTAINER),
+            $(constants.NOTIFICATIONS_CONTAINER),
         );
     } else {
-        showSuccess(message, $(NOTIFICATIONS_CONTAINER), 5000);
+        showSuccess(message, $(constants.NOTIFICATIONS_CONTAINER), 5000);
     }
 };
 
@@ -438,7 +436,6 @@ var smallScreenListener = function (callback) {
     };
 };
 
-export {NOTIFICATIONS_CONTAINER};
 export default {
     dateFormat: dateFormat,
     convertTwoDigitYear: convertTwoDigitYear,
@@ -450,7 +447,6 @@ export default {
     showHTMLError: showHTMLError,
     showSuccess: showSuccess,
     getErrorNotificationTexts: getErrorNotificationTexts,
-    NOTIFICATIONS_CONTAINER: NOTIFICATIONS_CONTAINER,
     clearUserDataComplete: clearUserDataComplete,
     breakLocksComplete: breakLocksComplete,
     formplayerLoading: formplayerLoading,

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -107,6 +107,17 @@ var _show = function (message, $el, autoHideTime, classes, isHTML) {
     return $container;
 };
 
+const getErrorNotificationTexts = function () {
+    const texts = [];
+    $('#cloudcare-notifications .alert-danger').each(function () {
+        const text = $(this).text().replace(/\s+/g, ' ').trim();
+        if (text) {
+            texts.push(text);
+        }
+    });
+    return texts;
+};
+
 var shouldShowLoading = function () {
     const answerInProgress = (sessionStorage.answerQuestionInProgress && JSON.parse(sessionStorage.answerQuestionInProgress));
     const validationInProgress = (sessionStorage.validationInProgress && JSON.parse(sessionStorage.validationInProgress));
@@ -435,6 +446,7 @@ export default {
     showWarning: showWarning,
     showHTMLError: showHTMLError,
     showSuccess: showSuccess,
+    getErrorNotificationTexts: getErrorNotificationTexts,
     clearUserDataComplete: clearUserDataComplete,
     breakLocksComplete: breakLocksComplete,
     formplayerLoading: formplayerLoading,

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -22,6 +22,8 @@ NProgress.configure({
     showSpinner: false,
 });
 
+const NOTIFICATIONS_CONTAINER = '#cloudcare-notifications';
+
 var showError = function (message, $el, reportToHq, additionalData) {
     message = getErrorMessage(message);
     // Make message more user friendly since html isn't useful here
@@ -109,7 +111,7 @@ var _show = function (message, $el, autoHideTime, classes, isHTML) {
 
 const getErrorNotificationTexts = function () {
     const texts = [];
-    $('#cloudcare-notifications .alert-danger').each(function () {
+    $(`${NOTIFICATIONS_CONTAINER} .alert-danger`).each(function () {
         const text = $(this).text().replace(/\s+/g, ' ').trim();
         if (text) {
             texts.push(text);
@@ -190,7 +192,7 @@ var formplayerLoadingComplete = function (isError, message) {
     sessionStorage.formplayerQueryInProgress = false;
     hideLoading();
     if (isError) {
-        showError(message || gettext('Error saving!'), $('#cloudcare-notifications'));
+        showError(message || gettext('Error saving!'), $(NOTIFICATIONS_CONTAINER));
     }
 };
 
@@ -202,11 +204,11 @@ var formplayerSyncComplete = function (isError) {
     hideLoading();
     if (isError) {
         const notificationText = gettext('Could not sync user data. Please report an issue if this persists.');
-        showError(notificationText, $('#cloudcare-notifications'));
+        showError(notificationText, $(NOTIFICATIONS_CONTAINER));
         updateScreenReaderNotification(notificationText);
     } else {
         const notificationText = gettext('User Data successfully synced.');
-        showSuccess(notificationText, $('#cloudcare-notifications'), 5000);
+        showSuccess(notificationText, $(NOTIFICATIONS_CONTAINER), 5000);
         updateScreenReaderNotification(notificationText);
     }
 };
@@ -216,10 +218,10 @@ var clearUserDataComplete = function (isError) {
     if (isError) {
         showError(
             gettext('Could not clear user data. Please report an issue if this persists.'),
-            $('#cloudcare-notifications'),
+            $(NOTIFICATIONS_CONTAINER),
         );
     } else {
-        showSuccess(gettext('User data successfully cleared.'), $('#cloudcare-notifications'), 5000);
+        showSuccess(gettext('User data successfully cleared.'), $(NOTIFICATIONS_CONTAINER), 5000);
     }
 };
 
@@ -228,10 +230,10 @@ var breakLocksComplete = function (isError, message) {
     if (isError) {
         showError(
             gettext('Error breaking locks. Please report an issue if this persists.'),
-            $('#cloudcare-notifications'),
+            $(NOTIFICATIONS_CONTAINER),
         );
     } else {
-        showSuccess(message, $('#cloudcare-notifications'), 5000);
+        showSuccess(message, $(NOTIFICATIONS_CONTAINER), 5000);
     }
 };
 
@@ -436,6 +438,7 @@ var smallScreenListener = function (callback) {
     };
 };
 
+export {NOTIFICATIONS_CONTAINER};
 export default {
     dateFormat: dateFormat,
     convertTwoDigitYear: convertTwoDigitYear,
@@ -447,6 +450,7 @@ export default {
     showHTMLError: showHTMLError,
     showSuccess: showSuccess,
     getErrorNotificationTexts: getErrorNotificationTexts,
+    NOTIFICATIONS_CONTAINER: NOTIFICATIONS_CONTAINER,
     clearUserDataComplete: clearUserDataComplete,
     breakLocksComplete: breakLocksComplete,
     formplayerLoading: formplayerLoading,

--- a/corehq/apps/cloudcare/static/cloudcare/js/utils.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/utils.js
@@ -108,14 +108,9 @@ var _show = function (message, $el, autoHideTime, classes, isHTML) {
 };
 
 const getErrorNotificationTexts = function () {
-    const texts = [];
-    $(`${constants.NOTIFICATIONS_CONTAINER} .alert-danger`).each(function () {
-        const text = $(this).text().replace(/\s+/g, ' ').trim();
-        if (text) {
-            texts.push(text);
-        }
-    });
-    return texts;
+    return $(`${constants.NOTIFICATIONS_CONTAINER} .alert-danger`).map(function () {
+                return $(this).text().replace(/\s+/g, ' ').trim();
+            }).get();
 };
 
 var shouldShowLoading = function () {

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/mocha.html
@@ -9,6 +9,7 @@
   <div id="persistent-case-tile" class="container"></div>
   <div id="menu-region" class="container"></div>
   <div id="sidebar-region" class="container"></div>
+  <section id="cloudcare-notifications"></section>
 
   {% include 'cloudcare/partials/confirmation_modal.html' %}
   {% include 'cloudcare/partials/all_templates.html' %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/preview_app.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/preview_app.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -38,8 +38,8 @@
+@@ -17,8 +17,8 @@
  _private.isFormdesigner = false;
  
  _private.showAppPreview = function (triggerAnalytics) {
@@ -11,7 +11,7 @@
  
      if (triggerAnalytics) {
          noopMetrics.track.event("[app-preview] Clicked Show App Preview");
-@@ -54,8 +54,8 @@
+@@ -33,8 +33,8 @@
  };
  
  _private.hideAppPreview = function (triggerAnalytics) {


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This PR collects errors user see in App Preview and send it to OCS.

For example, if user see this in app preview
<img width="294" height="544" alt="Screenshot 2026-07-07 at 3 39 18 PM" src="https://github.com/user-attachments/assets/ce168a14-ae86-4336-98d9-0c372ec014d1" />

We send this to the OCS:
```
app_preview_errors: [
    "Cannot make new version Validation Error: Encountered a problem with display condition for node [/data/name] at line: !!?12#!@, Couldn't understand the expression starting at ..."
]
```

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
The App Preview renders inside an <iframe>, so its error notifications live in a separate frame from the App Builder page hosting the OCS widget. jQuery data and DOM lookups don't cross the frame boundary, so the errors are surfaced explicitly on the iframe's own window:

- `cloudcare/js/utils.js` gains `getErrorNotificationTexts()`, which reads the `.alert-danger` texts out of the `#cloudcare-notifications` container.
- `preview_app/main.js` exposes it as `window.getAppPreviewErrors` on the iframe.
- `ocs_widget_app_manager_context.js` registers a collector that reaches into `PREVIEW_WINDOW_IFRAME.contentWindow.getAppPreviewErrors` and includes the result as app_preview_errors when non-empty.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`OCS_CHATBOT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The collector is a no-op unless the OCS widget is present and the preview iframe exposes `getAppPreviewErrors`
It didn't affect the existing functionality, only add new function

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
A happy path added in corehq/apps/cloudcare/static/cloudcare/js/spec/utils_spec.js

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not planing on QA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
