### PR TITLE
Extract shared form action logic 

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_utils.py
+++ b/corehq/apps/data_interfaces/tests/test_utils.py
@@ -4,7 +4,14 @@ from django.test import SimpleTestCase, TestCase
 
 from corehq.apps.data_interfaces.interfaces import FormManagementMode
 from corehq.apps.data_interfaces.tasks import task_generate_ids_and_operate_on_payloads
-from corehq.apps.data_interfaces.utils import archive_or_restore_forms, operate_on_payloads
+from corehq.apps.data_interfaces.utils import (
+    SKIPPED,
+    SUCCEEDED,
+    FormActionResult,
+    apply_form_action,
+    archive_or_restore_forms,
+    operate_on_payloads,
+)
 
 
 DOMAIN = 'test-domain'
@@ -471,15 +478,13 @@ class TestArchiveOrRestoreForms(SimpleTestCase):
         assert result['messages']['errors'] == ["Could not find XForm missing"]
         assert result['messages']['success'] == []
 
-    def test_wrong_domain_reports_does_not_belong(self):
+    def test_wrong_domain_reports_not_found(self):
         form = Mock(form_id='f1', domain='other-domain')
         result = self._patched_archive_or_restore_forms(
             self._archive_mode(), ['f1'], [form]
         )
         form.archive.assert_not_called()
-        assert result['messages']['errors'] == [
-            "XForm f1 does not belong to domain test-domain"
-        ]
+        assert result['messages']['errors'] == ["Could not find XForm f1"]
 
     def test_action_exception_reported(self):
         form = Mock(form_id='f1', domain=DOMAIN)
@@ -505,3 +510,58 @@ class TestArchiveOrRestoreForms(SimpleTestCase):
             "by user 'user@example.com'"
         ]
         assert result['errors'] == []
+
+
+class TestApplyFormAction(SimpleTestCase):
+
+    def _patched_apply_form_action(self, form_ids, forms, action_fn=None):
+        action_fn = action_fn or (lambda xform: None)
+        with patch(
+            'corehq.apps.data_interfaces.utils.XFormInstance.objects.iter_forms',
+            return_value=forms,
+        ):
+            return list(apply_form_action(DOMAIN, form_ids, action_fn))
+
+    def test_empty_form_ids(self):
+        assert self._patched_apply_form_action([], []) == []
+
+    def test_success(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+        calls = []
+        results = self._patched_apply_form_action(
+            ['f1'], [form], action_fn=calls.append
+        )
+        assert calls == [form]
+        assert results == [FormActionResult('f1', SUCCEEDED)]
+
+    def test_missing_is_not_found(self):
+        results = self._patched_apply_form_action(['missing'], [])
+        assert results == [FormActionResult('missing', SKIPPED, 'not_found')]
+
+    def test_wrong_domain_is_not_found(self):
+        form = Mock(form_id='f1', domain='other-domain')
+        called = []
+        results = self._patched_apply_form_action(
+            ['f1'], [form], action_fn=called.append
+        )
+        assert called == []  # action not applied to out-of-domain forms
+        assert results == [FormActionResult('f1', SKIPPED, 'not_found')]
+
+    def test_exception_is_unexpected_error(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+
+        def unexpected_error(xform):
+            raise Exception('error')
+
+        results = self._patched_apply_form_action(
+            ['f1'], [form], action_fn=unexpected_error
+        )
+        assert results == [FormActionResult('f1', SKIPPED, 'unexpected_error')]
+
+    def test_mixed_results(self):
+        found = Mock(form_id='f1', domain=DOMAIN)
+        results = self._patched_apply_form_action(['f1', 'missing'], [found])
+        assert results == [
+            FormActionResult('f1', SUCCEEDED),
+            FormActionResult('missing', SKIPPED, 'not_found'),
+        ]

--- a/corehq/apps/data_interfaces/tests/test_utils.py
+++ b/corehq/apps/data_interfaces/tests/test_utils.py
@@ -1,9 +1,10 @@
 from unittest.mock import Mock, patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
+from corehq.apps.data_interfaces.interfaces import FormManagementMode
 from corehq.apps.data_interfaces.tasks import task_generate_ids_and_operate_on_payloads
-from corehq.apps.data_interfaces.utils import operate_on_payloads
+from corehq.apps.data_interfaces.utils import archive_or_restore_forms, operate_on_payloads
 
 
 DOMAIN = 'test-domain'
@@ -411,3 +412,96 @@ class TestTasks(TestCase):
         self.assertEqual(mock_payload_one.requeue.call_count, 1)
         self.assertEqual(mock_payload_two.requeue.call_count, 0)
         self.assertEqual(response, expected_response)
+
+
+class TestArchiveOrRestoreForms(SimpleTestCase):
+    """Only intended to test how archive_or_restore_forms behaves"""
+
+    USER_ID = 'user-id'
+    USERNAME = 'user@example.com'
+
+    def _archive_mode(self):
+        return FormManagementMode(FormManagementMode.ARCHIVE_MODE)
+
+    def _restore_mode(self):
+        return FormManagementMode(FormManagementMode.RESTORE_MODE)
+
+    def _patched_archive_or_restore_forms(
+        self, mode, form_ids, forms, **kwargs
+    ):
+        with patch(
+            'corehq.apps.data_interfaces.utils.XFormInstance.objects.iter_forms',
+            return_value=forms,
+        ):
+            return archive_or_restore_forms(
+                DOMAIN, self.USER_ID, self.USERNAME, form_ids, mode, **kwargs
+            )
+
+    def test_archive_success(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+        result = self._patched_archive_or_restore_forms(
+            self._archive_mode(), ['f1'], [form]
+        )
+        form.archive.assert_called_once_with(user_id=self.USER_ID)
+        messages = result['messages']
+        assert messages['errors'] == []
+        assert messages['success'] == [
+            "Successfully archived XForm f1 for domain test-domain "
+            "by user 'user@example.com'"
+        ]
+        assert messages['success_count_msg'] == 'Successfully archived  1 form(s)'
+
+    def test_restore_success(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+        result = self._patched_archive_or_restore_forms(
+            self._restore_mode(), ['f1'], [form]
+        )
+        form.unarchive.assert_called_once_with(user_id=self.USER_ID)
+        messages = result['messages']
+        assert messages['success'] == [
+            "Successfully unarchived XForm f1 for domain test-domain "
+            "by user 'user@example.com'"
+        ]
+        assert messages['success_count_msg'] == 'Successfully restored  1 form(s)'
+
+    def test_missing_form_reported_not_found(self):
+        result = self._patched_archive_or_restore_forms(
+            self._archive_mode(), ['missing'], []
+        )
+        assert result['messages']['errors'] == ["Could not find XForm missing"]
+        assert result['messages']['success'] == []
+
+    def test_wrong_domain_reports_does_not_belong(self):
+        form = Mock(form_id='f1', domain='other-domain')
+        result = self._patched_archive_or_restore_forms(
+            self._archive_mode(), ['f1'], [form]
+        )
+        form.archive.assert_not_called()
+        assert result['messages']['errors'] == [
+            "XForm f1 does not belong to domain test-domain"
+        ]
+
+    def test_action_exception_reported(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+        form.archive.side_effect = Exception('error')
+        result = self._patched_archive_or_restore_forms(
+            self._archive_mode(), ['f1'], [form]
+        )
+        assert result['messages']['errors'] == [
+            "Could not archive XForm f1 for domain test-domain "
+            "by user 'user@example.com': error"
+        ]
+        assert result['messages']['success'] == []
+
+    def test_from_excel_returns_raw_response(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+        result = self._patched_archive_or_restore_forms(
+            self._archive_mode(), ['f1'], [form], from_excel=True
+        )
+        assert 'messages' not in result
+        assert 'success_count_msg' not in result
+        assert result['success'] == [
+            "Successfully archived XForm f1 for domain test-domain "
+            "by user 'user@example.com'"
+        ]
+        assert result['errors'] == []

--- a/corehq/apps/data_interfaces/tests/test_utils.py
+++ b/corehq/apps/data_interfaces/tests/test_utils.py
@@ -489,12 +489,14 @@ class TestArchiveOrRestoreForms(SimpleTestCase):
     def test_action_exception_reported(self):
         form = Mock(form_id='f1', domain=DOMAIN)
         form.archive.side_effect = Exception('error')
-        result = self._patched_archive_or_restore_forms(
-            self._archive_mode(), ['f1'], [form]
-        )
+        with patch('corehq.apps.data_interfaces.utils.notify_exception') as notify:
+            result = self._patched_archive_or_restore_forms(
+                self._archive_mode(), ['f1'], [form]
+            )
+        notify.assert_called_once()
         assert result['messages']['errors'] == [
             "Could not archive XForm f1 for domain test-domain "
-            "by user 'user@example.com': error"
+            "by user 'user@example.com'"
         ]
         assert result['messages']['success'] == []
 
@@ -553,10 +555,14 @@ class TestApplyFormAction(SimpleTestCase):
         def unexpected_error(xform):
             raise Exception('error')
 
-        results = self._patched_apply_form_action(
-            ['f1'], [form], action_fn=unexpected_error
-        )
+        with patch(
+            'corehq.apps.data_interfaces.utils.notify_exception'
+        ) as notify:
+            results = self._patched_apply_form_action(
+                ['f1'], [form], action_fn=unexpected_error
+            )
         assert results == [FormActionResult('f1', SKIPPED, 'unexpected_error')]
+        notify.assert_called_once()
 
     def test_mixed_results(self):
         found = Mock(form_id='f1', domain=DOMAIN)

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -137,8 +137,11 @@ def archive_or_restore_forms(domain, user_id, username, form_ids, archive_or_res
             response['success'].append(message)
             success_count = success_count + 1
         else:
-            response['errors'].append(
-                _("Could not archive {form}").format(form=xform_string))
+            if is_archive:
+                message = _("Could not archive {form}").format(form=xform_string)
+            else:
+                message = _("Could not unarchive {form}").format(form=xform_string)
+            response['errors'].append(message)
 
         if task:
             DownloadBase.set_progress(task, success_count, len(form_ids))

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -149,9 +149,9 @@ def archive_or_restore_forms(domain, user_id, username, form_ids, archive_or_res
     if from_excel:
         return response
 
-    response["success_count_msg"] = _("{success_msg} {count} form(s)".format(
+    response["success_count_msg"] = _("{success_msg} {count} form(s)").format(
         success_msg=archive_or_restore.success_text,
-        count=success_count))
+        count=success_count)
     return {"messages": response}
 
 

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import List, Optional
 
@@ -63,50 +64,85 @@ def add_cases_to_case_group(domain, case_group_id, uploaded_data, progress_track
     return response
 
 
+SUCCEEDED = 'succeeded'
+SKIPPED = 'skipped'
+
+
+@dataclass(frozen=True)
+class FormActionResult:
+    """Outcome of a bulk form action for a single requested form id."""
+    form_id: str
+    status: str  # SUCCEEDED | SKIPPED
+    reason: Optional[str] = None  # not_found | not_archived | unexpected_error
+
+
+def apply_form_action(domain, form_ids, action_fn):
+    """Apply ``action_fn`` to each form and yield a ``FormActionResult`` per id.
+
+    :param action_fn: callable taking an ``XFormInstance``
+    """
+    unresolved_ids = set(form_ids)
+    for xform in XFormInstance.objects.iter_forms(form_ids):
+        if xform.domain != domain:
+            # skip forms not belonging to the specified domain
+            continue
+        unresolved_ids.discard(xform.form_id)
+        try:
+            action_fn(xform)
+        except Exception:
+            yield FormActionResult(xform.form_id, SKIPPED, 'unexpected_error')
+        else:
+            yield FormActionResult(xform.form_id, SUCCEEDED)
+    for form_id in unresolved_ids:
+        yield FormActionResult(form_id, SKIPPED, 'not_found')
+
+
 def archive_or_restore_forms(domain, user_id, username, form_ids, archive_or_restore, task=None, from_excel=False):
     response = {
         'errors': [],
         'success': [],
     }
+    captured_errors = {}
+    is_archive = archive_or_restore.is_archive_mode()
 
-    missing_forms = set(form_ids)
+    def action_fn(xform):
+        try:
+            if is_archive:
+                xform.archive(user_id=user_id)
+            else:
+                xform.unarchive(user_id=user_id)
+        except Exception as e:
+            captured_errors[xform.form_id] = e
+            raise
+
     success_count = 0
-
     if task:
         DownloadBase.set_progress(task, 0, len(form_ids))
 
-    for xform in XFormInstance.objects.iter_forms(form_ids):
-        missing_forms.discard(xform.form_id)
-
-        if xform.domain != domain:
-            response['errors'].append(_("XForm {form_id} does not belong to domain {domain}").format(
-                form_id=xform.form_id, domain=domain))
+    for result in apply_form_action(domain, form_ids, action_fn):
+        if result.reason == 'not_found':
+            response['errors'].append(
+                _("Could not find XForm {form_id}").format(form_id=result.form_id))
             continue
 
         xform_string = _("XForm {form_id} for domain {domain} by user '{username}'").format(
-            form_id=xform.form_id,
-            domain=xform.domain,
+            form_id=result.form_id,
+            domain=domain,
             username=username)
 
-        try:
-            if archive_or_restore.is_archive_mode():
-                xform.archive(user_id=user_id)
+        if result.status == SUCCEEDED:
+            if is_archive:
                 message = _("Successfully archived {form}").format(form=xform_string)
             else:
-                xform.unarchive(user_id=user_id)
                 message = _("Successfully unarchived {form}").format(form=xform_string)
             response['success'].append(message)
             success_count = success_count + 1
-        except Exception as e:
+        else:
             response['errors'].append(_("Could not archive {form}: {error}").format(
-                form=xform_string, error=e))
+                form=xform_string, error=captured_errors.get(result.form_id)))
 
         if task:
             DownloadBase.set_progress(task, success_count, len(form_ids))
-
-    for missing_form_id in missing_forms:
-        response['errors'].append(
-            _("Could not find XForm {form_id}").format(form_id=missing_form_id))
 
     if from_excel:
         return response

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -73,7 +73,7 @@ class FormActionResult:
     """Outcome of a bulk form action for a single requested form id."""
     form_id: str
     status: str  # SUCCEEDED | SKIPPED
-    reason: Optional[str] = None  # not_found | not_archived | unexpected_error
+    reason: Optional[str] = None  # not_found | unexpected_error
 
 
 def apply_form_action(domain, form_ids, action_fn):
@@ -90,6 +90,10 @@ def apply_form_action(domain, form_ids, action_fn):
         try:
             action_fn(xform)
         except Exception:
+            notify_exception(None, "Error applying bulk form action", {
+                'domain': domain,
+                'form_id': xform.form_id,
+            })
             yield FormActionResult(xform.form_id, SKIPPED, 'unexpected_error')
         else:
             yield FormActionResult(xform.form_id, SUCCEEDED)
@@ -102,18 +106,13 @@ def archive_or_restore_forms(domain, user_id, username, form_ids, archive_or_res
         'errors': [],
         'success': [],
     }
-    captured_errors = {}
     is_archive = archive_or_restore.is_archive_mode()
 
     def action_fn(xform):
-        try:
-            if is_archive:
-                xform.archive(user_id=user_id)
-            else:
-                xform.unarchive(user_id=user_id)
-        except Exception as e:
-            captured_errors[xform.form_id] = e
-            raise
+        if is_archive:
+            xform.archive(user_id=user_id)
+        else:
+            xform.unarchive(user_id=user_id)
 
     success_count = 0
     if task:
@@ -138,8 +137,8 @@ def archive_or_restore_forms(domain, user_id, username, form_ids, archive_or_res
             response['success'].append(message)
             success_count = success_count + 1
         else:
-            response['errors'].append(_("Could not archive {form}: {error}").format(
-                form=xform_string, error=captured_errors.get(result.form_id)))
+            response['errors'].append(
+                _("Could not archive {form}").format(form=xform_string))
 
         if task:
             DownloadBase.set_progress(task, success_count, len(form_ids))


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-19975

This PR modifies the existing `archive_or_restore_forms` implementation, which is used in the form management UI (i.e. bulk archival). We plan to implement a bulk archival API endpoint as well as a new bulk deletion API endpoint. This PR is purely setting up  the new `apply_form_action` function to be shared and used by these various features.

There is one intentional behavior change here, which is to skip forms that do not have a matching domain to the domain the request originated from. This shouldn't be possible via the UI anyway which is the only place the `archive_or_restore_forms` function is used, but just wanted to call that out.


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Added tests for `archive_or_restore_forms` prior to refactoring that mock underlying archive/restore behavior, but should be sufficient to ensure the code changes here do not lead to regressions since the behavior of `archive_or_restore_forms` remains the same.

As far as blast radius, this is function is only used in the bulk archival/restore UI, so if something did break, it would be limited to that feature. I will test this on staging myself.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
See safety story.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No, will test on staging myself.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
