### PR TITLE
Public Webforms: handle submission validation and session completion

### DIFF
--- a/corehq/apps/app_manager/models/public_webforms.py
+++ b/corehq/apps/app_manager/models/public_webforms.py
@@ -103,6 +103,11 @@ class PublicFormUser:
     def is_authenticated(self):
         return True
 
+    @property
+    def language(self):
+        # Set None to fall back to Django's cookie-based language resolution
+        return None
+
     def is_web_user(self):
         return False
 

--- a/corehq/apps/app_manager/public_webform_submissions.py
+++ b/corehq/apps/app_manager/public_webform_submissions.py
@@ -1,0 +1,53 @@
+import logging
+
+from casexml.apps.case.xform import get_case_updates
+
+from corehq.apps.app_manager.models import PublicWebformTypes
+from corehq.apps.users.util import PUBLIC_USER_ID
+from corehq.form_processor.models import CommCareCase
+
+logger = logging.getLogger(__name__)
+
+
+def validate_public_form_submission(session, form_json):
+    """
+    Structural gate for a public form submission, run before the form is
+    persisted. Returns an error message if the submission is not allowed for
+    the session's webform type, else ``None``.
+
+    - Survey webforms may not submit any case data.
+    - Registration webforms may only create new cases with PUBLIC_USER_ID.
+    """
+    session_type = session.public_webform.session_type
+    case_updates = get_case_updates(form_json)
+
+    if session_type == PublicWebformTypes.SURVEY:
+        if case_updates:
+            return "Survey public forms may not submit case data."
+        return None
+
+    if session_type == PublicWebformTypes.REGISTRATION:
+        return _validate_registration_case_updates(session, case_updates)
+
+    return f"Unsupported public webform session type: {session_type}"
+
+
+def _validate_registration_case_updates(session, case_updates):
+    for case_update in case_updates:
+        create_action = case_update.get_create_action()
+        if create_action is None:
+            # No create action means the block targets an existing case.
+            return "Registration public forms may only create new cases."
+        if create_action.owner_id != PUBLIC_USER_ID:
+            return f"Registration public form cases must be owned by '{PUBLIC_USER_ID}'."
+        update_action = case_update.get_update_action()
+        if update_action and update_action.owner_id and update_action.owner_id != PUBLIC_USER_ID:
+            return "Registration public forms may not reassign case ownership."
+        if case_update.get_index_action():
+            return "Registration public forms may not index cases."
+
+    domain = session.public_webform.domain
+    case_ids = [case_update.id for case_update in case_updates]
+    if case_ids and CommCareCase.objects.get_case_ids_that_exist(domain, case_ids):
+        return "Registration public form may not reuse an existing case id."
+    return None

--- a/corehq/apps/app_manager/public_webform_submissions.py
+++ b/corehq/apps/app_manager/public_webform_submissions.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.utils import timezone
 
 from casexml.apps.case.xform import get_case_updates
@@ -8,9 +6,6 @@ from corehq.apps.app_manager.models import PublicFormSession, PublicWebformTypes
 from corehq.apps.users.util import PUBLIC_USER_ID
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.utils.xform import extract_meta_user_id
-from corehq.util.metrics import metrics_counter
-
-logger = logging.getLogger(__name__)
 
 
 def validate_public_form_submission(session, form_json):
@@ -61,18 +56,16 @@ def _validate_registration_case_updates(session, case_updates):
     return None
 
 
+def public_form_session_already_submitted(session):
+    return PublicFormSession.objects.filter(
+        pk=session.pk,
+        submitted_at__isnull=False,
+    ).exists()
+
+
 def consume_public_form_session(session, xform):
-    """
-    On the first successful submission, mark the session used and record the
-    resulting xform id.
-    """
     consumed = PublicFormSession.objects.filter(
         pk=session.pk,
         submitted_at__isnull=True,
     ).update(submitted_at=timezone.now(), xform_id=xform.form_id)
-    if not consumed:
-        metrics_counter(
-            'commcare.public_form.already_consumed',
-            tags={'domain': session.public_webform.domain},
-        )
     return bool(consumed)

--- a/corehq/apps/app_manager/public_webform_submissions.py
+++ b/corehq/apps/app_manager/public_webform_submissions.py
@@ -1,11 +1,14 @@
 import logging
 
+from django.utils import timezone
+
 from casexml.apps.case.xform import get_case_updates
 
-from corehq.apps.app_manager.models import PublicWebformTypes
+from corehq.apps.app_manager.models import PublicFormSession, PublicWebformTypes
 from corehq.apps.users.util import PUBLIC_USER_ID
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.utils.xform import extract_meta_user_id
+from corehq.util.metrics import metrics_counter
 
 logger = logging.getLogger(__name__)
 
@@ -56,3 +59,20 @@ def _validate_registration_case_updates(session, case_updates):
     if case_ids and CommCareCase.objects.get_case_ids_that_exist(domain, case_ids):
         return "Registration public form may not reuse an existing case id."
     return None
+
+
+def consume_public_form_session(session, xform):
+    """
+    On the first successful submission, mark the session used and record the
+    resulting xform id.
+    """
+    consumed = PublicFormSession.objects.filter(
+        pk=session.pk,
+        submitted_at__isnull=True,
+    ).update(submitted_at=timezone.now(), xform_id=xform.form_id)
+    if not consumed:
+        metrics_counter(
+            'commcare.public_form.already_consumed',
+            tags={'domain': session.public_webform.domain},
+        )
+    return bool(consumed)

--- a/corehq/apps/app_manager/public_webform_submissions.py
+++ b/corehq/apps/app_manager/public_webform_submissions.py
@@ -5,6 +5,7 @@ from casexml.apps.case.xform import get_case_updates
 from corehq.apps.app_manager.models import PublicWebformTypes
 from corehq.apps.users.util import PUBLIC_USER_ID
 from corehq.form_processor.models import CommCareCase
+from corehq.form_processor.utils.xform import extract_meta_user_id
 
 logger = logging.getLogger(__name__)
 
@@ -15,9 +16,13 @@ def validate_public_form_submission(session, form_json):
     persisted. Returns an error message if the submission is not allowed for
     the session's webform type, else ``None``.
 
+    - Every submission must be attributed to PUBLIC_USER_ID.
     - Survey webforms may not submit any case data.
     - Registration webforms may only create new cases with PUBLIC_USER_ID.
     """
+    if extract_meta_user_id(form_json) != PUBLIC_USER_ID:
+        return f"Public form submissions must be attributed to '{PUBLIC_USER_ID}'."
+
     session_type = session.public_webform.session_type
     case_updates = get_case_updates(form_json)
 

--- a/corehq/apps/app_manager/tests/test_public_webform_submissions.py
+++ b/corehq/apps/app_manager/tests/test_public_webform_submissions.py
@@ -1,14 +1,22 @@
+import datetime
 from uuid import uuid4
 
-from unmagic import use
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import Client
+from django.urls import reverse
+
+from unmagic import fixture, use
 
 from casexml.apps.case.mock import CaseBlock, CaseFactory
 
 from corehq.apps.app_manager.models import PublicFormSession, PublicWebform
 from corehq.apps.app_manager.public_webform_submissions import (
+    consume_public_form_session,
     validate_public_form_submission,
 )
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.util import PUBLIC_USER_ID
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 from corehq.form_processor.utils.xform import convert_xform_to_json
 
 DOMAIN = 'public-webform-submissions'
@@ -44,6 +52,11 @@ def _session(session_type, domain=DOMAIN):
     domain off the (unsaved) webform."""
     webform = PublicWebform(domain=domain, session_type=session_type)
     return PublicFormSession(public_webform=webform)
+
+
+class _FakeXForm:
+    def __init__(self, form_id):
+        self.form_id = form_id
 
 
 class TestValidateAttribution:
@@ -124,3 +137,120 @@ class TestValidateRegistrationSubmission:
         session = _session('registration')
         block = _create_block(case_id=existing.case_id)
         assert validate_public_form_submission(session, _form_json(block)) is not None
+
+
+@use('db')
+@fixture
+def consumable_session():
+    future_expiration = datetime.datetime.today() + datetime.timedelta(days=30)
+    webform = PublicWebform.objects.create(
+        domain=DOMAIN,
+        app_id='app',
+        app_build_id='build',
+        form_unique_id='form',
+        endpoint_id='endpoint',
+        session_type='survey',
+        allow_sms=False,
+        allow_email=True,
+        expires_at=future_expiration,
+    )
+    yield PublicFormSession.objects.create(
+        public_webform=webform,
+        expires_at=future_expiration,
+    )
+
+
+@use(consumable_session)
+class TestConsumePublicFormSession:
+
+    def test_consume_sets_submitted_at_and_xform_id(self):
+        session = consumable_session()
+        assert consume_public_form_session(session, _FakeXForm('form-abc')) is True
+        session.refresh_from_db()
+        assert session.submitted_at is not None
+        assert session.xform_id == 'form-abc'
+
+    def test_second_consume_is_a_noop(self):
+        session = consumable_session()
+        assert consume_public_form_session(session, _FakeXForm('form-abc')) is True
+        assert consume_public_form_session(session, _FakeXForm('form-xyz')) is False
+        session.refresh_from_db()
+        # still the first form; the replay did not overwrite
+        assert session.xform_id == 'form-abc'
+
+
+@use('transactional_db')
+@fixture
+def receiver_webform():
+    """A survey webform on a real domain, for driving the receiver end to end.
+
+    Uses transactional_db (not db): the receiver writes the form to the
+    sharded backend, whose proxy reads cannot see uncommitted changes, so a
+    wrapping per-test transaction would hide the write. transactional_db
+    truncates between tests instead of rolling back.
+    """
+    domain_obj = create_domain('public-receiver')
+    try:
+        yield PublicWebform.objects.create(
+            domain=domain_obj.name,
+            app_id='app',
+            app_build_id='build',
+            form_unique_id='form',
+            endpoint_id='endpoint',
+            session_type='survey',
+            allow_sms=False,
+            allow_email=True,
+            expires_at=datetime.datetime.today() + datetime.timedelta(days=30),
+        )
+    finally:
+        FormProcessorTestUtils.delete_all_xforms(domain_obj.name)
+        domain_obj.delete()
+
+
+@sharded
+@use(receiver_webform)
+class TestPublicFormReceiverIntegration:
+    """End-to-end: a submission carrying the public session cookie + header is
+    resolved to a PublicFormUser, validated pre-persist, and consumes the
+    session on success."""
+
+    def _session(self):
+        return PublicFormSession.objects.create(
+            public_webform=receiver_webform(), expires_at=datetime.datetime.today() + datetime.timedelta(days=30))
+
+    def _submit(self, session, case_block_xml=''):
+        form_xml = (
+            '<?xml version="1.0" ?>'
+            '<data xmlns="http://commcarehq.org/public-form-test">'
+            '<name>test</name>'
+            f'{case_block_xml}'
+            '<n0:meta xmlns:n0="http://openrosa.org/jr/xforms">'
+            f'<n0:instanceID>{uuid4().hex}</n0:instanceID>'
+            f'<n0:userID>{PUBLIC_USER_ID}</n0:userID>'
+            '</n0:meta>'
+            '</data>'
+        )
+        client = Client()
+        client.cookies['public_form_session_key'] = str(session.session_key)
+        url = reverse('receiver_post', args=[receiver_webform().domain])
+        return client.post(
+            url,
+            {'xml_submission_file': SimpleUploadedFile('form.xml', form_xml.encode('utf-8'))},
+            headers={'CommCare-Public-Session': 'true'},
+        )
+
+    def test_survey_submission_accepted_and_consumes_session(self):
+        session = self._session()
+        response = self._submit(session)
+        assert response.status_code == 201
+        session.refresh_from_db()
+        assert session.submitted_at is not None
+        assert session.xform_id
+
+    def test_survey_submission_with_case_data_is_rejected(self):
+        session = self._session()
+        case_xml = _create_block().as_text()
+        response = self._submit(session, case_xml)
+        assert response.status_code == 400
+        session.refresh_from_db()
+        assert session.submitted_at is None

--- a/corehq/apps/app_manager/tests/test_public_webform_submissions.py
+++ b/corehq/apps/app_manager/tests/test_public_webform_submissions.py
@@ -1,0 +1,99 @@
+from uuid import uuid4
+
+from unmagic import use
+
+from casexml.apps.case.mock import CaseBlock, CaseFactory
+
+from corehq.apps.app_manager.models import PublicFormSession, PublicWebform
+from corehq.apps.app_manager.public_webform_submissions import (
+    validate_public_form_submission,
+)
+from corehq.apps.users.util import PUBLIC_USER_ID
+from corehq.form_processor.utils.xform import convert_xform_to_json
+
+DOMAIN = 'public-webform-submissions'
+
+
+def _form_json(*case_blocks):
+    cases = ''.join(cb.as_text() for cb in case_blocks)
+    return convert_xform_to_json(
+        f'<data xmlns="http://example.com/public-form">{cases}</data>'
+    )
+
+
+def _create_block(owner_id=PUBLIC_USER_ID, case_id=None, **kwargs):
+    return CaseBlock(
+        case_id=case_id or uuid4().hex,
+        create=True,
+        owner_id=owner_id,
+        case_type='patient',
+        case_name='Test',
+        **kwargs,
+    )
+
+
+def _session(session_type, domain=DOMAIN):
+    """An in-memory session for validation, which reads only session_type and
+    domain off the (unsaved) webform."""
+    webform = PublicWebform(domain=domain, session_type=session_type)
+    return PublicFormSession(public_webform=webform)
+
+
+class TestValidateSurveySubmission:
+
+    def test_survey_without_case_data_is_allowed(self):
+        session = _session('survey')
+        assert validate_public_form_submission(session, _form_json()) is None
+
+    def test_survey_with_case_data_is_rejected(self):
+        session = _session('survey')
+        error = validate_public_form_submission(session, _form_json(_create_block()))
+        assert error is not None
+
+
+@use('db')
+class TestValidateRegistrationSubmission:
+
+    def test_create_owned_by_public_user_is_allowed(self):
+        session = _session('registration')
+        block = _create_block(update={'age': '30'})
+        assert validate_public_form_submission(session, _form_json(block)) is None
+
+    def test_create_with_wrong_owner_is_rejected(self):
+        session = _session('registration')
+        block = _create_block(owner_id='some-real-user')
+        assert validate_public_form_submission(session, _form_json(block)) is not None
+
+    def test_update_without_create_is_rejected(self):
+        session = _session('registration')
+        block = CaseBlock(case_id=uuid4().hex, update={'age': '30'})
+        assert validate_public_form_submission(session, _form_json(block)) is not None
+
+    def test_owner_reassignment_via_update_is_rejected(self):
+        # A crafted submission that creates as the public owner but reassigns
+        # ownership in the update block. CaseBlock refuses to build this, so
+        # the XML is hand-written as a hostile client could send it.
+        session = _session('registration')
+        case_xml = (
+            f'<case case_id="{uuid4().hex}" date_modified="2020-01-01T00:00:00.000000Z"'
+            f' xmlns="http://commcarehq.org/case/transaction/v2">'
+            f'<create><case_type>patient</case_type><case_name>Test</case_name>'
+            f'<owner_id>{PUBLIC_USER_ID}</owner_id></create>'
+            f'<update><owner_id>some-real-user</owner_id></update>'
+            f'</case>'
+        )
+        form_json = convert_xform_to_json(
+            f'<data xmlns="http://example.com/public-form">{case_xml}</data>'
+        )
+        assert validate_public_form_submission(session, form_json) is not None
+
+    def test_index_is_rejected(self):
+        session = _session('registration')
+        block = _create_block(index={'parent': ('patient', uuid4().hex)})
+        assert validate_public_form_submission(session, _form_json(block)) is not None
+
+    def test_reusing_existing_case_id_is_rejected(self):
+        existing = CaseFactory(DOMAIN).create_case(owner_id=PUBLIC_USER_ID)
+        session = _session('registration')
+        block = _create_block(case_id=existing.case_id)
+        assert validate_public_form_submission(session, _form_json(block)) is not None

--- a/corehq/apps/app_manager/tests/test_public_webform_submissions.py
+++ b/corehq/apps/app_manager/tests/test_public_webform_submissions.py
@@ -10,7 +10,8 @@ from unmagic import fixture, use
 
 from casexml.apps.case.mock import CaseBlock, CaseFactory
 
-from corehq.apps.accounting.tests import generator as accounting_generator
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.app_manager.models import PublicFormSession, PublicWebform
 from corehq.apps.app_manager.public_webform_submissions import (
     consume_public_form_session,
@@ -183,43 +184,46 @@ class TestConsumePublicFormSession:
 
 @use('transactional_db')
 @fixture
-def receiver_webform():
-    """A survey webform on a real domain, for driving the receiver end to end.
+def receiver_domain():
+    """A domain with an active subscription, for driving the receiver end to end.
 
-    Uses transactional_db (not db): the receiver writes the form to the
-    sharded backend, whose proxy reads cannot see uncommitted changes, so a
-    wrapping per-test transaction would hide the write. transactional_db
-    truncates between tests instead of rolling back.
+    Uses transactional_db (not db): the receiver writes the form to the sharded
+    backend, whose proxy reads cannot see uncommitted changes, so a wrapping
+    per-test transaction would hide the write. transactional_db truncates
+    between tests instead of rolling back; the subscription setup here must
+    re-bootstrap roles and default plans.
     """
+    call_command('cchq_prbac_bootstrap')
     domain_obj = create_domain('public-receiver')
+    subscription = DomainSubscriptionMixin()
+    subscription.setup_subscription(domain_obj.name, SoftwarePlanEdition.ADVANCED)
     try:
-        yield PublicWebform.objects.create(
-            domain=domain_obj.name,
-            app_id='app',
-            app_build_id='build',
-            form_unique_id='form',
-            endpoint_id='endpoint',
-            session_type='survey',
-            allow_sms=False,
-            allow_email=True,
-            expires_at=datetime.datetime.today() + datetime.timedelta(days=30),
-        )
+        yield domain_obj
     finally:
+        subscription.teardown_subscription(domain_obj.name)
         FormProcessorTestUtils.delete_all_xforms(domain_obj.name)
         domain_obj.delete()
 
 
-@use('transactional_db')
+@use(receiver_domain)
 @fixture
-def default_software_plans():
-    call_command('cchq_prbac_bootstrap')
-    accounting_generator.init_default_currency()
-    accounting_generator.bootstrap_test_software_plan_versions()
-    yield
+def receiver_webform():
+    """A survey webform on the receiver domain, for driving the receiver end to end."""
+    yield PublicWebform.objects.create(
+        domain=receiver_domain().name,
+        app_id='app',
+        app_build_id='build',
+        form_unique_id='form',
+        endpoint_id='endpoint',
+        session_type='survey',
+        allow_sms=False,
+        allow_email=True,
+        expires_at=datetime.datetime.today() + datetime.timedelta(days=30),
+    )
 
 
 @sharded
-@use(default_software_plans, receiver_webform)
+@use(receiver_webform)
 class TestPublicFormReceiverIntegration:
     """End-to-end: a submission carrying the public session cookie + header is
     resolved to a PublicFormUser, validated pre-persist, and consumes the

--- a/corehq/apps/app_manager/tests/test_public_webform_submissions.py
+++ b/corehq/apps/app_manager/tests/test_public_webform_submissions.py
@@ -15,6 +15,7 @@ from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.app_manager.models import PublicFormSession, PublicWebform
 from corehq.apps.app_manager.public_webform_submissions import (
     consume_public_form_session,
+    public_form_session_already_submitted,
     validate_public_form_submission,
 )
 from corehq.apps.domain.shortcuts import create_domain
@@ -180,6 +181,18 @@ class TestConsumePublicFormSession:
         session.refresh_from_db()
         # still the first form; the replay did not overwrite
         assert session.xform_id == 'form-abc'
+
+
+@use(consumable_session)
+class TestPublicFormSessionAlreadySubmitted:
+
+    def test_false_before_submission(self):
+        assert public_form_session_already_submitted(consumable_session()) is False
+
+    def test_true_after_submission(self):
+        session = consumable_session()
+        consume_public_form_session(session, _FakeXForm('form-abc'))
+        assert public_form_session_already_submitted(session) is True
 
 
 @use('transactional_db')

--- a/corehq/apps/app_manager/tests/test_public_webform_submissions.py
+++ b/corehq/apps/app_manager/tests/test_public_webform_submissions.py
@@ -14,11 +14,18 @@ from corehq.form_processor.utils.xform import convert_xform_to_json
 DOMAIN = 'public-webform-submissions'
 
 
-def _form_json(*case_blocks):
+def _form_json(*case_blocks, user_id=PUBLIC_USER_ID):
+    return convert_xform_to_json(_form_xml(*case_blocks, user_id=user_id))
+
+
+def _form_xml(*case_blocks, user_id=PUBLIC_USER_ID):
+    meta = (
+        '<n0:meta xmlns:n0="http://openrosa.org/jr/xforms">'
+        f'<n0:userID>{user_id}</n0:userID>'
+        '</n0:meta>'
+    ) if user_id is not None else ''
     cases = ''.join(cb.as_text() for cb in case_blocks)
-    return convert_xform_to_json(
-        f'<data xmlns="http://example.com/public-form">{cases}</data>'
-    )
+    return f'<data xmlns="http://example.com/public-form">{meta}{cases}</data>'
 
 
 def _create_block(owner_id=PUBLIC_USER_ID, case_id=None, **kwargs):
@@ -37,6 +44,21 @@ def _session(session_type, domain=DOMAIN):
     domain off the (unsaved) webform."""
     webform = PublicWebform(domain=domain, session_type=session_type)
     return PublicFormSession(public_webform=webform)
+
+
+class TestValidateAttribution:
+    # userID attribution is checked for every session type before any case
+    # data, so a survey session is sufficient to exercise it.
+
+    def test_wrong_user_id_is_rejected(self):
+        session = _session('survey')
+        assert validate_public_form_submission(
+            session, _form_json(user_id='some-real-user')) is not None
+
+    def test_missing_user_id_is_rejected(self):
+        session = _session('survey')
+        assert validate_public_form_submission(
+            session, _form_json(user_id=None)) is not None
 
 
 class TestValidateSurveySubmission:
@@ -82,8 +104,13 @@ class TestValidateRegistrationSubmission:
             f'<update><owner_id>some-real-user</owner_id></update>'
             f'</case>'
         )
+        meta = (
+            '<n0:meta xmlns:n0="http://openrosa.org/jr/xforms">'
+            f'<n0:userID>{PUBLIC_USER_ID}</n0:userID>'
+            '</n0:meta>'
+        )
         form_json = convert_xform_to_json(
-            f'<data xmlns="http://example.com/public-form">{case_xml}</data>'
+            f'<data xmlns="http://example.com/public-form">{meta}{case_xml}</data>'
         )
         assert validate_public_form_submission(session, form_json) is not None
 

--- a/corehq/apps/app_manager/tests/test_public_webform_submissions.py
+++ b/corehq/apps/app_manager/tests/test_public_webform_submissions.py
@@ -2,6 +2,7 @@ import datetime
 from uuid import uuid4
 
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.management import call_command
 from django.test import Client
 from django.urls import reverse
 
@@ -9,6 +10,7 @@ from unmagic import fixture, use
 
 from casexml.apps.case.mock import CaseBlock, CaseFactory
 
+from corehq.apps.accounting.tests import generator as accounting_generator
 from corehq.apps.app_manager.models import PublicFormSession, PublicWebform
 from corehq.apps.app_manager.public_webform_submissions import (
     consume_public_form_session,
@@ -207,8 +209,17 @@ def receiver_webform():
         domain_obj.delete()
 
 
+@use('transactional_db')
+@fixture
+def default_software_plans():
+    call_command('cchq_prbac_bootstrap')
+    accounting_generator.init_default_currency()
+    accounting_generator.bootstrap_test_software_plan_versions()
+    yield
+
+
 @sharded
-@use(receiver_webform)
+@use(default_software_plans, receiver_webform)
 class TestPublicFormReceiverIntegration:
     """End-to-end: a submission carrying the public session cookie + header is
     resolved to a PublicFormUser, validated pre-persist, and consumes the

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -64,7 +64,7 @@ from corehq.apps.users.models import CouchUser
 from corehq.form_processor.exceptions import XFormLockError
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.submission_post import SubmissionPost
-from corehq.form_processor.utils.xform import convert_xform_to_json
+from corehq.form_processor.utils.xform import convert_xform_to_json, extract_meta_instance_id
 from corehq.util.metrics import metrics_counter, metrics_histogram
 from corehq.util.timer import TimingContext, set_request_duration_reporting_threshold
 from couchdbkit import ResourceNotFound
@@ -207,8 +207,9 @@ def _process_form(request, domain, app_id, user_id, authenticated,
                 metrics_counter('commcare.xformlocked.count', tags={
                     'domain': domain, 'authenticated': authenticated
                 })
+                locked_form_id = extract_meta_instance_id(instance_json) if instance_json else None
                 return _submission_error(
-                    request, "XFormLockError: %s" % err,
+                    request, "XFormLockError: %s" % locked_form_id,
                     metric_tags, domain, app_id, user_id, authenticated, status=423,
                     notify=False,
                 )

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from contextlib import nullcontext
 
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.views.decorators.csrf import csrf_exempt
@@ -11,6 +12,7 @@ from corehq.apps.app_manager.decorators import allow_public_form_session
 from corehq.apps.app_manager.models import PublicFormUser
 from corehq.apps.app_manager.public_webform_submissions import (
     consume_public_form_session,
+    public_form_session_already_submitted,
     validate_public_form_submission,
 )
 from corehq.apps.hqwebapp.decorators import waf_allow
@@ -21,6 +23,7 @@ from couchforms import openrosa_response
 from couchforms.const import MAGIC_PROPERTY
 from couchforms.exceptions import BadSubmissionRequest, UnprocessableFormSubmission
 from couchforms.getters import MultimediaBug
+from dimagi.utils.couch import CriticalSection
 from dimagi.utils.decorators.profile import profile_dump
 from dimagi.utils.logging import notify_exception
 
@@ -147,7 +150,8 @@ def _process_form(request, domain, app_id, user_id, authenticated,
             return HttpNotAcceptable(DEVICE_RATE_LIMIT_MESSAGE)
 
     couch_user = getattr(request, 'couch_user', None)
-    if isinstance(couch_user, PublicFormUser) and instance_json is not None:
+    is_public = isinstance(couch_user, PublicFormUser) and instance_json is not None
+    if is_public:
         error = validate_public_form_submission(couch_user.session, instance_json)
         if error is not None:
             metrics_counter(
@@ -158,53 +162,62 @@ def _process_form(request, domain, app_id, user_id, authenticated,
             _record_metrics(metric_tags, 'known_failures', response)
             return response
 
-    with TimingContext() as timer:
-        app_id, build_id = get_app_and_build_ids(domain, app_id)
-        submission_post = SubmissionPost(
-            instance=instance,
-            instance_json=instance_json,
-            attachments=attachments,
-            domain=domain,
-            app_id=app_id,
-            build_id=build_id,
-            auth_context=auth_cls(
-                domain=domain,
-                user_id=user_id,
-                authenticated=authenticated,
-            ),
-            location=couchforms.get_location(request),
-            received_on=couchforms.get_received_on(request),
-            date_header=couchforms.get_date_header(request),
-            path=couchforms.get_path(request),
-            submit_ip=couchforms.get_submit_ip(request),
-            last_sync_token=couchforms.get_last_sync_token(request),
-            openrosa_headers=couchforms.get_openrosa_headers(request),
-            force_logs=request.GET.get('force_logs', 'false') == 'true',
-            timing_context=timer
-        )
-
-        try:
-            result = submission_post.run()
-        except XFormLockError as err:
-            logging.warning('Unable to get lock for form %s', err)
-            metrics_counter('commcare.xformlocked.count', tags={
-                'domain': domain, 'authenticated': authenticated
-            })
-            return _submission_error(
-                request, "XFormLockError: %s" % err,
-                metric_tags, domain, app_id, user_id, authenticated, status=423,
-                notify=False,
-            )
-
-    response = result.response
-    response.request_timer = timer  # logged as Sentry breadcrumbs in LogLongRequestMiddleware
-
-    if (
-        isinstance(couch_user, PublicFormUser)
-        and result.xform is not None
-        and response.status_code < 400
+    with (
+        CriticalSection([f'public-form-session-{couch_user.session.id}'], fail_hard=True)
+        if is_public else nullcontext()
     ):
-        consume_public_form_session(couch_user.session, result.xform)
+        # Ensure concurrent submissions on a public form session cannot persist more than one form.
+        if is_public and public_form_session_already_submitted(couch_user.session):
+            metrics_counter(
+                'commcare.public_form.already_consumed',
+                tags={'domain': domain},
+            )
+            response = HttpResponseBadRequest('This form link has already been used.')
+            _record_metrics(metric_tags, 'known_failures', response)
+            return response
+
+        with TimingContext() as timer:
+            app_id, build_id = get_app_and_build_ids(domain, app_id)
+            submission_post = SubmissionPost(
+                instance=instance,
+                instance_json=instance_json,
+                attachments=attachments,
+                domain=domain,
+                app_id=app_id,
+                build_id=build_id,
+                auth_context=auth_cls(
+                    domain=domain,
+                    user_id=user_id,
+                    authenticated=authenticated,
+                ),
+                location=couchforms.get_location(request),
+                received_on=couchforms.get_received_on(request),
+                date_header=couchforms.get_date_header(request),
+                path=couchforms.get_path(request),
+                submit_ip=couchforms.get_submit_ip(request),
+                last_sync_token=couchforms.get_last_sync_token(request),
+                openrosa_headers=couchforms.get_openrosa_headers(request),
+                force_logs=request.GET.get('force_logs', 'false') == 'true',
+                timing_context=timer
+            )
+            try:
+                result = submission_post.run()
+            except XFormLockError as err:
+                logging.warning('Unable to get lock for form %s', err)
+                metrics_counter('commcare.xformlocked.count', tags={
+                    'domain': domain, 'authenticated': authenticated
+                })
+                return _submission_error(
+                    request, "XFormLockError: %s" % err,
+                    metric_tags, domain, app_id, user_id, authenticated, status=423,
+                    notify=False,
+                )
+
+        response = result.response
+        response.request_timer = timer  # logged as Sentry breadcrumbs in LogLongRequestMiddleware
+
+        if is_public and result.xform is not None and response.status_code < 400:
+            consume_public_form_session(couch_user.session, result.xform)
 
     _record_metrics(metric_tags, result.submission_type, result.response, timer, result.xform)
 

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -10,6 +10,7 @@ from casexml.apps.case.xform import get_case_updates, is_device_report
 from corehq.apps.app_manager.decorators import allow_public_form_session
 from corehq.apps.app_manager.models import PublicFormUser
 from corehq.apps.app_manager.public_webform_submissions import (
+    consume_public_form_session,
     validate_public_form_submission,
 )
 from corehq.apps.hqwebapp.decorators import waf_allow
@@ -197,6 +198,13 @@ def _process_form(request, domain, app_id, user_id, authenticated,
 
     response = result.response
     response.request_timer = timer  # logged as Sentry breadcrumbs in LogLongRequestMiddleware
+
+    if (
+        isinstance(couch_user, PublicFormUser)
+        and result.xform is not None
+        and response.status_code < 400
+    ):
+        consume_public_form_session(couch_user.session, result.xform)
 
     _record_metrics(metric_tags, result.submission_type, result.response, timer, result.xform)
 

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -7,6 +7,11 @@ from django.views.decorators.http import require_POST
 
 import couchforms
 from casexml.apps.case.xform import get_case_updates, is_device_report
+from corehq.apps.app_manager.decorators import allow_public_form_session
+from corehq.apps.app_manager.models import PublicFormUser
+from corehq.apps.app_manager.public_webform_submissions import (
+    validate_public_form_submission,
+)
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.device_rate_limiter import device_rate_limiter, DEVICE_RATE_LIMIT_MESSAGE
@@ -140,6 +145,18 @@ def _process_form(request, domain, app_id, user_id, authenticated,
         if should_limit:
             return HttpNotAcceptable(DEVICE_RATE_LIMIT_MESSAGE)
 
+    couch_user = getattr(request, 'couch_user', None)
+    if isinstance(couch_user, PublicFormUser) and instance_json is not None:
+        error = validate_public_form_submission(couch_user.session, instance_json)
+        if error is not None:
+            metrics_counter(
+                'commcare.public_form.rejected_submission',
+                tags={'domain': domain},
+            )
+            response = HttpResponseBadRequest(error)
+            _record_metrics(metric_tags, 'known_failures', response)
+            return response
+
     with TimingContext() as timer:
         app_id, build_id = get_app_and_build_ids(domain, app_id)
         submission_post = SubmissionPost(
@@ -261,6 +278,7 @@ def post_api(request, domain):
 @require_POST
 @check_domain_mobile_access
 @set_request_duration_reporting_threshold(60)
+@allow_public_form_session
 def post(request, domain, app_id=None):
     try:
         if domain_requires_auth(domain):


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19917
https://dimagi.atlassian.net/browse/SAAS-19918

Builds on #37906. That PR resolves a public session onto `request.couch_user` as a `PublicFormUser`; this PR is what happens when such a session submits a form. New module wired into` _process_form` and gated on `isinstance(couch_user, PublicFormUser)` so no other submission path is affected.

Pre-validator (before persistence) — because on a direct-to-receiver POST the XML is entirely user-controlled once they have a valid public session:
- Attribution: reject unless meta/userID == PUBLIC_USER_ID. Legit formplayer submissions always are (it flows from the restore registration block); this stops a link holder from attributing a form to a real user.
- Survey: no case data at all.
- Registration: create-only, owned by PUBLIC_USER_ID — no update-without-create, no ownership reassignment, no indexing, no reuse of an existing case id.

Error strings are untranslated, consistent with the rest of the receiver's text/plain submission responses.

Consume (after a successful persist) — mark the session used and record its xform_id. Concurrent/replayed submissions are a no-op.

Additionally, adds `PublicFormUser.language` — returns None so the `SyncUserLanguageMiddleware`, which reads `couch_user.language` on every response, falls back to cookie-based language resolution instead of error-ing. Surfaced by the end-to-end receiver test.

Code and this PR-description co-written by AI and edited by human.

## Feature Flag
This change is not feature flagged. Code will be reachable once a way to create PublicWebforms and PublicFormSessions is created (which itself will be gated by `PUBLIC_WEBFORMS` during development).

## Safety Assurance

### Safety story
Additive and effectively unreachable. The two `_process_form` hooks are guarded by `isinstance(couch_user, PublicFormUser);` for every existing submission path `couch_user` is never that type, so behavior is unchanged. The only always-live change is `PublicFormUser.language`, a new attribute on a type that itself only exists behind the (not-yet-reachable) public flow.


### Automated test coverage
corehq/apps/app_manager/tests/test_public_webform_submissions.py:
- attribution rejection (wrong/missing userID);
- survey (case data rejected);
- registration structural rules (wrong owner, update-without-create, ownership reassignment via hand-written hostile XML, indexing, case-id reuse); 
- consume atomicity + replay no-op; and
- a `@sharded` end-to-end test driving a real submission through the receiver and asserting the session is consumed (and that case data on a survey link is rejected 400).

### QA Plan
Not yet. Will get QA as part of Public Webforms holistically.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
