### PR TITLE
Cut bulk form archive/unarchive over to BulkAsyncJob (SAAS-19895)

### DIFF
--- a/corehq/apps/data_interfaces/bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/bulk_form_actions.py
@@ -13,7 +13,6 @@ from attrs import frozen
 
 from dimagi.utils.logging import notify_exception
 
-from corehq.apps.data_interfaces.interfaces import FormManagementMode
 from corehq.apps.data_interfaces.models import BulkAsyncJob
 from corehq.apps.users.models import CouchUser
 from corehq.blobs import get_blob_db
@@ -36,15 +35,12 @@ class FormActionResult:
     reason: Optional[str] = None  # not_found | unexpected_error
 
 
-def create_bulk_form_job(domain, mode, requested_by, form_ids):
+def create_bulk_form_job(domain, action, requested_by, form_ids):
     """Create and persist a BulkAsyncJob for a bulk form archive/unarchive.
 
     The blob write and row save share an ``AtomicBlobs`` transaction so a
     failed save can't orphan the requested-ids blob.
     """
-    action = (BulkAsyncJob.Action.UNARCHIVE
-              if mode == FormManagementMode.RESTORE_MODE
-              else BulkAsyncJob.Action.ARCHIVE)
     with AtomicBlobs(get_blob_db()) as db:
         job = BulkAsyncJob(
             domain=domain,

--- a/corehq/apps/data_interfaces/bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/bulk_form_actions.py
@@ -75,6 +75,19 @@ def run_bulk_form_action(job):
     job.save()
 
 
+def mark_job_failed(job_id):
+    """Mark a job ``failed`` unless it already reached a terminal state."""
+    try:
+        job = BulkAsyncJob.objects.get(id=job_id)
+    except BulkAsyncJob.DoesNotExist:
+        return
+    if job.is_done:
+        return
+    job.status = BulkAsyncJob.Status.FAILED
+    job.completed_at = datetime.now(tz=UTC)
+    job.save()
+
+
 def _resolve_user_id(username):
     user = CouchUser.get_by_username(username)
     if user is None:

--- a/corehq/apps/data_interfaces/bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/bulk_form_actions.py
@@ -1,0 +1,83 @@
+"""Execution logic for bulk form actions (archive/unarchive).
+
+Kept separate from ``tasks.py`` so the job lifecycle can be tested without
+Celery. The Celery task is a thin wrapper around ``run_bulk_form_action``.
+"""
+import logging
+from collections import defaultdict
+from datetime import UTC, datetime
+from typing import Callable, Optional
+
+from attrs import frozen
+
+from corehq.apps.data_interfaces.models import BulkAsyncJob
+from corehq.apps.data_interfaces.utils import SUCCEEDED, apply_form_action
+from corehq.apps.users.models import CouchUser
+
+log = logging.getLogger(__name__)
+
+SAVE_EVERY = 100
+
+
+@frozen
+class FormAction:
+    run: Callable
+    validate: Optional[Callable] = None
+
+
+def build_form_action(job, user_id):
+    """Return the ``FormAction`` for ``job.action``."""
+    Action = BulkAsyncJob.Action
+    if job.action == Action.ARCHIVE:
+        return FormAction(run=lambda f: f.archive(user_id=user_id))
+    if job.action == Action.UNARCHIVE:
+        return FormAction(
+            run=lambda f: f.unarchive(user_id=user_id),
+            validate=lambda f: None if f.is_archived else 'already_unarchived',
+        )
+    raise ValueError(f'unknown bulk action: {job.action}')
+
+
+def run_bulk_form_action(job):
+    """Execute ``job`` start to finish, updating counts and status on the row."""
+    job.status = BulkAsyncJob.Status.RUNNING
+    job.started_at = datetime.now(tz=UTC)
+    job.save()
+
+    user_id = _resolve_user_id(job.requested_by)
+    form_ids = job.get_requested_ids()
+    form_action = build_form_action(job, user_id)
+
+    skipped = defaultdict(list)
+    processed = succeeded = 0
+    for result in apply_form_action(
+        job.domain, form_ids, form_action.run, validate=form_action.validate,
+    ):
+        processed += 1
+        if result.status == SUCCEEDED:
+            succeeded += 1
+        else:
+            skipped[result.reason].append(result.form_id)
+        if processed % SAVE_EVERY == 0:
+            job.processed_count = processed
+            job.succeeded_count = succeeded
+            job.save(update_fields=['processed_count', 'succeeded_count'])
+            log.info(
+                "bulk_%s bulk_async_job_id=%s domain=%s processed=%s/%s",
+                job.action, job.id, job.domain, processed, job.requested_count,
+            )
+
+    job.processed_count = processed
+    job.succeeded_count = succeeded
+    job.set_skipped(dict(skipped))
+    job.status = BulkAsyncJob.Status.COMPLETE
+    job.completed_at = datetime.now(tz=UTC)
+    job.save()
+
+
+def _resolve_user_id(username):
+    user = CouchUser.get_by_username(username)
+    if user is None:
+        log.warning("bulk form action: user %s not found; using user_id=None", username)
+        return None
+    return user.user_id

--- a/corehq/apps/data_interfaces/bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/bulk_form_actions.py
@@ -10,13 +10,39 @@ from typing import Callable, Optional
 
 from attrs import frozen
 
+from corehq.apps.data_interfaces.interfaces import FormManagementMode
 from corehq.apps.data_interfaces.models import BulkAsyncJob
 from corehq.apps.data_interfaces.utils import SUCCEEDED, apply_form_action
 from corehq.apps.users.models import CouchUser
+from corehq.blobs import get_blob_db
+from corehq.blobs.atomic import AtomicBlobs
+from corehq.form_processor.models import XFormInstance
 
 log = logging.getLogger(__name__)
 
 SAVE_EVERY = 100
+
+
+def create_bulk_form_job(domain, mode, requested_by, form_ids):
+    """Create and persist a BulkAsyncJob for a bulk form archive/unarchive.
+
+    The blob write and row save share an ``AtomicBlobs`` transaction so a
+    failed save can't orphan the requested-ids blob.
+    """
+    action = (BulkAsyncJob.Action.UNARCHIVE
+              if mode == FormManagementMode.RESTORE_MODE
+              else BulkAsyncJob.Action.ARCHIVE)
+    with AtomicBlobs(get_blob_db()) as db:
+        job = BulkAsyncJob(
+            domain=domain,
+            model=XFormInstance,
+            action=action,
+            requested_by=requested_by,
+        )
+        stored_ids = job.set_requested_ids(form_ids, db=db)
+        job.requested_count = len(stored_ids)
+        job.save()
+    return job
 
 
 @frozen

--- a/corehq/apps/data_interfaces/bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/bulk_form_actions.py
@@ -89,9 +89,7 @@ def run_bulk_form_action(job):
 
     skipped = defaultdict(list)
     processed = succeeded = 0
-    for result in apply_form_action(
-        job.domain, form_ids, form_action.run, validate=form_action.validate,
-    ):
+    for result in _apply_form_action(job.domain, form_ids, form_action):
         processed += 1
         if result.status == SUCCEEDED:
             succeeded += 1
@@ -114,25 +112,20 @@ def run_bulk_form_action(job):
     job.save()
 
 
-def apply_form_action(domain, form_ids, action_fn, validate=None):
-    """Apply ``action_fn`` to each form and yield a ``FormActionResult`` per id.
-
-    :param action_fn: callable taking an ``XFormInstance``
-    :param validate: optional callable taking an ``XFormInstance`` and returning
-        a skip reason (or ``None`` to proceed).
-    """
+def _apply_form_action(domain, form_ids, form_action):
+    """Apply ``form_action`` to each form and yield a ``FormActionResult`` per id."""
     unresolved_ids = set(form_ids)
     for xform in XFormInstance.objects.iter_forms(form_ids):
         if xform.domain != domain:
             # skip forms not belonging to the specified domain
             continue
         unresolved_ids.discard(xform.form_id)
-        reason = validate(xform) if validate else None
+        reason = form_action.validate(xform) if form_action.validate else None
         if reason:
             yield FormActionResult(xform.form_id, SKIPPED, reason)
             continue
         try:
-            action_fn(xform)
+            form_action.run(xform)
         except Exception:
             notify_exception(None, "Error applying bulk form action", {
                 'domain': domain,

--- a/corehq/apps/data_interfaces/bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/bulk_form_actions.py
@@ -5,14 +5,16 @@ Celery. The Celery task is a thin wrapper around ``run_bulk_form_action``.
 """
 import logging
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Callable, Optional
 
 from attrs import frozen
 
+from dimagi.utils.logging import notify_exception
+
 from corehq.apps.data_interfaces.interfaces import FormManagementMode
 from corehq.apps.data_interfaces.models import BulkAsyncJob
-from corehq.apps.data_interfaces.utils import SUCCEEDED, apply_form_action
 from corehq.apps.users.models import CouchUser
 from corehq.blobs import get_blob_db
 from corehq.blobs.atomic import AtomicBlobs
@@ -21,6 +23,17 @@ from corehq.form_processor.models import XFormInstance
 log = logging.getLogger(__name__)
 
 SAVE_EVERY = 100
+
+SUCCEEDED = 'succeeded'
+SKIPPED = 'skipped'
+
+
+@dataclass(frozen=True)
+class FormActionResult:
+    """Outcome of a bulk form action for a single requested form id."""
+    form_id: str
+    status: str  # SUCCEEDED | SKIPPED
+    reason: Optional[str] = None  # not_found | unexpected_error
 
 
 def create_bulk_form_job(domain, mode, requested_by, form_ids):
@@ -99,6 +112,37 @@ def run_bulk_form_action(job):
     job.status = BulkAsyncJob.Status.COMPLETE
     job.completed_at = datetime.now(tz=UTC)
     job.save()
+
+
+def apply_form_action(domain, form_ids, action_fn, validate=None):
+    """Apply ``action_fn`` to each form and yield a ``FormActionResult`` per id.
+
+    :param action_fn: callable taking an ``XFormInstance``
+    :param validate: optional callable taking an ``XFormInstance`` and returning
+        a skip reason (or ``None`` to proceed).
+    """
+    unresolved_ids = set(form_ids)
+    for xform in XFormInstance.objects.iter_forms(form_ids):
+        if xform.domain != domain:
+            # skip forms not belonging to the specified domain
+            continue
+        unresolved_ids.discard(xform.form_id)
+        reason = validate(xform) if validate else None
+        if reason:
+            yield FormActionResult(xform.form_id, SKIPPED, reason)
+            continue
+        try:
+            action_fn(xform)
+        except Exception:
+            notify_exception(None, "Error applying bulk form action", {
+                'domain': domain,
+                'form_id': xform.form_id,
+            })
+            yield FormActionResult(xform.form_id, SKIPPED, 'unexpected_error')
+        else:
+            yield FormActionResult(xform.form_id, SUCCEEDED)
+    for form_id in unresolved_ids:
+        yield FormActionResult(form_id, SKIPPED, 'not_found')
 
 
 def mark_job_failed(job_id):

--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -261,6 +261,13 @@ class FormManagementMode(object):
     def is_archive_mode(self):
         return self.mode_name == self.ARCHIVE_MODE
 
+    @classmethod
+    def bulk_action(cls, mode):
+        """Map a mode name to the corresponding ``BulkAsyncJob.Action``."""
+        from corehq.apps.data_interfaces.models import BulkAsyncJob
+        return (BulkAsyncJob.Action.UNARCHIVE if mode == cls.RESTORE_MODE
+                else BulkAsyncJob.Action.ARCHIVE)
+
 
 class ArchiveOrNormalFormFilter(BaseSingleOptionFilter):
     slug = 'archive_or_restore'

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1991,9 +1991,9 @@ class BulkAsyncJob(models.Model):
     def is_done(self):
         return self.status in (self.Status.COMPLETE, self.Status.FAILED)
 
-    def set_requested_ids(self, form_ids):
+    def set_requested_ids(self, form_ids, db=None):
         ids = sorted(set(form_ids))
-        self.requested_ids_blob_key = self._put_blob(ids)
+        self.requested_ids_blob_key = self._put_blob(ids, db=db)
         return ids
 
     def get_requested_ids(self):
@@ -2006,8 +2006,8 @@ class BulkAsyncJob(models.Model):
     def get_skipped(self):
         return self._get_blob(self.skipped_ids_blob_key)
 
-    def _put_blob(self, payload):
-        db = get_blob_db()
+    def _put_blob(self, payload, db=None):
+        db = db or get_blob_db()
         content = BytesIO(json.dumps(payload).encode("utf-8"))
         meta = db.put(
             content,

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1,10 +1,12 @@
 import csv
 import hashlib
+import json
 import operator
 import re
 import uuid
 from collections import defaultdict
 from datetime import date, datetime, time, timedelta
+from io import BytesIO
 
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
@@ -47,6 +49,7 @@ from corehq.apps.data_interfaces.utils import property_references_parent
 from corehq.apps.hqcase.utils import bulk_update_cases, update_case, AUTO_UPDATE_XMLNS, is_copied_case, resave_case
 from corehq.apps.users.util import SYSTEM_USER_ID, cached_owner_id_to_display
 from corehq.apps.users.cases import get_wrapped_owner
+from corehq.blobs import CODES, get_blob_db
 from corehq.form_processor.models import DEFAULT_PARENT_IDENTIFIER
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCaseIndex, CommCareCase, XFormInstance
@@ -1983,3 +1986,37 @@ class BulkAsyncJob(models.Model):
 
     class Meta:
         app_label = 'data_interfaces'
+
+    def set_requested_ids(self, form_ids):
+        ids = sorted(set(form_ids))
+        self.requested_ids_blob_key = self._put_blob(ids)
+        return ids
+
+    def get_requested_ids(self):
+        return self._get_blob(self.requested_ids_blob_key)
+
+    def set_skipped(self, grouped):
+        sorted_groups = {reason: sorted(ids) for reason, ids in grouped.items()}
+        self.skipped_ids_blob_key = self._put_blob(sorted_groups)
+
+    def get_skipped(self):
+        return self._get_blob(self.skipped_ids_blob_key)
+
+    def _put_blob(self, payload):
+        db = get_blob_db()
+        content = BytesIO(json.dumps(payload).encode("utf-8"))
+        meta = db.put(
+            content,
+            domain=self.domain,
+            parent_id=self.id.hex,
+            type_code=CODES.bulk_async_job,
+            key=uuid.uuid4().hex,
+        )
+        return meta.key
+
+    def _get_blob(self, key):
+        # Read through the BlobMeta to ensure content is decompressed.
+        db = get_blob_db()
+        meta = db.metadb.get(key=key, parent_id=self.id.hex)
+        with db.get(meta=meta) as stream:
+            return json.loads(stream.read())

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1987,6 +1987,10 @@ class BulkAsyncJob(models.Model):
     class Meta:
         app_label = 'data_interfaces'
 
+    @property
+    def is_done(self):
+        return self.status in (self.Status.COMPLETE, self.Status.FAILED)
+
     def set_requested_ids(self, form_ids):
         ids = sorted(set(form_ids))
         self.requested_ids_blob_key = self._put_blob(ids)

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -27,7 +27,11 @@ from corehq.toggles import DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK
 from corehq.util.celery_utils import no_result_task
 from corehq.util.log import send_HTML_email
 
-from .bulk_form_actions import mark_job_failed, run_bulk_form_action
+from .bulk_form_actions import (
+    create_bulk_form_job,
+    mark_job_failed,
+    run_bulk_form_action,
+)
 from .deduplication import backfill_deduplicate_rule, reset_deduplicate_rule
 from .models import (
     AutomaticUpdateRule,
@@ -105,6 +109,16 @@ def bulk_form_action_async(job_id, domain):
     except Exception:
         mark_job_failed(job_id)
         raise
+
+
+@task(serializer='pickle')
+def bulk_form_management_async(archive_or_restore, domain, couch_user, form_ids):
+    """Deprecated shim: drains messages queued under the old task name before
+    the BulkAsyncJob cutover. Reconstructs a job from the old pickle args and
+    hands off to bulk_form_action_async. Remove one release after deploy.
+    """
+    job = create_bulk_form_job(domain, archive_or_restore, couch_user.username, form_ids)
+    bulk_form_action_async.delay(job.id.hex, domain)
 
 
 @periodic_task(

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -4,7 +4,6 @@ from typing import List, Literal, Optional  # noqa: F401
 from django.conf import settings
 from django.core.cache import cache
 from django.template.loader import render_to_string
-from django.utils.translation import gettext as _
 
 from celery.schedules import crontab
 from celery.utils.log import get_task_logger
@@ -28,10 +27,11 @@ from corehq.toggles import DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK
 from corehq.util.celery_utils import no_result_task
 from corehq.util.log import send_HTML_email
 
+from .bulk_form_actions import mark_job_failed, run_bulk_form_action
 from .deduplication import backfill_deduplicate_rule, reset_deduplicate_rule
-from .interfaces import FormManagementMode
 from .models import (
     AutomaticUpdateRule,
+    BulkAsyncJob,
     CaseDuplicate,
     CaseDuplicateNew,
     CaseRuleSubmission,
@@ -39,7 +39,6 @@ from .models import (
 )
 from .utils import (
     add_cases_to_case_group,
-    archive_or_restore_forms,
     iter_cases_and_run_rules,
     operate_on_payloads,
     run_rules_for_case,
@@ -98,16 +97,14 @@ def bulk_upload_cases_to_group(upload_id, domain, case_group_id, cases):
     cache.set(upload_id, results, ONE_HOUR)
 
 
-@task(serializer='pickle')
-def bulk_form_management_async(archive_or_restore, domain, couch_user, form_ids):
-    task = bulk_form_management_async
-    mode = FormManagementMode(archive_or_restore, validate=True)
-
-    if not form_ids:
-        return {'messages': {'errors': [_('No Forms are supplied')]}}
-
-    response = archive_or_restore_forms(domain, couch_user.user_id, couch_user.username, form_ids, mode, task)
-    return response
+@serial_task('{domain}', default_retry_delay=300, max_retries=48, timeout=60 * 60)
+def bulk_form_action_async(job_id, domain):
+    try:
+        job = BulkAsyncJob.objects.get(id=job_id)
+        run_bulk_form_action(job)
+    except Exception:
+        mark_job_failed(job_id)
+        raise
 
 
 @periodic_task(

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -33,6 +33,7 @@ from .bulk_form_actions import (
     run_bulk_form_action,
 )
 from .deduplication import backfill_deduplicate_rule, reset_deduplicate_rule
+from .interfaces import FormManagementMode
 from .models import (
     AutomaticUpdateRule,
     BulkAsyncJob,
@@ -117,7 +118,8 @@ def bulk_form_management_async(archive_or_restore, domain, couch_user, form_ids)
     the BulkAsyncJob cutover. Reconstructs a job from the old pickle args and
     hands off to bulk_form_action_async. Remove one release after deploy.
     """
-    job = create_bulk_form_job(domain, archive_or_restore, couch_user.username, form_ids)
+    action = FormManagementMode.bulk_action(archive_or_restore)
+    job = create_bulk_form_job(domain, action, couch_user.username, form_ids)
     bulk_form_action_async.delay(job.id.hex, domain)
 
 

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/xform_management_status.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/xform_management_status.html
@@ -1,42 +1,61 @@
 {% load i18n %}
-{% if is_ready %}
+{% if legacy %}
   <div id="ready_{{ download_id }}">
-    <legend>{{ on_complete_short }}</legend>
-    {% block results %}
-      {% if result.success %}
-        <div class="alert alert-success">
-          <h4>{{ result.success_count_msg }}</h4>
-          {% if result.errors %}
-            {% for s in result.success %}
-              <p>{{ s }}</p>
-            {% endfor %}
-          {% endif %}
-        </div>
-        {% if result.errors %}
-          <div class="alert alert-danger">
-            <h3>{% trans "However, we ran into the following problems:" %}</h3>
-            {% for e in result.errors %}
-              <p>{{ e }}</p>
-            {% endfor %}
-          </div>
-        {% endif %}
-      {% else %}
-        <div class="alert alert-danger">
-          <h3>{{ mode.fail_text }}</h3>
-          {% for e in result.errors %}
-            <p>{{ e }}</p>
+    <div class="alert alert-info">
+      <p>
+        {% trans "This request is being processed. Return to Manage Forms to check for changes to your forms." %}
+      </p>
+    </div>
+  </div>
+{% elif is_done %}
+  <div id="ready_{{ download_id }}">
+    {% if has_failed %}
+      <div class="alert alert-danger">
+        <h3>{{ mode.fail_text }}</h3>
+        <p>{% trans "The job failed. Please try again." %}</p>
+      </div>
+    {% else %}
+      <legend>{{ on_complete_short }}</legend>
+      <div class="alert alert-success">
+        <h4>
+          {# prettier-ignore-start #}
+          {% blocktrans count counter=succeeded_count %}
+            {{ counter }} form processed successfully
+          {% plural %}
+            {{ counter }} forms processed successfully
+          {% endblocktrans %}
+          {# prettier-ignore-end #}
+        </h4>
+      </div>
+      {% if skipped %}
+        <div class="alert alert-warning">
+          <h3>{% trans "Some forms were skipped:" %}</h3>
+          {% for reason, ids in skipped.items %}
+            <p><strong>{{ reason }}</strong>: {{ ids|length }}</p>
           {% endfor %}
         </div>
       {% endif %}
-    {% endblock results %}
+    {% endif %}
   </div>
   <span>{{ mode.help_message }}</span>
   {% blocktrans %}
-    <span>Return to <a href="{{form_management_url}}">Manage Forms</a> to reverse this.</span>
+    <span
+      >Return to <a href="{{ form_management_url }}">Manage Forms</a> to reverse
+      this.</span
+    >
   {% endblocktrans %}
 {% else %}
-  <legend>
-    {{ mode.progress_text }}
-  </legend>
-  {% include 'soil/partials/download_in_progress.html' %}
+  <legend>{{ mode.progress_text }}</legend>
+  <div class="progress">
+    <div
+      class="progress-bar progress-bar-striped active"
+      role="progressbar"
+      aria-valuenow="{{ progress.percent }}"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      style="width: {{ progress.percent }}%"
+    >
+      {{ progress.percent }}%
+    </div>
+  </div>
 {% endif %}

--- a/corehq/apps/data_interfaces/tests/test_bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/tests/test_bulk_form_actions.py
@@ -1,0 +1,82 @@
+from django.test import TestCase
+
+from corehq.apps.data_interfaces.bulk_form_actions import (
+    build_form_action,
+    run_bulk_form_action,
+)
+from corehq.apps.data_interfaces.models import BulkAsyncJob
+from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
+from corehq.form_processor.models.forms import XFormInstance
+from corehq.form_processor.tests.utils import create_form_for_test, sharded
+
+DOMAIN = 'bulk-actions-test'
+
+
+class TestBuildFormAction(TestCase):
+
+    def _job(self, action):
+        return BulkAsyncJob(
+            domain=DOMAIN, model=XFormInstance, action=action, requested_by='u',
+        )
+
+    def test_archive_action(self):
+        form_action = build_form_action(self._job(BulkAsyncJob.Action.ARCHIVE), user_id='uid')
+        assert form_action.validate is None
+
+    def test_unarchive_action_validates_already_unarchived(self):
+        form_action = build_form_action(self._job(BulkAsyncJob.Action.UNARCHIVE), user_id='uid')
+        archived = create_form_for_test(DOMAIN, state=XFormInstance.ARCHIVED, save=False)
+        normal = create_form_for_test(DOMAIN, state=XFormInstance.NORMAL, save=False)
+        assert form_action.validate(archived) is None
+        assert form_action.validate(normal) == 'already_unarchived'
+
+
+@sharded
+class TestRunBulkFormAction(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.blob_db = TemporaryFilesystemBlobDB()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.blob_db.close()
+        super().tearDownClass()
+
+    def _job(self, action, form_ids):
+        job = BulkAsyncJob(
+            domain=DOMAIN, model=XFormInstance, action=action, requested_by='u',
+        )
+        stored = job.set_requested_ids(form_ids)
+        job.requested_count = len(stored)
+        job.save()
+        return job
+
+    def test_archive_marks_complete_and_counts(self):
+        form = create_form_for_test(DOMAIN, state=XFormInstance.NORMAL)
+        job = self._job(BulkAsyncJob.Action.ARCHIVE, [form.form_id])
+
+        run_bulk_form_action(job)
+
+        job.refresh_from_db()
+        assert job.status == BulkAsyncJob.Status.COMPLETE
+        assert job.started_at is not None and job.completed_at is not None
+        assert job.processed_count == 1
+        assert job.succeeded_count == 1
+        assert job.get_skipped() == {}
+        assert XFormInstance.objects.get_form(form.form_id, DOMAIN).is_archived
+
+    def test_missing_id_recorded_not_found(self):
+        job = self._job(BulkAsyncJob.Action.ARCHIVE, ['does-not-exist'])
+        run_bulk_form_action(job)
+        job.refresh_from_db()
+        assert job.succeeded_count == 0
+        assert job.get_skipped() == {'not_found': ['does-not-exist']}
+
+    def test_unarchive_skips_already_unarchived(self):
+        normal = create_form_for_test(DOMAIN, state=XFormInstance.NORMAL)
+        job = self._job(BulkAsyncJob.Action.UNARCHIVE, [normal.form_id])
+        run_bulk_form_action(job)
+        job.refresh_from_db()
+        assert job.get_skipped() == {'already_unarchived': [normal.form_id]}

--- a/corehq/apps/data_interfaces/tests/test_bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/tests/test_bulk_form_actions.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 
 from corehq.apps.data_interfaces.bulk_form_actions import (
     build_form_action,
+    mark_job_failed,
     run_bulk_form_action,
 )
 from corehq.apps.data_interfaces.models import BulkAsyncJob
@@ -80,3 +81,30 @@ class TestRunBulkFormAction(TestCase):
         run_bulk_form_action(job)
         job.refresh_from_db()
         assert job.get_skipped() == {'already_unarchived': [normal.form_id]}
+
+
+class TestMarkJobFailed(TestCase):
+
+    def _job(self, status):
+        job = BulkAsyncJob(
+            domain=DOMAIN, model=XFormInstance,
+            action=BulkAsyncJob.Action.ARCHIVE, requested_by='u', status=status,
+        )
+        job.save()
+        return job
+
+    def test_marks_pending_job_failed(self):
+        job = self._job(BulkAsyncJob.Status.PENDING)
+        mark_job_failed(job.id)
+        job.refresh_from_db()
+        assert job.status == BulkAsyncJob.Status.FAILED
+        assert job.completed_at is not None
+
+    def test_does_not_touch_completed_job(self):
+        job = self._job(BulkAsyncJob.Status.COMPLETE)
+        mark_job_failed(job.id)
+        job.refresh_from_db()
+        assert job.status == BulkAsyncJob.Status.COMPLETE
+
+    def test_missing_job_is_noop(self):
+        mark_job_failed('00000000-0000-0000-0000-000000000000')  # no error

--- a/corehq/apps/data_interfaces/tests/test_bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/tests/test_bulk_form_actions.py
@@ -1,6 +1,12 @@
-from django.test import TestCase
+from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase, TestCase
 
 from corehq.apps.data_interfaces.bulk_form_actions import (
+    SKIPPED,
+    SUCCEEDED,
+    FormActionResult,
+    apply_form_action,
     build_form_action,
     mark_job_failed,
     run_bulk_form_action,
@@ -108,3 +114,79 @@ class TestMarkJobFailed(TestCase):
 
     def test_missing_job_is_noop(self):
         mark_job_failed('00000000-0000-0000-0000-000000000000')  # no error
+
+
+class TestApplyFormAction(SimpleTestCase):
+
+    def _patched_apply_form_action(self, form_ids, forms, action_fn=None, validate=None):
+        action_fn = action_fn or (lambda xform: None)
+        with patch(
+            'corehq.apps.data_interfaces.bulk_form_actions.XFormInstance.objects.iter_forms',
+            return_value=forms,
+        ):
+            return list(apply_form_action(DOMAIN, form_ids, action_fn, validate=validate))
+
+    def test_empty_form_ids(self):
+        assert self._patched_apply_form_action([], []) == []
+
+    def test_success(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+        calls = []
+        results = self._patched_apply_form_action(
+            ['f1'], [form], action_fn=calls.append
+        )
+        assert calls == [form]
+        assert results == [FormActionResult('f1', SUCCEEDED)]
+
+    def test_missing_is_not_found(self):
+        results = self._patched_apply_form_action(['missing'], [])
+        assert results == [FormActionResult('missing', SKIPPED, 'not_found')]
+
+    def test_wrong_domain_is_not_found(self):
+        form = Mock(form_id='f1', domain='other-domain')
+        called = []
+        results = self._patched_apply_form_action(
+            ['f1'], [form], action_fn=called.append
+        )
+        assert called == []  # action not applied to out-of-domain forms
+        assert results == [FormActionResult('f1', SKIPPED, 'not_found')]
+
+    def test_exception_is_unexpected_error(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+
+        def unexpected_error(xform):
+            raise Exception('error')
+
+        with patch(
+            'corehq.apps.data_interfaces.bulk_form_actions.notify_exception'
+        ) as notify:
+            results = self._patched_apply_form_action(
+                ['f1'], [form], action_fn=unexpected_error
+            )
+        assert results == [FormActionResult('f1', SKIPPED, 'unexpected_error')]
+        notify.assert_called_once()
+
+    def test_mixed_results(self):
+        found = Mock(form_id='f1', domain=DOMAIN)
+        results = self._patched_apply_form_action(['f1', 'missing'], [found])
+        assert results == [
+            FormActionResult('f1', SUCCEEDED),
+            FormActionResult('missing', SKIPPED, 'not_found'),
+        ]
+
+    def test_validate_skip_reason(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+        acted = []
+        results = self._patched_apply_form_action(
+            ['f1'], [form], action_fn=acted.append,
+            validate=lambda f: 'not_archived',
+        )
+        assert acted == []  # validation skip means action is never applied
+        assert results == [FormActionResult('f1', SKIPPED, 'not_archived')]
+
+    def test_validate_pass_runs_action(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+        results = self._patched_apply_form_action(
+            ['f1'], [form], action_fn=lambda f: None, validate=lambda f: None,
+        )
+        assert results == [FormActionResult('f1', SUCCEEDED)]

--- a/corehq/apps/data_interfaces/tests/test_bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/tests/test_bulk_form_actions.py
@@ -5,8 +5,9 @@ from django.test import SimpleTestCase, TestCase
 from corehq.apps.data_interfaces.bulk_form_actions import (
     SKIPPED,
     SUCCEEDED,
+    FormAction,
     FormActionResult,
-    apply_form_action,
+    _apply_form_action,
     build_form_action,
     mark_job_failed,
     run_bulk_form_action,
@@ -118,36 +119,31 @@ class TestMarkJobFailed(TestCase):
 
 class TestApplyFormAction(SimpleTestCase):
 
-    def _patched_apply_form_action(self, form_ids, forms, action_fn=None, validate=None):
-        action_fn = action_fn or (lambda xform: None)
+    def _patched_apply_form_action(self, form_ids, forms, form_action):
         with patch(
             'corehq.apps.data_interfaces.bulk_form_actions.XFormInstance.objects.iter_forms',
             return_value=forms,
         ):
-            return list(apply_form_action(DOMAIN, form_ids, action_fn, validate=validate))
+            return list(_apply_form_action(DOMAIN, form_ids, form_action))
 
     def test_empty_form_ids(self):
-        assert self._patched_apply_form_action([], []) == []
+        assert self._patched_apply_form_action([], [], FormAction(run=lambda f: None)) == []
 
     def test_success(self):
         form = Mock(form_id='f1', domain=DOMAIN)
         calls = []
-        results = self._patched_apply_form_action(
-            ['f1'], [form], action_fn=calls.append
-        )
+        results = self._patched_apply_form_action(['f1'], [form], FormAction(run=calls.append))
         assert calls == [form]
         assert results == [FormActionResult('f1', SUCCEEDED)]
 
     def test_missing_is_not_found(self):
-        results = self._patched_apply_form_action(['missing'], [])
+        results = self._patched_apply_form_action(['missing'], [], FormAction(run=lambda f: None))
         assert results == [FormActionResult('missing', SKIPPED, 'not_found')]
 
     def test_wrong_domain_is_not_found(self):
         form = Mock(form_id='f1', domain='other-domain')
         called = []
-        results = self._patched_apply_form_action(
-            ['f1'], [form], action_fn=called.append
-        )
+        results = self._patched_apply_form_action(['f1'], [form], FormAction(run=called.append))
         assert called == []  # action not applied to out-of-domain forms
         assert results == [FormActionResult('f1', SKIPPED, 'not_found')]
 
@@ -160,15 +156,13 @@ class TestApplyFormAction(SimpleTestCase):
         with patch(
             'corehq.apps.data_interfaces.bulk_form_actions.notify_exception'
         ) as notify:
-            results = self._patched_apply_form_action(
-                ['f1'], [form], action_fn=unexpected_error
-            )
+            results = self._patched_apply_form_action(['f1'], [form], FormAction(run=unexpected_error))
         assert results == [FormActionResult('f1', SKIPPED, 'unexpected_error')]
         notify.assert_called_once()
 
     def test_mixed_results(self):
         found = Mock(form_id='f1', domain=DOMAIN)
-        results = self._patched_apply_form_action(['f1', 'missing'], [found])
+        results = self._patched_apply_form_action(['f1', 'missing'], [found], FormAction(run=lambda f: None))
         assert results == [
             FormActionResult('f1', SUCCEEDED),
             FormActionResult('missing', SKIPPED, 'not_found'),
@@ -178,8 +172,8 @@ class TestApplyFormAction(SimpleTestCase):
         form = Mock(form_id='f1', domain=DOMAIN)
         acted = []
         results = self._patched_apply_form_action(
-            ['f1'], [form], action_fn=acted.append,
-            validate=lambda f: 'not_archived',
+            ['f1'], [form],
+            FormAction(run=acted.append, validate=lambda f: 'not_archived'),
         )
         assert acted == []  # validation skip means action is never applied
         assert results == [FormActionResult('f1', SKIPPED, 'not_archived')]
@@ -187,6 +181,6 @@ class TestApplyFormAction(SimpleTestCase):
     def test_validate_pass_runs_action(self):
         form = Mock(form_id='f1', domain=DOMAIN)
         results = self._patched_apply_form_action(
-            ['f1'], [form], action_fn=lambda f: None, validate=lambda f: None,
+            ['f1'], [form], FormAction(run=lambda f: None, validate=lambda f: None),
         )
         assert results == [FormActionResult('f1', SUCCEEDED)]

--- a/corehq/apps/data_interfaces/tests/test_models.py
+++ b/corehq/apps/data_interfaces/tests/test_models.py
@@ -5,6 +5,7 @@ from django.test import SimpleTestCase, TestCase
 
 from corehq.apps.data_interfaces.models import (
     AutomaticUpdateRule,
+    BulkAsyncJob,
     CaseDeduplicationActionDefinition,
     CaseRuleAction,
     CaseRuleCriteria,
@@ -24,7 +25,9 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.models import LocationType, SQLLocation
 from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
 from corehq.form_processor.models.cases import CommCareCase
+from corehq.form_processor.models.forms import XFormInstance
 
 from corehq.apps.data_interfaces.tests.deduplication_helpers import create_dedupe_rule
 
@@ -644,3 +647,32 @@ def create_dict_mock(class_, data):
     obj = class_()
     patch.object(obj, 'to_dict', lambda: data).start()
     return obj
+
+
+class TestBulkAsyncJobBlobs(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.blob_db = TemporaryFilesystemBlobDB()
+        cls.addClassCleanup(cls.blob_db.close)
+
+    def _job(self):
+        return BulkAsyncJob(
+            domain='test-domain',
+            model=XFormInstance,
+            action=BulkAsyncJob.Action.ARCHIVE,
+            requested_by='someone',
+        )
+
+    def test_requested_ids_round_trip_dedups_and_sorts(self):
+        job = self._job()
+        stored = job.set_requested_ids(['c', 'a', 'b', 'a'])
+        assert stored == ['a', 'b', 'c']
+        assert job.requested_ids_blob_key
+        assert job.get_requested_ids() == ['a', 'b', 'c']
+
+    def test_skipped_round_trip_sorts_each_group(self):
+        job = self._job()
+        job.set_skipped({'not_found': ['z', 'a'], 'not_archived': ['n', 'm']})
+        assert job.get_skipped() == {'not_found': ['a', 'z'], 'not_archived': ['m', 'n']}

--- a/corehq/apps/data_interfaces/tests/test_models.py
+++ b/corehq/apps/data_interfaces/tests/test_models.py
@@ -676,3 +676,20 @@ class TestBulkAsyncJobBlobs(TestCase):
         job = self._job()
         job.set_skipped({'not_found': ['z', 'a'], 'not_archived': ['n', 'm']})
         assert job.get_skipped() == {'not_found': ['a', 'z'], 'not_archived': ['m', 'n']}
+
+
+class TestBulkAsyncJobModelField(TestCase):
+
+    def test_survives_update_after_insert(self):
+        # Regression: the model= ModelClassField column made the worker's
+        # second save (an UPDATE) raise TypeError. See ModelClassField.pre_save.
+        job = BulkAsyncJob.objects.create(
+            domain='test-domain',
+            model=XFormInstance,
+            action=BulkAsyncJob.Action.ARCHIVE,
+            requested_by='someone',
+        )
+        job.status = BulkAsyncJob.Status.RUNNING
+        job.save()
+        job.refresh_from_db()
+        assert job.model is XFormInstance

--- a/corehq/apps/data_interfaces/tests/test_models.py
+++ b/corehq/apps/data_interfaces/tests/test_models.py
@@ -693,3 +693,20 @@ class TestBulkAsyncJobModelField(TestCase):
         job.save()
         job.refresh_from_db()
         assert job.model is XFormInstance
+
+
+class TestBulkAsyncJobIsDone(SimpleTestCase):
+
+    def _job(self, status):
+        return BulkAsyncJob(
+            domain='test-domain', model=XFormInstance,
+            action=BulkAsyncJob.Action.ARCHIVE, requested_by='u', status=status,
+        )
+
+    def test_terminal_statuses_are_done(self):
+        assert self._job(BulkAsyncJob.Status.COMPLETE).is_done
+        assert self._job(BulkAsyncJob.Status.FAILED).is_done
+
+    def test_non_terminal_statuses_are_not_done(self):
+        assert not self._job(BulkAsyncJob.Status.PENDING).is_done
+        assert not self._job(BulkAsyncJob.Status.RUNNING).is_done

--- a/corehq/apps/data_interfaces/tests/test_tasks.py
+++ b/corehq/apps/data_interfaces/tests/test_tasks.py
@@ -1,10 +1,16 @@
-from django.test import SimpleTestCase
 from unittest.mock import patch
 
+from django.test import SimpleTestCase, TestCase
+
+from corehq.apps.data_interfaces.models import BulkAsyncJob
 from corehq.apps.data_interfaces.tasks import (
+    bulk_form_action_async,
     task_generate_ids_and_operate_on_payloads,
     task_operate_on_payloads,
 )
+from corehq.form_processor.models.forms import XFormInstance
+
+TASK_DOMAIN = 'bulk-task-test'
 
 
 class TestTasks(SimpleTestCase):
@@ -82,3 +88,33 @@ class TestTasks(SimpleTestCase):
         )
         self.assertEqual(response,
                          {'messages': {'errors': ['No payloads specified']}})
+
+
+class TestBulkFormActionAsync(TestCase):
+
+    def _job(self):
+        job = BulkAsyncJob(
+            domain=TASK_DOMAIN, model=XFormInstance,
+            action=BulkAsyncJob.Action.ARCHIVE, requested_by='u',
+        )
+        job.save()
+        return job
+
+    def test_task_runs_job(self):
+        job = self._job()
+        with patch(
+            'corehq.apps.data_interfaces.tasks.run_bulk_form_action'
+        ) as mock_run:
+            bulk_form_action_async(str(job.id), TASK_DOMAIN)
+        assert mock_run.call_count == 1
+        assert mock_run.call_args[0][0].id == job.id
+
+    def test_task_marks_job_failed_on_error(self):
+        job = self._job()
+        with patch(
+            'corehq.apps.data_interfaces.tasks.run_bulk_form_action',
+            side_effect=ValueError('boom'),
+        ), self.assertRaises(ValueError):
+            bulk_form_action_async(str(job.id), TASK_DOMAIN)
+        job.refresh_from_db()
+        assert job.status == BulkAsyncJob.Status.FAILED

--- a/corehq/apps/data_interfaces/tests/test_tasks.py
+++ b/corehq/apps/data_interfaces/tests/test_tasks.py
@@ -5,9 +5,12 @@ from django.test import SimpleTestCase, TestCase
 from corehq.apps.data_interfaces.models import BulkAsyncJob
 from corehq.apps.data_interfaces.tasks import (
     bulk_form_action_async,
+    bulk_form_management_async,
     task_generate_ids_and_operate_on_payloads,
     task_operate_on_payloads,
 )
+from corehq.apps.users.models import WebUser
+from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
 from corehq.form_processor.models.forms import XFormInstance
 
 TASK_DOMAIN = 'bulk-task-test'
@@ -118,3 +121,24 @@ class TestBulkFormActionAsync(TestCase):
             bulk_form_action_async(str(job.id), TASK_DOMAIN)
         job.refresh_from_db()
         assert job.status == BulkAsyncJob.Status.FAILED
+
+
+class TestBulkFormManagementShim(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.blob_db = TemporaryFilesystemBlobDB()
+        cls.addClassCleanup(cls.blob_db.close)
+
+    def test_reroutes_legacy_message_to_new_task(self):
+        couch_user = WebUser(username='someone')
+        with patch(
+            'corehq.apps.data_interfaces.tasks.bulk_form_action_async.delay'
+        ) as mock_delay:
+            bulk_form_management_async('archive', TASK_DOMAIN, couch_user, ['form-1', 'form-2'])
+        job = BulkAsyncJob.objects.get(domain=TASK_DOMAIN)
+        assert job.action == BulkAsyncJob.Action.ARCHIVE
+        assert job.requested_count == 2
+        assert job.get_requested_ids() == ['form-1', 'form-2']
+        mock_delay.assert_called_once_with(job.id.hex, TASK_DOMAIN)

--- a/corehq/apps/data_interfaces/tests/test_utils.py
+++ b/corehq/apps/data_interfaces/tests/test_utils.py
@@ -2,14 +2,12 @@ from unittest.mock import Mock, patch
 
 from django.test import SimpleTestCase, TestCase
 
-from corehq.apps.data_interfaces.interfaces import FormManagementMode
 from corehq.apps.data_interfaces.tasks import task_generate_ids_and_operate_on_payloads
 from corehq.apps.data_interfaces.utils import (
     SKIPPED,
     SUCCEEDED,
     FormActionResult,
     apply_form_action,
-    archive_or_restore_forms,
     operate_on_payloads,
 )
 
@@ -419,99 +417,6 @@ class TestTasks(TestCase):
         self.assertEqual(mock_payload_one.requeue.call_count, 1)
         self.assertEqual(mock_payload_two.requeue.call_count, 0)
         self.assertEqual(response, expected_response)
-
-
-class TestArchiveOrRestoreForms(SimpleTestCase):
-    """Only intended to test how archive_or_restore_forms behaves"""
-
-    USER_ID = 'user-id'
-    USERNAME = 'user@example.com'
-
-    def _archive_mode(self):
-        return FormManagementMode(FormManagementMode.ARCHIVE_MODE)
-
-    def _restore_mode(self):
-        return FormManagementMode(FormManagementMode.RESTORE_MODE)
-
-    def _patched_archive_or_restore_forms(
-        self, mode, form_ids, forms, **kwargs
-    ):
-        with patch(
-            'corehq.apps.data_interfaces.utils.XFormInstance.objects.iter_forms',
-            return_value=forms,
-        ):
-            return archive_or_restore_forms(
-                DOMAIN, self.USER_ID, self.USERNAME, form_ids, mode, **kwargs
-            )
-
-    def test_archive_success(self):
-        form = Mock(form_id='f1', domain=DOMAIN)
-        result = self._patched_archive_or_restore_forms(
-            self._archive_mode(), ['f1'], [form]
-        )
-        form.archive.assert_called_once_with(user_id=self.USER_ID)
-        messages = result['messages']
-        assert messages['errors'] == []
-        assert messages['success'] == [
-            "Successfully archived XForm f1 for domain test-domain "
-            "by user 'user@example.com'"
-        ]
-        assert messages['success_count_msg'] == 'Successfully archived  1 form(s)'
-
-    def test_restore_success(self):
-        form = Mock(form_id='f1', domain=DOMAIN)
-        result = self._patched_archive_or_restore_forms(
-            self._restore_mode(), ['f1'], [form]
-        )
-        form.unarchive.assert_called_once_with(user_id=self.USER_ID)
-        messages = result['messages']
-        assert messages['success'] == [
-            "Successfully unarchived XForm f1 for domain test-domain "
-            "by user 'user@example.com'"
-        ]
-        assert messages['success_count_msg'] == 'Successfully restored  1 form(s)'
-
-    def test_missing_form_reported_not_found(self):
-        result = self._patched_archive_or_restore_forms(
-            self._archive_mode(), ['missing'], []
-        )
-        assert result['messages']['errors'] == ["Could not find XForm missing"]
-        assert result['messages']['success'] == []
-
-    def test_wrong_domain_reports_not_found(self):
-        form = Mock(form_id='f1', domain='other-domain')
-        result = self._patched_archive_or_restore_forms(
-            self._archive_mode(), ['f1'], [form]
-        )
-        form.archive.assert_not_called()
-        assert result['messages']['errors'] == ["Could not find XForm f1"]
-
-    def test_action_exception_reported(self):
-        form = Mock(form_id='f1', domain=DOMAIN)
-        form.archive.side_effect = Exception('error')
-        with patch('corehq.apps.data_interfaces.utils.notify_exception') as notify:
-            result = self._patched_archive_or_restore_forms(
-                self._archive_mode(), ['f1'], [form]
-            )
-        notify.assert_called_once()
-        assert result['messages']['errors'] == [
-            "Could not archive XForm f1 for domain test-domain "
-            "by user 'user@example.com'"
-        ]
-        assert result['messages']['success'] == []
-
-    def test_from_excel_returns_raw_response(self):
-        form = Mock(form_id='f1', domain=DOMAIN)
-        result = self._patched_archive_or_restore_forms(
-            self._archive_mode(), ['f1'], [form], from_excel=True
-        )
-        assert 'messages' not in result
-        assert 'success_count_msg' not in result
-        assert result['success'] == [
-            "Successfully archived XForm f1 for domain test-domain "
-            "by user 'user@example.com'"
-        ]
-        assert result['errors'] == []
 
 
 class TestApplyFormAction(SimpleTestCase):

--- a/corehq/apps/data_interfaces/tests/test_utils.py
+++ b/corehq/apps/data_interfaces/tests/test_utils.py
@@ -1,18 +1,9 @@
 from unittest.mock import Mock, patch
 
-from django.test import SimpleTestCase, TestCase
+from django.test import TestCase
 
 from corehq.apps.data_interfaces.tasks import task_generate_ids_and_operate_on_payloads
-from corehq.apps.data_interfaces.utils import (
-    SKIPPED,
-    SUCCEEDED,
-    FormActionResult,
-    apply_form_action,
-    operate_on_payloads,
-)
-
-
-DOMAIN = 'test-domain'
+from corehq.apps.data_interfaces.utils import operate_on_payloads
 
 
 class TestTasks(TestCase):
@@ -417,79 +408,3 @@ class TestTasks(TestCase):
         self.assertEqual(mock_payload_one.requeue.call_count, 1)
         self.assertEqual(mock_payload_two.requeue.call_count, 0)
         self.assertEqual(response, expected_response)
-
-
-class TestApplyFormAction(SimpleTestCase):
-
-    def _patched_apply_form_action(self, form_ids, forms, action_fn=None, validate=None):
-        action_fn = action_fn or (lambda xform: None)
-        with patch(
-            'corehq.apps.data_interfaces.utils.XFormInstance.objects.iter_forms',
-            return_value=forms,
-        ):
-            return list(apply_form_action(DOMAIN, form_ids, action_fn, validate=validate))
-
-    def test_empty_form_ids(self):
-        assert self._patched_apply_form_action([], []) == []
-
-    def test_success(self):
-        form = Mock(form_id='f1', domain=DOMAIN)
-        calls = []
-        results = self._patched_apply_form_action(
-            ['f1'], [form], action_fn=calls.append
-        )
-        assert calls == [form]
-        assert results == [FormActionResult('f1', SUCCEEDED)]
-
-    def test_missing_is_not_found(self):
-        results = self._patched_apply_form_action(['missing'], [])
-        assert results == [FormActionResult('missing', SKIPPED, 'not_found')]
-
-    def test_wrong_domain_is_not_found(self):
-        form = Mock(form_id='f1', domain='other-domain')
-        called = []
-        results = self._patched_apply_form_action(
-            ['f1'], [form], action_fn=called.append
-        )
-        assert called == []  # action not applied to out-of-domain forms
-        assert results == [FormActionResult('f1', SKIPPED, 'not_found')]
-
-    def test_exception_is_unexpected_error(self):
-        form = Mock(form_id='f1', domain=DOMAIN)
-
-        def unexpected_error(xform):
-            raise Exception('error')
-
-        with patch(
-            'corehq.apps.data_interfaces.utils.notify_exception'
-        ) as notify:
-            results = self._patched_apply_form_action(
-                ['f1'], [form], action_fn=unexpected_error
-            )
-        assert results == [FormActionResult('f1', SKIPPED, 'unexpected_error')]
-        notify.assert_called_once()
-
-    def test_mixed_results(self):
-        found = Mock(form_id='f1', domain=DOMAIN)
-        results = self._patched_apply_form_action(['f1', 'missing'], [found])
-        assert results == [
-            FormActionResult('f1', SUCCEEDED),
-            FormActionResult('missing', SKIPPED, 'not_found'),
-        ]
-
-    def test_validate_skip_reason(self):
-        form = Mock(form_id='f1', domain=DOMAIN)
-        acted = []
-        results = self._patched_apply_form_action(
-            ['f1'], [form], action_fn=acted.append,
-            validate=lambda f: 'not_archived',
-        )
-        assert acted == []  # validation skip means action is never applied
-        assert results == [FormActionResult('f1', SKIPPED, 'not_archived')]
-
-    def test_validate_pass_runs_action(self):
-        form = Mock(form_id='f1', domain=DOMAIN)
-        results = self._patched_apply_form_action(
-            ['f1'], [form], action_fn=lambda f: None, validate=lambda f: None,
-        )
-        assert results == [FormActionResult('f1', SUCCEEDED)]

--- a/corehq/apps/data_interfaces/tests/test_utils.py
+++ b/corehq/apps/data_interfaces/tests/test_utils.py
@@ -516,13 +516,13 @@ class TestArchiveOrRestoreForms(SimpleTestCase):
 
 class TestApplyFormAction(SimpleTestCase):
 
-    def _patched_apply_form_action(self, form_ids, forms, action_fn=None):
+    def _patched_apply_form_action(self, form_ids, forms, action_fn=None, validate=None):
         action_fn = action_fn or (lambda xform: None)
         with patch(
             'corehq.apps.data_interfaces.utils.XFormInstance.objects.iter_forms',
             return_value=forms,
         ):
-            return list(apply_form_action(DOMAIN, form_ids, action_fn))
+            return list(apply_form_action(DOMAIN, form_ids, action_fn, validate=validate))
 
     def test_empty_form_ids(self):
         assert self._patched_apply_form_action([], []) == []
@@ -571,3 +571,20 @@ class TestApplyFormAction(SimpleTestCase):
             FormActionResult('f1', SUCCEEDED),
             FormActionResult('missing', SKIPPED, 'not_found'),
         ]
+
+    def test_validate_skip_reason(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+        acted = []
+        results = self._patched_apply_form_action(
+            ['f1'], [form], action_fn=acted.append,
+            validate=lambda f: 'not_archived',
+        )
+        assert acted == []  # validation skip means action is never applied
+        assert results == [FormActionResult('f1', SKIPPED, 'not_archived')]
+
+    def test_validate_pass_runs_action(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+        results = self._patched_apply_form_action(
+            ['f1'], [form], action_fn=lambda f: None, validate=lambda f: None,
+        )
+        assert results == [FormActionResult('f1', SUCCEEDED)]

--- a/corehq/apps/data_interfaces/tests/test_views.py
+++ b/corehq/apps/data_interfaces/tests/test_views.py
@@ -1,11 +1,14 @@
 from unittest.mock import patch
 
+from django.template.loader import render_to_string
 from django.test import RequestFactory, TestCase, override_settings
+from django.urls import reverse
 
 from django_prbac.models import Grant, Role
 
 from corehq import privileges
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
+from corehq.apps.data_interfaces.interfaces import FormManagementMode
 from corehq.apps.data_interfaces.models import (
     AutomaticUpdateRule,
     BulkAsyncJob,
@@ -16,6 +19,8 @@ from corehq.apps.data_interfaces.views import (
     AutomaticUpdateRuleListView,
     DeduplicationRuleCreateView,
     XFormManagementView,
+    _job_percent,
+    _xform_management_job_context,
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
@@ -146,6 +151,98 @@ class XFormManagementPostTests(TestCase):
 
         assert response.status_code == 400
         assert not BulkAsyncJob.objects.filter(domain=self.domain).exists()
+
+
+class XFormManagementJobPollTests(TestCase):
+
+    TEMPLATE = 'data_interfaces/partials/xform_management_status.html'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'xform-poll-test'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+        cls.blob_db = TemporaryFilesystemBlobDB()
+        cls.addClassCleanup(cls.blob_db.close)
+
+    def _job(self, **kw):
+        defaults = dict(domain=self.domain, model=XFormInstance,
+                        action=BulkAsyncJob.Action.ARCHIVE, requested_by='u')
+        defaults.update(kw)
+        return BulkAsyncJob(**defaults)
+
+    def test_job_percent_zero_when_nothing_requested(self):
+        assert _job_percent(self._job(requested_count=0)) == 0
+
+    def test_job_percent_ratio(self):
+        assert _job_percent(self._job(requested_count=4, processed_count=1)) == 25
+
+    def test_context_running(self):
+        job = self._job(status=BulkAsyncJob.Status.RUNNING,
+                        requested_count=4, processed_count=1)
+        ctx = _xform_management_job_context(job, FormManagementMode('archive'))
+        assert ctx['is_done'] is False
+        assert ctx['has_failed'] is False
+        assert ctx['progress']['percent'] == 25
+        assert ctx['download_id'] == job.id.hex
+
+    def test_context_complete_reads_skipped(self):
+        job = self._job(status=BulkAsyncJob.Status.COMPLETE, requested_count=2,
+                        processed_count=2, succeeded_count=1)
+        job.set_skipped({'not_found': ['a']})
+        ctx = _xform_management_job_context(job, FormManagementMode('archive'))
+        assert ctx['is_done'] is True
+        assert ctx['has_failed'] is False
+        assert ctx['succeeded_count'] == 1
+        assert ctx['skipped'] == {'not_found': ['a']}
+
+    def test_context_failed_has_no_skipped(self):
+        job = self._job(status=BulkAsyncJob.Status.FAILED, requested_count=2)
+        ctx = _xform_management_job_context(job, FormManagementMode('archive'))
+        assert ctx['is_done'] is True
+        assert ctx['has_failed'] is True
+        assert ctx['skipped'] == {}
+
+    def test_template_running_shows_percent_not_ready(self):
+        job = self._job(status=BulkAsyncJob.Status.RUNNING,
+                        requested_count=4, processed_count=1)
+        ctx = _xform_management_job_context(job, FormManagementMode('archive'))
+        html = render_to_string(self.TEMPLATE, ctx)
+        assert 'ready_' not in html
+        assert '25%' in html
+
+    def test_template_complete_shows_ready_sentinel_and_counts(self):
+        job = self._job(status=BulkAsyncJob.Status.COMPLETE, requested_count=2,
+                        processed_count=2, succeeded_count=2)
+        job.set_skipped({})
+        ctx = _xform_management_job_context(job, FormManagementMode('archive'))
+        html = render_to_string(self.TEMPLATE, ctx)
+        assert f'ready_{job.id.hex}' in html
+        assert '2 forms processed successfully' in html
+
+    def test_template_legacy_id_shows_processing_message(self):
+        html = render_to_string(self.TEMPLATE, {'legacy': True, 'download_id': 'dl-abc123'})
+        assert 'ready_dl-abc123' in html   # sentinel so polling stops
+        assert 'being processed' in html
+
+    def test_job_lookup_is_scoped_to_domain(self):
+        job = self._job()
+        job.save()
+        assert BulkAsyncJob.objects.filter(id=job.id, domain=self.domain).exists()
+        assert not BulkAsyncJob.objects.filter(id=job.id, domain='another-domain').exists()
+
+    def test_poll_requires_authentication(self):
+        # A RUNNING job would render 200 if the view body were reached, so an
+        # unauthenticated request being redirected proves the auth decorators
+        # are applied to the poll view.
+        job = self._job(status=BulkAsyncJob.Status.RUNNING,
+                        requested_count=4, processed_count=1)
+        job.save()
+        url = reverse('xform_management_job_poll', args=[self.domain, job.id.hex])
+        response = self.client.get(url, {'mode': 'archive'})
+        assert response.status_code == 302
+        assert '/login/' in response['Location']
 
 
 class DeduplicationRuleCreateViewTests(TestCase):

--- a/corehq/apps/data_interfaces/tests/test_views.py
+++ b/corehq/apps/data_interfaces/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import RequestFactory, TestCase, override_settings
 
 from django_prbac.models import Grant, Role
@@ -6,15 +8,19 @@ from corehq import privileges
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.apps.data_interfaces.models import (
     AutomaticUpdateRule,
+    BulkAsyncJob,
     CaseRuleAction,
     UpdateCaseDefinition,
 )
 from corehq.apps.data_interfaces.views import (
     AutomaticUpdateRuleListView,
     DeduplicationRuleCreateView,
+    XFormManagementView,
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
+from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
+from corehq.form_processor.models import XFormInstance
 
 
 @override_settings(REQUIRE_TWO_FACTOR_FOR_SUPERUSERS=False)
@@ -89,6 +95,57 @@ class AutomaticUpdateRuleListViewTests(TestCase):
         request.user = self.user
         request.role = self.test_role
         return request
+
+
+class XFormManagementPostTests(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'xform-mgmt-test'
+        cls.blob_db = TemporaryFilesystemBlobDB()
+        cls.addClassCleanup(cls.blob_db.close)
+
+    def test_post_creates_job_and_enqueues(self):
+        request = RequestFactory().post(
+            '/x', {'mode': 'archive', 'xform_ids': ['form-1', 'form-2']})
+        request.couch_user = WebUser(username='someone')
+        request.can_access_all_locations = True
+
+        view = XFormManagementView()
+        view.request = request
+        view.args = ()
+        view.kwargs = {'domain': self.domain}
+
+        with patch(
+            'corehq.apps.data_interfaces.views.bulk_form_action_async.delay'
+        ) as mock_delay:
+            response = view.post(request)
+
+        assert response.status_code == 302
+        job = BulkAsyncJob.objects.get(domain=self.domain)
+        assert job.model is XFormInstance
+        assert job.action == BulkAsyncJob.Action.ARCHIVE
+        assert job.requested_count == 2
+        assert job.get_requested_ids() == ['form-1', 'form-2']
+        mock_delay.assert_called_once_with(job.id.hex, self.domain)
+        # the redirect (poll) url includes the job id
+        assert job.id.hex in response['Location']
+
+    def test_post_with_no_forms_is_rejected(self):
+        request = RequestFactory().post('/x', {'mode': 'archive'})
+        request.couch_user = WebUser(username='someone')
+        request.can_access_all_locations = True
+
+        view = XFormManagementView()
+        view.request = request
+        view.args = ()
+        view.kwargs = {'domain': self.domain}
+
+        response = view.post(request)
+
+        assert response.status_code == 400
+        assert not BulkAsyncJob.objects.filter(domain=self.domain).exists()
 
 
 class DeduplicationRuleCreateViewTests(TestCase):

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -76,10 +76,12 @@ class FormActionResult:
     reason: Optional[str] = None  # not_found | unexpected_error
 
 
-def apply_form_action(domain, form_ids, action_fn):
+def apply_form_action(domain, form_ids, action_fn, validate=None):
     """Apply ``action_fn`` to each form and yield a ``FormActionResult`` per id.
 
     :param action_fn: callable taking an ``XFormInstance``
+    :param validate: optional callable taking an ``XFormInstance`` and returning
+        a skip reason (or ``None`` to proceed).
     """
     unresolved_ids = set(form_ids)
     for xform in XFormInstance.objects.iter_forms(form_ids):
@@ -87,6 +89,10 @@ def apply_form_action(domain, form_ids, action_fn):
             # skip forms not belonging to the specified domain
             continue
         unresolved_ids.discard(xform.form_id)
+        reason = validate(xform) if validate else None
+        if reason:
+            yield FormActionResult(xform.form_id, SKIPPED, reason)
+            continue
         try:
             action_fn(xform)
         except Exception:

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -107,60 +107,6 @@ def apply_form_action(domain, form_ids, action_fn, validate=None):
         yield FormActionResult(form_id, SKIPPED, 'not_found')
 
 
-def archive_or_restore_forms(domain, user_id, username, form_ids, archive_or_restore, task=None, from_excel=False):
-    response = {
-        'errors': [],
-        'success': [],
-    }
-    is_archive = archive_or_restore.is_archive_mode()
-
-    def action_fn(xform):
-        if is_archive:
-            xform.archive(user_id=user_id)
-        else:
-            xform.unarchive(user_id=user_id)
-
-    success_count = 0
-    if task:
-        DownloadBase.set_progress(task, 0, len(form_ids))
-
-    for result in apply_form_action(domain, form_ids, action_fn):
-        if result.reason == 'not_found':
-            response['errors'].append(
-                _("Could not find XForm {form_id}").format(form_id=result.form_id))
-            continue
-
-        xform_string = _("XForm {form_id} for domain {domain} by user '{username}'").format(
-            form_id=result.form_id,
-            domain=domain,
-            username=username)
-
-        if result.status == SUCCEEDED:
-            if is_archive:
-                message = _("Successfully archived {form}").format(form=xform_string)
-            else:
-                message = _("Successfully unarchived {form}").format(form=xform_string)
-            response['success'].append(message)
-            success_count = success_count + 1
-        else:
-            if is_archive:
-                message = _("Could not archive {form}").format(form=xform_string)
-            else:
-                message = _("Could not unarchive {form}").format(form=xform_string)
-            response['errors'].append(message)
-
-        if task:
-            DownloadBase.set_progress(task, success_count, len(form_ids))
-
-    if from_excel:
-        return response
-
-    response["success_count_msg"] = _("{success_msg} {count} form(s)").format(
-        success_msg=archive_or_restore.success_text,
-        count=success_count)
-    return {"messages": response}
-
-
 def property_references_parent(case_property):
     return isinstance(case_property, str) and (
         case_property.startswith("parent/")

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import List, Optional
 
@@ -13,7 +12,7 @@ from soil import DownloadBase
 from corehq.apps.casegroups.models import CommCareCaseGroup
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
-from corehq.form_processor.models import CommCareCase, XFormInstance
+from corehq.form_processor.models import CommCareCase
 
 
 def add_cases_to_case_group(domain, case_group_id, uploaded_data, progress_tracker):
@@ -62,49 +61,6 @@ def add_cases_to_case_group(domain, case_group_id, uploaded_data, progress_track
         case_group.save()
 
     return response
-
-
-SUCCEEDED = 'succeeded'
-SKIPPED = 'skipped'
-
-
-@dataclass(frozen=True)
-class FormActionResult:
-    """Outcome of a bulk form action for a single requested form id."""
-    form_id: str
-    status: str  # SUCCEEDED | SKIPPED
-    reason: Optional[str] = None  # not_found | unexpected_error
-
-
-def apply_form_action(domain, form_ids, action_fn, validate=None):
-    """Apply ``action_fn`` to each form and yield a ``FormActionResult`` per id.
-
-    :param action_fn: callable taking an ``XFormInstance``
-    :param validate: optional callable taking an ``XFormInstance`` and returning
-        a skip reason (or ``None`` to proceed).
-    """
-    unresolved_ids = set(form_ids)
-    for xform in XFormInstance.objects.iter_forms(form_ids):
-        if xform.domain != domain:
-            # skip forms not belonging to the specified domain
-            continue
-        unresolved_ids.discard(xform.form_id)
-        reason = validate(xform) if validate else None
-        if reason:
-            yield FormActionResult(xform.form_id, SKIPPED, reason)
-            continue
-        try:
-            action_fn(xform)
-        except Exception:
-            notify_exception(None, "Error applying bulk form action", {
-                'domain': domain,
-                'form_id': xform.form_id,
-            })
-            yield FormActionResult(xform.form_id, SKIPPED, 'unexpected_error')
-        else:
-            yield FormActionResult(xform.form_id, SUCCEEDED)
-    for form_id in unresolved_ids:
-        yield FormActionResult(form_id, SKIPPED, 'not_found')
 
 
 def property_references_parent(case_property):

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -3,6 +3,7 @@ import uuid
 
 from django.contrib import messages
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.http import (
     Http404,
@@ -59,6 +60,7 @@ from corehq.apps.data_interfaces.forms import (
 from corehq.apps.data_interfaces.bulk_form_actions import create_bulk_form_job
 from corehq.apps.data_interfaces.models import (
     AutomaticUpdateRule,
+    BulkAsyncJob,
     CaseDeduplicationActionDefinition,
     CaseDuplicateNew,
     DomainCaseRuleRun,
@@ -555,19 +557,37 @@ class XFormManagementStatusView(DataInterfaceSection):
 @require_form_management_privilege
 def xform_management_job_poll(request, domain, download_id,
                               template="data_interfaces/partials/xform_management_status.html"):
-    mode = FormManagementMode(request.GET.get('mode'), validate=True)
     try:
-        context = get_download_context(download_id)
-    except TaskFailedError:
-        return HttpResponseServerError()
+        job = BulkAsyncJob.objects.get(id=download_id, domain=domain)
+    except (BulkAsyncJob.DoesNotExist, ValueError, ValidationError):
+        # A legacy soil download_id (pre-cutover, mid-deploy) isn't a valid
+        # job UUID. Render a terminal message so polling stops.
+        return render(request, template, {'legacy': True, 'download_id': download_id})
+    mode = FormManagementMode(request.GET.get('mode'), validate=True)
+    context = _xform_management_job_context(job, mode)
+    return render(request, template, context)
 
-    context.update({
+
+def _job_percent(job):
+    if not job.requested_count:
+        return 0
+    return int(100 * job.processed_count / job.requested_count)
+
+
+def _xform_management_job_context(job, mode):
+    """Build the soil-compatible poll context for ``job``."""
+    return {
+        'download_id': job.id.hex,
+        'is_done': job.is_done,
+        'has_failed': job.status == BulkAsyncJob.Status.FAILED,
+        'succeeded_count': job.succeeded_count,
+        'skipped': job.get_skipped() if job.is_done and job.skipped_ids_blob_key else {},
+        'progress': {'percent': _job_percent(job)},
         'on_complete_short': mode.complete_short,
         'mode': mode,
         'form_management_url': reverse(EditDataInterfaceDispatcher.name(),
-                                       args=[domain, BulkFormManagementInterface.slug])
-    })
-    return render(request, template, context)
+                                       args=[job.domain, BulkFormManagementInterface.slug]),
+    }
 
 
 class BulkCaseActionSatusView(DataInterfaceSection):

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -469,7 +469,7 @@ class XFormManagementView(DataInterfaceSection):
 
         mode = self.request.POST.get('mode')
         job = create_bulk_form_job(
-            self.domain, mode, self.request.couch_user.username, form_ids)
+            self.domain, FormManagementMode.bulk_action(mode), self.request.couch_user.username, form_ids)
         # download_id must be in hex format (no hyphens) to conform to soil's framework
         bulk_form_action_async.delay(job.id.hex, self.domain)
         return HttpResponseRedirect(

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -24,7 +24,7 @@ from no_exceptions.exceptions import Http403
 
 from dimagi.utils.logging import notify_exception
 from soil.exceptions import TaskFailedError
-from soil.util import expose_cached_download, get_download_context
+from soil.util import get_download_context
 
 from corehq import privileges, toggles
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
@@ -56,6 +56,7 @@ from corehq.apps.data_interfaces.forms import (
     DedupeCaseFilterForm,
     UpdateCaseGroupForm,
 )
+from corehq.apps.data_interfaces.bulk_form_actions import create_bulk_form_job
 from corehq.apps.data_interfaces.models import (
     AutomaticUpdateRule,
     CaseDeduplicationActionDefinition,
@@ -63,7 +64,7 @@ from corehq.apps.data_interfaces.models import (
     DomainCaseRuleRun,
 )
 from corehq.apps.data_interfaces.tasks import (
-    bulk_form_management_async,
+    bulk_form_action_async,
     bulk_upload_cases_to_group,
 )
 from corehq.apps.domain.decorators import login_and_domain_required
@@ -455,6 +456,8 @@ class XFormManagementView(DataInterfaceSection):
 
     def post(self, request, *args, **kwargs):
         form_ids = self.get_xform_ids(request)
+        if not form_ids:
+            return HttpResponseBadRequest(_("No forms were supplied."))
         if not self.request.can_access_all_locations:
             inaccessible_forms_accessed = self.inaccessible_forms_accessed(
                 form_ids, self.domain, request.couch_user)
@@ -463,19 +466,14 @@ class XFormManagementView(DataInterfaceSection):
                     "Inaccessible forms accessed. Id(s): %s " % ','.join(inaccessible_forms_accessed))
 
         mode = self.request.POST.get('mode')
-        task_ref = expose_cached_download(payload=None, expiry=1 * 60 * 60, file_extension=None)
-        task = bulk_form_management_async.delay(
-            mode,
-            self.domain,
-            self.request.couch_user,
-            form_ids
-        )
-        task_ref.set_task(task)
-
+        job = create_bulk_form_job(
+            self.domain, mode, self.request.couch_user.username, form_ids)
+        # download_id must be in hex format (no hyphens) to conform to soil's framework
+        bulk_form_action_async.delay(job.id.hex, self.domain)
         return HttpResponseRedirect(
             reverse(
                 XFormManagementStatusView.urlname,
-                args=[self.domain, mode, task_ref.download_id]
+                args=[self.domain, mode, job.id.hex]
             )
         )
 

--- a/corehq/blobs/metadata.py
+++ b/corehq/blobs/metadata.py
@@ -14,6 +14,9 @@ from . import CODES
 
 from .models import BlobMeta
 
+# Blob type codes whose contents are always gzipped.
+ALWAYS_COMPRESSED_CODES = (CODES.form_xml, CODES.bulk_async_job)
+
 
 class MetaDB(object):
     """Blob metadata database interface
@@ -35,7 +38,7 @@ class MetaDB(object):
                     "keyword arguments are incompatible with `meta` argument")
             return blob_meta_args["meta"]
         timeout = blob_meta_args.pop("timeout", None)
-        if blob_meta_args.get('type_code') == CODES.form_xml:
+        if blob_meta_args.get('type_code') in ALWAYS_COMPRESSED_CODES:
             blob_meta_args['compressed_length'] = -1
         meta = BlobMeta(**blob_meta_args)
         if not meta.domain:

--- a/corehq/sql_db/fields.py
+++ b/corehq/sql_db/fields.py
@@ -39,6 +39,14 @@ class ModelClassField(CharField):
             return value
         return self._slug_by_model[value]
 
+    def pre_save(self, model_instance, add):
+        # This field's value is a model class, and every Django model has a
+        # prepare_database_save method. The UPDATE compiler treats any value with
+        # that method as a related-object assignment; since this isn't a relation it
+        # rejects the value before it would convert it. Return the slug so
+        # UPDATE sees a plain string, like every other column.
+        return self.get_prep_value(getattr(model_instance, self.attname))
+
 
 class CharIdField(CharField):
     """CharField that does not create varchar_pattern_ops index

--- a/corehq/sql_db/tests/test_fields.py
+++ b/corehq/sql_db/tests/test_fields.py
@@ -76,3 +76,17 @@ def has_pattern_ops_index(statements):
 def test_ModelClassField_slugs_are_unique():
     slugs = list(ModelClassField()._slug_by_model.values())
     assert len(slugs) == len(set(slugs)), f"Duplicate slugs: {slugs}"
+
+
+def test_ModelClassField_pre_save_returns_slug_for_class():
+    # The stored value is a model class; pre_save must hand the UPDATE compiler
+    # the slug string instead (see ModelClassField.pre_save for why).
+    from corehq.form_processor.models import XFormInstance
+
+    @unregistered_django_model
+    class Test(models.Model):
+        model = ModelClassField()
+
+    field = {f.name: f for f in Test._meta.fields}["model"]
+    obj = Test(model=XFormInstance)
+    assert field.pre_save(obj, add=False) == 'xform'


### PR DESCRIPTION
## Product Description

No new user-facing feature. The bulk form **archive/unarchive** flow in Data Cleanup behaves the same, but its progress/results page is now rendered from a durable `BulkAsyncJob` row instead of soil. At scale this reports **counts + forms grouped by skip reason** ("N forms processed successfully" + grouped skips) rather than one line per form.

Known follow-up: the status page currently shows raw skip-reason slugs (`not_found`, `already_unarchived`) rather than friendly, translated labels — see Safety story.

## Technical Summary

- Ticket: **SAAS-19895** (epic **SAAS-19558 — Bulk Form Actions API**)
- Design doc and implementation plan are included in the diff under `docs/superpowers/` (they account for ~1,250 of the changed lines — the code change is much smaller than the diffstat suggests).
- **Stacked PR:** base branch is `gh/extract-form-action-logic` (SAAS-19975, the `apply_form_action` extraction), not `master`. Review/merge that first.

This replaces soil/`DownloadBase` with `BulkAsyncJob` as the persistence + status layer for the archive/unarchive UI flow, so the UI and the future Bulk Form Actions API share one code path: a generalized `apply_form_action` (adds a per-form `validate` hook), blob-backed requested/skipped id lists on `BulkAsyncJob`, a testable `bulk_form_actions` execution module, a `serial_task` worker (one job per domain) with a `task_failure` receiver, a view that creates the job, and the existing soil-polled status page repointed at the job. The throwaway shim is deleted last.

Decisions worth flagging to the reviewer:
- **`delete` action is deferred** to the API ticket that will consume it (no endpoint invokes it here), so nothing delete-related or batch-related is built in this PR.
- **`download_id` is `job.id.hex`** (32 hex chars), because the status/poll URL regex `[0-9a-fA-Z]{25,32}` rejects hyphenated UUIDs.
- Includes a small fix to **`ModelClassField.pre_save`** (`corehq/sql_db/fields.py`): a Django model *class* inherits `prepare_database_save`, which the UPDATE compiler rejects, so a `BulkAsyncJob` couldn't be `save()`d more than once. INSERT already converted the class to a slug; this makes UPDATE do the same. `Tombstone` (the only other `ModelClassField` user) is insert-only and unaffected.

## Feature Flag

None.

## Safety Assurance

### Safety story

Built test-first, one task per commit, with an independent review after each task and a final whole-branch review. Inherent-safety points:
- `serial_task('{domain}')` allows only one bulk job per domain at a time, so two jobs can't mutate the same domain's forms concurrently.
- Blob writes in the view are wrapped in `AtomicBlobs`, so a failed row save can't orphan a blob.
- A `task_failure` receiver (scoped to this task only) flips a crashed/lock-exhausted job to `FAILED`; retries fire `task_retry`, not `task_failure`, so lock contention won't wrongly fail a job.
- `delete` is out of scope, so no destructive path is added.

Deferred (non-blocking, tracked in the plan): the task enqueue happens after the row commit but outside a DB transaction, so a broker outage could leave a job stuck `PENDING` — to be addressed with `transaction.on_commit` + a stale-`PENDING` reaper. And the raw skip-reason slugs in the template are a wording regression to tidy up.

### Automated test coverage

`corehq/apps/data_interfaces/tests/` (`test_utils`, `test_models`, `test_bulk_form_actions`, `test_tasks`, `test_views`) and `corehq/sql_db/tests/test_fields.py` cover: `validate`/skip semantics, blob round-trips (dedup/sort/gzip), execution counts + grouped skips + status lifecycle, the failure receiver, the view create-and-enqueue path, domain-scoped poll lookup, an auth-gate test on the poll view, and real template renders for running/complete/failed. Full feature sweep: **114 passing** (Kafka required for the form-mutating tests).

### QA Plan

Archive and unarchive a batch of forms from Data Cleanup → Bulk Form Management; confirm the status page shows progress then a success count (and grouped skips when some forms don't qualify), and that the forms end up archived/unarchived.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
