### PR TITLE
Only rate limit restores above a global threshold, with runtime-adjustable limits

### DIFF
--- a/corehq/apps/ota/rate_limiter.py
+++ b/corehq/apps/ota/rate_limiter.py
@@ -4,27 +4,54 @@ from corehq.project_limits.rate_limiter import (
     PerUserRateDefinition,
     RateDefinition,
     RateLimiter,
+    get_dynamic_rate_definition,
 )
 from corehq.project_limits.shortcuts import get_standard_ratio_rate_definition
 from corehq.toggles import RATE_LIMIT_RESTORES, NAMESPACE_DOMAIN, BLOCK_RESTORES
 from corehq.util.decorators import run_only_when, silence_and_report_error
-from corehq.util.metrics import metrics_counter
+from corehq.util.metrics import metrics_counter, metrics_gauge
+from corehq.util.quickcache import quickcache
 
 RESTORES_PER_DAY = 3
 
 restore_rate_limiter = RateLimiter(
     feature_key='restores',
-    get_rate_limits=PerUserRateDefinition(
-        per_user_rate_definition=get_standard_ratio_rate_definition(
-            events_per_day=RESTORES_PER_DAY),
-        constant_rate_definition=RateDefinition(
-            per_week=50,
-            per_day=25,
-            per_hour=15,
-            per_minute=5,
-            per_second=1,
+    get_rate_limits=lambda domain: _get_per_user_restore_rate_definition(domain)
+)
+
+
+def _get_per_user_restore_rate_definition(domain):
+    return PerUserRateDefinition(
+        per_user_rate_definition=get_dynamic_rate_definition(
+            'restores_per_user',
+            default=get_standard_ratio_rate_definition(
+                events_per_day=RESTORES_PER_DAY),
         ),
-    ).get_rate_limits
+        constant_rate_definition=get_dynamic_rate_definition(
+            'baseline_restores_per_project',
+            default=RateDefinition(
+                per_week=50,
+                per_day=25,
+                per_hour=15,
+                per_minute=5,
+                per_second=1,
+            ),
+        ),
+    ).get_rate_limits(domain)
+
+
+global_restore_rate_limiter = RateLimiter(
+    feature_key='global_restores',
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
+        'global_restores',
+        # Scaled from the global submission defaults by the
+        # restore/submission per-user ratio (3/46)
+        default=RateDefinition(
+            per_hour=1000,
+            per_minute=30,
+            per_second=3,
+        )
+    ).get_rate_limits(),
 )
 
 
@@ -44,12 +71,23 @@ def rate_limit_restore(domain):
         return False
 
 
+def _allow_restore_usage(domain):
+    return (global_restore_rate_limiter.allow_usage()
+            or restore_rate_limiter.allow_usage(domain))
+
+
+def _report_restore_usage(domain):
+    restore_rate_limiter.report_usage(domain)
+    global_restore_rate_limiter.report_usage()
+    _report_current_global_restore_thresholds()
+
+
 def _rate_limit_restore(domain):
 
-    allow_usage = restore_rate_limiter.allow_usage(domain)
+    allow_usage = _allow_restore_usage(domain)
 
     if allow_usage:
-        restore_rate_limiter.report_usage(domain)
+        _report_restore_usage(domain)
     else:
         metrics_counter('commcare.restore.rate_limited', tags={
             'domain': domain,
@@ -59,8 +97,22 @@ def _rate_limit_restore(domain):
 
 
 def _rate_limit_restore_test(domain):
-    if not restore_rate_limiter.allow_usage(domain):
+    if not _allow_restore_usage(domain):
         metrics_counter('commcare.restore.rate_limited.test', tags={
             'domain': domain,
         })
-    restore_rate_limiter.report_usage(domain)
+    _report_restore_usage(domain)
+
+
+@quickcache([], timeout=60)  # Only report up to once a minute
+def _report_current_global_restore_thresholds():
+    for scope, limits in global_restore_rate_limiter.iter_rates():
+        for rate_counter, value, threshold in limits:
+            metrics_gauge('commcare.restores.global_threshold', threshold, tags={
+                'window': rate_counter.key,
+                'scope': scope
+            }, multiprocess_mode='max')
+            metrics_gauge('commcare.restores.global_usage', value, tags={
+                'window': rate_counter.key,
+                'scope': scope
+            }, multiprocess_mode='max')

--- a/corehq/apps/ota/rate_limiter.py
+++ b/corehq/apps/ota/rate_limiter.py
@@ -6,7 +6,10 @@ from corehq.project_limits.rate_limiter import (
     RateLimiter,
     get_dynamic_rate_definition,
 )
-from corehq.project_limits.shortcuts import get_standard_ratio_rate_definition
+from corehq.project_limits.shortcuts import (
+    delay_and_report_rate_limit,
+    get_standard_ratio_rate_definition,
+)
 from corehq.toggles import RATE_LIMIT_RESTORES, NAMESPACE_DOMAIN, BLOCK_RESTORES
 from corehq.util.decorators import run_only_when, silence_and_report_error
 from corehq.util.metrics import metrics_counter, metrics_gauge
@@ -61,9 +64,9 @@ SHOULD_RATE_LIMIT_RESTORES = not settings.ENTERPRISE_MODE and not settings.UNIT_
 @run_only_when(lambda: SHOULD_RATE_LIMIT_RESTORES)
 @silence_and_report_error("Exception raised in the restore rate limiter",
                           'commcare.restores.rate_limiter_errors')
-def rate_limit_restore(domain):
+def rate_limit_restore(domain, max_wait=15):
     if RATE_LIMIT_RESTORES.enabled(domain, namespace=NAMESPACE_DOMAIN):
-        return _rate_limit_restore(domain)
+        return _rate_limit_restore(domain, max_wait=max_wait)
     elif BLOCK_RESTORES.enabled(domain, namespace=NAMESPACE_DOMAIN):
         return True
     else:
@@ -82,16 +85,19 @@ def _report_restore_usage(domain):
     _report_current_global_restore_thresholds()
 
 
-def _rate_limit_restore(domain):
+def _rate_limit_restore(domain, max_wait=15):
 
     allow_usage = _allow_restore_usage(domain)
 
+    if not allow_usage:
+        allow_usage = delay_and_report_rate_limit(
+            domain, max_wait=max_wait, delay_rather_than_reject=False,
+            datadog_metric='commcare.restore.rate_limited',
+            limiter=restore_rate_limiter,
+        )
+
     if allow_usage:
         _report_restore_usage(domain)
-    else:
-        metrics_counter('commcare.restore.rate_limited', tags={
-            'domain': domain,
-        })
 
     return not allow_usage
 

--- a/corehq/apps/ota/rate_limiter.py
+++ b/corehq/apps/ota/rate_limiter.py
@@ -92,7 +92,7 @@ def _rate_limit_restore(domain, max_wait=15):
     if not allow_usage:
         allow_usage = delay_and_report_rate_limit(
             domain, max_wait=max_wait, delay_rather_than_reject=False,
-            datadog_metric='commcare.restore.rate_limited',
+            datadog_metric='commcare.restores.rate_limited',
             limiter=restore_rate_limiter,
         )
 
@@ -104,7 +104,7 @@ def _rate_limit_restore(domain, max_wait=15):
 
 def _rate_limit_restore_test(domain):
     if not _allow_restore_usage(domain):
-        metrics_counter('commcare.restore.rate_limited.test', tags={
+        metrics_counter('commcare.restores.rate_limited.test', tags={
             'domain': domain,
         })
     _report_restore_usage(domain)

--- a/corehq/apps/ota/rate_limiter.py
+++ b/corehq/apps/ota/rate_limiter.py
@@ -31,7 +31,7 @@ restore_rate_limiter = RateLimiter(
 SHOULD_RATE_LIMIT_RESTORES = not settings.ENTERPRISE_MODE and not settings.UNIT_TESTING
 
 
-@run_only_when(SHOULD_RATE_LIMIT_RESTORES)
+@run_only_when(lambda: SHOULD_RATE_LIMIT_RESTORES)
 @silence_and_report_error("Exception raised in the restore rate limiter",
                           'commcare.restores.rate_limiter_errors')
 def rate_limit_restore(domain):

--- a/corehq/apps/ota/tests/test_rate_limiter.py
+++ b/corehq/apps/ota/tests/test_rate_limiter.py
@@ -2,6 +2,7 @@
 from contextlib import contextmanager
 from unittest.mock import patch
 
+import attr
 import pytest
 
 from django.test import TestCase
@@ -24,50 +25,83 @@ from corehq.util.test_utils import flag_disabled, flag_enabled
 DOMAIN = 'restore-rate-limit-test'
 
 
+@attr.s(auto_attribs=True)
+class LimiterMocks:
+    global_report_usage: object
+    domain_report_usage: object
+    wait: object
+
+
 @contextmanager
-def restore_rate_limiters(global_allowed, domain_allowed):
+def restore_rate_limiters(global_allowed, domain_allowed, wait_acquires=False):
     with (
         patch('corehq.apps.ota.rate_limiter.SHOULD_RATE_LIMIT_RESTORES', True),
         patch.object(global_restore_rate_limiter, 'allow_usage',
                      return_value=global_allowed),
         patch.object(restore_rate_limiter, 'allow_usage',
                      return_value=domain_allowed),
+        patch.object(restore_rate_limiter, 'wait',
+                     return_value=wait_acquires) as wait,
         patch.object(global_restore_rate_limiter, 'report_usage') as global_report_usage,
         patch.object(restore_rate_limiter, 'report_usage') as domain_report_usage,
         patch('corehq.apps.ota.rate_limiter._report_current_global_restore_thresholds'),
     ):
-        yield global_report_usage, domain_report_usage
+        yield LimiterMocks(global_report_usage, domain_report_usage, wait)
 
 
-@pytest.mark.parametrize("global_allowed, domain_allowed, expect_limited", [
-    (True, True, False),
+@pytest.mark.parametrize("global_allowed, domain_allowed, wait_acquires, expect_limited", [
+    (True, True, False, False),
     # under the global threshold, domain limits don't apply
-    (True, False, False),
+    (True, False, False, False),
     # over the global threshold, but the domain has capacity
-    (False, True, False),
-    # over the global threshold and the domain's own limits
-    (False, False, True),
+    (False, True, False, False),
+    # over all limits, but capacity freed up while waiting
+    (False, False, True, False),
+    # over all limits and no capacity freed up while waiting
+    (False, False, False, True),
 ])
-def test_rate_limit_restore(global_allowed, domain_allowed, expect_limited):
+def test_rate_limit_restore(global_allowed, domain_allowed, wait_acquires, expect_limited):
     with flag_enabled('RATE_LIMIT_RESTORES'), \
-            restore_rate_limiters(global_allowed, domain_allowed):
+            restore_rate_limiters(global_allowed, domain_allowed, wait_acquires):
         assert rate_limit_restore(DOMAIN) is expect_limited
+
+
+def test_restore_with_capacity_does_not_wait():
+    with flag_enabled('RATE_LIMIT_RESTORES'), \
+            restore_rate_limiters(False, True) as mocks:
+        rate_limit_restore(DOMAIN)
+    mocks.wait.assert_not_called()
+
+
+def test_over_limit_restore_waits_for_capacity():
+    with flag_enabled('RATE_LIMIT_RESTORES'), \
+            restore_rate_limiters(False, False) as mocks:
+        rate_limit_restore(DOMAIN)
+    mocks.wait.assert_called_once_with(DOMAIN, timeout=15)
 
 
 def test_allowed_restore_reports_usage_to_both_limiters():
     with flag_enabled('RATE_LIMIT_RESTORES'), \
-            restore_rate_limiters(True, False) as (global_report_usage, domain_report_usage):
+            restore_rate_limiters(True, False) as mocks:
         rate_limit_restore(DOMAIN)
-    global_report_usage.assert_called_once()
-    domain_report_usage.assert_called_once_with(DOMAIN)
+    mocks.global_report_usage.assert_called_once()
+    mocks.domain_report_usage.assert_called_once_with(DOMAIN)
+
+
+def test_delayed_restore_reports_usage_to_both_limiters():
+    with flag_enabled('RATE_LIMIT_RESTORES'), \
+            restore_rate_limiters(False, False, wait_acquires=True) as mocks:
+        rate_limit_restore(DOMAIN)
+    mocks.global_report_usage.assert_called_once()
+    mocks.domain_report_usage.assert_called_once_with(DOMAIN)
 
 
 def test_rate_limited_restore_does_not_report_usage():
     with flag_enabled('RATE_LIMIT_RESTORES'), \
-            restore_rate_limiters(False, False) as (global_report_usage, domain_report_usage):
+            restore_rate_limiters(False, False) as mocks:
         rate_limit_restore(DOMAIN)
-    global_report_usage.assert_not_called()
-    domain_report_usage.assert_not_called()
+    mocks.global_report_usage.assert_not_called()
+    mocks.domain_report_usage.assert_not_called()
 
 
 def test_rate_limited_restore_emits_metric():
@@ -92,12 +126,13 @@ def test_block_restores_rejects_regardless_of_capacity():
         assert rate_limit_restore(DOMAIN) is True
 
 
-def test_toggles_off_never_limits_but_still_reports_usage():
+def test_toggles_off_never_limits_never_waits_but_still_reports_usage():
     with flag_disabled('RATE_LIMIT_RESTORES'), flag_disabled('BLOCK_RESTORES'), \
-            restore_rate_limiters(False, False) as (global_report_usage, domain_report_usage):
+            restore_rate_limiters(False, False) as mocks:
         assert rate_limit_restore(DOMAIN) is False
-    global_report_usage.assert_called_once()
-    domain_report_usage.assert_called_once_with(DOMAIN)
+    mocks.wait.assert_not_called()
+    mocks.global_report_usage.assert_called_once()
+    mocks.domain_report_usage.assert_called_once_with(DOMAIN)
 
 
 class RestoreRateDefinitionDefaultsTest(TestCase):

--- a/corehq/apps/ota/tests/test_rate_limiter.py
+++ b/corehq/apps/ota/tests/test_rate_limiter.py
@@ -1,0 +1,66 @@
+"""Tests for restore rate limiting dispatch."""
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from corehq.apps.ota.rate_limiter import (
+    rate_limit_restore,
+    restore_rate_limiter,
+)
+from corehq.util.metrics.tests.utils import capture_metrics
+from corehq.util.test_utils import flag_disabled, flag_enabled
+
+DOMAIN = 'restore-rate-limit-test'
+
+
+@contextmanager
+def restore_rate_limiters(domain_allowed):
+    with (
+        patch('corehq.apps.ota.rate_limiter.SHOULD_RATE_LIMIT_RESTORES', True),
+        patch.object(restore_rate_limiter, 'allow_usage',
+                     return_value=domain_allowed),
+        patch.object(restore_rate_limiter, 'report_usage') as report_usage,
+    ):
+        yield report_usage
+
+
+def test_restore_with_capacity_is_not_limited():
+    with flag_enabled('RATE_LIMIT_RESTORES'), \
+            restore_rate_limiters(True) as report_usage:
+        assert rate_limit_restore(DOMAIN) is False
+    report_usage.assert_called_once_with(DOMAIN)
+
+
+def test_over_limit_restore_is_rate_limited():
+    with flag_enabled('RATE_LIMIT_RESTORES'), \
+            restore_rate_limiters(False) as report_usage:
+        assert rate_limit_restore(DOMAIN) is True
+    report_usage.assert_not_called()
+
+
+def test_rate_limited_restore_emits_metric():
+    with capture_metrics() as metrics, \
+            flag_enabled('RATE_LIMIT_RESTORES'), \
+            restore_rate_limiters(False):
+        rate_limit_restore(DOMAIN)
+    assert metrics.list('commcare.restore.rate_limited', domain=DOMAIN)
+
+
+def test_toggles_off_rate_limited_restore_emits_test_metric():
+    with capture_metrics() as metrics, \
+            flag_disabled('RATE_LIMIT_RESTORES'), flag_disabled('BLOCK_RESTORES'), \
+            restore_rate_limiters(False):
+        rate_limit_restore(DOMAIN)
+    assert metrics.list('commcare.restore.rate_limited.test', domain=DOMAIN)
+
+
+def test_block_restores_rejects_regardless_of_capacity():
+    with flag_disabled('RATE_LIMIT_RESTORES'), flag_enabled('BLOCK_RESTORES'), \
+            restore_rate_limiters(True):
+        assert rate_limit_restore(DOMAIN) is True
+
+
+def test_toggles_off_never_limits_but_still_reports_usage():
+    with flag_disabled('RATE_LIMIT_RESTORES'), flag_disabled('BLOCK_RESTORES'), \
+            restore_rate_limiters(False) as report_usage:
+        assert rate_limit_restore(DOMAIN) is False
+    report_usage.assert_called_once_with(DOMAIN)

--- a/corehq/apps/ota/tests/test_rate_limiter.py
+++ b/corehq/apps/ota/tests/test_rate_limiter.py
@@ -109,7 +109,7 @@ def test_rate_limited_restore_emits_metric():
             flag_enabled('RATE_LIMIT_RESTORES'), \
             restore_rate_limiters(False, False):
         rate_limit_restore(DOMAIN)
-    assert metrics.list('commcare.restore.rate_limited', domain=DOMAIN)
+    assert metrics.list('commcare.restores.rate_limited', domain=DOMAIN)
 
 
 def test_toggles_off_rate_limited_restore_emits_test_metric():
@@ -117,7 +117,7 @@ def test_toggles_off_rate_limited_restore_emits_test_metric():
             flag_disabled('RATE_LIMIT_RESTORES'), flag_disabled('BLOCK_RESTORES'), \
             restore_rate_limiters(False, False):
         rate_limit_restore(DOMAIN)
-    assert metrics.list('commcare.restore.rate_limited.test', domain=DOMAIN)
+    assert metrics.list('commcare.restores.rate_limited.test', domain=DOMAIN)
 
 
 def test_block_restores_rejects_regardless_of_capacity():

--- a/corehq/apps/ota/tests/test_rate_limiter.py
+++ b/corehq/apps/ota/tests/test_rate_limiter.py
@@ -1,11 +1,23 @@
-"""Tests for restore rate limiting dispatch."""
+"""Tests for restore rate limiting dispatch and rate definitions."""
 from contextlib import contextmanager
 from unittest.mock import patch
 
+import pytest
+
+from django.test import TestCase
+
 from corehq.apps.ota.rate_limiter import (
+    _get_per_user_restore_rate_definition,
+    global_restore_rate_limiter,
     rate_limit_restore,
     restore_rate_limiter,
 )
+from corehq.project_limits.models import DynamicRateDefinition
+from corehq.project_limits.rate_limiter import (
+    PerUserRateDefinition,
+    RateDefinition,
+)
+from corehq.project_limits.shortcuts import get_standard_ratio_rate_definition
 from corehq.util.metrics.tests.utils import capture_metrics
 from corehq.util.test_utils import flag_disabled, flag_enabled
 
@@ -13,34 +25,55 @@ DOMAIN = 'restore-rate-limit-test'
 
 
 @contextmanager
-def restore_rate_limiters(domain_allowed):
+def restore_rate_limiters(global_allowed, domain_allowed):
     with (
         patch('corehq.apps.ota.rate_limiter.SHOULD_RATE_LIMIT_RESTORES', True),
+        patch.object(global_restore_rate_limiter, 'allow_usage',
+                     return_value=global_allowed),
         patch.object(restore_rate_limiter, 'allow_usage',
                      return_value=domain_allowed),
-        patch.object(restore_rate_limiter, 'report_usage') as report_usage,
+        patch.object(global_restore_rate_limiter, 'report_usage') as global_report_usage,
+        patch.object(restore_rate_limiter, 'report_usage') as domain_report_usage,
+        patch('corehq.apps.ota.rate_limiter._report_current_global_restore_thresholds'),
     ):
-        yield report_usage
+        yield global_report_usage, domain_report_usage
 
 
-def test_restore_with_capacity_is_not_limited():
+@pytest.mark.parametrize("global_allowed, domain_allowed, expect_limited", [
+    (True, True, False),
+    # under the global threshold, domain limits don't apply
+    (True, False, False),
+    # over the global threshold, but the domain has capacity
+    (False, True, False),
+    # over the global threshold and the domain's own limits
+    (False, False, True),
+])
+def test_rate_limit_restore(global_allowed, domain_allowed, expect_limited):
     with flag_enabled('RATE_LIMIT_RESTORES'), \
-            restore_rate_limiters(True) as report_usage:
-        assert rate_limit_restore(DOMAIN) is False
-    report_usage.assert_called_once_with(DOMAIN)
+            restore_rate_limiters(global_allowed, domain_allowed):
+        assert rate_limit_restore(DOMAIN) is expect_limited
 
 
-def test_over_limit_restore_is_rate_limited():
+def test_allowed_restore_reports_usage_to_both_limiters():
     with flag_enabled('RATE_LIMIT_RESTORES'), \
-            restore_rate_limiters(False) as report_usage:
-        assert rate_limit_restore(DOMAIN) is True
-    report_usage.assert_not_called()
+            restore_rate_limiters(True, False) as (global_report_usage, domain_report_usage):
+        rate_limit_restore(DOMAIN)
+    global_report_usage.assert_called_once()
+    domain_report_usage.assert_called_once_with(DOMAIN)
+
+
+def test_rate_limited_restore_does_not_report_usage():
+    with flag_enabled('RATE_LIMIT_RESTORES'), \
+            restore_rate_limiters(False, False) as (global_report_usage, domain_report_usage):
+        rate_limit_restore(DOMAIN)
+    global_report_usage.assert_not_called()
+    domain_report_usage.assert_not_called()
 
 
 def test_rate_limited_restore_emits_metric():
     with capture_metrics() as metrics, \
             flag_enabled('RATE_LIMIT_RESTORES'), \
-            restore_rate_limiters(False):
+            restore_rate_limiters(False, False):
         rate_limit_restore(DOMAIN)
     assert metrics.list('commcare.restore.rate_limited', domain=DOMAIN)
 
@@ -48,19 +81,63 @@ def test_rate_limited_restore_emits_metric():
 def test_toggles_off_rate_limited_restore_emits_test_metric():
     with capture_metrics() as metrics, \
             flag_disabled('RATE_LIMIT_RESTORES'), flag_disabled('BLOCK_RESTORES'), \
-            restore_rate_limiters(False):
+            restore_rate_limiters(False, False):
         rate_limit_restore(DOMAIN)
     assert metrics.list('commcare.restore.rate_limited.test', domain=DOMAIN)
 
 
 def test_block_restores_rejects_regardless_of_capacity():
     with flag_disabled('RATE_LIMIT_RESTORES'), flag_enabled('BLOCK_RESTORES'), \
-            restore_rate_limiters(True):
+            restore_rate_limiters(True, True):
         assert rate_limit_restore(DOMAIN) is True
 
 
 def test_toggles_off_never_limits_but_still_reports_usage():
     with flag_disabled('RATE_LIMIT_RESTORES'), flag_disabled('BLOCK_RESTORES'), \
-            restore_rate_limiters(False) as report_usage:
+            restore_rate_limiters(False, False) as (global_report_usage, domain_report_usage):
         assert rate_limit_restore(DOMAIN) is False
-    report_usage.assert_called_once_with(DOMAIN)
+    global_report_usage.assert_called_once()
+    domain_report_usage.assert_called_once_with(DOMAIN)
+
+
+class RestoreRateDefinitionDefaultsTest(TestCase):
+    """The dynamic rate definitions' defaults preserve the previously
+    hardcoded restore limits, and the global limiter gets the agreed
+    starting thresholds."""
+
+    def tearDown(self):
+        for definition in DynamicRateDefinition.objects.filter(key__in=[
+                'restores_per_user', 'baseline_restores_per_project', 'global_restores']):
+            # delete one by one to also trigger clearing caches
+            definition.delete()
+        super().tearDown()
+
+    def test_per_project_defaults_match_previous_hardcoded_values(self):
+        with patch('corehq.project_limits.rate_limiter.get_n_users_in_domain',
+                   return_value=10), \
+                patch('corehq.project_limits.rate_limiter.get_n_users_in_subscription',
+                      return_value=100), \
+                patch('corehq.project_limits.rate_limiter._get_account_name',
+                      return_value='account:test'):
+            expected = PerUserRateDefinition(
+                per_user_rate_definition=get_standard_ratio_rate_definition(
+                    events_per_day=3),
+                constant_rate_definition=RateDefinition(
+                    per_week=50,
+                    per_day=25,
+                    per_hour=15,
+                    per_minute=5,
+                    per_second=1,
+                ),
+            ).get_rate_limits(DOMAIN)
+            actual = _get_per_user_restore_rate_definition(DOMAIN)
+        assert actual == expected
+
+    def test_global_restore_defaults(self):
+        global_restore_rate_limiter.get_rate_limits('')
+        definition = DynamicRateDefinition.objects.get(key='global_restores')
+        assert definition.per_week is None
+        assert definition.per_day is None
+        assert definition.per_hour == 1000
+        assert definition.per_minute == 30
+        assert definition.per_second == 3


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-20029


## Product Description
No user-facing change by default. Restores continue to get a 429 only for domains where the `RATE_LIMIT_RESTORES` flag applies; what changes is when the limits kick in and how they are computed.

## Technical Summary
Restore rate limiting predates the pattern we later settled on for submissions and case updates: its thresholds were hardcoded, and a domain over its own limits was throttled regardless of overall system load. This brings it in line with the submission limiter:

- Per-project limits (`restores_per_user`, `baseline_restores_per_project`) now come from `DynamicRateDefinition`, adjustable at runtime through Django admin. Their defaults are the previously hardcoded values, so per-project behavior is identical until someone edits them.
- A new global limiter (`global_restores`) is checked first: no domain is rate limited while system-wide restore volume is under the global threshold. The starting thresholds (1000/hr, 30/min, 3/sec) are the global submission defaults scaled by the restore/submission per-user ratio (3/46) — expect to tune them once the new `commcare.restores.global_threshold` / `commcare.restores.global_usage` gauges show real volume.

- Restores also adopt the submission limiter's delay mechanism: an over-limit restore now waits up to 15 seconds (via `delay_and_report_rate_limit`) for capacity to free up before getting a 429. Consequently the rate-limited metric gains the `duration`/`throttle_method` tags its submission equivalent has, and now also counts delayed-but-allowed restores (`throttle_method:delay`).
- The `commcare.restore.rate_limited(.test)` counters are renamed to `commcare.restores.rate_limited(.test)`, matching the `commcare.restores.*` prefix every other restore metric uses. Anything in Datadog keyed on the old name needs updating — which was already true given the tag/semantics changes above.

`BLOCK_RESTORES` and the test-mode metrics path (which never delays) are unchanged. `run_only_when` now reads `SHOULD_RATE_LIMIT_RESTORES` at call time, matching the submission limiter and making the entry point patchable in tests.

## Feature Flag
`RATE_LIMIT_RESTORES` (existing) — the toggle dispatch is unchanged.

## Safety Assurance

### Safety story
The change is strictly not-more-restrictive: the new check is `global.allow_usage() or domain.allow_usage(domain)` with a wait-for-capacity fallback, so every restore that was allowed before is still allowed (some now delayed instead of rejected, which only converts 429s into slower successes). The dynamic definitions' defaults reproduce the old hardcoded limits exactly (asserted by a test). Limiter exceptions are still swallowed and reported by `silence_and_report_error`, so a defect here degrades to "no rate limiting" rather than blocked restores.

One capacity consideration: an over-limit restore can now hold its worker for up to 15 seconds before rejecting, same as submissions. This only happens for domains where `RATE_LIMIT_RESTORES` applies and only once global volume exceeds the global threshold.

Tested on staging that restores work normally, and that if I click restore incessantly, I eventually get an error and datadog metrics that show it being throttled.

### Automated test coverage
New `corehq/apps/ota/tests/test_rate_limiter.py` covers the global/domain gating matrix (including the delayed-acquire and delayed-reject outcomes), when the limiter does and doesn't wait, usage reporting to both limiters, `BLOCK_RESTORES`, the toggle-off test-mode path, and that the dynamic defaults match the previously hardcoded values.

### QA Plan
No QA ticket; covered by automated tests plus monitoring the new global usage/threshold gauges after deploy.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

(Reverting returns to the hardcoded limits; any `DynamicRateDefinition` rows created in the meantime are simply unused.)

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change