### PR TITLE
Bring migrations-in-practice doc up to date

### DIFF
--- a/docs/migrations_in_practice.rst
+++ b/docs/migrations_in_practice.rst
@@ -28,7 +28,7 @@ in files like ``corehq/apps/<app>/management/commands/my_command.py``
 **Private release** - If you need to run code from a branch that’s not currently
 deployed, use a `private release`_.
 
-.. _`private release`: https://github.com/dimagi/commcare-cloud/blob/master/src/commcare_cloud/fab/README.md#private-releases
+.. _`private release`: https://commcare-cloud.readthedocs.io/en/latest/reference/1-commcare-cloud/commands.html#private
 
 
 General Principles
@@ -192,8 +192,8 @@ the deploy.
 Multiple deploys
 ----------------
 
-This is the most robust approach, and is advocated for in the `couch-to-sql
-<https://commcare-hq.readthedocs.io/couch_to_sql_models.html>`__ pattern. You
+This is the most robust approach, and is advocated for in the
+:ref:`couch-to-sql <couch-to-sql-model-migration>` pattern. You
 make two PRs:
 
 - **PR 1**: Schema migration; handle new data correctly; data migration

--- a/docs/migrations_in_practice.rst
+++ b/docs/migrations_in_practice.rst
@@ -273,8 +273,10 @@ production environment is on the master branch.
 
 Run your schema migration and management command directly:
 
-    ``cchq <ENV> django-manage --release=<NAME> migrate <APP_NAME>``
-    ``cchq <ENV> django-manage --release=<NAME> my_data_migration_command``
+.. code-block:: sh
+
+    cchq <ENV> django-manage --release=<NAME> migrate <APP_NAME>
+    cchq <ENV> django-manage --release=<NAME> my_data_migration_command
 
 Then merge PR 2. The subsequent deploy will run your management command again,
 though it should be very quick this time around, since nearly all data has been

--- a/docs/migrations_in_practice.rst
+++ b/docs/migrations_in_practice.rst
@@ -17,7 +17,7 @@ complicated if not backwards-compatible.
 potential to be quite slow
 
 **Django migration** - A migration (either kind) that is run automatically on
-deploy by ``./manage.py migrate``. These are in files like
+deploy by ``./manage.py migrate_multi``. These are in files like
 ``corehq/apps/<app>/migrations/0001_my_migration.py``
 
 **Management command** - Some data migrations are written as management
@@ -275,7 +275,7 @@ Run your schema migration and management command directly:
 
 .. code-block:: sh
 
-    cchq <ENV> django-manage --release=<NAME> migrate <APP_NAME>
+    cchq <ENV> django-manage --release=<NAME> migrate_multi <APP_NAME>
     cchq <ENV> django-manage --release=<NAME> my_data_migration_command
 
 Then merge PR 2. The subsequent deploy will run your management command again,


### PR DESCRIPTION
## Product Description

N/A — documentation only.

## Technical Summary

A staleness pass over the [migrations in practice](https://commcare-hq.readthedocs.io/migrations_in_practice.html) doc:

- The doc said Django migrations are run on deploy by `./manage.py migrate`, but deploys actually run `migrate_multi` ([commcare-cloud runs `migrate_multi --noinput`](https://github.com/dimagi/commcare-cloud/blob/master/src/commcare_cloud/ansible/roles/deploy_hq/tasks/run_migrations.yml)), which wraps `migrate` across every configured database. Plain `migrate` would miss the shard databases on partitioned environments, so the manual single-deploy instructions were corrected too.
- The private release link pointed at the deleted fab README; it now points at the commcare-cloud readthedocs page. The couch-to-sql link is now a Sphinx `:ref:` since that doc lives in this repo.
- The two `cchq` commands in the single-deploy section were one reST paragraph, so they rendered joined together on a single line; they're now a code block.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Documentation-only change, no runtime impact. The reST was checked with `rstcheck`, and the `migrate_multi` claim was verified against the commcare-cloud deploy tasks linked above.

### Automated test coverage

N/A — docs only.

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
