### PR TITLE
Collect all other errors outside of form designer

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/commcarehq.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/commcarehq.js
@@ -10,3 +10,4 @@ import 'hqwebapp/js/bootstrap3/base_main';
 import 'open-chat-studio-widget';
 import 'hqwebapp/js/lib/userflow';
 import 'hqwebapp/js/ocs_page_context';
+import 'hqwebapp/js/ocs_page_errors';

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/commcarehq.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/commcarehq.js
@@ -10,3 +10,4 @@ import 'hqwebapp/js/bootstrap5/base_main';
 import 'open-chat-studio-widget';
 import 'hqwebapp/js/lib/userflow';
 import 'hqwebapp/js/ocs_page_context';
+import 'hqwebapp/js/ocs_page_errors';

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_errors.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_errors.js
@@ -14,6 +14,8 @@ const SCRAPE_SELECTORS = [
     {selector: '.invalid-feedback', level: 'error', type: 'inline'},
     {selector: '.error-message', level: 'error', type: 'inline'},
     {selector: '.has-error .help-block', level: 'error', type: 'inline'},
+    // The shared HTMX error modal.
+    {selector: '#htmxRequestErrorModal .modal-body', level: 'error', type: 'modal'},
 ];
 
 function _elementText(element) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_errors.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_errors.js
@@ -11,6 +11,9 @@ import ocsContext from "hqwebapp/js/ocs_page_context";
 const SCRAPE_SELECTORS = [
     {selector: '.alert-danger', level: 'error', type: 'banner'},
     {selector: '.alert-warning', level: 'warning', type: 'banner'},
+    {selector: '.invalid-feedback', level: 'error', type: 'inline'},
+    {selector: '.error-message', level: 'error', type: 'inline'},
+    {selector: '.has-error .help-block', level: 'error', type: 'inline'},
 ];
 
 function _elementText(element) {
@@ -27,6 +30,19 @@ function _isReportable(element) {
     return element.offsetParent !== null && !element.closest('#formdesigner');
 }
 
+// Label for an inline field error.
+// Walk up to a field wrapper, then take its first label/legend.
+// Wrappers:
+//   [id^="div_"]  — crispy forms (#div_id_<field>)
+//   .form-group   — Bootstrap 3 field groups
+//   fieldset      — grouped inputs with a <legend>
+//   .q            — Web Apps questions
+function _fieldLabel(element) {
+    const container = element.closest('[id^="div_"], .form-group, fieldset, .q');
+    const label = container && container.querySelector('label, legend');
+    return label ? _elementText(label) : '';
+}
+
 function _scrapeErrorMessages() {
     const messages = [];
     SCRAPE_SELECTORS.forEach(({selector, level, type}) => {
@@ -34,7 +50,11 @@ function _scrapeErrorMessages() {
             if (!_isReportable(element)) {
                 return;
             }
-            const message = _elementText(element);
+            let message = _elementText(element);
+            if (type === 'inline') {
+                const label = _fieldLabel(element);
+                message = label ? `${label}: ${message}` : message;
+            }
             messages.push({level, message, type});
         });
     });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_errors.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_errors.js
@@ -45,19 +45,30 @@ function _fieldLabel(element) {
     return label ? _elementText(label) : '';
 }
 
+function _documentsToScrape() {
+    const roots = [document];
+    const previewDoc = document.querySelector('iframe.preview-phone-window')?.contentDocument;
+    if (previewDoc) {
+        roots.push(previewDoc);
+    }
+    return roots;
+}
+
 function _scrapeErrorMessages() {
     const messages = [];
-    SCRAPE_SELECTORS.forEach(({selector, level, type}) => {
-        document.querySelectorAll(selector).forEach((element) => {
-            if (!_isReportable(element)) {
-                return;
-            }
-            let message = _elementText(element);
-            if (type === 'inline') {
-                const label = _fieldLabel(element);
-                message = label ? `${label}: ${message}` : message;
-            }
-            messages.push({level, message, type});
+    _documentsToScrape().forEach((root) => {
+        SCRAPE_SELECTORS.forEach(({selector, level, type}) => {
+            root.querySelectorAll(selector).forEach((element) => {
+                if (!_isReportable(element)) {
+                    return;
+                }
+                let message = _elementText(element);
+                if (type === 'inline') {
+                    const label = _fieldLabel(element);
+                    message = label ? `${label}: ${message}` : message;
+                }
+                messages.push({level, message, type});
+            });
         });
     });
     return messages;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_errors.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_errors.js
@@ -28,8 +28,18 @@ function _elementText(element) {
 
 function _isReportable(element) {
     // offsetParent is null when the element or an ancestor is display:none.
+    if (element.offsetParent === null) {
+        return false;
+    }
     // Vellum has its own collector in ocs_widget_form_designer_context.js
-    return element.offsetParent !== null && !element.closest('#formdesigner');
+    if (element.closest('#formdesigner')) {
+        return false;
+    }
+    // Skip alerts nested inside another alert so the same text isn't reported twice.
+    if (element.parentElement.closest('.alert-danger, .alert-warning')) {
+        return false;
+    }
+    return true;
 }
 
 // Label for an inline field error.

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_errors.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_errors.js
@@ -1,0 +1,54 @@
+/*
+ *  Collects the error and warning messages currently shown to the user, for the
+ *  OCS chat widget's page context, by scraping the rendered error UI from the DOM.
+ *
+ *  Judging relevance (a real error the user faces vs. a decorative/informational banner)
+ *  is deliberately left to the chat widget.
+ */
+
+import ocsContext from "hqwebapp/js/ocs_page_context";
+
+const SCRAPE_SELECTORS = [
+    {selector: '.alert-danger', level: 'error', type: 'banner'},
+    {selector: '.alert-warning', level: 'warning', type: 'banner'},
+];
+
+function _elementText(element) {
+    const clone = element.cloneNode(true);
+    clone.querySelectorAll(
+        '.btn-close, .close, [data-dismiss], [data-bs-dismiss], .sr-only, .visually-hidden',
+    ).forEach((node) => node.remove());
+    return (clone.textContent || "").replace(/\s+/g, " ").trim();
+}
+
+function _isReportable(element) {
+    // offsetParent is null when the element or an ancestor is display:none.
+    // Vellum has its own collector in ocs_widget_form_designer_context.js
+    return element.offsetParent !== null && !element.closest('#formdesigner');
+}
+
+function _scrapeErrorMessages() {
+    const messages = [];
+    SCRAPE_SELECTORS.forEach(({selector, level, type}) => {
+        document.querySelectorAll(selector).forEach((element) => {
+            if (!_isReportable(element)) {
+                return;
+            }
+            const message = _elementText(element);
+            messages.push({level, message, type});
+        });
+    });
+    return messages;
+}
+
+function _collectPageWarnings() {
+    const messages = _scrapeErrorMessages();
+    return messages.length ? {page_warnings: messages} : {};
+}
+
+ocsContext.registerContextCollector(_collectPageWarnings);
+
+export const exportedForTesting = {
+    _collectPageWarnings,
+    _scrapeErrorMessages,
+};

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/bootstrap5/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/bootstrap5/main.js
@@ -4,6 +4,7 @@ import "hqwebapp/spec/assert_properties_spec";
 import "hqwebapp/spec/email_validator_spec";
 import "hqwebapp/spec/bootstrap5/inactivity_spec";
 import "hqwebapp/spec/urllib_spec";
+import "hqwebapp/spec/ocs_page_errors_spec";
 import "hqwebapp/spec/bootstrap5/widgets_spec";
 
 hqMocha.run();

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/ocs_page_errors_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/ocs_page_errors_spec.js
@@ -1,0 +1,45 @@
+import {exportedForTesting} from "hqwebapp/js/ocs_page_errors";
+
+const {_scrapeErrorMessages} = exportedForTesting;
+
+describe("OCS page warnings collector", function () {
+    it("scrapes visible alert banners, skipping hidden, form-designer", function () {
+        const dom = document.createElement("div");
+        dom.innerHTML = `
+            <div class="alert alert-danger">Server error banner</div>
+            <div class="alert alert-warning">A warning banner</div>
+            <div class="alert alert-danger" style="display: none;">Hidden, ignored</div>
+            <div id="formdesigner"><div class="alert alert-danger">Form designer (own collector)</div></div>
+        `;
+        document.body.appendChild(dom);
+
+        try {
+            assert.deepEqual(_scrapeErrorMessages(), [
+                {level: "error", message: "Server error banner", type: "banner"},
+                {level: "warning", message: "A warning banner", type: "banner"},
+            ]);
+        } finally {
+            document.body.removeChild(dom);
+        }
+    });
+
+    it("excludes the dismiss control and screen-reader-only text from the message", function () {
+        const dom = document.createElement("div");
+        dom.innerHTML = `
+            <div class="alert alert-danger">
+                Something broke
+                <span class="sr-only">extra accessibility detail</span>
+                <a class="close" data-dismiss="alert" href="#">&times;</a>
+            </div>
+        `;
+        document.body.appendChild(dom);
+
+        try {
+            assert.deepEqual(_scrapeErrorMessages(), [
+                {level: "error", message: "Something broke", type: "banner"},
+            ]);
+        } finally {
+            document.body.removeChild(dom);
+        }
+    });
+});

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/ocs_page_errors_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/ocs_page_errors_spec.js
@@ -42,4 +42,36 @@ describe("OCS page warnings collector", function () {
             document.body.removeChild(dom);
         }
     });
+
+    it("scrapes inline field errors with the field label, ignoring sr-only text", function () {
+        const dom = document.createElement("div");
+        dom.innerHTML = `
+            <div id="div_id_name" class="mb-3">
+                <label for="id_name" class="form-label">Name</label>
+                <span class="invalid-feedback" style="display: block;">This field is required</span>
+            </div>
+            <div class="q">
+                <label class="caption form-label">
+                    <span class="caption-text">Age</span>
+                    <span class="sr-only">A response is required for this question.</span>
+                </label>
+                <div class="text-danger error-message">An answer is required</div>
+            </div>
+            <div class="form-group has-error">
+                <label class="control-label">Email</label>
+                <span class="help-block">Enter a valid email</span>
+            </div>
+        `;
+        document.body.appendChild(dom);
+
+        try {
+            assert.deepEqual(_scrapeErrorMessages(), [
+                {level: "error", message: "Name: This field is required", type: "inline"},
+                {level: "error", message: "Age: An answer is required", type: "inline"},
+                {level: "error", message: "Email: Enter a valid email", type: "inline"},
+            ]);
+        } finally {
+            document.body.removeChild(dom);
+        }
+    });
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/ocs_page_errors_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/ocs_page_errors_spec.js
@@ -92,4 +92,20 @@ describe("OCS page warnings collector", function () {
             document.body.removeChild(dom);
         }
     });
+
+    it("scrapes error banners inside the App Preview's same-origin iframe", function () {
+        const iframe = document.createElement("iframe");
+        iframe.className = "preview-phone-window";
+        document.body.appendChild(iframe);
+        iframe.contentDocument.body.innerHTML =
+            `<div class="alert alert-danger">Preview form error</div>`;
+
+        try {
+            assert.deepEqual(_scrapeErrorMessages(), [
+                {level: "error", message: "Preview form error", type: "banner"},
+            ]);
+        } finally {
+            document.body.removeChild(iframe);
+        }
+    });
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/ocs_page_errors_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/ocs_page_errors_spec.js
@@ -93,6 +93,38 @@ describe("OCS page warnings collector", function () {
         }
     });
 
+    it("reports the label and error but never the field's own value (possible PII)", function () {
+        const ssn = "123-45-6789";
+        const patientName = "Jane Doe";
+        const dom = document.createElement("div");
+        dom.innerHTML = `
+            <div id="div_id_ssn" class="mb-3">
+                <label for="id_ssn" class="form-label">Social security number</label>
+                <input id="id_ssn" class="form-control is-invalid" value="${ssn}">
+                <span class="invalid-feedback" style="display: block;">Invalid format</span>
+            </div>
+            <div class="form-group has-error">
+                <label class="control-label">Notes</label>
+                <textarea class="form-control">${patientName}</textarea>
+                <span class="help-block">This field is required</span>
+            </div>
+        `;
+        document.body.appendChild(dom);
+
+        try {
+            const messages = _scrapeErrorMessages();
+            assert.deepEqual(messages, [
+                {level: "error", message: "Social security number: Invalid format", type: "inline"},
+                {level: "error", message: "Notes: This field is required", type: "inline"},
+            ]);
+            const allText = messages.map((m) => m.message).join(" ");
+            assert.notInclude(allText, ssn);
+            assert.notInclude(allText, patientName);
+        } finally {
+            document.body.removeChild(dom);
+        }
+    });
+
     it("scrapes the visible HTMX error modal", function () {
         const dom = document.createElement("div");
         dom.innerHTML = `

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/ocs_page_errors_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/ocs_page_errors_spec.js
@@ -43,6 +43,24 @@ describe("OCS page warnings collector", function () {
         }
     });
 
+    it("reports only the outermost of nested alerts", function () {
+        const dom = document.createElement("div");
+        dom.innerHTML = `
+            <div class="alert alert-danger">
+                <div class="alert alert-warning alert-build">Cannot make new version</div>
+            </div>
+        `;
+        document.body.appendChild(dom);
+
+        try {
+            assert.deepEqual(_scrapeErrorMessages(), [
+                {level: "error", message: "Cannot make new version", type: "banner"},
+            ]);
+        } finally {
+            document.body.removeChild(dom);
+        }
+    });
+
     it("scrapes inline field errors with the field label, ignoring sr-only text", function () {
         const dom = document.createElement("div");
         dom.innerHTML = `

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/ocs_page_errors_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/ocs_page_errors_spec.js
@@ -74,4 +74,22 @@ describe("OCS page warnings collector", function () {
             document.body.removeChild(dom);
         }
     });
+
+    it("scrapes the visible HTMX error modal", function () {
+        const dom = document.createElement("div");
+        dom.innerHTML = `
+            <div id="htmxRequestErrorModal">
+                <div class="modal-body">Server Error Encountered (500)</div>
+            </div>
+        `;
+        document.body.appendChild(dom);
+
+        try {
+            assert.deepEqual(_scrapeErrorMessages(), [
+                {level: "error", message: "Server Error Encountered (500)", type: "modal"},
+            ]);
+        } finally {
+            document.body.removeChild(dom);
+        }
+    });
 });


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
This PR is going to collect all other errors except for the one we already collected in https://github.com/dimagi/commcare-hq/pull/37907

This PR will collect errors from https://github.com/dimagi/commcare-hq/pull/37909 twice, so it should be reverted after this PR is merged.

No user-visible change on its own — this only adds to the context payload the
widget already collects.
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19938

Adds `hqwebapp/js/ocs_page_errors.js`, a context collector registered with `ocsContext.registerContextCollector` that emits `page_warnings: [{level, message, type}]`.

Design decision — pure DOM scrape. The downside is some banner is purely informative to alert user, not indicating an error. The scraping means we will send those banner as warning to the bot as well. Deciding whether a given banner is a real error the user is stuck on vs. a decorative/informational one is deliberately left to the bot; the collector just reports what's on screen.

Other alternatives that I've tried:
- Purely server side collection: 
There are some errors are written in template, like `{% if has_form_errors %} <div class="alert alert-danger"> ... </div> {% endif %}`, thus purely server side is impossible
- Hybrid, collect from server side when possible, if not possible collect from DOM scraping:
  - If only scrape by the error style, then we will double count errors, because some server side error will using the same styling
  - Otherwise, tag those error elements in the template with `data-ocs-report='error'`. But this requires human to scan through all templates, and it has high maintenance effort.


What gets scraped (`SCRAPE_SELECTORS`):
- **`banner`** — `.alert-danger` (error) / `.alert-warning` (warning). Covers Django messages, `alert_user.js`, cloudcare notifications, etc.
- **`inline`** — `.invalid-feedback`, `.error-message`, and `.has-error  .help-block`. Each is prefixed with its field label. It reports `"<label>: <error>"` and never the field value — values may contain PII.
- **`modal`** — the shared HTMX error modal (`#htmxRequestErrorModal .modal-body`).

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`OCS_CHATBOT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Purely additive and read-only on the frontend: it reads the DOM and appends to a context object. It never mutates the page and touches no server code or data. Worst case a scrape throws, which is confined to this collector and does not affect page rendering. Verified locally against real error surfaces (Django messages, crispy form validation, Web Apps question errors, the HTMX error modal, and App Preview build errors).

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
`hqwebapp/spec/ocs_page_errors_spec.js` covers each surface: banner scraping (skipping hidden + `#formdesigner`), dismiss/sr-only stripping, nested-alert de-duplication, inline errors with field labels, the HTMX modal, and the App Preview iframe.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not planning on QA.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
