### PR TITLE
Show checkbox validation errors on Bootstrap 5 forms

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/checkbox_widget.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/checkbox_widget.html
@@ -1,4 +1,6 @@
 <div class="form-check {% if is_invalid %}is-invalid{% endif %}">
   <input {{ attrs }} />
-  <label class="form-check-label" for="{{ input_id }}">{{ inline_label }}</label>
+  <label class="form-check-label" for="{{ input_id }}"
+    >{{ inline_label }}</label
+  >
 </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/checkbox_widget.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/bootstrap5/checkbox_widget.html
@@ -1,4 +1,4 @@
-<div class="form-check">
+<div class="form-check {% if is_invalid %}is-invalid{% endif %}">
   <input {{ attrs }} />
   <label class="form-check-label" for="{{ input_id }}">{{ inline_label }}</label>
 </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/switch_widget.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/switch_widget.html
@@ -1,4 +1,6 @@
 <div class="form-check form-switch {% if is_invalid %}is-invalid{% endif %}">
   <input {{ attrs }} />
-  <label class="form-check-label" for="{{ input_id }}">{{ inline_label }}</label>
+  <label class="form-check-label" for="{{ input_id }}"
+    >{{ inline_label }}</label
+  >
 </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/crispy/switch_widget.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/crispy/switch_widget.html
@@ -1,4 +1,4 @@
-<div class="form-check form-switch">
+<div class="form-check form-switch {% if is_invalid %}is-invalid{% endif %}">
   <input {{ attrs }} />
   <label class="form-check-label" for="{{ input_id }}">{{ inline_label }}</label>
 </div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/crispy/checkbox_widget.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/crispy/checkbox_widget.html.diff.txt
@@ -1,8 +1,10 @@
 --- 
 +++ 
-@@ -1 +1,4 @@
+@@ -1 +1,6 @@
 -<label class="checkbox"><input {{ attrs }} /> {{ inline_label }}</label>
-+<div class="form-check">
++<div class="form-check {% if is_invalid %}is-invalid{% endif %}">
 +  <input {{ attrs }} />
-+  <label class="form-check-label" for="{{ input_id }}">{{ inline_label }}</label>
++  <label class="form-check-label" for="{{ input_id }}"
++    >{{ inline_label }}</label
++  >
 +</div>

--- a/corehq/apps/hqwebapp/tests/test_widgets.py
+++ b/corehq/apps/hqwebapp/tests/test_widgets.py
@@ -1,0 +1,157 @@
+"""Tests for checkbox widget rendering, in particular that field validation
+errors are visible on Bootstrap 5 forms (SAAS-19669).
+
+Bootstrap 5 keeps ``.invalid-feedback`` at ``display: none`` unless a
+preceding sibling has the ``is-invalid`` class, so the widget must preserve
+the ``is-invalid`` class that crispy forms adds when a field has errors, and
+its wrapper div (the error span's actual sibling) must carry it too.
+"""
+import re
+
+from django import forms
+from django.template import Context, Template
+
+import crispy_forms.bootstrap as twbscrispy
+import crispy_forms.layout as crispy
+import pytest
+from crispy_forms.helper import FormHelper
+from unmagic import fixture, use  # https://github.com/dimagi/pytest-unmagic
+
+from corehq.apps.hqwebapp.utils.bootstrap import (
+    clear_bootstrap_version,
+    set_bootstrap_version3,
+    set_bootstrap_version5,
+)
+from corehq.apps.hqwebapp.widgets import (
+    BootstrapCheckboxInput,
+    BootstrapSwitchInput,
+)
+
+
+@fixture
+def bootstrap5():
+    set_bootstrap_version5()
+    try:
+        yield
+    finally:
+        clear_bootstrap_version()
+
+
+@fixture
+def bootstrap3():
+    set_bootstrap_version3()
+    try:
+        yield
+    finally:
+        clear_bootstrap_version()
+
+
+def _rendered_input_classes(widget, incoming_class):
+    context = widget.get_context('is_active', True, {'class': incoming_class})
+    match = re.search(r'class="([^"]*)"', context['attrs'])
+    return match.group(1)
+
+
+@use(bootstrap5)
+@pytest.mark.parametrize('incoming_class, expected', [
+    # crispy's bootstrap5 checkbox path: is-invalid on error, plus the
+    # lowercased widget class name that CrispyFieldNode always appends
+    ('form-check-input is-invalid bootstrapcheckboxinput', 'form-check-input is-invalid'),
+    # crispy's PrependedText path styles checkboxes as generic controls
+    ('form-control is-invalid', 'form-check-input is-invalid'),
+    ('form-select is-invalid', 'form-check-input is-invalid'),
+    ('form-check-input bootstrapcheckboxinput', 'form-check-input'),
+    ('', 'form-check-input'),
+])
+def test_checkbox_input_classes_bootstrap5(incoming_class, expected):
+    assert _rendered_input_classes(BootstrapCheckboxInput(), incoming_class) == expected
+
+
+@use(bootstrap5)
+def test_custom_widget_classes_are_preserved():
+    classes = _rendered_input_classes(BootstrapCheckboxInput(), 'custom-class is-invalid')
+    assert classes == 'form-check-input custom-class is-invalid'
+
+
+@use(bootstrap5)
+def test_switch_input_filters_its_own_class_name():
+    classes = _rendered_input_classes(BootstrapSwitchInput(), 'form-control is-invalid bootstrapswitchinput')
+    assert classes == 'form-check-input is-invalid'
+
+
+@use(bootstrap5)
+@pytest.mark.parametrize('incoming_class, is_invalid', [
+    ('form-check-input is-invalid', True),
+    ('form-check-input', False),
+])
+def test_context_exposes_is_invalid(incoming_class, is_invalid):
+    context = BootstrapCheckboxInput().get_context('is_active', True, {'class': incoming_class})
+    assert context['is_invalid'] is is_invalid
+
+
+@use(bootstrap5)
+def test_switch_wrapper_gets_is_invalid():
+    html = BootstrapSwitchInput().render('is_active', True, attrs={'class': 'is-invalid'})
+    assert '<div class="form-check form-switch is-invalid">' in html
+
+
+@use(bootstrap3)
+def test_checkbox_input_classes_bootstrap3():
+    classes = _rendered_input_classes(BootstrapCheckboxInput(), 'form-control is-invalid')
+    assert classes == 'bootstrapcheckboxinput is-invalid'
+
+
+class DemoForm(forms.Form):
+    is_active = forms.BooleanField(
+        label="Active Status",
+        required=False,
+        widget=BootstrapCheckboxInput(inline_label="Single Sign On is active"),
+    )
+
+    def __init__(self, *args, use_prepended_text=False, error=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._error = error
+        self.helper = FormHelper()
+        self.helper.form_tag = False
+        self.helper.layout = crispy.Layout(
+            twbscrispy.PrependedText('is_active', '') if use_prepended_text
+            else crispy.Field('is_active')
+        )
+
+    def clean_is_active(self):
+        if self._error:
+            raise forms.ValidationError("checkbox error")
+        return self.cleaned_data['is_active']
+
+
+def _render_crispy_bootstrap5(form):
+    template = Template("{% load crispy_forms_tags %}{% crispy form %}")
+    return template.render(Context({'form': form, 'use_bootstrap5': True}))
+
+
+def _get_input_tag(html):
+    return re.search(r'<input[^>]*name="is_active"[^>]*>', html).group(0)
+
+
+@use(bootstrap5)
+@pytest.mark.parametrize('use_prepended_text', [False, True])
+def test_validation_error_is_visible_on_bootstrap5_form(use_prepended_text):
+    form = DemoForm(data={'is_active': 'on'}, error=True, use_prepended_text=use_prepended_text)
+    assert not form.is_valid()
+    html = _render_crispy_bootstrap5(form)
+    input_tag = _get_input_tag(html)
+    assert 'is-invalid' in input_tag
+    assert 'form-control' not in input_tag
+    # the widget's wrapper div is the invalid-feedback span's preceding
+    # sibling, so it needs is-invalid for the span to be displayed
+    assert '<div class="form-check is-invalid">' in html
+    assert 'invalid-feedback' in html
+
+
+@use(bootstrap5)
+@pytest.mark.parametrize('use_prepended_text', [False, True])
+def test_valid_bootstrap5_form_has_no_error_styling(use_prepended_text):
+    form = DemoForm(data={'is_active': 'on'}, use_prepended_text=use_prepended_text)
+    assert form.is_valid()
+    html = _render_crispy_bootstrap5(form)
+    assert 'is-invalid' not in html

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -39,14 +39,25 @@ class BootstrapCheckboxInput(CheckboxInput):
             final_attrs['value'] = force_str(value)
         from corehq.apps.hqwebapp.utils.bootstrap import get_bootstrap_version, BOOTSTRAP_5
         use_bootstrap5 = get_bootstrap_version() == BOOTSTRAP_5
-        final_attrs['class'] = 'form-check-input' if use_bootstrap5 else 'bootstrapcheckboxinput'
+        base_class = 'form-check-input' if use_bootstrap5 else 'bootstrapcheckboxinput'
+        final_attrs['class'] = self._merge_css_classes(base_class, final_attrs.get('class', ''))
         context.update({
             'use_bootstrap5': use_bootstrap5,
             'input_id': final_attrs.get('id'),
             'inline_label': self.inline_label,
+            'is_invalid': 'is-invalid' in final_attrs['class'].split(),
             'attrs': mark_safe(flatatt(final_attrs)),  # nosec: trusting the user to sanitize attributes
         })
         return context
+
+    def _merge_css_classes(self, base_class, incoming_classes):
+        # crispy forms adds classes meant for generic full-width controls,
+        # plus the lowercased widget class name; neither belongs on a
+        # checkbox, but classes like is-invalid must survive (SAAS-19669)
+        unwanted = {'form-control', 'form-select', base_class, type(self).__name__.lower()}
+        merged = [base_class]
+        merged += [css_class for css_class in incoming_classes.split() if css_class not in unwanted]
+        return ' '.join(merged)
 
 
 class BootstrapSwitchInput(BootstrapCheckboxInput):

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -53,7 +53,7 @@ class BootstrapCheckboxInput(CheckboxInput):
     def _merge_css_classes(self, base_class, incoming_classes):
         # crispy forms adds classes meant for generic full-width controls,
         # plus the lowercased widget class name; neither belongs on a
-        # checkbox, but classes like is-invalid must survive (SAAS-19669)
+        # checkbox, but classes like is-invalid must survive
         unwanted = {'form-control', 'form-select', base_class, type(self).__name__.lower()}
         merged = [base_class]
         merged += [css_class for css_class in incoming_classes.split() if css_class not in unwanted]


### PR DESCRIPTION
## Product Description

On Bootstrap 5 forms, validation errors on checkbox fields using `BootstrapCheckboxInput` (and `BootstrapSwitchInput`) were silently invisible — the form would appear to "do nothing" on submit. Discovered on the SSO Identity Provider admin page: checking "Single Sign On is active" on an IdP missing its SAML fields and submitting came back with the checkbox still checked — even though there's a silent error — and no explanation; if you reloaded the page, the checkbox would be unchecked, because nothing had been saved (due to the error). Errors now render normally, with Bootstrap 5's red checkbox border and label.

Before:

<img width="637" height="92" alt="Screenshot 2026-07-15 at 4 35 27 PM" src="https://github.com/user-attachments/assets/3d6240d5-cf2f-45e1-a6a7-babfa16f509a" />

(error is there but invisible)

After:
<img width="1102" height="111" alt="Screenshot 2026-07-15 at 4 33 17 PM" src="https://github.com/user-attachments/assets/09d6609b-8d2e-4d66-af7a-bc8b329740c6" />

## Technical Summary

[SAAS-19669](https://dimagi.atlassian.net/browse/SAAS-19669)

Two things conspired to hide the errors, so the ticket's suggested one-line fix (merge classes instead of overwriting) wouldn't have been enough on its own:

1. The widget unconditionally overwrote the input's `class` attribute, stripping the `is-invalid` class crispy forms adds when the field has errors. Bootstrap 5 keeps `.invalid-feedback` at `display: none` unless a preceding sibling has `is-invalid`, so the error markup rendered but never displayed.
2. Even with `is-invalid` restored on the input, the widget's template wraps the input in its own `<div class="form-check">`, so the input is never a *sibling* of the error span — the wrapper is. The wrapper now also takes `is-invalid` when the field has errors, which is what actually un-hides the feedback.

The overwrite also turned out to be accidentally load-bearing: crispy's `PrependedText` path (used by the SSO form) injects `form-control is-invalid` because its template doesn't special-case checkboxes, and `CrispyFieldNode` always appends the lowercased widget class name. A naive merge would leak both onto the input, so the merge filters out `form-control`/`form-select` and the class-name junk while carrying everything else through.

## Feature Flag

None.

## Safety Assurance

### Safety story

The change is confined to the two widgets' class-attribute handling and their Bootstrap 5 templates. On valid forms the rendered output is byte-identical to before except for a trailing space in the wrapper's class attribute. Bootstrap 3 pages keep the same `bootstrapcheckboxinput` base class and show errors via `help-block`, which was never affected. No callers pass custom classes to these widgets today (checked all 41 usages), so the overwrite→merge change has no collateral effect.

### Automated test coverage

New `test_widgets.py` covers the class-merge logic directly (both Bootstrap versions, both widgets, crispy's two injection patterns) and renders a form with errors through the real `bootstrap3to5` crispy pipeline in both layout paths (`crispy.Field` and `PrependedText`), asserting the DOM shape Bootstrap 5's `.is-invalid ~ .invalid-feedback` selector requires. The first commit adds the tests failing against the old behavior.

### QA Plan

No QA planned; covered by automated tests. Manual spot-check available via Accounting Admin → Identity Providers: activate SSO on an IdP missing SAML fields and confirm the error message appears.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19669]: https://dimagi.atlassian.net/browse/SAAS-19669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ