### PR TITLE
Stop gunicorn worker recycling from killing long-running requests

### DIFF
--- a/deployment/gunicorn/gunicorn_conf.py
+++ b/deployment/gunicorn/gunicorn_conf.py
@@ -5,10 +5,12 @@ preload_app = True
 worker_class = 'gevent'
 keepalive = 60
 timeout = 900
-max_requests = 240
+max_requests = 2000
 max_requests_jitter = int(max_requests * 0.5)
-# defaults to 30 sec, setting to 5 minutes to fight `GreenletExit`s
-graceful_timeout = 5*60
+# Should be at least as long as the longest request we're willing to serve
+# (nginx proxy_read_timeout allows up to 900s), otherwise worker recycling
+# force-kills in-flight requests when this expires.
+graceful_timeout = 900
 # defaults to 4094, increasing to avoid https://manage.dimagi.com/default.asp?283517#1532884
 limit_request_line = 4500
 


### PR DESCRIPTION
## Product Description

No direct user-facing changes. Indirectly: mobile users should see fewer dropped long-running requests (phone restores/syncs) that today fail when the gunicorn worker serving them is recycled mid-request.

## Technical Summary

`max_requests = 240` dates to 2014 (#4252). The only recorded rationale for keeping it low was a suspected memory leak on Rackspace webworkers (#21966), which reverted shortly after (#22174), and there was no recorded rationale for the specific number 240. Nobody has re-evaluated it since.

Analysis of production gunicorn logs (one hour, all 14 webworkers) shows what it costs today:

- Workers recycle every 120–360 requests: roughly every 50s per mobile host, every ~2 min per hq/api host.
- On the mobile pool, **~1 in 6 recycles drains for exactly ~302s** — the worker still had an in-flight request when `graceful_timeout` (300s) expired, and gunicorn force-killed it. That's ~40 killed requests/hour in steady state, typically restores, whose nginx `proxy_read_timeout` budget is 900s.

This PR raises `max_requests` to 2000 (recycle ~8× less often; jitter stays proportional at 50%) and raises `graceful_timeout` to 900s so the drain window is never shorter than the request budget nginx grants. Together these should take steady-state force-kills to ~zero: the only requests a recycle can then kill are ones that would have hit nginx's 900s timeout anyway.

Note `graceful_timeout` does not affect deploy-time shutdowns in practice: supervisor's default `stopwaitsecs` of 10s SIGKILLs the master long before either the old or new value matters. I'm treating that as out of scope for now.

## Feature Flag

None.

## Safety Assurance

### Safety story

- Config-only change to gunicorn worker recycling; no application code paths change.
- The main risk is memory: a low `max_requests` masks slow leaks by restarting workers frequently, though we have no specific reason to expect there to be such a leak. After deploy, worker RSS on the webworker groups should be watched for a week or so; if it climbs linearly with worker age, this value can be tuned down without any other considerations.
- Secondary effect: a genuinely hung request now keeps its retired worker draining for up to 15 minutes instead of 5 (holding memory and a DB connection). With recycles ~8× rarer and observed drains almost always sub-second, expected overlap is negligible.

### Automated test coverage

None applicable — the values under change are load/traffic-dependent tuning parameters. Existing `testapps/test_gunicorn/` coverage of the config module's hooks is unaffected.

### QA Plan

No QA ticket. Verification is post-deploy observation: restart frequency (`Autorestarting worker` log lines), force-kill count (`Worker graceful timeout` log lines), and webworker memory trends.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
