### PR TITLE
Fix flaky ReportAPITest.test_basic caused by leaked openpyxl export writer

### DIFF
--- a/corehq/ex-submodules/couchexport/export.py
+++ b/corehq/ex-submodules/couchexport/export.py
@@ -40,8 +40,10 @@ def export_from_tables(tables, file, format, max_column_size=2000):
         rows_by_sheet.append((worksheet_title, row_generator))
 
     writer.open(sheet_headers, file, max_column_size=max_column_size)
-    writer.write(rows_by_sheet)
-    writer.close()
+    try:
+        writer.write(rows_by_sheet)
+    finally:
+        writer.close()
 
 
 def export_raw(headers, data, file, format=Format.XLS_2007,
@@ -90,11 +92,13 @@ def export_raw_to_writer(headers, data, file, format=Format.XLS_2007,
     headers = FormattedRow.wrap_all_rows(headers)
     writer.open(headers, file, max_column_size=max_column_size)
 
-    # do the same for the data
-    data = FormattedRow.wrap_all_rows(data)
-    writer.write(data)
-    yield writer
-    writer.close()
+    try:
+        # do the same for the data
+        data = FormattedRow.wrap_all_rows(data)
+        writer.write(data)
+        yield writer
+    finally:
+        writer.close()
 
 
 class Constant(object):

--- a/corehq/ex-submodules/couchexport/tests/test_writers.py
+++ b/corehq/ex-submodules/couchexport/tests/test_writers.py
@@ -1,13 +1,16 @@
 from codecs import BOM_UTF8
 from contextlib import closing
+import gc
 import io
 import os
+import warnings
 
 from django.test import SimpleTestCase
 from lxml import html, etree
+from openpyxl.worksheet._write_only import WriteOnlyWorksheet
 from unittest.mock import patch, Mock
 
-from couchexport.export import export_from_tables
+from couchexport.export import export_from_tables, export_raw_to_writer
 from couchexport.models import Format
 from couchexport.writers import (
     MAX_XLS_COLUMNS,
@@ -122,6 +125,73 @@ class Excel2007ExportWriterTests(SimpleTestCase):
         ]
         tables = [[b'table\xe2\x80\x93title', table]]
         export_from_tables(tables, file_, format_)
+
+
+class ExportWriterCleanupTests(SimpleTestCase):
+    """
+    If a write fails partway through, the writer must still be closed.
+    Otherwise an in-progress openpyxl write-only workbook is abandoned:
+    its generator-based XML writer is left suspended and gets garbage
+    collected at some arbitrary later point (potentially during an
+    unrelated test), raising unraisable lxml errors at that time.
+    """
+
+    def test_export_from_tables_closes_writer_on_write_error(self):
+        mock_writer = Mock()
+        mock_writer.write.side_effect = ValueError("boom")
+        with patch('couchexport.export.get_writer', return_value=mock_writer):
+            with self.assertRaises(ValueError):
+                export_from_tables([['title', [['header']]]], io.BytesIO(), Format.XLS_2007)
+        mock_writer.close.assert_called_once()
+
+    def test_export_raw_to_writer_closes_writer_on_write_error(self):
+        mock_writer = Mock()
+        mock_writer.write.side_effect = ValueError("boom")
+        with patch('couchexport.export.get_writer', return_value=mock_writer):
+            with self.assertRaises(ValueError):
+                with export_raw_to_writer([['title', ['header']]], [['title', []]], io.BytesIO()):
+                    pass
+        mock_writer.close.assert_called_once()
+
+    def test_export_raw_to_writer_closes_writer_on_consumer_error(self):
+        mock_writer = Mock()
+        with patch('couchexport.export.get_writer', return_value=mock_writer):
+            with self.assertRaises(ValueError):
+                with export_raw_to_writer([['title', ['header']]], [['title', []]], io.BytesIO()):
+                    raise ValueError("boom")
+        mock_writer.close.assert_called_once()
+
+    def test_xlsx_write_failure_does_not_leave_unraisable_generator(self):
+        """
+        A real (unmocked) regression test for the mechanism above: an
+        openpyxl write-only workbook whose write is interrupted, and never
+        saved/closed, leaves its lxml-backed generators suspended. When
+        those get garbage collected -- possibly much later, during an
+        unrelated test -- lxml raises unraisable errors from within the
+        abandoned generator's __del__.
+        """
+        original_append = WriteOnlyWorksheet.append
+        calls = {'n': 0}
+
+        def flaky_append(self, *args, **kwargs):
+            calls['n'] += 1
+            if calls['n'] == 2:
+                raise ValueError("simulated failure mid-write")
+            return original_append(self, *args, **kwargs)
+
+        WriteOnlyWorksheet.append = flaky_append
+        try:
+            tables = [['title', [['h1', 'h2'], ['r1', 'r2']]]]
+            with self.assertRaises(ValueError):
+                export_from_tables(tables, io.BytesIO(), Format.XLS_2007)
+        finally:
+            WriteOnlyWorksheet.append = original_append
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            gc.collect()
+        unraisable = [w for w in caught if 'Unraisable' in w.category.__name__]
+        self.assertEqual(unraisable, [])
 
 
 class Excel2003ExportWriterTests(SimpleTestCase):


### PR DESCRIPTION
## Product Description
No user-facing change. This fixes a flaky test failure in CI that has been occurring frequently for about a month. The failure seems unrelated to the test it was reported against.

Example failure: https://github.com/dimagi/commcare-hq/actions/runs/29506840997/job/87649709757

## Technical Summary

- `ReportAPITest.test_basic` was intermittently failing at test *setup* with an `ExceptionGroup` containing `lxml.etree.LxmlSyntaxError` ("not in an element" / "inconsistent exit action in context manager") raised from inside openpyxl's write-only worksheet generators during garbage collection.
- Root cause: `couchexport.export.export_from_tables` and `export_raw_to_writer` never wrapped `writer.write()` in `try`/`finally`. If a write fails partway through, `writer.close()` (which calls `openpyxl.Workbook.save()`) was skipped, abandoning the write-only workbook's internal, generator-based XML writer mid-stream.
- `lxml`'s incremental writer raises `LxmlSyntaxError` when an abandoned generator's context managers are torn down out of order. This may be new behavior in v6.1.0 (see speculation below).
- Fix: wrap the write step of both `export_from_tables` and `export_raw_to_writer` in `try`/`finally` so `writer.close()` always runs, ensuring the workbook's generators are always drained even when writing fails.

### Speculation:

A change in `lxml`, which was bumped from 6.0.0 to 6.1.0 earlier this year, may have caused the issue. The [upgrade](https://github.com/dimagi/commcare-hq/pull/37619) occurred a couple months before I started noticing flaky failures, so the timing is not perfect. I also haven't verified that 6.0.0 behaves differently, so it's possible the underlying bug was already present and some other condition surfaced it.

Q: Why was it consistently failing on the same test?

A: Best guess: `pytest`'s `unraisableexception` plugin checks for pending unraisable exceptions at the start of every test's setup phase, and the suite runs in a fixed order. It seems plausible that the same GC allocation threshold was crossed at the same point on every run, consistently failing in `test_basic` setup.



## Safety Assurance

### Safety story

This only changes control flow around resource cleanup on an already-erroring path — it does not change behavior when writes succeed. The reported real-world `ExceptionGroup` was reproduced with an openpyxl write failure, confirmed to reproduce on the pre-fix code and to disappear after the fix.

### Automated test coverage

Yes.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations