### PR TITLE
Stop double billing users on customer invoices after a plan version change

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -52,6 +52,7 @@ from corehq.apps.accounting.models import (
 )
 from corehq.apps.accounting.utils import (
     ensure_domain_instance,
+    is_active_subscription,
     log_accounting_error,
     log_accounting_info,
     get_first_day_x_months_later,
@@ -532,15 +533,24 @@ class LineItemFactory(object):
     @memoized
     def subscribed_domains(self):
         if self.subscription.account.is_customer_billing_account:
-            return list(self.subscription.account.subscription_set.filter(
-                Q(date_end__isnull=True) | Q(date_end__gt=self.invoice.date_start),
-                date_start__lte=self.invoice.date_end
-            ).filter(
-                plan_version=self.subscription.plan_version
-            ).values_list(
-                'subscriber__domain', flat=True
-            ))
+            return list(self._subscription_date_ranges_by_domain)
         return [self.subscription.subscriber.domain]
+
+    @property
+    @memoized
+    def _subscription_date_ranges_by_domain(self):
+        """The account's subscriptions on this line item's plan version that
+        overlap the invoice period, as ``{domain: [(date_start, date_end)]}``.
+        """
+        date_ranges = defaultdict(list)
+        subscriptions = self.subscription.account.subscription_set.filter(
+            Q(date_end__isnull=True) | Q(date_end__gt=self.invoice.date_start),
+            date_start__lte=self.invoice.date_end,
+            plan_version=self.subscription.plan_version,
+        ).values_list('subscriber__domain', 'date_start', 'date_end')
+        for domain, date_start, date_end in subscriptions:
+            date_ranges[domain].append((date_start, date_end))
+        return date_ranges
 
     def create(self):
         line_item = LineItem(
@@ -769,23 +779,10 @@ class UserLineItemFactory(FeatureLineItemFactory):
             domain
             for domain, date_ranges in self._subscription_date_ranges_by_domain.items()
             if any(
-                date_start <= date and (date_end is None or date < date_end)
+                is_active_subscription(date_start, date_end, today=date)
                 for date_start, date_end in date_ranges
             )
         ]
-
-    @property
-    @memoized
-    def _subscription_date_ranges_by_domain(self):
-        date_ranges = defaultdict(list)
-        subscriptions = self.subscription.account.subscription_set.filter(
-            Q(date_end__isnull=True) | Q(date_end__gt=self.invoice.date_start),
-            date_start__lte=self.invoice.date_end,
-            plan_version=self.subscription.plan_version,
-        ).values_list('subscriber__domain', 'date_start', 'date_end')
-        for domain, date_start, date_end in subscriptions:
-            date_ranges[domain].append((date_start, date_end))
-        return date_ranges
 
     def total_users_for_date(self, date):
         total_users = 0
@@ -851,7 +848,7 @@ class WebUserLineItemFactory(UserLineItemFactory):
     def total_users_for_date(self, date):
         # Web users are counted account-wide, so bill a month end only if
         # this line item's plan version had an active subscription then
-        if self.invoice.is_customer_invoice and not self.subscribed_domains_for_date(date):
+        if not self.subscribed_domains_for_date(date):
             return 0
         try:
             history = BillingAccountWebUserHistory.objects.get(

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -832,7 +832,7 @@ class FormSubmittingMobileWorkerLineItemFactory(UserLineItemFactory):
 
     def total_users_for_date(self, date):
         total_users = 0
-        for domain in self.subscribed_domains:
+        for domain in self.subscribed_domains_for_date(date):
             try:
                 history = FormSubmittingMobileWorkerHistory.objects.get(domain=domain, record_date=date)
                 total_users += history.num_users

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -753,9 +753,43 @@ class UserLineItemFactory(FeatureLineItemFactory):
             excess_users += max(total_users - self.rate.monthly_limit, 0)
         return excess_users
 
+    def subscribed_domains_for_date(self, date):
+        """Domains whose subscription on this line item's plan version was
+        active on ``date``.
+
+        A customer invoice can span months during which a domain moved to a
+        different plan version (ending one subscription and starting another,
+        as ``Subscription.change_plan`` does). Each month end must only be
+        billed under the plan version that was active on that date, otherwise
+        the same month's users are billed once per plan version.
+        """
+        if not self.invoice.is_customer_invoice:
+            return self.subscribed_domains
+        return [
+            domain
+            for domain, date_ranges in self._subscription_date_ranges_by_domain.items()
+            if any(
+                date_start <= date and (date_end is None or date < date_end)
+                for date_start, date_end in date_ranges
+            )
+        ]
+
+    @property
+    @memoized
+    def _subscription_date_ranges_by_domain(self):
+        date_ranges = defaultdict(list)
+        subscriptions = self.subscription.account.subscription_set.filter(
+            Q(date_end__isnull=True) | Q(date_end__gt=self.invoice.date_start),
+            date_start__lte=self.invoice.date_end,
+            plan_version=self.subscription.plan_version,
+        ).values_list('subscriber__domain', 'date_start', 'date_end')
+        for domain, date_start, date_end in subscriptions:
+            date_ranges[domain].append((date_start, date_end))
+        return date_ranges
+
     def total_users_for_date(self, date):
         total_users = 0
-        for domain in self.subscribed_domains:
+        for domain in self.subscribed_domains_for_date(date):
             try:
                 history = DomainUserHistory.objects.get(domain=domain, record_date=date)
                 total_users += history.num_users
@@ -815,6 +849,10 @@ class FormSubmittingMobileWorkerLineItemFactory(UserLineItemFactory):
 class WebUserLineItemFactory(UserLineItemFactory):
 
     def total_users_for_date(self, date):
+        # Web users are counted account-wide, so bill a month end only if
+        # this line item's plan version had an active subscription then
+        if self.invoice.is_customer_invoice and not self.subscribed_domains_for_date(date):
+            return 0
         try:
             history = BillingAccountWebUserHistory.objects.get(
                 billing_account=self.subscription.account, record_date=date)

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -746,8 +746,7 @@ class TestUserLineItemsAfterMidQuarterPlanVersionChange(BaseAccountingTest):
 
         billing_contact = generator.create_arbitrary_web_user_name()
         dimagi_user = generator.create_arbitrary_web_user_name(is_dimagi=True)
-        cls.account = generator.billing_account(dimagi_user, billing_contact)
-        cls.account.is_customer_billing_account = True
+        cls.account = generator.billing_account(dimagi_user, billing_contact, is_customer_account=True)
         cls.account.invoicing_plan = InvoicingPlan.QUARTERLY
         cls.account.save()
 
@@ -759,7 +758,8 @@ class TestUserLineItemsAfterMidQuarterPlanVersionChange(BaseAccountingTest):
             plan_version.plan.is_customer_software_plan = True
             plan_version.plan.save()
 
-        cls.domain = cls._create_domain('mid-quarter-plan-change')
+        cls.domain = create_domain('mid-quarter-plan-change')
+        cls.addClassCleanup(cls.domain.delete)
 
         # Invoicing on 2018-04-01 creates the invoice for 2018-01-01 - 2018-03-31
         cls.invoice_date = date(2018, 4, 1)
@@ -781,12 +781,6 @@ class TestUserLineItemsAfterMidQuarterPlanVersionChange(BaseAccountingTest):
             date_end=date(2018, 7, 1),
             plan_version=cls.new_plan_version,
         )
-
-    @classmethod
-    def _create_domain(cls, name):
-        domain_obj = create_domain(name)
-        cls.addClassCleanup(domain_obj.delete)
-        return domain_obj
 
     def _create_domain_user_history(self, domain, num_users):
         for month_end in self.month_ends:
@@ -895,6 +889,45 @@ class TestUserLineItemsAfterMidQuarterPlanVersionChange(BaseAccountingTest):
             plan_version.feature_rates.add(rate)
             rates.append(rate)
         return rates
+
+    def test_change_on_a_month_end_bills_that_month_under_the_new_plan_version(self):
+        boundary_domain = create_domain('plan-change-on-month-end')
+        self.addCleanup(boundary_domain.delete)
+        month_end_change_date = date(2018, 2, 28)
+        generator.generate_domain_subscription(
+            self.account,
+            boundary_domain,
+            date_start=date(2017, 7, 1),
+            date_end=month_end_change_date,
+            plan_version=self.old_plan_version,
+        )
+        generator.generate_domain_subscription(
+            self.account,
+            boundary_domain,
+            date_start=month_end_change_date,
+            date_end=None,
+            plan_version=self.new_plan_version,
+        )
+        num_users = 20
+        self._create_domain_user_history(self.domain, 0)
+        self._create_domain_user_history(boundary_domain, num_users)
+
+        tasks.generate_invoices_based_on_date(self.invoice_date)
+
+        invoice = CustomerInvoice.objects.get()
+        old_line_item = self._user_line_item(invoice, self.old_plan_version)
+        new_line_item = self._user_line_item(invoice, self.new_plan_version)
+        # A subscription's date_end is exclusive, so the old subscription is
+        # no longer active on its own end date and the February month end is
+        # billed under the new, open-ended subscription
+        self.assertEqual(
+            old_line_item.quantity,
+            num_users - old_line_item.feature_rate.monthly_limit,
+        )
+        self.assertEqual(
+            new_line_item.quantity,
+            2 * (num_users - new_line_item.feature_rate.monthly_limit),
+        )
 
     def test_domain_remaining_on_the_old_plan_version_is_billed_every_month(self):
         steady_domain = create_domain('steady-on-old-plan')

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -20,6 +20,7 @@ from corehq.apps.accounting.models import (
     Feature,
     FeatureRate,
     FeatureType,
+    FormSubmittingMobileWorkerHistory,
     InvoicingPlan,
     SoftwarePlanEdition,
     Subscription,
@@ -819,8 +820,39 @@ class TestUserLineItemsAfterMidQuarterPlanVersionChange(BaseAccountingTest):
             2 * (num_users - new_line_item.feature_rate.monthly_limit),
         )
 
+    def test_form_submitting_mobile_worker_excess_is_billed_under_one_plan_version_per_month(self):
+        old_worker_rate, new_worker_rate = self._add_feature_rates(
+            "Form-Submitting Mobile Worker", FeatureType.FORM_SUBMITTING_MOBILE_WORKER)
+        # Both plan versions carry a USER rate, so mobile user history is
+        # needed for invoice generation to succeed at all
+        self._create_domain_user_history(self.domain, 0)
+        num_workers = 20
+        for month_end in self.month_ends:
+            FormSubmittingMobileWorkerHistory.objects.create(
+                domain=self.domain.name,
+                num_users=num_workers,
+                record_date=month_end,
+            )
+
+        tasks.generate_invoices_based_on_date(self.invoice_date)
+
+        invoice = CustomerInvoice.objects.get()
+        worker_line_items = invoice.lineitem_set.get_feature_by_type(
+            FeatureType.FORM_SUBMITTING_MOBILE_WORKER)
+        old_line_item = worker_line_items.get(feature_rate=old_worker_rate)
+        new_line_item = worker_line_items.get(feature_rate=new_worker_rate)
+        self.assertEqual(
+            old_line_item.quantity,
+            num_workers - old_worker_rate.monthly_limit,
+        )
+        self.assertEqual(
+            new_line_item.quantity,
+            2 * (num_workers - new_worker_rate.monthly_limit),
+        )
+
     def test_web_user_excess_is_billed_under_one_plan_version_per_month(self):
-        old_web_user_rate, new_web_user_rate = self._add_web_user_rates()
+        old_web_user_rate, new_web_user_rate = self._add_feature_rates(
+            "Web User", FeatureType.WEB_USER)
         self.account.bill_web_user = True
         self.account.save()
         # Both plan versions carry a USER rate, so mobile user history is
@@ -849,13 +881,13 @@ class TestUserLineItemsAfterMidQuarterPlanVersionChange(BaseAccountingTest):
             2 * (num_web_users - new_web_user_rate.monthly_limit),
         )
 
-    def _add_web_user_rates(self):
-        web_user_feature, __ = Feature.objects.get_or_create(
-            name="Web User", defaults={"feature_type": FeatureType.WEB_USER})
+    def _add_feature_rates(self, feature_name, feature_type):
+        feature, __ = Feature.objects.get_or_create(
+            name=feature_name, defaults={"feature_type": feature_type})
         rates = []
         for plan_version, monthly_limit in ((self.old_plan_version, 10), (self.new_plan_version, 12)):
             rate = FeatureRate.objects.create(
-                feature=web_user_feature,
+                feature=feature,
                 monthly_fee=Decimal('0.00'),
                 monthly_limit=monthly_limit,
                 per_excess_fee=Decimal('10.00'),

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -12,10 +12,13 @@ from dimagi.utils.dates import add_months_to_date
 from corehq.apps.accounting import tasks, utils
 from corehq.apps.accounting.invoicing import LineItemFactory
 from corehq.apps.accounting.models import (
+    BillingAccountWebUserHistory,
     CreditLine,
     CustomerInvoice,
     DefaultProductPlan,
     DomainUserHistory,
+    Feature,
+    FeatureRate,
     FeatureType,
     InvoicingPlan,
     SoftwarePlanEdition,
@@ -714,6 +717,178 @@ class TestQuarterlyInvoicing(BaseCustomerInvoiceCase):
         self.assertEqual(CustomerInvoice.objects.count(), 1)
         invoice = CustomerInvoice.objects.first()
         return invoice.lineitem_set.get_feature_by_type(FeatureType.SMS)
+
+
+class TestUserLineItemsAfterMidQuarterPlanVersionChange(BaseAccountingTest):
+    """
+    Changing a customer account subscription's plan version part-way through
+    a multi-month invoicing period (e.g. via the bulk upgrade on the
+    plan-version admin form) end-dates the old subscription and starts a new
+    one on the change date, so the customer invoice bills each plan version's
+    line items separately. Each month end's user count must be billed under
+    exactly one plan version — the one whose subscription was active on that
+    date.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        generator.bootstrap_test_software_plan_versions()
+        cls.addClassCleanup(utils.clear_plan_version_cache)
+        generator.init_default_currency()
+
+        billing_contact = generator.create_arbitrary_web_user_name()
+        dimagi_user = generator.create_arbitrary_web_user_name(is_dimagi=True)
+        cls.account = generator.billing_account(dimagi_user, billing_contact)
+        cls.account.is_customer_billing_account = True
+        cls.account.invoicing_plan = InvoicingPlan.QUARTERLY
+        cls.account.save()
+
+        cls.old_plan_version = DefaultProductPlan.get_default_plan_version(
+            edition=SoftwarePlanEdition.PRO)
+        cls.new_plan_version = DefaultProductPlan.get_default_plan_version(
+            edition=SoftwarePlanEdition.ADVANCED)
+        for plan_version in (cls.old_plan_version, cls.new_plan_version):
+            plan_version.plan.is_customer_software_plan = True
+            plan_version.plan.save()
+
+        cls.domain = cls._create_domain('mid-quarter-plan-change')
+
+        # Invoicing on 2018-04-01 creates the invoice for 2018-01-01 - 2018-03-31
+        cls.invoice_date = date(2018, 4, 1)
+        cls.month_ends = [date(2018, 1, 31), date(2018, 2, 28), date(2018, 3, 31)]
+        # As with Subscription.change_plan, the old subscription's date_end
+        # and the new subscription's date_start are both the change date
+        cls.change_date = date(2018, 2, 15)
+        cls.old_subscription = generator.generate_domain_subscription(
+            cls.account,
+            cls.domain,
+            date_start=date(2017, 7, 1),
+            date_end=cls.change_date,
+            plan_version=cls.old_plan_version,
+        )
+        cls.new_subscription = generator.generate_domain_subscription(
+            cls.account,
+            cls.domain,
+            date_start=cls.change_date,
+            date_end=date(2018, 7, 1),
+            plan_version=cls.new_plan_version,
+        )
+
+    @classmethod
+    def _create_domain(cls, name):
+        domain_obj = create_domain(name)
+        cls.addClassCleanup(domain_obj.delete)
+        return domain_obj
+
+    def _create_domain_user_history(self, domain, num_users):
+        for month_end in self.month_ends:
+            DomainUserHistory.objects.create(
+                domain=domain.name,
+                num_users=num_users,
+                record_date=month_end,
+            )
+
+    def _user_line_item(self, invoice, plan_version):
+        user_rate = plan_version.feature_rates.get(feature__feature_type=FeatureType.USER)
+        return invoice.lineitem_set.get_feature_by_type(FeatureType.USER).get(feature_rate=user_rate)
+
+    def test_mobile_user_excess_is_billed_under_one_plan_version_per_month(self):
+        num_users = 20
+        self._create_domain_user_history(self.domain, num_users)
+
+        tasks.generate_invoices_based_on_date(self.invoice_date)
+
+        invoice = CustomerInvoice.objects.get()
+        old_line_item = self._user_line_item(invoice, self.old_plan_version)
+        new_line_item = self._user_line_item(invoice, self.new_plan_version)
+        # Only January's month end falls before the plan change
+        self.assertEqual(
+            old_line_item.quantity,
+            num_users - old_line_item.feature_rate.monthly_limit,
+        )
+        # February's and March's month ends fall after it
+        self.assertEqual(
+            new_line_item.quantity,
+            2 * (num_users - new_line_item.feature_rate.monthly_limit),
+        )
+
+    def test_web_user_excess_is_billed_under_one_plan_version_per_month(self):
+        old_web_user_rate, new_web_user_rate = self._add_web_user_rates()
+        self.account.bill_web_user = True
+        self.account.save()
+        # Both plan versions carry a USER rate, so mobile user history is
+        # needed for invoice generation to succeed at all
+        self._create_domain_user_history(self.domain, 0)
+        num_web_users = 30
+        for month_end in self.month_ends:
+            BillingAccountWebUserHistory.objects.create(
+                billing_account=self.account,
+                num_users=num_web_users,
+                record_date=month_end,
+            )
+
+        tasks.generate_invoices_based_on_date(self.invoice_date)
+
+        invoice = CustomerInvoice.objects.get()
+        web_user_line_items = invoice.lineitem_set.get_feature_by_type(FeatureType.WEB_USER)
+        old_line_item = web_user_line_items.get(feature_rate=old_web_user_rate)
+        new_line_item = web_user_line_items.get(feature_rate=new_web_user_rate)
+        self.assertEqual(
+            old_line_item.quantity,
+            num_web_users - old_web_user_rate.monthly_limit,
+        )
+        self.assertEqual(
+            new_line_item.quantity,
+            2 * (num_web_users - new_web_user_rate.monthly_limit),
+        )
+
+    def _add_web_user_rates(self):
+        web_user_feature, __ = Feature.objects.get_or_create(
+            name="Web User", defaults={"feature_type": FeatureType.WEB_USER})
+        rates = []
+        for plan_version, monthly_limit in ((self.old_plan_version, 10), (self.new_plan_version, 12)):
+            rate = FeatureRate.objects.create(
+                feature=web_user_feature,
+                monthly_fee=Decimal('0.00'),
+                monthly_limit=monthly_limit,
+                per_excess_fee=Decimal('10.00'),
+            )
+            plan_version.feature_rates.add(rate)
+            rates.append(rate)
+        return rates
+
+    def test_domain_remaining_on_the_old_plan_version_is_billed_every_month(self):
+        steady_domain = create_domain('steady-on-old-plan')
+        self.addCleanup(steady_domain.delete)
+        generator.generate_domain_subscription(
+            self.account,
+            steady_domain,
+            date_start=date(2017, 7, 1),
+            date_end=date(2018, 7, 1),
+            plan_version=self.old_plan_version,
+        )
+        num_users = 20
+        self._create_domain_user_history(self.domain, num_users)
+        self._create_domain_user_history(steady_domain, num_users)
+
+        tasks.generate_invoices_based_on_date(self.invoice_date)
+
+        invoice = CustomerInvoice.objects.get()
+        old_line_item = self._user_line_item(invoice, self.old_plan_version)
+        new_line_item = self._user_line_item(invoice, self.new_plan_version)
+        old_limit = old_line_item.feature_rate.monthly_limit
+        new_limit = new_line_item.feature_rate.monthly_limit
+        # January: both domains were on the old plan version; February and
+        # March: only the steady domain remained on it
+        self.assertEqual(
+            old_line_item.quantity,
+            (2 * num_users - old_limit) + 2 * (num_users - old_limit),
+        )
+        self.assertEqual(
+            new_line_item.quantity,
+            2 * (num_users - new_limit),
+        )
 
 
 class TestDomainsInLineItemForCustomerInvoicing(TestCase):

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -649,10 +649,16 @@ class TestQuarterlyInvoicing(BaseCustomerInvoiceCase):
 
         invoice = CustomerInvoice.objects.first()
         user_line_items = invoice.lineitem_set.get_feature_by_type(FeatureType.USER)
-        num_excess_users_quarterly = (self.num_users * 2 - self.user_rate.monthly_limit) * 12
+        # The yearly invoice covers Apr 2016 - Mar 2017, and the non-main
+        # subscriptions end on 2016-12-23, so non_main_domain1's users only
+        # count toward the eight month ends through November
+        num_excess_users_yearly = (
+            8 * (self.num_users * 2 - self.user_rate.monthly_limit)
+            + 4 * (self.num_users - self.user_rate.monthly_limit)
+        )
         self.assertEqual(user_line_items.count(), 1)
         for user_line_item in user_line_items:
-            self.assertEqual(user_line_item.quantity, num_excess_users_quarterly)
+            self.assertEqual(user_line_item.quantity, num_excess_users_yearly)
 
     def test_sms_over_limit_in_quarterly_invoice(self):
         num_sms = random.randint(self.sms_rate.monthly_limit + 1, self.sms_rate.monthly_limit + 2)


### PR DESCRIPTION
## Product Description

On quarterly and yearly customer (enterprise) invoices, changing a subscription's plan version part-way through the invoicing period — most directly via the "upgrade subscriptions to latest plan version" checkbox on the plan version admin form, or any `Subscription.change_plan` — billed mobile user, form-submitting mobile worker, and web user excess fees **twice** for the same months: once under the old plan version's line items and once under the new one's. With this change, a domain's usage at each month end is billed under exactly one plan version — the one whose subscription was active on that date.

## Technical Summary

`CustomerAccountInvoiceFactory` groups a customer account's subscriptions by plan version and generates line items per group. A mid-period plan change end-dates the old subscription and starts a new one, so both groups appear on the invoice. But `UserLineItemFactory.quantity` counted excess users at *every* month end of the invoice period, ignoring when each group's subscriptions were actually active — so both groups billed the full period. `SmsLineItemFactory` already guards against exactly this ("otherwise, excess billables will be counted twice in both subscription timeframes"); the user-based line items never did.

The fix filters per domain rather than per group: a domain's users count toward a month end only if that domain's subscription on the line item's plan version was active on that date (`date_start <= month_end < date_end`, via the existing `is_active_subscription` helper). Per-domain filtering also handles a *partial* switch (one domain moves plan versions while others stay) that a simpler whole-group date clamp would get wrong. It applies to all three `total_users_for_date` implementations — mobile users, form-submitting mobile workers, and web users. Web users are counted account-wide with no per-domain history, so a month end is billed only if the plan version had any active subscription then.

Two deliberate behavior consequences to note:

- A domain whose subscription ends mid-period *without* a replacement is no longer billed for month ends after it ended. `test_user_over_limit_in_yearly_invoice`'s expectation encoded the old behavior and is updated in the fix commit.
- The month containing the change is attributed entirely to the plan version active at its month end (consistent with existing month-end snapshot billing).

Regular per-domain invoices are untouched (`invoice.is_customer_invoice` guard) — they are single-month and already bounded to the subscription's dates by `DomainInvoiceFactory`.

**Known related issues left out of scope (both pre-existing):**

- For the line-item subscription that starts or ends mid-period, `unit_cost` is still prorated via `num_prorated_days`, whose day-of-month arithmetic doesn't generalize to multi-month customer invoice periods. On a switch quarter this now under-charges relative to full per-user rates (before this PR it over-charged via doubled quantities). Fixing proration semantics for customer invoices deserves its own discussion.
- When two plan versions with web user rates are *concurrently* active on one account (domains split across plan versions), each line item still bills the full account-wide web user count against its own limit. That exists on master today independent of any plan change; partitioning an account-wide count across plan versions needs a product decision.

## Feature Flag

None.

## Safety Assurance

### Safety story

- The bug was reproduced with failing tests first (the first commit is deliberately red); the fix commit turns them green.
- Scope is limited to customer invoices; regular domain invoices keep their existing behavior exactly.
- In every affected scenario the change bills *less* than before (it removes double-counted months), so a defect here risks under-billing rather than over-charging customers.
- No data migrations; only invoice generation logic. Already-generated invoices are unaffected.

### Automated test coverage

- New `TestUserLineItemsAfterMidQuarterPlanVersionChange` covers: mobile user, form-submitting mobile worker, and web user excess after a full switch; a partial switch where a second domain stays on the old plan version; and a change date landing exactly on a month end with an open-ended replacement subscription (pinning the half-open boundary semantics).
- Updated `test_user_over_limit_in_yearly_invoice` pins the corrected treatment of a subscription ending mid-period.
- Full `corehq/apps/accounting` test suite passes locally.

### QA Plan

None — covered by automated tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
