### PR TITLE
Case management cleanup

### DIFF
--- a/corehq/apps/app_manager/form_action_diff.py
+++ b/corehq/apps/app_manager/form_action_diff.py
@@ -35,19 +35,6 @@ def get_case_mappings(actions):
     return data
 
 
-def from_combined_diff(combined_diff, *, is_registration):
-    """Convert Vellum case mapping diff to `merge_case_mappings` structure"""
-    data = combined_diff.copy()
-    diff = {'update_case': data}
-    if is_registration:
-        open_diff = diff['open_case'] = {}
-        for key in ['add', 'update', 'delete']:
-            if key in data and 'name' in data[key]:
-                data[key] = data[key].copy()
-                open_diff[key] = data[key].pop('name')
-    return diff
-
-
 def make_multi(actions_json):
     """Convert FormActions JSON to case_config_ui.js structure
 

--- a/corehq/apps/app_manager/form_action_diff.py
+++ b/corehq/apps/app_manager/form_action_diff.py
@@ -18,16 +18,20 @@ def get_case_mappings(actions):
     data = {}
     if actions.open_case:
         items = [actions.open_case.name_update] + actions.open_case.conflicts
-        data.update({'name': [to_json(u) for u in items]})
+        name_updates = [to_json(u) for u in items if u.question_path]
+        if name_updates:
+            data['name'] = name_updates
     if actions.update_case:
         conflicts = actions.update_case.conflicts
-        data.update({
-            prop: [to_json(u) for u in [update] + conflicts.get(prop, [])]
-            for prop, update in actions.update_case.update.items()
-        })
+        for prop, update in actions.update_case.update.items():
+            updates = [to_json(u) for u in [update] + conflicts.get(prop, []) if u.question_path]
+            if updates:
+                data[prop] = updates
         # concurrent delete + change -> conflict with no item in update_case.update
         for prop in conflicts.keys() - actions.update_case.update.keys():
-            data[prop] = [to_json(q, conflicting_delete=True) for q in conflicts[prop]]
+            items = [to_json(q, conflicting_delete=True) for q in conflicts[prop] if q.question_path]
+            if items:
+                data[prop] = items
     return data
 
 

--- a/corehq/apps/app_manager/models/form_actions.py
+++ b/corehq/apps/app_manager/models/form_actions.py
@@ -85,31 +85,6 @@ class UpdateCaseAction(FormAction):
     update = SchemaDictProperty(ConditionalCaseUpdate)
     conflicts = SchemaDictProperty(SchemaListProperty(ConditionalCaseUpdate))
 
-    @classmethod
-    def wrap(cls, data):
-        # Can be removed after all test projects that used
-        # FORMBUILDER_SAVE_TO_CASE toggle no longer need to track
-        # legacy conflicts in update_multi
-
-        def _exclude(ccu, ccus):
-            exclude_path = ccu.get('question_path')
-            return [c for c in ccus if c['question_path'] != exclude_path]
-
-        multi = data.pop('update_multi', None)
-        if multi:
-            assert not data.get('conflicts')
-            update = data.get('update') or {}
-            if update:
-                # should never happen, indicates a bug in legacy multi logic
-                data['conflicts'] = {
-                    key: _exclude(update.get(key) or {}, items)
-                    for key, items in multi.items()
-                }
-            else:
-                data['update'] = {key: items[0] for key, items in multi.items() if items}
-                data['conflicts'] = {key: items[1:] for key, items in multi.items() if len(items) > 1}
-        return super().wrap(data)
-
 
 class PreloadAction(FormAction):
 
@@ -141,24 +116,6 @@ class OpenCaseAction(FormAction):
     name_update = SchemaProperty(ConditionalCaseUpdate)
     conflicts = SchemaListProperty(ConditionalCaseUpdate)
     external_id = StringProperty()
-
-    @classmethod
-    def wrap(cls, data):
-        # Can be removed after all test projects that used
-        # FORMBUILDER_SAVE_TO_CASE toggle no longer need to track
-        # legacy conflicts in name_update_multi
-        multi = data.pop('name_update_multi', None)
-        if multi:
-            assert not data.get('conflicts')
-            update = data.get('name_update') or {}
-            if update and update.get('question_path'):
-                # should never happen, indicates a bug in legacy multi logic
-                exclude_path = update.get('question_path')
-                data['conflicts'] = [x for x in multi if x['question_path'] != exclude_path]
-            else:
-                data['name_update'] = multi[0]
-                data['conflicts'] = multi[1:]
-        return super().wrap(data)
 
 
 class OpenSubCaseAction(FormAction, IndexedSchema):

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -49,8 +49,8 @@ class OpenCaseActionApplyDiffTests(SimpleTestCase):
         merge_case_mappings(diff, actions)
         action = actions.open_case
 
-        multi_paths = [update.question_path for update in [action.name_update] + action.conflicts]
-        assert multi_paths == ['/data/name', '/data/new_name']
+        paths = [update.question_path for update in [action.name_update] + action.conflicts]
+        assert paths == ['/data/name', '/data/new_name']
 
     def test_conflicting_name_addition_is_overwritten(self):
         # added "/name" mapping should overwrite existing "/name" mapping
@@ -67,8 +67,9 @@ class OpenCaseActionApplyDiffTests(SimpleTestCase):
         assert not action.conflicts
 
     def test_merge_case_mappings_remove_name(self):
-        actions = FormActions(open_case=OpenCaseAction.wrap({
-            'name_update_multi': [{'question_path': '/data/name1'}, {'question_path': '/data/name2'}]
+        actions = FormActions(open_case=OpenCaseAction({
+            'name_update': {'question_path': '/data/name1'},
+            'conflicts': [{'question_path': '/data/name2'}],
         }))
 
         diff = {'open_case': {'delete': [{'question_path': '/data/name1'}]}}
@@ -183,20 +184,6 @@ class UpdateCaseActionApplyDiffTests(SimpleTestCase):
         assert set(self._conflicting(actions)) == {'one'}
         paths = {c.question_path for c in self._conflicting(actions)['one']}
         assert paths == {'/data/question1', '/data/question2'}
-
-    def test_add_value_with_legacy_update_multi_conflict(self):
-        form_actions = FormActions({'update_case': {'update_multi': {
-            'one': [{'question_path': '/data/question1'}, {'question_path': '/data/question2'}]
-        }}})
-
-        merge_case_mappings({'update_case': {
-            'add': {'one': [{'question_path': '/data/question3'}]}
-        }}, form_actions)
-        actions = form_actions.update_case
-
-        assert set(actions.conflicts) == {'one'}
-        paths = [update.question_path for update in self._conflicting(actions)['one']]
-        assert set(paths) == {'/data/question1', '/data/question2', '/data/question3'}
 
     def test_add_value_with_existing_conflict(self):
         actions = UpdateCaseAction({

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -419,6 +419,20 @@ class FormActionsTests(SimpleTestCase):
             ],
         }
 
+    def test_get_case_mappings_omits_empty_case_name_mapping(self):
+        actions = FormActions(
+            open_case=OpenCaseAction(),
+            update_case=UpdateCaseAction({
+                # edge case probably not possible in practice
+                'update': {'one': {'question_path': ''}},
+                'conflicts': {'one': [{'question_path': None}]},
+            }),
+        )
+
+        json = get_case_mappings(actions)
+
+        assert json == {}
+
     def test_merge_case_mappings_raises_on_unrecognized_key(self):
         actions = FormActions()
         diff = {'malicious_key': {'update': {}}}

--- a/corehq/apps/app_manager/tests/test_form_actions_diff.py
+++ b/corehq/apps/app_manager/tests/test_form_actions_diff.py
@@ -8,7 +8,6 @@ from ..form_action_diff import (
     _convert_update_to_delete_plus_add,
     collect_locked_advanced_mappings,
     collect_locked_mappings,
-    from_combined_diff,
     get_case_mappings,
     merge_case_mappings,
     make_multi,
@@ -751,63 +750,6 @@ class ConvertUpdateToAddPlusDeleteTests(SimpleTestCase):
             ]},
         }
         assert diff == snapshot, 'original diff should not change'
-
-
-class CombinedDiffTests(SimpleTestCase):
-
-    def test_from_combined_diff_non_registration_name_stays_in_update(self):
-        combined_diff = {
-            'add': {
-                'name': [{'question_path': '/data/one'}],
-                'other': [{'question_path': '/data/two'}],
-            },
-            'update': {
-                'name': [{'question_path': '/data/three'}],
-                'other': [{'question_path': '/data/four'}],
-            },
-            'delete': {
-                'name': [{'question_path': '/data/five'}],
-                'other': [{'question_path': '/data/six'}],
-            },
-        }
-        snapshot = deepcopy(combined_diff)
-
-        diff = from_combined_diff(combined_diff, is_registration=False)
-
-        assert not diff.get('open_case')
-        assert diff['update_case'] == combined_diff
-        assert combined_diff == snapshot, 'combined_diff should not be mutated'
-
-    def test_from_combined_diff_registration_name_is_in_open_case(self):
-        combined_diff = {
-            'add': {
-                'name': [{'question_path': '/data/one'}],
-                'other': [{'question_path': '/data/two'}],
-            },
-            'update': {
-                'name': [{'question_path': '/data/three'}],
-                'other': [{'question_path': '/data/four'}],
-            },
-            'delete': {
-                'name': [{'question_path': '/data/five'}],
-                'other': [{'question_path': '/data/six'}],
-            },
-        }
-        snapshot = deepcopy(combined_diff)
-
-        diff = from_combined_diff(combined_diff, is_registration=True)
-
-        assert diff['open_case'] == {
-            'add': [{'question_path': '/data/one'}],
-            'update': [{'question_path': '/data/three'}],
-            'delete': [{'question_path': '/data/five'}],
-        }
-        assert diff['update_case'] == {
-            'add': {'other': [{'question_path': '/data/two'}]},
-            'update': {'other': [{'question_path': '/data/four'}]},
-            'delete': {'other': [{'question_path': '/data/six'}]},
-        }
-        assert combined_diff == snapshot, 'combined_diff should not be mutated'
 
 
 class CollectLockedMappingsTests(SimpleTestCase):

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -248,10 +248,9 @@ def _get_base_vellum_options(request, domain, form, displayLang):
         },
     }
 
-    has_vellum_case_mapping = toggles.FORMBUILDER_SAVE_TO_CASE.enabled_for_request(request)
     is_advanced_form = isinstance(form, AdvancedForm)
     case_type = form.get_module().case_type
-    if case_type and has_vellum_case_mapping and not is_advanced_form:
+    if case_type and not is_advanced_form:
         options['caseManagement'] = {
             'mappings': get_case_mappings(form.actions),
             'properties': sorted(get_case_properties(domain, case_type).values_list('name', flat=True)),

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -750,9 +750,8 @@ def apply_patch(patch, text):
 
 
 def _get_case_mapping_diff(request, form):
-    has_vellum_case_mapping = toggles.FORMBUILDER_SAVE_TO_CASE.enabled_for_request(request)
     is_advanced_form = isinstance(form, AdvancedForm)
-    if has_vellum_case_mapping and not is_advanced_form:
+    if not is_advanced_form:
         if 'case_mapping_diff' in request.POST:
             return json.loads(request.POST['case_mapping_diff'])
         return {}  # not None, prevent name mapping in save_xform
@@ -772,10 +771,9 @@ def _get_xform_conflict_response(form, sha1_checksum):
 
 def _add_case_management_data(response_json, form, request):
     """Allow clients to immediately display concurrent edit conflict warnings"""
-    has_vellum_case_mapping = toggles.FORMBUILDER_SAVE_TO_CASE.enabled_for_request(request)
     is_advanced_form = isinstance(form, AdvancedForm)
     case_type = form.get_module().case_type
-    if case_type and has_vellum_case_mapping and not is_advanced_form:
+    if case_type and not is_advanced_form:
         response_json['caseManagement'] = {
             "mappings": get_case_mappings(form.actions),
         }

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -62,7 +62,6 @@ from corehq.apps.app_manager.exceptions import (
 from corehq.apps.app_manager.form_action_diff import (
     collect_locked_advanced_mappings,
     collect_locked_mappings,
-    from_combined_diff,
     get_case_mappings,
     make_multi,
     merge_case_mappings,
@@ -764,12 +763,6 @@ def _get_case_mapping_diff(request, form):
     if has_vellum_case_mapping and not is_advanced_form:
         if 'case_mapping_diff' in request.POST:
             return json.loads(request.POST['case_mapping_diff'])
-        if 'mapping_diff' in request.POST:
-            # Legacy, can be removed when Vellum always sends case_mapping_diff
-            return from_combined_diff(
-                json.loads(request.POST['mapping_diff']),
-                is_registration=form.is_registration_form(),
-            )
         return {}  # not None, prevent name mapping in save_xform
     return None
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -253,16 +253,8 @@ def edit_form_actions(request, domain, app_id, form_unique_id):
     old_load_from_form = form.actions.load_from_form
 
     actions_json = json.loads(request.POST['actions'])
-
-    if 'case_mapping_diff' in request.POST:
-        diff = json.loads(request.POST['case_mapping_diff'])
-    elif 'update_diff' in request.POST:
-        # LEGACY can be removed after case_mapping_diff is deployed
-        # and enough time has passed for front-end code to be updated
-        diff = json.loads(request.POST['update_diff'])
-    else:
-        diff = {}
-
+    diff_json = request.POST.get('case_mapping_diff')
+    diff = json.loads(diff_json) if diff_json else {}
     try:
         _apply_form_actions_change(request, domain, form, actions_json, diff)
     except LockedQuestionError:

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1093,14 +1093,6 @@ def _ensure_search_index_is_enabled(domain, enabled):
         reindex_case_search_for_domain.delay(domain)
 
 
-FORMBUILDER_SAVE_TO_CASE = StaticToggle(
-    'saas_formbuilder_save_to_case',
-    'Form Builder - Save Questions to Case Properties',
-    TAG_INTERNAL,
-    namespaces=[NAMESPACE_DOMAIN],
-    description='Allows users to save questions to case properties within the Form Builder'
-)
-
 ACTION_TIMES_API = StaticToggle(
     'action_times_api',
     'Enable the Action Times API',


### PR DESCRIPTION
## Product Description
No user-facing changes. Internal cleanup of legacy case-mapping code paths and feature flag. The feature has been released on all Dimagi-managed environments.

https://dimagi.atlassian.net/browse/SAAS-17607

:blowfish: Review by commit.

## Feature Flag
`FORMBUILDER_SAVE_TO_CASE` - removed.

## Safety Assurance

### Safety story
Each commit is small and isolated. The removed code paths are all legacy fallbacks whose modern equivalents have been the only paths in real use for some time. Existing tests cover the retained behavior, and obsolete tests targeting the removed legacy paths were removed alongside the code.

### Automated test coverage
Yes.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations
