### PR TITLE
ProjectDB: Add array, fuzzy, phonetic, and gps capabilities

### DIFF
--- a/corehq/apps/project_db/README.rst
+++ b/corehq/apps/project_db/README.rst
@@ -14,8 +14,9 @@ Layout
 - One table per case type, named after the case type.
 - Each table has a fixed set of columns mirroring ``CommCareCase``, plus a
   ``prop__<name>`` column for every case property (defaults to `''`). Typed
-  properties (date, number, select) get an additional typed column, e.g.
-  ``date_prop__<name>``.
+  properties (date, number, select, gps) get an additional typed column, e.g.
+  ``date_prop__<name>``. GPS properties are stored as the earthdistance
+  ``earth`` type, which requires the ``cube`` and ``earthdistance`` extensions.
 
 Postgres truncates identifiers at 63 bytes, so schema, table, and column names
 are truncated with a hash suffix for uniqueness, with the raw values stored as

--- a/corehq/apps/project_db/README.rst
+++ b/corehq/apps/project_db/README.rst
@@ -14,7 +14,7 @@ Layout
 - One table per case type, named after the case type.
 - Each table has a fixed set of columns mirroring ``CommCareCase``, plus a
   ``prop__<name>`` column for every case property (defaults to `''`). Typed
-  properties (date, number) get an additional typed column, e.g.
+  properties (date, number, select) get an additional typed column, e.g.
   ``date_prop__<name>``.
 
 Postgres truncates identifiers at 63 bytes, so schema, table, and column names

--- a/corehq/apps/project_db/populate.py
+++ b/corehq/apps/project_db/populate.py
@@ -1,7 +1,7 @@
 import datetime
 from decimal import Decimal, InvalidOperation
 
-from sqlalchemy import Text
+from sqlalchemy import ARRAY, Text
 from sqlalchemy.dialects.postgresql import insert
 
 from dimagi.utils.chunked import chunked
@@ -41,8 +41,11 @@ def _normalize(row, columns):
     filled = {}  # Row with all columns present
     for column in columns:
         value = row.get(column.name)
-        if value is None and not column.nullable and isinstance(column.type, Text):
-            value = ''
+        if value is None and not column.nullable:
+            if isinstance(column.type, ARRAY):
+                value = []
+            elif isinstance(column.type, Text):
+                value = ''
         filled[column.name] = value
     return filled
 
@@ -92,8 +95,16 @@ def coerce_to_number(value):
         return None
 
 
+def coerce_to_select(value):
+    """Split a space-separated multi-select value into a list of choices"""
+    if value is None:
+        return []
+    return [x for x in str(value).split(' ') if x]
+
+
 # Parallels CaseTable.COERCED_PROPERTY_TYPES
 _TYPED_COERCIONS = [
     (CaseProperty.DataType.DATE, coerce_to_date),
     (CaseProperty.DataType.NUMBER, coerce_to_number),
+    (CaseProperty.DataType.SELECT, coerce_to_select),
 ]

--- a/corehq/apps/project_db/populate.py
+++ b/corehq/apps/project_db/populate.py
@@ -1,12 +1,16 @@
 import datetime
+import math
 from decimal import Decimal, InvalidOperation
 
 from sqlalchemy import ARRAY, Text
 from sqlalchemy.dialects.postgresql import insert
 
+from jsonobject.exceptions import BadValueError
+
 from dimagi.utils.chunked import chunked
 
 from corehq.apps.data_dictionary.models import CaseProperty
+from couchforms.geopoint import GeoPoint
 
 from .table_ddl import CaseTable, get_project_db_engine, property_column
 
@@ -102,9 +106,29 @@ def coerce_to_select(value):
     return [x for x in str(value).split(' ') if x]
 
 
+
+
+def coerce_to_gps(value):
+    """Parse a GPS case property into an earthdistance ``earth`` cube literal."""
+    try:
+        point = GeoPoint.from_string(str(value), flexible=True)
+    except BadValueError:
+        return None
+
+    # Mirrors `ll_to_earth(lat, lon)` from the earthdistance extension
+    lat = math.radians(point.latitude)
+    lon = math.radians(point.longitude)
+    EARTH_RADIUS = 6378168.0  # In meters, from earthdistance
+    x = EARTH_RADIUS * math.cos(lat) * math.cos(lon)
+    y = EARTH_RADIUS * math.cos(lat) * math.sin(lon)
+    z = EARTH_RADIUS * math.sin(lat)
+    return f'({x}, {y}, {z})'
+
+
 # Parallels CaseTable.COERCED_PROPERTY_TYPES
 _TYPED_COERCIONS = [
     (CaseProperty.DataType.DATE, coerce_to_date),
     (CaseProperty.DataType.NUMBER, coerce_to_number),
     (CaseProperty.DataType.SELECT, coerce_to_select),
+    (CaseProperty.DataType.GPS, coerce_to_gps),
 ]

--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -7,6 +7,7 @@ from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from sqlalchemy import ARRAY, Boolean, Column, Date, DateTime, Numeric, Table, Text
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.types import UserDefinedType
 
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.sql_db.connections import PROJECT_DB_ENGINE_ID, connection_manager
@@ -38,7 +39,9 @@ def get_project_db_engine():
         raise ImproperlyConfigured(
             f"'{PROJECT_DB_ENGINE_ID}' database not defined in REPORTING_DATABASES"
         )
-    return connection_manager.get_engine(PROJECT_DB_ENGINE_ID)
+    engine = connection_manager.get_engine(PROJECT_DB_ENGINE_ID)
+    _register_earth_type(engine.dialect)
+    return engine
 
 
 def create_project_db_extensions():
@@ -100,12 +103,25 @@ class DomainSchema:
         ))
 
 
+class Earth(UserDefinedType):
+    """The ``earth`` type from PostgreSQL's earthdistance extension."""
+
+    def get_col_spec(self, **kw):
+        return 'earth'
+
+
+def _register_earth_type(dialect):
+    if 'earth' not in dialect.ischema_names:
+        dialect.ischema_names = {**dialect.ischema_names, 'earth': Earth}
+
+
 class CaseTable:
     COERCED_PROPERTY_TYPES = {
         # CaseProperty data_type:  (SQLAlchemy column type, default)
         CaseProperty.DataType.DATE: (Date, None),
         CaseProperty.DataType.NUMBER: (Numeric, None),
         CaseProperty.DataType.SELECT: (ARRAY(Text), '{}'),
+        CaseProperty.DataType.GPS: (Earth, None),
     }
 
     def __init__(self, domain, case_type):

--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ImproperlyConfigured
 import sqlalchemy
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
-from sqlalchemy import Boolean, Column, Date, DateTime, Numeric, Table, Text
+from sqlalchemy import ARRAY, Boolean, Column, Date, DateTime, Numeric, Table, Text
 from sqlalchemy.dialects import postgresql
 
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
@@ -102,9 +102,10 @@ class DomainSchema:
 
 class CaseTable:
     COERCED_PROPERTY_TYPES = {
-        # CaseProperty data_type to SQLAlchemy column type
-        CaseProperty.DataType.DATE: Date,
-        CaseProperty.DataType.NUMBER: Numeric,
+        # CaseProperty data_type:  (SQLAlchemy column type, default)
+        CaseProperty.DataType.DATE: (Date, None),
+        CaseProperty.DataType.NUMBER: (Numeric, None),
+        CaseProperty.DataType.SELECT: (ARRAY(Text), '{}'),
     }
 
     def __init__(self, domain, case_type):
@@ -138,8 +139,10 @@ class CaseTable:
         for name, data_type in self._get_dd_properties():
             yield Column(property_column(name), Text, nullable=False, server_default='', comment=name)
 
-            if col_type := self.COERCED_PROPERTY_TYPES.get(data_type):
-                yield Column(property_column(name, data_type), col_type, comment=name)
+            if data_type in self.COERCED_PROPERTY_TYPES:
+                col_type, default = self.COERCED_PROPERTY_TYPES[data_type]
+                yield Column(property_column(name, data_type), col_type, comment=name,
+                             nullable=default is None, server_default=default)
 
     def _get_dd_properties(self):
         return CaseProperty.objects.filter(

--- a/corehq/apps/project_db/tests/test_name_queries.py
+++ b/corehq/apps/project_db/tests/test_name_queries.py
@@ -1,0 +1,80 @@
+import pytest
+from sqlalchemy import func, select
+from unmagic import fixture, use
+
+from corehq.apps.project_db.table_ddl import CaseTable, get_project_db_engine
+
+from .util import project_db_table
+
+DOMAIN = 'test-projectdb-queries'
+
+# (case_id, first_name, last_name)
+CLIENTS = [
+    ('c1', 'Sarah', 'Smith'),
+    ('c2', 'Sara', 'Smyth'),
+    ('c3', 'Saraah', 'Smithe'),
+    ('c4', 'John', 'Johnson'),
+    ('c5', 'Jon', 'Jonson'),
+    ('c6', 'Michael', 'Brown'),
+    ('c7', 'Micheal', 'Braun'),
+    ('c8', 'Katherine', 'Nguyen'),
+    ('c9', 'Catherine', 'Wynn'),
+    ('c10', 'Robert', 'Williams'),
+]
+
+
+@fixture(scope='module')
+def loaded_clients():
+    with project_db_table(DOMAIN, 'client', {
+        'first_name': 'plain',
+        'last_name': 'plain',
+    }):
+        table = CaseTable(DOMAIN, 'client').reflect()
+        with get_project_db_engine().begin() as conn:
+            conn.execute(table.insert(), [
+                {'case_id': case_id,
+                 'owner_id': 'owner1',
+                 'prop__first_name': first_name,
+                 'prop__last_name': last_name}
+                for case_id, first_name, last_name in CLIENTS
+            ])
+        yield table
+
+
+@use('db', loaded_clients)
+@pytest.mark.parametrize('query, expected', [
+    ('Sara', ['Sara', 'Sarah', 'Saraah']),  # Matches all three, in order
+    ('Michael', ['Michael', 'Micheal']),    # Micheal typo scores 0.33
+    ('Jon', ['Jon']),                       # John scores 0.29, below threshold
+    ('Robert', ['Robert']),                 # exact match, no false positives
+])
+def test_trigram_matches_typos(query, expected):
+    table = loaded_clients()
+    with get_project_db_engine().begin() as conn:
+        column = table.c['prop__first_name']
+        similarity = func.similarity(column, query)
+        rows = conn.execute(
+            select([column, similarity])
+            .where(similarity >= 0.3)
+            .order_by(similarity.desc())
+        ).fetchall()
+    assert [r[0] for r in rows] == expected
+
+
+@use('db', loaded_clients)
+@pytest.mark.parametrize('prop, query, expected', [
+    ('last_name', 'Smyth', {'Smith', 'Smyth', 'Smithe'}),   # Smith / Smyth / Smithe -> SM0
+    ('first_name', 'Jon', {'John', 'Jon'}),          # John / Jon -> JN
+    ('first_name', 'Catherine', {'Catherine', 'Katherine'}),    # Catherine / Katherine -> K0RN
+    ('last_name', 'Braun', {'Brown', 'Braun'}),         # Brown / Braun -> PRN
+    ('first_name', 'Michael', {'Michael'}),            # Micheal's code (MXL) differs, so misses
+])
+def test_phonetic_matches(prop, query, expected):
+    table = loaded_clients()
+    with get_project_db_engine().begin() as conn:
+        column = table.c[f'prop__{prop}']
+        rows = conn.execute(
+            select([column])
+            .where(func.dmetaphone(column) == func.dmetaphone(query))
+        ).fetchall()
+    assert {r[0] for r in rows} == expected

--- a/corehq/apps/project_db/tests/test_populate.py
+++ b/corehq/apps/project_db/tests/test_populate.py
@@ -9,6 +9,7 @@ from corehq.apps.project_db.populate import (
     case_to_row,
     coerce_to_date,
     coerce_to_number,
+    coerce_to_select,
     send_to_project_db,
     upsert_cases,
 )
@@ -45,6 +46,19 @@ def test_coerce_to_date(value, expected):
 ])
 def test_coerce_to_number(value, expected):
     assert coerce_to_number(value) == expected
+
+
+@pytest.mark.parametrize('value, expected', [
+    ('red',            ['red']),
+    (' red ',         ['red']),
+    ('red  blue',     ['red', 'blue']),
+    ('red green blue', ['red', 'green', 'blue']),
+    (None,            []),
+    ('',              []),
+    ('  ',           []),
+])
+def test_coerce_to_select(value, expected):
+    assert coerce_to_select(value) == expected
 
 
 def _make_index(identifier, referenced_id):
@@ -109,6 +123,11 @@ def test_static_fields_mapped_to_columns():
       'prop__weight': '70.5', 'number_prop__weight': Decimal('70.5')}),
     # typed value skipped when only the raw column exists
     ({'dob': '1990-05-20'}, {'prop__dob'}, {'prop__dob': '1990-05-20'}),
+    # select property populates both the raw and the text[] column
+    ({'interests': 'sports music'},
+     {'prop__interests', 'select_prop__interests'},
+     {'prop__interests': 'sports music',
+      'select_prop__interests': ['sports', 'music']}),
 ])
 def test_property_columns(case_json, columns, expected_props):
     result = case_to_row(_make_case(case_json=case_json), columns)
@@ -168,6 +187,22 @@ def test_send_to_project_db():
         rows = conn.execute(table.select()).fetchall()
     assert [r[0] for r in rows] == ['Alice', 'Bob', '']
     assert CaseTable('test-upsert', 'clinic').reflect() is None
+
+
+@use('db', project_db_table('test-select', 'patient', {'interests': 'select'}))
+def test_send_select_property_round_trip():
+    send_to_project_db('test-select', 'patient', [
+        _make_case({'interests': 'sports music'}, case_id='c1', type='patient'),
+        _make_case({}, case_id='c2', type='patient'),  # absent -> empty array, not NULL
+    ])
+
+    table = CaseTable('test-select', 'patient').reflect()
+    with get_project_db_engine().begin() as conn:
+        rows = conn.execute(
+            table.select().order_by(table.c.case_id)
+        ).fetchall()
+    interests = {r['case_id']: r['select_prop__interests'] for r in rows}
+    assert interests == {'c1': ['sports', 'music'], 'c2': []}
 
 
 @use('db', project_db_table('test-long-prop', 'patient', {'x' * 100: 'date'}))

--- a/corehq/apps/project_db/tests/test_populate.py
+++ b/corehq/apps/project_db/tests/test_populate.py
@@ -3,11 +3,14 @@ import uuid
 from decimal import Decimal
 
 import pytest
+import sqlalchemy
+from sqlalchemy import func
 from unmagic import use
 
 from corehq.apps.project_db.populate import (
     case_to_row,
     coerce_to_date,
+    coerce_to_gps,
     coerce_to_number,
     coerce_to_select,
     send_to_project_db,
@@ -59,6 +62,32 @@ def test_coerce_to_number(value, expected):
 ])
 def test_coerce_to_select(value, expected):
     assert coerce_to_select(value) == expected
+
+
+def assert_gps_equals(actual_str, expected):
+    actual = tuple(float(n) for n in actual_str.strip('()').split(','))
+    # approx match to account for float rounding
+    assert actual == pytest.approx(expected, abs=1e-3)
+
+
+@pytest.mark.parametrize('value, expected', [
+    (None,             None),
+    ('',               None),
+    ('not a gps',      None),
+    ('91 0 0 0',       None),  # latitude out of range
+    ('0 0 0 0',        (6378168.0, 0.0, 0.0)),  # equator / prime meridian
+    ('0 90 0 0',       (0.0, 6378168.0, 0.0)),  # equator, 90°E
+    ('0 90',           (0.0, 6378168.0, 0.0)),  # two-element version works fine too
+    ('90 0 0 0',       (0.0, 0.0, 6378168.0)),  # north pole
+    ('42.365 -71.102', (1526343.604, -4458592.705, 4297935.938)),
+
+])
+def test_coerce_to_gps(value, expected):
+    result = coerce_to_gps(value)
+    if expected is None:
+        assert result is None
+    else:
+        assert_gps_equals(result, expected)
 
 
 def _make_index(identifier, referenced_id):
@@ -134,6 +163,15 @@ def test_property_columns(case_json, columns, expected_props):
     assert {k: v for k, v in result.items() if 'prop__' in k} == expected_props
 
 
+def test_gps_property_column_populated():
+    result = case_to_row(
+        _make_case(case_json={'location': '0 0 0 0'}),
+        {'prop__location', 'gps_prop__location'},
+    )
+    assert result['prop__location'] == '0 0 0 0'
+    assert_gps_equals(result['gps_prop__location'], (6378168.0, 0, 0))
+
+
 @pytest.mark.parametrize('indices, expected_parent, expected_host', [
     ([],                             None, None),
     ([_make_index('parent', 'p1')],  'p1', None),
@@ -203,6 +241,30 @@ def test_send_select_property_round_trip():
         ).fetchall()
     interests = {r['case_id']: r['select_prop__interests'] for r in rows}
     assert interests == {'c1': ['sports', 'music'], 'c2': []}
+
+
+@use('db')
+def test_send_gps_property_round_trip():
+    # Stored earth values must line up with postgres ll_to_earth, proving the
+    # Python cube formula stays in sync with the earthdistance extension.
+    domain = 'test-gps'
+    with project_db_table(domain, 'patient', {'location': 'gps'}):
+        send_to_project_db(domain, 'patient', [
+            _make_case({'location': '40.7128 -74.006 10 5'}, case_id='c1', type='patient'),
+            _make_case({'location': 'garbage'}, case_id='c2', type='patient'),
+            _make_case({}, case_id='c3', type='patient'),  # absent -> NULL
+        ])
+        table = CaseTable(domain, 'patient').reflect()
+        column = table.c['gps_prop__location']
+        distance = func.earth_distance(column, func.ll_to_earth(40.7128, -74.006))
+        with get_project_db_engine().begin() as conn:
+            rows = conn.execute(
+                sqlalchemy.select([table.c.case_id, distance]).order_by(table.c.case_id)
+            ).fetchall()
+    by_id = {r[0]: r[1] for r in rows}
+    assert by_id['c1'] == pytest.approx(0, abs=0.01)  # within a centimeter
+    assert by_id['c2'] is None  # unparseable -> NULL
+    assert by_id['c3'] is None
 
 
 @use('db', project_db_table('test-long-prop', 'patient', {'x' * 100: 'date'}))

--- a/corehq/apps/project_db/tests/test_table_ddl.py
+++ b/corehq/apps/project_db/tests/test_table_ddl.py
@@ -10,6 +10,7 @@ from unmagic import fixture, use
 from corehq.apps.project_db.table_ddl import (
     CaseTable,
     DomainSchema,
+    Earth,
     create_or_update_project_db,
     get_project_db_engine,
     preview_drop,
@@ -103,6 +104,7 @@ def test_case_table_basics():
         ('favorite_color', 'select'),
         ('dob', 'date'),
         ('children_count', 'number'),
+        ('location', 'gps'),
     ]):
         table = (CaseTable('test-domain', 'person')
                  .build_definition(sqlalchemy.MetaData()))
@@ -122,13 +124,16 @@ def test_case_table_basics():
     assert isinstance(table.c['date_prop__dob'].type, sqlalchemy.Date)
     assert isinstance(table.c['prop__children_count'].type, sqlalchemy.Text)
     assert isinstance(table.c['number_prop__children_count'].type, sqlalchemy.Numeric)
+    assert isinstance(table.c['prop__location'].type, sqlalchemy.Text)
+    assert isinstance(table.c['gps_prop__location'].type, Earth)
 
-    # Text property columns are NOT NULL; date/number columns stay nullable,
+    # Text property columns are NOT NULL; date/number/gps columns stay nullable,
     # but select columns are NOT NULL and default to an empty array
     assert table.c['prop__nickname'].nullable is False
     assert table.c['prop__dob'].nullable is False
     assert table.c['date_prop__dob'].nullable is True
     assert table.c['number_prop__children_count'].nullable is True
+    assert table.c['gps_prop__location'].nullable is True
     assert table.c['select_prop__favorite_color'].nullable is False
 
     # Both plain and typed columns carry the raw property name as a comment
@@ -136,6 +141,7 @@ def test_case_table_basics():
     assert table.c['date_prop__dob'].comment == 'dob'
     assert table.c['prop__children_count'].comment == 'children_count'
     assert table.c['number_prop__children_count'].comment == 'children_count'
+    assert table.c['gps_prop__location'].comment == 'location'
     assert table.c['select_prop__favorite_color'].comment == 'favorite_color'
 
 

--- a/corehq/apps/project_db/tests/test_table_ddl.py
+++ b/corehq/apps/project_db/tests/test_table_ddl.py
@@ -116,22 +116,27 @@ def test_case_table_basics():
 
     assert isinstance(table.c['prop__nickname'].type, sqlalchemy.Text)
     assert isinstance(table.c['prop__favorite_color'].type, sqlalchemy.Text)
+    assert isinstance(table.c['select_prop__favorite_color'].type, sqlalchemy.ARRAY)
+    assert isinstance(table.c['select_prop__favorite_color'].type.item_type, sqlalchemy.Text)
     assert isinstance(table.c['prop__dob'].type, sqlalchemy.Text)
     assert isinstance(table.c['date_prop__dob'].type, sqlalchemy.Date)
     assert isinstance(table.c['prop__children_count'].type, sqlalchemy.Text)
     assert isinstance(table.c['number_prop__children_count'].type, sqlalchemy.Numeric)
 
-    # Text property columns are NOT NULL; typed columns stay nullable
+    # Text property columns are NOT NULL; date/number columns stay nullable,
+    # but select columns are NOT NULL and default to an empty array
     assert table.c['prop__nickname'].nullable is False
     assert table.c['prop__dob'].nullable is False
     assert table.c['date_prop__dob'].nullable is True
     assert table.c['number_prop__children_count'].nullable is True
+    assert table.c['select_prop__favorite_color'].nullable is False
 
     # Both plain and typed columns carry the raw property name as a comment
     assert table.c['prop__dob'].comment == 'dob'
     assert table.c['date_prop__dob'].comment == 'dob'
     assert table.c['prop__children_count'].comment == 'children_count'
     assert table.c['number_prop__children_count'].comment == 'children_count'
+    assert table.c['select_prop__favorite_color'].comment == 'favorite_color'
 
 
 def test_long_property_names_are_truncated():
@@ -210,7 +215,8 @@ def test_create_project_db(get_dd_properties, get_case_types):
     schema = _project_db_schema('test_create_project_db')
 
     get_case_types.return_value = ['patient']
-    get_dd_properties.return_value = [('nickname', 'plain'), ('dob', 'plain')]
+    get_dd_properties.return_value = [
+        ('nickname', 'plain'), ('dob', 'plain'), ('interests', 'select')]
     create_or_update_project_db(domain)
     _assert_db_created_as_expected(schema.name)
 
@@ -235,6 +241,10 @@ def _assert_db_created_as_expected(schema):
         assert isinstance(col_types['prop__nickname'], sqlalchemy.Text)
         assert isinstance(col_types['prop__dob'], sqlalchemy.Text)
         assert 'date_prop__dob' not in cols
+        # A select property gets a text[] column that is NOT NULL, defaulting to {}
+        assert isinstance(col_types['select_prop__interests'], sqlalchemy.ARRAY)
+        assert cols['select_prop__interests']['nullable'] is False
+        assert cols['select_prop__interests']['default'] == "'{}'::text[]"
 
         # Property columns store the raw case property name as a comment
         assert cols['prop__nickname']['comment'] == 'nickname'


### PR DESCRIPTION
## Product Description
Not turned on for users yet

## Technical Summary
https://dimagi.atlassian.net/browse/USH-6591
Builds on the work of https://github.com/dimagi/commcare-hq/pull/37938 and https://github.com/dimagi/commcare-cloud/pull/6951, which add extensions to the ProjectDB database.

Read commit by commit for a breakdown.  In brief, this adds:

* string array column to support multiselect case properties
* fuzzy and phonetic search examples
* "earth" column type to support gps properties and distance calculations (more optimizable than a Haversine calcultion against a point column type).

## Feature Flag


## Safety Assurance
Nothing here is used by real projects yet.  It's currently on staging and working as expected.

### Safety story


### Automated test coverage
yep

### QA Plan
nope

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
