### PR TITLE
Revert "Stop gunicorn worker recycling from killing long-running requests"

### DIFF
--- a/deployment/gunicorn/gunicorn_conf.py
+++ b/deployment/gunicorn/gunicorn_conf.py
@@ -5,6 +5,9 @@ preload_app = True
 worker_class = 'gevent'
 keepalive = 60
 timeout = 900
+# In the standard production setup, max_requests, max_requests_jitter, and
+# graceful_timeout are overridden by command-line arguments in the supervisor
+# conf (managed by commcare-cloud), which take precedence over this file.
 max_requests = 240
 max_requests_jitter = int(max_requests * 0.5)
 # defaults to 30 sec, setting to 5 minutes to fight `GreenletExit`s

--- a/deployment/gunicorn/gunicorn_conf.py
+++ b/deployment/gunicorn/gunicorn_conf.py
@@ -5,12 +5,10 @@ preload_app = True
 worker_class = 'gevent'
 keepalive = 60
 timeout = 900
-max_requests = 2000
+max_requests = 240
 max_requests_jitter = int(max_requests * 0.5)
-# Should be at least as long as the longest request we're willing to serve
-# (nginx proxy_read_timeout allows up to 900s), otherwise worker recycling
-# force-kills in-flight requests when this expires.
-graceful_timeout = 900
+# defaults to 30 sec, setting to 5 minutes to fight `GreenletExit`s
+graceful_timeout = 5*60
 # defaults to 4094, increasing to avoid https://manage.dimagi.com/default.asp?283517#1532884
 limit_request_line = 4500
 


### PR DESCRIPTION
Reverts dimagi/commcare-hq#37927

Replacing with https://github.com/dimagi/commcare-cloud/pull/6949