### PR TITLE
Fix false-positive alerts in Sentry for missing XForm attachments

### DIFF
--- a/corehq/form_processor/submission_validation.py
+++ b/corehq/form_processor/submission_validation.py
@@ -70,14 +70,17 @@ def _walk(node, found):
 
 def _is_image_answer(form_answer):
     """
-    Returns True if ``form_answer`` is an image answer. Excludes form
-    images like icons.
+    Returns True if ``form_answer`` is an image-capture answer (a bare
+    image filename). Excludes form images like icons and derived hidden
+    question values.
 
-    >>> _is_image_answer('https://www.commcarehq.org/a/domain/api/form/attachment/abc/123.jpg')
+    >>> _is_image_answer('123.jpg')
     True
+    >>> _is_image_answer('https://www.commcarehq.org/a/domain/api/form/attachment/abc/123.jpg')
+    False
     >>> _is_image_answer('jr://file/commcare/image/data/green_increased.png')
     False
 
     """
     lower = form_answer.lower()
-    return lower.endswith(IMAGE_EXTENSIONS) and not lower.startswith('jr://')
+    return lower.endswith(IMAGE_EXTENSIONS) and '/' not in lower


### PR DESCRIPTION
## Technical Summary

Context: [SAAS-19082](https://dimagi.atlassian.net/browse/SAAS-19082)

Image question answers in FormXML are filenames, and the filenames should match the filenames of the form's attachments. We have observed that this is not always true -- there are rare occasions when an attachment is missing.

The code that this PR covers notifies us of this using Sentry.

`_is_image_answer()` should return `True` if its parameter is the answer to an image question. It has been making false positive errors by returning `True` for both image question answers, and also hidden question values derived from those answers. This change fixes that by ensuring that the value is a simple filename without a path.

## Safety Assurance

### Safety story

Small change

### Automated test coverage

Yes

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19082]: https://dimagi.atlassian.net/browse/SAAS-19082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ