### PR TITLE
Provision ProjectDB explicitly for real environments

### DIFF
--- a/corehq/apps/project_db/management/commands/manage_project_db.py
+++ b/corehq/apps/project_db/management/commands/manage_project_db.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
 import dateutil.parser
@@ -9,6 +10,7 @@ from corehq.apps.project_db.populate import send_to_project_db
 from corehq.apps.project_db.table_ddl import (
     DomainSchema,
     create_or_update_project_db,
+    create_project_db_extensions,
     get_project_db_engine,
     preview_drop,
 )
@@ -60,6 +62,8 @@ class Command(BaseCommand):
             raise CommandError("--since is only used in conjunction with --populate.")
 
         if sync:
+            if settings.DEBUG:
+                create_project_db_extensions()
             create_or_update_project_db(domain)
             self.stdout.write("Synced ProjectDB table definition")
         if populate:

--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -1,5 +1,7 @@
 import hashlib
 
+from django.core.exceptions import ImproperlyConfigured
+
 import sqlalchemy
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
@@ -32,6 +34,10 @@ def property_column(name, data_type=None):
 
 def get_project_db_engine():
     """Return a SQLAlchemy engine for project DB tables"""
+    if not connection_manager.engine_id_is_available(PROJECT_DB_ENGINE_ID):
+        raise ImproperlyConfigured(
+            f"'{PROJECT_DB_ENGINE_ID}' database not defined in REPORTING_DATABASES"
+        )
     return connection_manager.get_engine(PROJECT_DB_ENGINE_ID)
 
 

--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -41,6 +41,20 @@ def get_project_db_engine():
     return connection_manager.get_engine(PROJECT_DB_ENGINE_ID)
 
 
+def create_project_db_extensions():
+    """Create the Postgres extensions project DB depends on, if absent."""
+    # Production envs install extensions via commcare-cloud
+    engine = get_project_db_engine()
+    with engine.begin() as conn:
+        for ext in [
+            'cube',  # Provides `cube` type needed by earthdistance
+            'earthdistance',  # `earth` column type and associated geopoint distance calculations
+            'pg_trgm',  # trigram-based similarity() function for fuzzy search
+            'fuzzystrmatch',  # phonetic match dmetaphone() function, also soundex and levenshtein
+        ]:
+            conn.execute(sqlalchemy.text(f'CREATE EXTENSION IF NOT EXISTS {ext}'))
+
+
 class DomainSchema:
     """A PostgreSQL schema that stores a domain's ProjectDB tables"""
     def __init__(self, domain):

--- a/corehq/apps/project_db/tests/test_table_ddl.py
+++ b/corehq/apps/project_db/tests/test_table_ddl.py
@@ -2,6 +2,8 @@ from unittest.mock import patch
 
 import pytest
 import sqlalchemy
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
 from sqlalchemy import Table
 from unmagic import fixture, use
 
@@ -14,8 +16,17 @@ from corehq.apps.project_db.table_ddl import (
     truncate_identifier,
     update_table,
 )
+from corehq.sql_db.connections import ConnectionManager
 
 from .util import project_db_table
+
+
+# DEBUG/UNIT_TESTING off so the dev/test fallback doesn't supply project_db
+@override_settings(REPORTING_DATABASES={'default': 'default'}, DEBUG=False, UNIT_TESTING=False)
+def test_get_project_db_engine_not_configured():
+    with patch('corehq.apps.project_db.table_ddl.connection_manager', ConnectionManager()):
+        with pytest.raises(ImproperlyConfigured, match='project_db'):
+            get_project_db_engine()
 
 
 def test_schema_name():

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -182,7 +182,11 @@ class ConnectionManager(object):
             self.engine_id_django_db_map[DEFAULT_ENGINE_ID] = DEFAULT_DB_ALIAS
         if UCR_ENGINE_ID not in self.engine_id_django_db_map:
             self.engine_id_django_db_map[UCR_ENGINE_ID] = DEFAULT_DB_ALIAS
-        if PROJECT_DB_ENGINE_ID not in self.engine_id_django_db_map:
+        # Real environments must configure project_db explicitly; only fall
+        # back to the default database for local dev and tests.
+        if PROJECT_DB_ENGINE_ID not in self.engine_id_django_db_map and (
+            settings.DEBUG or settings.UNIT_TESTING
+        ):
             self.engine_id_django_db_map[PROJECT_DB_ENGINE_ID] = DEFAULT_DB_ALIAS
 
     @memoized

--- a/corehq/sql_db/tests/test_connections.py
+++ b/corehq/sql_db/tests/test_connections.py
@@ -64,7 +64,7 @@ class ConnectionManagerTests(SimpleTestCase):
         self.assertEqual(manager.engine_id_django_db_map, {
             'default': 'default',
             'ucr': 'default',
-            'project_db': 'default',
+            'project_db': 'default',  # dev/test fallback
         })
 
     @override_settings(REPORTING_DATABASES={'default': DEFAULT_DB_ALIAS, 'ucr': 'ucr', 'other': 'other'})
@@ -74,8 +74,23 @@ class ConnectionManagerTests(SimpleTestCase):
             'default': 'default',
             'ucr': 'ucr',
             'other': 'other',
-            'project_db': 'default',
+            'project_db': 'default',  # dev/test fallback
         })
+
+    @override_settings(REPORTING_DATABASES={'default': DEFAULT_DB_ALIAS, 'project_db': 'other'})
+    def test_project_db_opt_in(self):
+        manager = ConnectionManager()
+        self.assertEqual(manager.engine_id_django_db_map, {
+            'default': 'default',
+            'ucr': 'default',
+            'project_db': 'other',
+        })
+
+    @override_settings(REPORTING_DATABASES={'default': DEFAULT_DB_ALIAS}, DEBUG=False, UNIT_TESTING=False)
+    def test_project_db_absent_without_fallback(self):
+        # Real environments (not dev/test) must configure project_db explicitly
+        manager = ConnectionManager()
+        self.assertNotIn('project_db', manager.engine_id_django_db_map)
 
     @mock.patch('corehq.sql_db.util.get_replication_delay_for_standby', return_value=0)
     @mock.patch('corehq.sql_db.util.get_standby_databases', return_value={'ucr', 'other'})
@@ -91,7 +106,7 @@ class ConnectionManagerTests(SimpleTestCase):
             self.assertEqual(manager.engine_id_django_db_map, {
                 'default': 'default',
                 'ucr': 'ucr',
-                'project_db': 'default',
+                'project_db': 'default',  # dev/test fallback
             })
 
             # test that load balancing works with a 10% margin for randomness
@@ -128,7 +143,7 @@ class ConnectionManagerTests(SimpleTestCase):
             self.assertEqual(manager.engine_id_django_db_map, {
                 'default': 'default',
                 'ucr': 'ucr',
-                'project_db': 'default',
+                'project_db': 'default',  # dev/test fallback
             })
 
             urls = {

--- a/corehq/tests/pytest_plugins/reusedb.py
+++ b/corehq/tests/pytest_plugins/reusedb.py
@@ -249,6 +249,8 @@ class DeferredDatabaseContext:
 @unit_testing_only
 @contextmanager
 def couch_sql_context(config):
+    from corehq.apps.project_db.table_ddl import create_project_db_extensions
+
     if config.skip_setup_for_reuse_db and sql_databases_ok():
         if config.reuse_db == "migrate":
             call_command('migrate_multi', interactive=False)
@@ -268,6 +270,8 @@ def couch_sql_context(config):
             keepdb=config.skip_setup_for_reuse_db,
             serialized_aliases=(),
         )
+
+    create_project_db_extensions()
 
     try:
         yield

--- a/settings.py
+++ b/settings.py
@@ -967,7 +967,6 @@ STRIPE_PRIVATE_KEY = ''
 REPORTING_DATABASES = {
     'default': 'default',
     'ucr': 'default',
-    'project_db': 'default',
 }
 
 PL_PROXY_CLUSTER_NAME = 'commcarehq'


### PR DESCRIPTION
## Product Description
No user-facing changes

## Technical Summary
In conjunction with https://github.com/dimagi/commcare-cloud/pull/6951 this should make it such that development and test environments have ProjectDB tables created in the `default` postgres database, but environments managed by `commcare-cloud` will error if it isn't explicitly provisioned.

It also ensures the extensions are created in test and dev contexts.

The features that build on these extensions are coming in a different PR: https://github.com/dimagi/commcare-hq/pull/37932 

## Feature Flag


## Safety Assurance
Not yet used in any production contexts

### Safety story
Decent automated test coverage, and I'll try this all on staging before merge.

### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
