### PR TITLE
Put bot context collection work behind release toggle

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/bootstrap3/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/bootstrap3/releases.js
@@ -299,7 +299,7 @@ function releasesMainModel(o) {
         $('.modal.fade.in').modal('hide');
         try {
             self.download_modal.modal({show: true});
-        } catch (e) {
+        } catch {
             // do nothing. this error only shows up in mocha tests when run
             // via grunt rather than the browser due to how the DOM is
             // interpreted. this runs fine in the browser.

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_context.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_context.js
@@ -51,7 +51,7 @@ function collectGlobalContext() {
 function runCollector(collectContext) {
     try {
         return collectContext() || {};
-    } catch (error) {
+    } catch {
         console.error("OCS context collector failed");
         return {};
     }

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_context.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ocs_page_context.js
@@ -8,6 +8,7 @@
 
 import $ from "jquery";
 import initialPageData from "hqwebapp/js/initial_page_data";
+import toggles from "hqwebapp/js/toggles";
 
 const WIDGET_SELECTOR = 'open-chat-studio-widget';
 const BEFORE_SEND_EVENT = 'ocs:message:before-send';
@@ -66,7 +67,7 @@ function getClientPageContext() {
 
 document.addEventListener('DOMContentLoaded', function () {
     const widget = document.querySelector(WIDGET_SELECTOR);
-    if (!widget) {
+    if (!widget || !toggles.toggleEnabled('OCS_CHATBOT_PAGE_CONTEXT')) {
         return;
     }
     _fetchMyRole();

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/releases/releases.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/app_manager/js/releases/releases.js.diff.txt
@@ -75,7 +75,7 @@
 -        $('.modal.fade.in').modal('hide');
 -        try {
 -            self.download_modal.modal({show: true});
--        } catch (e) {
+-        } catch {
 -            // do nothing. this error only shows up in mocha tests when run
 -            // via grunt rather than the browser due to how the DOM is
 -            // interpreted. this runs fine in the browser.

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/spec/main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/spec/main.js.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -2,8 +2,8 @@
+@@ -2,8 +2,9 @@
  
  import "hqwebapp/spec/assert_properties_spec";
  import "hqwebapp/spec/email_validator_spec";
@@ -8,6 +8,7 @@
 +import "hqwebapp/spec/bootstrap5/inactivity_spec";
  import "hqwebapp/spec/urllib_spec";
 -import "hqwebapp/spec/bootstrap3/widgets_spec";
++import "hqwebapp/spec/ocs_page_errors_spec";
 +import "hqwebapp/spec/bootstrap5/widgets_spec";
  
  hqMocha.run();

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -923,6 +923,20 @@ PUBLIC_WEBFORMS = FeatureRelease(
     """
 )
 
+OCS_CHATBOT_PAGE_CONTEXT = FeatureRelease(
+    'ocs_chatbot_page_context',
+    'Collect page context for the CommCare Companion AI support bot',
+    TAG_RELEASE,
+    namespaces=[NAMESPACE_USER, NAMESPACE_DOMAIN],
+    owner='Jing Cheng',
+    description="""
+        Gates client-side collection of page context (URL, app structure, form designer
+        state, and the requesting user's role/permissions) that is sent to the OCS chat
+        widget. Requires the CommCare Companion AI Support Bot (OCS_CHATBOT) preview to be
+        enabled for the widget to be present.
+    """,
+)
+
 WEB_APPS_PERMISSIONS_VIA_GROUPS = StaticToggle(
     'web_apps_permissions_via_groups',
     "USH: Allow users to control access to specific web apps via mobile worker groups.",


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This is a clean up of `jc/ocs-context-base`.
- Gate the context collection with a release toggle
- fix lint errors
- rebuilt b5 diffs

I plan to merge https://github.com/dimagi/commcare-hq/pull/37800 after this PR is merged.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`OCS_CHATBOT` and `OCS_CHATBOT_PAGE_CONTEXT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
It is safe, I've tested locally that the context is only collected when the toggle is on.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
