### PR TITLE
Upgrade soupsieve from 2.5 to 2.9.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2989,11 +2989,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.5"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/21/952a240de1c196c7e3fbcd4e559681f0419b1280c617db21157a0390717b/soupsieve-2.5.tar.gz", hash = "sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690", size = 100943, upload-time = "2023-09-02T12:48:22.131Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/f3/038b302fdfbe3be7da016777069f26ceefe11a681055ea1f7817546508e3/soupsieve-2.5-py3-none-any.whl", hash = "sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7", size = 36131, upload-time = "2023-09-02T12:48:20.552Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
No user-facing changes. This is a routine dependency version bump with no functional impact.

- [Changelog](https://github.com/facelessuser/soupsieve/blob/main/docs/src/markdown/about/changelog.md)
- [Commits (2.5...2.9.1)](https://github.com/facelessuser/soupsieve/compare/2.5...2.9.1)

https://dimagi.atlassian.net/browse/SAAS-20078

## Safety Assurance

### Safety story
`soupsieve` is a transitive dependency used for CSS selector parsing via BeautifulSoup.

### Automated test coverage
Existing test suite covers usage of BeautifulSoup/soupsieve indirectly.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
