### PR TITLE
PR 2 Couch to sql migration for CommCareBuild

### DIFF
--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -13,8 +13,8 @@ from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.util import app_doc_types
 from corehq.apps.builds.models import (
     BuildSpec,
-    CommCareBuild,
     CommCareBuildConfig,
+    CommCareMobileBuild,
 )
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.blobs import CODES, get_blob_db
@@ -105,7 +105,7 @@ class SuiteMixin(TestXmlMixin):
 
 
 def add_build(version, build_number):
-    return CommCareBuild.create_without_artifacts(version, build_number)
+    return CommCareMobileBuild.objects.create(version=version, build_number=build_number)
 
 
 @nottest

--- a/corehq/apps/builds/management/commands/add_commcare_build.py
+++ b/corehq/apps/builds/management/commands/add_commcare_build.py
@@ -6,7 +6,6 @@ from django.core.management.base import BaseCommand, CommandError
 from corehq.apps.builds.models import (
     BuildMenuItem,
     BuildSpec,
-    CommCareBuild,
     CommCareBuildConfig,
     CommCareMobileBuild,
 )
@@ -39,7 +38,7 @@ class Command(BaseCommand):
             raise CommandError("<latest> or <build_number> not specified!")
 
     def _create_build_with_version(self, version):
-        if any(build.version == version for build in CommCareBuild.all_builds()):
+        if CommCareMobileBuild.objects.filter(version=version).exists():
             self.stdout.write(f"A build for version {version} already exists. You're up-to-date!")
         else:
             CommCareMobileBuild.objects.create(version=version, build_number=None)

--- a/corehq/apps/builds/management/commands/add_commcare_build.py
+++ b/corehq/apps/builds/management/commands/add_commcare_build.py
@@ -8,6 +8,7 @@ from corehq.apps.builds.models import (
     BuildSpec,
     CommCareBuild,
     CommCareBuildConfig,
+    CommCareMobileBuild,
 )
 
 
@@ -41,7 +42,7 @@ class Command(BaseCommand):
         if any(build.version == version for build in CommCareBuild.all_builds()):
             self.stdout.write(f"A build for version {version} already exists. You're up-to-date!")
         else:
-            CommCareBuild.create_without_artifacts(version, None)
+            CommCareMobileBuild.objects.create(version=version, build_number=None)
             _update_commcare_build_menu(version)
             self.stdout.write(f"Added build for version {version}.")
 

--- a/corehq/apps/builds/management/commands/populate_commcarebuild.py
+++ b/corehq/apps/builds/management/commands/populate_commcarebuild.py
@@ -20,7 +20,7 @@ class Command(PopulateSQLCommand):
 
     @classmethod
     def commit_adding_migration(cls):
-        return 'TODO: add once the PR adding this file is merged'
+        return "29d426b919b0c89e9a12d583efaabb4dbe490cdd"
 
     @classmethod
     def diff_couch_and_sql(cls, couch, sql):

--- a/corehq/apps/builds/migrations/0002_populate_commcaremobilebuild.py
+++ b/corehq/apps/builds/migrations/0002_populate_commcaremobilebuild.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+from corehq.apps.builds.management.commands.populate_commcarebuild import Command
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('builds', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(Command.migrate_from_migration,
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
+    ]

--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -187,9 +187,9 @@ class BuildSpec(DocumentSchema):
 
     def get_build(self):
         if self.latest:
-            return CommCareBuild.get_build(self.version, latest=True)
+            return CommCareMobileBuild.get_build(self.version)
         else:
-            return CommCareBuild.get_build(self.version, self.build_number)
+            return CommCareMobileBuild.get_build(self.version, self.build_number)
 
     def is_null(self):
         return not (self.version and (self.build_number or self.latest))

--- a/corehq/apps/builds/utils.py
+++ b/corehq/apps/builds/utils.py
@@ -1,6 +1,6 @@
 import re
 
-from corehq.apps.builds.models import CommCareBuild, CommCareBuildConfig
+from corehq.apps.builds.models import CommCareBuild, CommCareBuildConfig, CommCareMobileBuild
 
 
 def get_all_versions(versions):
@@ -79,7 +79,7 @@ def get_build_time(version, cache=None):
         return cache[version]
 
     try:
-        build = CommCareBuild.get_build(version, latest=True)
+        build = CommCareMobileBuild.get_build(version)
     except KeyError:
         cache[version] = None
         return None

--- a/corehq/apps/builds/utils.py
+++ b/corehq/apps/builds/utils.py
@@ -1,6 +1,6 @@
 import re
 
-from corehq.apps.builds.models import CommCareBuild, CommCareBuildConfig, CommCareMobileBuild
+from corehq.apps.builds.models import CommCareBuildConfig, CommCareMobileBuild
 
 
 def get_all_versions(versions):
@@ -8,10 +8,10 @@ def get_all_versions(versions):
     Returns a list of all versions found in the database,
     plus those in the optional list parameter.
     """
-    db = CommCareBuild.get_db()
-    results = db.view('builds/all', group_level=1).all()
-    versions += [result['key'][0] for result in results]
-    return sorted(list(set(versions)))
+    versions += list(
+        CommCareMobileBuild.objects.values_list('version', flat=True).distinct()
+    )
+    return sorted(set(versions))
 
 
 def get_default_build_spec():

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -17,7 +17,7 @@ from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.util.view_utils import json_error
 
-from .models import CommCareBuild, CommCareBuildConfig, CommCareMobileBuild, SemanticVersionProperty
+from .models import CommCareBuildConfig, CommCareMobileBuild, SemanticVersionProperty
 from .utils import get_all_versions
 
 
@@ -39,7 +39,7 @@ def post(request):
 @require_GET
 @require_superuser
 def get_all(request):
-    builds = sorted(CommCareBuild.all_builds(), key=lambda build: build.time)
+    builds = CommCareMobileBuild.objects.all().order_by('time')
     return render(request, 'builds/all.html', {'builds': builds})
 
 

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -17,7 +17,7 @@ from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.util.view_utils import json_error
 
-from .models import CommCareBuild, CommCareBuildConfig, SemanticVersionProperty
+from .models import CommCareBuild, CommCareBuildConfig, CommCareMobileBuild, SemanticVersionProperty
 from .utils import get_all_versions
 
 
@@ -32,7 +32,7 @@ def post(request):
     except ValueError:
         return HttpResponseBadRequest("build_number has to be a base-10 integer")
 
-    CommCareBuild.create_without_artifacts(version, build_number)
+    CommCareMobileBuild.objects.create(version=version, build_number=build_number)
     return HttpResponse()
 
 
@@ -97,12 +97,11 @@ def import_build(request):
             }
         }, status_code=400)
 
-    build = CommCareBuild.create_without_artifacts(version, None)
+    build = CommCareMobileBuild.objects.create(version=version, build_number=None)
 
     return json_response({
         'message': 'New CommCare build added',
         'info': {
             'version': version,
-            '_id': build.get_id,
         }
     })

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -97,7 +97,7 @@ def import_build(request):
             }
         }, status_code=400)
 
-    build = CommCareMobileBuild.objects.create(version=version, build_number=None)
+    CommCareMobileBuild.objects.create(version=version, build_number=None)
 
     return json_response({
         'message': 'New CommCare build added',

--- a/migrations.lock
+++ b/migrations.lock
@@ -226,6 +226,7 @@ blobs
  0015_rename_blobmeta_parent_id_type_code_name_blobs_blobm_parent__73d7c2_idx
 builds
  0001_initial
+ 0002_populate_commcaremobilebuild
 campaign
  0001_initial
  0002_dashboardmap_dashboardreport


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
PR 1: https://github.com/dimagi/commcare-hq/pull/37954
PR 3: https://github.com/dimagi/commcare-hq/pull/37956

This is a Couch to SQL migration following [the doc](https://commcare-hq.readthedocs.io/couch_to_sql_models.html)

This PR will populate all SQL database, and starts to read and write from SQL, the write will be synced to Couch.

⚠️ Before this PR is merged, add the hash of the commit that merged PR 1 into master to `commit_adding_migration`
^ This is already done in 70cef516dc4a41818c3e6ef033f4e0dfa7dabe86

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
The migration and the successful read and write has been tested locally and on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Not planning on QA. We did QA ourselves, which is:
```
- Use Import Build button to a new build in `https://www.commcarehq.org/builds/edit_menu/`
- Deploy the code to staging and run the migration
- Test that you can edit the created build in a shell (there is no way to edit it in UI ) and also create more new build
```

### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code. Pay particular attention to _backward incompatible_ operations like `RemoveField`, `RenameField`, `RemoveConstraint`, and [others described here](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md) that can cause errors when migrations are applied to a live database.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
