### PR TITLE
Enable daily task to purge forms deleted 90 days ago or more

### DIFF
--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -26,8 +26,8 @@ logger = logging.getLogger(__name__)
 SENTINEL_DOMAIN = object()
 
 
-# @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
-def purge_expired_data(dry_run=True):
+@periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
+def purge_expired_data(dry_run=False):
     """
     Permanently delete data with a ``deleted_on`` value older than
     ``settings.DATA_RETENTION_WINDOW`` days.

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 # special object used to bypass domain filter in hard_delete_forms
 # should only ever be used by permanently_delete_eligible_data
-SENTINEL_DOMAIN = object()
+ALL_DOMAINS_SENTINEL = object()
 
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -27,24 +27,17 @@ SENTINEL_DOMAIN = object()
 
 
 # @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
-def permanently_delete_eligible_data(dry_run=True):
+def purge_expired_data(dry_run=True):
     """
-    Permanently delete database objects that are eligible for hard deletion.
-    To be eligible an object must have a ``deleted_on`` value
-    older than the settings.DATA_RETENTION_WINDOW
+    Permanently delete data with a ``deleted_on`` value older than
+    ``settings.DATA_RETENTION_WINDOW`` days.
     :param dry_run: if True, no changes will be committed to the database
-    """
-    """
-    NOTE: Do not delete this function! In the interest of keeping deletion records for future reference,
-    data won't be completely hard deleted until the domain is deleted. Instead, they'll be converted
-    into a tombstone after the 90 day safety period. This task will be restructured to do that once a day
-    in a future PR coming soon (Q1 2024).
     """
     dry_run_tag = '[DRY RUN] ' if dry_run else ''
     commit = not dry_run
     form_counts = XFormInstance.objects.hard_delete_expired_forms(commit=commit)
     logger.info(
-        f"{dry_run_tag}'permanently_delete_eligible_data' deleted {form_counts} XFormInstance objects."
+        f"{dry_run_tag}'purge_expired_data' deleted {form_counts} XFormInstance objects."
     )
 
 

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -43,10 +43,9 @@ def permanently_delete_eligible_data(dry_run=True):
     dry_run_tag = '[DRY RUN] ' if dry_run else ''
     commit = not dry_run
     form_counts = XFormInstance.objects.hard_delete_expired_forms(commit=commit)
-
-    logger.info(f"{dry_run_tag}'permanently_delete_eligible_data' ran with the following results:\n")
-    for table, count in form_counts.items():
-        logger.info(f"{dry_run_tag}{count} {table} objects were deleted.")
+    logger.info(
+        f"{dry_run_tag}'permanently_delete_eligible_data' deleted {form_counts} XFormInstance objects."
+    )
 
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))

--- a/corehq/apps/cleanup/tests/test_tasks.py
+++ b/corehq/apps/cleanup/tests/test_tasks.py
@@ -5,27 +5,26 @@ from time_machine import travel
 
 from django.test import TestCase, override_settings
 
-from corehq.apps.cleanup.tasks import permanently_delete_eligible_data
+from corehq.apps.cleanup.tasks import purge_expired_data
 from corehq.form_processor.exceptions import XFormNotFound
 from corehq.form_processor.models import XFormInstance
 from corehq.form_processor.tests.utils import create_form_for_test
 
 
-class TestPermanentlyDeleteEligibleData(TestCase):
+class TestPurgeExpiredData(TestCase):
     """
-    This serves as a general smoke test. To see specific tests, see:
-    - corehq.form_processor.tests.test_forms.TestHardDeleteFormsBeforeCutoff
+    This serves as a general smoke test. More comprehensive tests should
+    exist for each table that is eligible for hard deletion.
+    (e.g., corehq.form_processor.tests.test_forms.TestHardDeleteExpiredForms)
     """
-
-    def setUp(self):
-        self.domain = 'test_permanently_delete_eligible_data'
+    domain = 'test_purge_expired_data'
 
     @travel('2020-01-10')
     def test_deletes_data_outside_of_retention_window(self):
         form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 2))
 
         with override_settings(DATA_RETENTION_WINDOW=7):
-            permanently_delete_eligible_data(dry_run=False)
+            purge_expired_data(dry_run=False)
 
         with pytest.raises(XFormNotFound):
             XFormInstance.objects.get_form(form.form_id)
@@ -35,7 +34,7 @@ class TestPermanentlyDeleteEligibleData(TestCase):
         form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 4))
 
         with override_settings(DATA_RETENTION_WINDOW=7):
-            permanently_delete_eligible_data(dry_run=False)
+            purge_expired_data(dry_run=False)
 
         assert XFormInstance.objects.get_form(form.form_id) is not None
 
@@ -44,6 +43,6 @@ class TestPermanentlyDeleteEligibleData(TestCase):
         form = create_form_for_test(self.domain, deleted_on=datetime(2020, 1, 2))
 
         with override_settings(DATA_RETENTION_WINDOW=7):
-            permanently_delete_eligible_data(dry_run=True)
+            purge_expired_data(dry_run=True)
 
         assert XFormInstance.objects.get_form(form.form_id) is not None

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -417,18 +417,18 @@ class XFormInstanceManager(RequireDBManager):
 
         deleted_count = 0
         for db_name, split_form_ids in split_list_by_db_partition(form_ids):
-            queryset = (
-                self.using(db_name)
-                .filter(domain_filter, form_id__in=split_form_ids)
-                .values_list('form_id', 'deleted_on', 'domain')
-            )
             shard_count = 0
-            while results := queryset[:BATCH_SIZE]:
+            for chunked_form_ids in chunked(split_form_ids, BATCH_SIZE):
+                chunked_queryset = (
+                    self.using(db_name)
+                    .filter(domain_filter, form_id__in=chunked_form_ids)
+                    .values_list('form_id', 'deleted_on', 'domain')
+                )
                 hard_deletion_date = datetime.now(tz=UTC)
                 form_ids_to_delete = []
                 form_ids_by_domain = defaultdict(list)
                 tombstones = []
-                for form_id, soft_deleted_on, form_domain in results:
+                for form_id, soft_deleted_on, form_domain in chunked_queryset:
                     form_ids_by_domain[form_domain].append(form_id)
                     form_ids_to_delete.append(form_id)
                     if leave_tombstones:
@@ -446,7 +446,7 @@ class XFormInstanceManager(RequireDBManager):
                     Tombstone.objects.using(db_name).bulk_create(
                         tombstones, ignore_conflicts=True
                     )
-                    _, batch_count = (
+                    _, chunk_count = (
                         self.using(db_name)
                         .filter(domain_filter, form_id__in=form_ids_to_delete)
                         .delete()
@@ -460,7 +460,7 @@ class XFormInstanceManager(RequireDBManager):
                     for _domain, form_ids_in_domain in form_ids_by_domain.items():
                         self.publish_deleted_forms(_domain, form_ids_in_domain)
 
-                shard_count += batch_count.get(self.model._meta.label, 0)
+                shard_count += chunk_count.get(self.model._meta.label, 0)
             deleted_count += shard_count
         return deleted_count
 

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -1,5 +1,6 @@
 import logging
-from collections import Counter, defaultdict
+from collections import defaultdict
+
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from io import BytesIO
@@ -380,15 +381,23 @@ class XFormInstanceManager(RequireDBManager):
         :param commit: defaults to False. If True, will delete expired forms
         :return: dictionary of count of deleted forms
         """
+        from corehq.apps.cleanup.tasks import SENTINEL_DOMAIN
+
         expiration_date = get_cutoff_date_for_data_deletion()
-        total_count = Counter({})
+        total_count = 0
         for db_name in get_db_aliases_for_partitioned_query():
-            queryset = self.using(db_name).filter(deleted_on__lt=expiration_date)
+            queryset = (
+                self.using(db_name)
+                .filter(deleted_on__lt=expiration_date)
+                .values_list('form_id', flat=True)
+            )
             if commit:
-                deleted_counts = queryset.delete()[1]
+                deleted_count = self.hard_delete_forms(
+                    SENTINEL_DOMAIN, list(queryset)
+                )
             else:
-                deleted_counts = {'form_processor.XFormInstance': queryset.count()}
-            total_count += Counter(deleted_counts)
+                deleted_count = queryset.count()
+            total_count += deleted_count
         return total_count
 
     def hard_delete_forms(self, domain, form_ids, *, publish_changes=True, leave_tombstones=True):

--- a/corehq/form_processor/models/forms.py
+++ b/corehq/form_processor/models/forms.py
@@ -381,7 +381,7 @@ class XFormInstanceManager(RequireDBManager):
         :param commit: defaults to False. If True, will delete expired forms
         :return: dictionary of count of deleted forms
         """
-        from corehq.apps.cleanup.tasks import SENTINEL_DOMAIN
+        from corehq.apps.cleanup.tasks import ALL_DOMAINS_SENTINEL
 
         expiration_date = get_cutoff_date_for_data_deletion()
         total_count = 0
@@ -393,7 +393,7 @@ class XFormInstanceManager(RequireDBManager):
             )
             if commit:
                 deleted_count = self.hard_delete_forms(
-                    SENTINEL_DOMAIN, list(queryset)
+                    ALL_DOMAINS_SENTINEL, list(queryset)
                 )
             else:
                 deleted_count = queryset.count()
@@ -410,10 +410,10 @@ class XFormInstanceManager(RequireDBManager):
             The user location mapping case and domain deletion are the only valid
             use cases for not leaving tombstones.
         """
-        from corehq.apps.cleanup.tasks import SENTINEL_DOMAIN
+        from corehq.apps.cleanup.tasks import ALL_DOMAINS_SENTINEL
         assert isinstance(form_ids, list)
 
-        domain_filter = Q() if domain == SENTINEL_DOMAIN else Q(domain=domain)
+        domain_filter = Q() if domain == ALL_DOMAINS_SENTINEL else Q(domain=domain)
 
         deleted_count = 0
         for db_name, split_form_ids in split_list_by_db_partition(form_ids):

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -390,7 +390,7 @@ class TestHardDeleteExpiredForms(TestCase):
         with override_settings(DATA_RETENTION_WINDOW=7):
             count = XFormInstance.objects.hard_delete_expired_forms(commit=True)
 
-        assert count == {'form_processor.XFormInstance': 1}
+        assert count == 1
         assert XFormInstance.objects.partitioned_get(valid_form.form_id)
         assert XFormInstance.objects.partitioned_get(soft_deleted_form.form_id)
         with pytest.raises(XFormInstance.DoesNotExist):
@@ -405,7 +405,7 @@ class TestHardDeleteExpiredForms(TestCase):
         with override_settings(DATA_RETENTION_WINDOW=7):
             count = XFormInstance.objects.hard_delete_expired_forms()
 
-        assert count == {'form_processor.XFormInstance': 1}
+        assert count == 1
         assert XFormInstance.objects.partitioned_get(valid_form.form_id)
         assert XFormInstance.objects.partitioned_get(soft_deleted_form.form_id)
         assert XFormInstance.objects.partitioned_get(expired_form.form_id)
@@ -423,8 +423,8 @@ class TestHardDeleteExpiredForms(TestCase):
             dry_run_counts = XFormInstance.objects.hard_delete_expired_forms()
             actual_counts = XFormInstance.objects.hard_delete_expired_forms(commit=True)
 
-        assert dry_run_counts == {'form_processor.XFormInstance': 5}
-        assert actual_counts == {'form_processor.XFormInstance': 5}
+        assert dry_run_counts == 5
+        assert actual_counts == 5
 
 
 @sharded

--- a/corehq/form_processor/tests/test_forms.py
+++ b/corehq/form_processor/tests/test_forms.py
@@ -479,10 +479,10 @@ class TestHardDeleteForms(TestCase):
         assert count == 1
 
     def test_sentinel_value_deletes_across_domains_and_creates_tombstones(self):
-        from corehq.apps.cleanup.tasks import SENTINEL_DOMAIN
+        from corehq.apps.cleanup.tasks import ALL_DOMAINS_SENTINEL
         form = create_form_for_test(DOMAIN)
         other_form = create_form_for_test('other_domain')
-        deleted = XFormInstance.objects.hard_delete_forms(SENTINEL_DOMAIN, [form.form_id, other_form.form_id])
+        deleted = XFormInstance.objects.hard_delete_forms(ALL_DOMAINS_SENTINEL, [form.form_id, other_form.form_id])
         assert deleted == 2
         for f in [form, other_form]:
             # should not raise errors


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-15221

This is an intentionally less efficient implementation in that we fetch the form ids for forms deleted more than 90 days ago, and then pass those ids into `hard_delete_forms` which handles the actual deletion. This could be done in one db delete request, but the goal is to keep the shared code simple and consistent to ensure when forms are deleted, tombstones are created, and blobs are deleted, which `hard_delete_forms` does. 

I thought about passing a queryset instead of a list of ids, and making `hard_delete_forms` handle that instead, but since we have to iterate over each form being deleted to create a tombstone anyway, the added complexity/blast radius of existing use cases didn't seem worth it.

Before rolling out, we should do a manual run of `purge_expired_data` since there will be a larger backlog than usual do to a build up of soft deleted forms. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
On staging, I ran `purge_expired_forms` in dry run mode. I manually confirmed that the dry run returned the same count of forms to delete that I would expect based on a manual query with the cutoff date. I also did the inverse query to confirm that the total number of soft deleted forms matches the number before the cutoff date and number after the cutoff date.

Next up, I ran `purge_expired_forms` for real. It took a notable amount longer, but did complete with the same count that the dry run logged. I checked the `Tombstone` table to confirm that the same number of rows were created today and spot checked a couple of rows specifically to see that the fields make sense (they do).

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
This area of code is pretty well tested generally, from form deletion -> tombstones, to hard deleting expired forms grabbing the correct cutoff date, I feel confident in the tests in this module.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No, manually tested.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
