### PR TITLE
[test] bulk async jobs

### DIFF
--- a/corehq/apps/data_interfaces/bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/bulk_form_actions.py
@@ -13,6 +13,8 @@ from dimagi.utils.logging import notify_exception
 
 from corehq.apps.data_interfaces.models import BulkAsyncJob
 from corehq.apps.users.models import CouchUser
+from corehq.blobs import get_blob_db
+from corehq.blobs.atomic import AtomicBlobs
 from corehq.form_processor.models import XFormInstance
 
 log = logging.getLogger(__name__)
@@ -27,6 +29,21 @@ class FormActionResult:
     form_id: str
     status: str  # SUCCEEDED | SKIPPED
     reason: Optional[str] = None  # not_found | unexpected_error
+
+
+def create_bulk_form_job(domain, action, requested_by, form_ids):
+    """Use ``AtomicBlobs`` to prevent an orphaned requested ids blob"""
+    with AtomicBlobs(get_blob_db()) as db:
+        job = BulkAsyncJob(
+            domain=domain,
+            model=XFormInstance,
+            action=action,
+            requested_by=requested_by,
+        )
+        stored_ids = job.set_requested_ids(form_ids, db=db)
+        job.requested_count = len(stored_ids)
+        job.save()
+    return job
 
 
 def build_form_action(job, user_id):

--- a/corehq/apps/data_interfaces/bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/bulk_form_actions.py
@@ -101,6 +101,19 @@ def _apply_form_action(domain, form_ids, action_fn):
         yield FormActionResult(form_id, SKIPPED, 'not_found')
 
 
+def mark_job_failed(job_id):
+    """Mark a job ``failed`` unless it already reached a terminal state."""
+    try:
+        job = BulkAsyncJob.objects.get(id=job_id)
+    except BulkAsyncJob.DoesNotExist:
+        return
+    if job.is_done:
+        return
+    job.status = BulkAsyncJob.Status.FAILED
+    job.completed_at = datetime.now(tz=UTC)
+    job.save()
+
+
 def _resolve_user_id(username):
     user = CouchUser.get_by_username(username)
     if user is None:

--- a/corehq/apps/data_interfaces/bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/bulk_form_actions.py
@@ -1,0 +1,109 @@
+"""Execution logic for bulk form actions (archive/unarchive).
+
+Kept separate from ``tasks.py`` so the job lifecycle can be tested without
+Celery. The Celery task is a thin wrapper around ``run_bulk_form_action``.
+"""
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Optional
+
+from dimagi.utils.logging import notify_exception
+
+from corehq.apps.data_interfaces.models import BulkAsyncJob
+from corehq.apps.users.models import CouchUser
+from corehq.form_processor.models import XFormInstance
+
+log = logging.getLogger(__name__)
+
+SUCCEEDED = 'succeeded'
+SKIPPED = 'skipped'
+
+
+@dataclass(frozen=True)
+class FormActionResult:
+    """Outcome of a bulk form action for a single requested form id."""
+    form_id: str
+    status: str  # SUCCEEDED | SKIPPED
+    reason: Optional[str] = None  # not_found | unexpected_error
+
+
+def build_form_action(job, user_id):
+    """Return the per-form action callable for ``job.action``."""
+    if job.action == BulkAsyncJob.Action.ARCHIVE:
+        return lambda f: f.archive(user_id=user_id)
+    if job.action == BulkAsyncJob.Action.UNARCHIVE:
+        return lambda f: f.unarchive(user_id=user_id)
+    raise ValueError(f'unknown bulk action: {job.action}')
+
+
+def _save_interval(requested_count):
+    """Every 5% or 100 forms, whichever is lower"""
+    return max(1, min(100, requested_count // 20))
+
+
+def run_bulk_form_action(job):
+    """Execute ``job`` start to finish, updating counts and status on the row."""
+    job.status = BulkAsyncJob.Status.RUNNING
+    job.started_at = datetime.now(tz=UTC)
+    job.save()
+
+    user_id = _resolve_user_id(job.requested_by)
+    form_ids = job.get_requested_ids()
+    action_fn = build_form_action(job, user_id)
+    save_interval = _save_interval(job.requested_count)
+
+    skipped = defaultdict(list)
+    processed = succeeded = 0
+    for result in _apply_form_action(job.domain, form_ids, action_fn):
+        processed += 1
+        if result.status == SUCCEEDED:
+            succeeded += 1
+        else:
+            skipped[result.reason].append(result.form_id)
+        if processed % save_interval == 0:
+            job.processed_count = processed
+            job.succeeded_count = succeeded
+            job.save(update_fields=['processed_count', 'succeeded_count'])
+            log.info(
+                "bulk_%s bulk_async_job_id=%s domain=%s processed=%s/%s",
+                job.action, job.id, job.domain, processed, job.requested_count,
+            )
+
+    job.processed_count = processed
+    job.succeeded_count = succeeded
+    job.set_skipped(dict(skipped))
+    job.status = BulkAsyncJob.Status.COMPLETE
+    job.completed_at = datetime.now(tz=UTC)
+    job.save()
+
+
+def _apply_form_action(domain, form_ids, action_fn):
+    """Apply ``action_fn`` to each form and yield a ``FormActionResult`` per id."""
+    unresolved_ids = set(form_ids)
+    for xform in XFormInstance.objects.iter_forms(form_ids):
+        if xform.domain != domain:
+            # skip forms not belonging to the specified domain
+            continue
+        unresolved_ids.discard(xform.form_id)
+        try:
+            action_fn(xform)
+        except Exception:
+            notify_exception(None, "Error applying bulk form action", {
+                'domain': domain,
+                'form_id': xform.form_id,
+            })
+            yield FormActionResult(xform.form_id, SKIPPED, 'unexpected_error')
+        else:
+            yield FormActionResult(xform.form_id, SUCCEEDED)
+    for form_id in unresolved_ids:
+        yield FormActionResult(form_id, SKIPPED, 'not_found')
+
+
+def _resolve_user_id(username):
+    user = CouchUser.get_by_username(username)
+    if user is None:
+        log.warning("bulk form action: user %s not found; using user_id=None", username)
+        return None
+    return user.user_id

--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -261,6 +261,18 @@ class FormManagementMode(object):
     def is_archive_mode(self):
         return self.mode_name == self.ARCHIVE_MODE
 
+    @classmethod
+    def bulk_action(cls, mode):
+        """Map a mode name to the corresponding ``BulkAsyncJob.Action``."""
+        from corehq.apps.data_interfaces.models import BulkAsyncJob
+        match mode:
+            case cls.ARCHIVE_MODE:
+                return BulkAsyncJob.Action.ARCHIVE
+            case cls.RESTORE_MODE:
+                return BulkAsyncJob.Action.UNARCHIVE
+            case _:
+                raise ValueError(f"unknown form management mode: {mode!r}")
+
 
 class ArchiveOrNormalFormFilter(BaseSingleOptionFilter):
     slug = 'archive_or_restore'

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1991,9 +1991,9 @@ class BulkAsyncJob(models.Model):
     def is_done(self):
         return self.status in (self.Status.COMPLETE, self.Status.FAILED)
 
-    def set_requested_ids(self, form_ids):
+    def set_requested_ids(self, form_ids, db=None):
         ids = sorted(set(form_ids))
-        self.requested_ids_blob_key = self._put_blob(ids)
+        self.requested_ids_blob_key = self._put_blob(ids, db=db)
         return ids
 
     def get_requested_ids(self):
@@ -2006,8 +2006,8 @@ class BulkAsyncJob(models.Model):
     def get_skipped(self):
         return self._get_blob(self.skipped_ids_blob_key)
 
-    def _put_blob(self, payload):
-        db = get_blob_db()
+    def _put_blob(self, payload, db=None):
+        db = db or get_blob_db()
         content = BytesIO(json.dumps(payload).encode("utf-8"))
         meta = db.put(
             content,

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1,10 +1,12 @@
 import csv
 import hashlib
+import json
 import operator
 import re
 import uuid
 from collections import defaultdict
 from datetime import date, datetime, time, timedelta
+from io import BytesIO
 
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
@@ -47,6 +49,7 @@ from corehq.apps.data_interfaces.utils import property_references_parent
 from corehq.apps.hqcase.utils import bulk_update_cases, update_case, AUTO_UPDATE_XMLNS, is_copied_case, resave_case
 from corehq.apps.users.util import SYSTEM_USER_ID, cached_owner_id_to_display
 from corehq.apps.users.cases import get_wrapped_owner
+from corehq.blobs import CODES, get_blob_db
 from corehq.form_processor.models import DEFAULT_PARENT_IDENTIFIER
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCaseIndex, CommCareCase, XFormInstance
@@ -1983,3 +1986,37 @@ class BulkAsyncJob(models.Model):
 
     class Meta:
         app_label = 'data_interfaces'
+
+    def set_requested_ids(self, form_ids):
+        ids = sorted(set(form_ids))
+        self.requested_ids_blob_key = self._put_blob(ids)
+        return ids
+
+    def get_requested_ids(self):
+        return self._get_blob(self.requested_ids_blob_key)
+
+    def set_skipped(self, grouped):
+        sorted_groups = {reason: sorted(ids) for reason, ids in grouped.items()}
+        self.skipped_ids_blob_key = self._put_blob(sorted_groups)
+
+    def get_skipped(self):
+        return self._get_blob(self.skipped_ids_blob_key)
+
+    def _put_blob(self, payload):
+        db = get_blob_db()
+        content = BytesIO(json.dumps(payload).encode("utf-8"))
+        meta = db.put(
+            content,
+            domain=self.domain,
+            parent_id=self.id.hex,
+            type_code=CODES.bulk_async_job,
+            key=uuid.uuid4().hex,
+        )
+        return meta.key
+
+    def _get_blob(self, key):
+        # Read through the BlobMeta to ensure content is decompressed.
+        db = get_blob_db()
+        meta = db.metadb.get(key=key, parent_id=self.id.hex)
+        with db.get(meta=meta) as stream:
+            return json.loads(stream.read())

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1987,6 +1987,10 @@ class BulkAsyncJob(models.Model):
     class Meta:
         app_label = 'data_interfaces'
 
+    @property
+    def is_done(self):
+        return self.status in (self.Status.COMPLETE, self.Status.FAILED)
+
     def set_requested_ids(self, form_ids):
         ids = sorted(set(form_ids))
         self.requested_ids_blob_key = self._put_blob(ids)

--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -7,6 +7,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import gettext as _
 
 from celery.schedules import crontab
+from celery.signals import task_failure
 from celery.utils.log import get_task_logger
 
 from dimagi.utils.couch import CriticalSection
@@ -28,10 +29,12 @@ from corehq.toggles import DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK
 from corehq.util.celery_utils import no_result_task
 from corehq.util.log import send_HTML_email
 
+from .bulk_form_actions import mark_job_failed, run_bulk_form_action
 from .deduplication import backfill_deduplicate_rule, reset_deduplicate_rule
 from .interfaces import FormManagementMode
 from .models import (
     AutomaticUpdateRule,
+    BulkAsyncJob,
     CaseDuplicate,
     CaseDuplicateNew,
     CaseRuleSubmission,
@@ -96,6 +99,17 @@ def bulk_upload_cases_to_group(upload_id, domain, case_group_id, cases):
         progress_tracker=_get_upload_progress_tracker(upload_id)
     )
     cache.set(upload_id, results, ONE_HOUR)
+
+
+@serial_task('{domain}', default_retry_delay=300, max_retries=48, timeout=60 * 60)
+def bulk_form_action_async(job_id, domain):
+    run_bulk_form_action(BulkAsyncJob.objects.get(id=job_id))
+
+
+@task_failure.connect(sender=bulk_form_action_async)
+def _mark_bulk_form_action_job_failed(sender=None, args=None, **kwargs):
+    if job_id := (args[0] if args else None):
+        mark_job_failed(job_id)
 
 
 @task(serializer='pickle')

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/xform_management_status_new.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/xform_management_status_new.html
@@ -1,0 +1,53 @@
+{% load i18n %}
+{% if is_done %}
+  <div id="ready_{{ download_id }}">
+    {% if has_failed %}
+      <div class="alert alert-danger">
+        <h3>{{ mode.fail_text }}</h3>
+        <p>{% trans "The job failed. Please try again." %}</p>
+      </div>
+    {% else %}
+      <legend>{{ on_complete_short }}</legend>
+      <div class="alert alert-success">
+        <h4>
+          {# prettier-ignore-start #}
+          {% blocktrans count counter=succeeded_count %}
+            {{ counter }} form processed successfully
+          {% plural %}
+            {{ counter }} forms processed successfully
+          {% endblocktrans %}
+          {# prettier-ignore-end #}
+        </h4>
+      </div>
+      {% if skipped %}
+        <div class="alert alert-warning">
+          <h3>{% trans "Some forms were skipped:" %}</h3>
+          {% for reason, ids in skipped.items %}
+            <p><strong>{{ reason }}</strong>: {{ ids|length }}</p>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endif %}
+  </div>
+  <span>{{ mode.help_message }}</span>
+  {% blocktrans %}
+    <span
+      >Return to <a href="{{ form_management_url }}">Manage Forms</a> to reverse
+      this.</span
+    >
+  {% endblocktrans %}
+{% else %}
+  <legend>{{ mode.progress_text }}</legend>
+  <div class="progress">
+    <div
+      class="progress-bar progress-bar-striped active"
+      role="progressbar"
+      aria-valuenow="{{ progress.percent }}"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      style="width: {{ progress.percent }}%"
+    >
+      {{ progress.percent }}%
+    </div>
+  </div>
+{% endif %}

--- a/corehq/apps/data_interfaces/tests/test_bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/tests/test_bulk_form_actions.py
@@ -1,0 +1,172 @@
+from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase, TestCase
+
+import pytest
+
+from corehq.apps.data_interfaces.bulk_form_actions import (
+    SKIPPED,
+    SUCCEEDED,
+    FormActionResult,
+    _apply_form_action,
+    _save_interval,
+    build_form_action,
+    run_bulk_form_action,
+)
+from corehq.apps.data_interfaces.models import BulkAsyncJob
+from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
+from corehq.form_processor.models.forms import XFormInstance
+from corehq.form_processor.tests.utils import create_form_for_test, sharded
+
+DOMAIN = 'bulk-actions-test'
+
+
+class TestBuildFormAction(TestCase):
+
+    def _job(self, action):
+        return BulkAsyncJob(
+            domain=DOMAIN, model=XFormInstance, action=action, requested_by='u',
+        )
+
+    def test_archive_action(self):
+        action_fn = build_form_action(self._job(BulkAsyncJob.Action.ARCHIVE), user_id='uid')
+        assert callable(action_fn)
+
+    def test_unarchive_action(self):
+        action_fn = build_form_action(self._job(BulkAsyncJob.Action.UNARCHIVE), user_id='uid')
+        assert callable(action_fn)
+
+
+@sharded
+class TestRunBulkFormAction(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.blob_db = TemporaryFilesystemBlobDB()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.blob_db.close()
+        super().tearDownClass()
+
+    def _job(self, action, form_ids):
+        job = BulkAsyncJob(
+            domain=DOMAIN, model=XFormInstance, action=action, requested_by='u',
+        )
+        stored = job.set_requested_ids(form_ids)
+        job.requested_count = len(stored)
+        job.save()
+        return job
+
+    def test_archive_marks_complete_and_counts(self):
+        form = create_form_for_test(DOMAIN, state=XFormInstance.NORMAL)
+        job = self._job(BulkAsyncJob.Action.ARCHIVE, [form.form_id])
+
+        run_bulk_form_action(job)
+
+        job.refresh_from_db()
+        assert job.status == BulkAsyncJob.Status.COMPLETE
+        assert job.started_at is not None and job.completed_at is not None
+        assert job.processed_count == 1
+        assert job.succeeded_count == 1
+        assert job.get_skipped() == {}
+        assert XFormInstance.objects.get_form(form.form_id, DOMAIN).is_archived
+
+    def test_missing_id_recorded_not_found(self):
+        job = self._job(BulkAsyncJob.Action.ARCHIVE, ['does-not-exist'])
+        run_bulk_form_action(job)
+        job.refresh_from_db()
+        assert job.succeeded_count == 0
+        assert job.get_skipped() == {'not_found': ['does-not-exist']}
+
+    def test_unarchive_already_unarchived_is_noop(self):
+        # unarchive is idempotent: a normal form is a no-op success, not a skip
+        normal = create_form_for_test(DOMAIN, state=XFormInstance.NORMAL)
+        job = self._job(BulkAsyncJob.Action.UNARCHIVE, [normal.form_id])
+        run_bulk_form_action(job)
+        job.refresh_from_db()
+        assert job.succeeded_count == 1
+        assert job.get_skipped() == {}
+
+    def test_persists_progress_before_completion(self):
+        # A small job (interval == 1) must persist counts as it goes, not only
+        # at completion, so the status poll's progress bar advances.
+        forms = [create_form_for_test(DOMAIN, state=XFormInstance.NORMAL) for _ in range(3)]
+        job = self._job(BulkAsyncJob.Action.ARCHIVE, [f.form_id for f in forms])
+        seen = []
+        original_save = job.save
+
+        def record_processed(*args, **kwargs):
+            seen.append(job.processed_count)
+            return original_save(*args, **kwargs)
+
+        job.save = record_processed
+        run_bulk_form_action(job)
+
+        assert seen == [0, 1, 2, 3, 3]
+
+
+@pytest.mark.parametrize("requested_count, expected", [
+    (0, 1),
+    (1, 1),
+    (5, 1),
+    (40, 2),
+    (100, 5),
+    (2000, 100),
+    (10000, 100),
+])
+def test_save_interval(requested_count, expected):
+    assert _save_interval(requested_count) == expected
+
+
+class TestApplyFormAction(SimpleTestCase):
+
+    def _patched_apply_form_action(self, form_ids, forms, action_fn):
+        with patch(
+            'corehq.apps.data_interfaces.bulk_form_actions.XFormInstance.objects.iter_forms',
+            return_value=forms,
+        ):
+            return list(_apply_form_action(DOMAIN, form_ids, action_fn))
+
+    def test_empty_form_ids(self):
+        assert self._patched_apply_form_action([], [], lambda f: None) == []
+
+    def test_success(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+        calls = []
+        results = self._patched_apply_form_action(['f1'], [form], calls.append)
+        assert calls == [form]
+        assert results == [FormActionResult('f1', SUCCEEDED)]
+
+    def test_missing_is_not_found(self):
+        results = self._patched_apply_form_action(['missing'], [], lambda f: None)
+        assert results == [FormActionResult('missing', SKIPPED, 'not_found')]
+
+    def test_wrong_domain_is_not_found(self):
+        form = Mock(form_id='f1', domain='other-domain')
+        called = []
+        results = self._patched_apply_form_action(['f1'], [form], called.append)
+        assert called == []  # action not applied to out-of-domain forms
+        assert results == [FormActionResult('f1', SKIPPED, 'not_found')]
+
+    def test_exception_is_unexpected_error(self):
+        form = Mock(form_id='f1', domain=DOMAIN)
+
+        def unexpected_error(xform):
+            raise Exception('error')
+
+        with patch(
+            'corehq.apps.data_interfaces.bulk_form_actions.notify_exception'
+        ) as notify:
+            results = self._patched_apply_form_action(['f1'], [form], unexpected_error)
+        assert results == [FormActionResult('f1', SKIPPED, 'unexpected_error')]
+        notify.assert_called_once()
+
+    def test_mixed_results(self):
+        found = Mock(form_id='f1', domain=DOMAIN)
+        results = self._patched_apply_form_action(['f1', 'missing'], [found], lambda f: None)
+        assert results == [
+            FormActionResult('f1', SUCCEEDED),
+            FormActionResult('missing', SKIPPED, 'not_found'),
+        ]

--- a/corehq/apps/data_interfaces/tests/test_bulk_form_actions.py
+++ b/corehq/apps/data_interfaces/tests/test_bulk_form_actions.py
@@ -11,6 +11,7 @@ from corehq.apps.data_interfaces.bulk_form_actions import (
     _apply_form_action,
     _save_interval,
     build_form_action,
+    mark_job_failed,
     run_bulk_form_action,
 )
 from corehq.apps.data_interfaces.models import BulkAsyncJob
@@ -105,6 +106,33 @@ class TestRunBulkFormAction(TestCase):
         run_bulk_form_action(job)
 
         assert seen == [0, 1, 2, 3, 3]
+
+
+class TestMarkJobFailed(TestCase):
+
+    def _job(self, status):
+        job = BulkAsyncJob(
+            domain=DOMAIN, model=XFormInstance,
+            action=BulkAsyncJob.Action.ARCHIVE, requested_by='u', status=status,
+        )
+        job.save()
+        return job
+
+    def test_marks_pending_job_failed(self):
+        job = self._job(BulkAsyncJob.Status.PENDING)
+        mark_job_failed(job.id)
+        job.refresh_from_db()
+        assert job.status == BulkAsyncJob.Status.FAILED
+        assert job.completed_at is not None
+
+    def test_does_not_touch_completed_job(self):
+        job = self._job(BulkAsyncJob.Status.COMPLETE)
+        mark_job_failed(job.id)
+        job.refresh_from_db()
+        assert job.status == BulkAsyncJob.Status.COMPLETE
+
+    def test_missing_job_is_noop(self):
+        mark_job_failed('00000000-0000-0000-0000-000000000000')  # no error
 
 
 @pytest.mark.parametrize("requested_count, expected", [

--- a/corehq/apps/data_interfaces/tests/test_models.py
+++ b/corehq/apps/data_interfaces/tests/test_models.py
@@ -5,6 +5,7 @@ from django.test import SimpleTestCase, TestCase
 
 from corehq.apps.data_interfaces.models import (
     AutomaticUpdateRule,
+    BulkAsyncJob,
     CaseDeduplicationActionDefinition,
     CaseRuleAction,
     CaseRuleCriteria,
@@ -24,7 +25,9 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.models import LocationType, SQLLocation
 from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
 from corehq.form_processor.models.cases import CommCareCase
+from corehq.form_processor.models.forms import XFormInstance
 
 from corehq.apps.data_interfaces.tests.deduplication_helpers import create_dedupe_rule
 
@@ -644,3 +647,32 @@ def create_dict_mock(class_, data):
     obj = class_()
     patch.object(obj, 'to_dict', lambda: data).start()
     return obj
+
+
+class TestBulkAsyncJobBlobs(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.blob_db = TemporaryFilesystemBlobDB()
+        cls.addClassCleanup(cls.blob_db.close)
+
+    def _job(self):
+        return BulkAsyncJob(
+            domain='test-domain',
+            model=XFormInstance,
+            action=BulkAsyncJob.Action.ARCHIVE,
+            requested_by='someone',
+        )
+
+    def test_requested_ids_round_trip_dedups_and_sorts(self):
+        job = self._job()
+        stored = job.set_requested_ids(['c', 'a', 'b', 'a'])
+        assert stored == ['a', 'b', 'c']
+        assert job.requested_ids_blob_key
+        assert job.get_requested_ids() == ['a', 'b', 'c']
+
+    def test_skipped_round_trip_sorts_each_group(self):
+        job = self._job()
+        job.set_skipped({'not_found': ['z', 'a'], 'not_archived': ['n', 'm']})
+        assert job.get_skipped() == {'not_found': ['a', 'z'], 'not_archived': ['m', 'n']}

--- a/corehq/apps/data_interfaces/tests/test_models.py
+++ b/corehq/apps/data_interfaces/tests/test_models.py
@@ -676,3 +676,20 @@ class TestBulkAsyncJobBlobs(TestCase):
         job = self._job()
         job.set_skipped({'not_found': ['z', 'a'], 'not_archived': ['n', 'm']})
         assert job.get_skipped() == {'not_found': ['a', 'z'], 'not_archived': ['m', 'n']}
+
+
+class TestBulkAsyncJobModelField(TestCase):
+
+    def test_survives_update_after_insert(self):
+        # Regression: the model= ModelClassField column made the worker's
+        # second save (an UPDATE) raise TypeError. See ModelClassField.pre_save.
+        job = BulkAsyncJob.objects.create(
+            domain='test-domain',
+            model=XFormInstance,
+            action=BulkAsyncJob.Action.ARCHIVE,
+            requested_by='someone',
+        )
+        job.status = BulkAsyncJob.Status.RUNNING
+        job.save()
+        job.refresh_from_db()
+        assert job.model is XFormInstance

--- a/corehq/apps/data_interfaces/tests/test_models.py
+++ b/corehq/apps/data_interfaces/tests/test_models.py
@@ -693,3 +693,20 @@ class TestBulkAsyncJobModelField(TestCase):
         job.save()
         job.refresh_from_db()
         assert job.model is XFormInstance
+
+
+class TestBulkAsyncJobIsDone(SimpleTestCase):
+
+    def _job(self, status):
+        return BulkAsyncJob(
+            domain='test-domain', model=XFormInstance,
+            action=BulkAsyncJob.Action.ARCHIVE, requested_by='u', status=status,
+        )
+
+    def test_terminal_statuses_are_done(self):
+        assert self._job(BulkAsyncJob.Status.COMPLETE).is_done
+        assert self._job(BulkAsyncJob.Status.FAILED).is_done
+
+    def test_non_terminal_statuses_are_not_done(self):
+        assert not self._job(BulkAsyncJob.Status.PENDING).is_done
+        assert not self._job(BulkAsyncJob.Status.RUNNING).is_done

--- a/corehq/apps/data_interfaces/tests/test_tasks.py
+++ b/corehq/apps/data_interfaces/tests/test_tasks.py
@@ -1,10 +1,16 @@
-from django.test import SimpleTestCase
 from unittest.mock import patch
 
+from django.test import SimpleTestCase, TestCase
+
+from corehq.apps.data_interfaces.models import BulkAsyncJob
 from corehq.apps.data_interfaces.tasks import (
+    bulk_form_action_async,
     task_generate_ids_and_operate_on_payloads,
     task_operate_on_payloads,
 )
+from corehq.form_processor.models.forms import XFormInstance
+
+TASK_DOMAIN = 'bulk-task-test'
 
 
 class TestTasks(SimpleTestCase):
@@ -82,3 +88,34 @@ class TestTasks(SimpleTestCase):
         )
         self.assertEqual(response,
                          {'messages': {'errors': ['No payloads specified']}})
+
+
+class TestBulkFormActionAsync(TestCase):
+
+    def _job(self):
+        job = BulkAsyncJob(
+            domain=TASK_DOMAIN, model=XFormInstance,
+            action=BulkAsyncJob.Action.ARCHIVE, requested_by='u',
+        )
+        job.save()
+        return job
+
+    def test_task_runs_job(self):
+        job = self._job()
+        with patch(
+            'corehq.apps.data_interfaces.tasks.run_bulk_form_action'
+        ) as mock_run:
+            bulk_form_action_async(str(job.id), TASK_DOMAIN)
+        assert mock_run.call_count == 1
+        assert mock_run.call_args[0][0].id == job.id
+
+    def test_task_marks_job_failed_on_error(self):
+        job = self._job()
+        with patch(
+            'corehq.apps.data_interfaces.tasks.run_bulk_form_action',
+            side_effect=ValueError('boom'),
+        ):
+            result = bulk_form_action_async.apply(args=[str(job.id), TASK_DOMAIN])
+        assert result.failed()
+        job.refresh_from_db()
+        assert job.status == BulkAsyncJob.Status.FAILED

--- a/corehq/apps/data_interfaces/tests/test_views.py
+++ b/corehq/apps/data_interfaces/tests/test_views.py
@@ -1,11 +1,13 @@
 from unittest.mock import patch
 
+from django.template.loader import render_to_string
 from django.test import RequestFactory, TestCase, override_settings
 
 from django_prbac.models import Grant, Role
 
 from corehq import privileges
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
+from corehq.apps.data_interfaces.interfaces import FormManagementMode
 from corehq.apps.data_interfaces.models import (
     AutomaticUpdateRule,
     BulkAsyncJob,
@@ -16,6 +18,9 @@ from corehq.apps.data_interfaces.views import (
     AutomaticUpdateRuleListView,
     DeduplicationRuleCreateView,
     XFormManagementView,
+    _job_percent,
+    _legacy_xform_management_job_poll,
+    _xform_management_job_context,
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
@@ -146,6 +151,87 @@ class XFormManagementPostTests(TestCase):
 
         assert response.status_code == 400
         assert not BulkAsyncJob.objects.filter(domain=self.domain).exists()
+
+
+class XFormManagementJobPollTests(TestCase):
+
+    TEMPLATE = 'data_interfaces/partials/xform_management_status_new.html'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'xform-poll-test'
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+        cls.blob_db = TemporaryFilesystemBlobDB()
+        cls.addClassCleanup(cls.blob_db.close)
+
+    def _job(self, **kw):
+        defaults = dict(domain=self.domain, model=XFormInstance,
+                        action=BulkAsyncJob.Action.ARCHIVE, requested_by='u')
+        defaults.update(kw)
+        return BulkAsyncJob(**defaults)
+
+    def test_job_percent_zero_when_nothing_requested(self):
+        assert _job_percent(self._job(requested_count=0)) == 0
+
+    def test_job_percent_is_correct(self):
+        assert _job_percent(self._job(requested_count=4, processed_count=1)) == 25
+
+    def test_context_running(self):
+        job = self._job(status=BulkAsyncJob.Status.RUNNING,
+                        requested_count=4, processed_count=1)
+        ctx = _xform_management_job_context(job, FormManagementMode('archive'))
+        assert ctx['is_done'] is False
+        assert ctx['has_failed'] is False
+        assert ctx['progress']['percent'] == 25
+        assert ctx['download_id'] == job.id.hex
+
+    def test_context_complete_reads_skipped(self):
+        job = self._job(status=BulkAsyncJob.Status.COMPLETE, requested_count=2,
+                        processed_count=2, succeeded_count=1)
+        job.set_skipped({'not_found': ['a']})
+        ctx = _xform_management_job_context(job, FormManagementMode('archive'))
+        assert ctx['is_done'] is True
+        assert ctx['has_failed'] is False
+        assert ctx['succeeded_count'] == 1
+        assert ctx['skipped'] == {'not_found': ['a']}
+
+    def test_context_failed_has_no_skipped(self):
+        job = self._job(status=BulkAsyncJob.Status.FAILED, requested_count=2)
+        ctx = _xform_management_job_context(job, FormManagementMode('archive'))
+        assert ctx['is_done'] is True
+        assert ctx['has_failed'] is True
+        assert ctx['skipped'] == {}
+
+    def test_template_running_shows_percent_not_ready(self):
+        job = self._job(status=BulkAsyncJob.Status.RUNNING,
+                        requested_count=4, processed_count=1)
+        ctx = _xform_management_job_context(job, FormManagementMode('archive'))
+        html = render_to_string(self.TEMPLATE, ctx)
+        assert 'ready_' not in html
+        assert '25%' in html
+
+    def test_template_complete_shows_ready_sentinel_and_counts(self):
+        job = self._job(status=BulkAsyncJob.Status.COMPLETE, requested_count=2,
+                        processed_count=2, succeeded_count=2)
+        job.set_skipped({})
+        ctx = _xform_management_job_context(job, FormManagementMode('archive'))
+        html = render_to_string(self.TEMPLATE, ctx)
+        assert f'ready_{job.id.hex}' in html
+        assert '2 forms processed successfully' in html
+
+    def test_legacy_poll_serves_soil_context(self):
+        request = RequestFactory().get('/x', {'mode': 'archive'})
+        soil_context = {'download_id': 'dl-abc123', 'is_ready': False}
+        with patch(
+            'corehq.apps.data_interfaces.views.get_download_context',
+            return_value=soil_context,
+        ) as mock_ctx:
+            response = _legacy_xform_management_job_poll(
+                request, self.domain, 'dl-abc123', FormManagementMode('archive'))
+        mock_ctx.assert_called_once_with('dl-abc123')
+        assert response.status_code == 200
 
 
 class DeduplicationRuleCreateViewTests(TestCase):

--- a/corehq/apps/data_interfaces/tests/test_views.py
+++ b/corehq/apps/data_interfaces/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import RequestFactory, TestCase, override_settings
 
 from django_prbac.models import Grant, Role
@@ -6,15 +8,19 @@ from corehq import privileges
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.apps.data_interfaces.models import (
     AutomaticUpdateRule,
+    BulkAsyncJob,
     CaseRuleAction,
     UpdateCaseDefinition,
 )
 from corehq.apps.data_interfaces.views import (
     AutomaticUpdateRuleListView,
     DeduplicationRuleCreateView,
+    XFormManagementView,
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
+from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
+from corehq.form_processor.models import XFormInstance
 
 
 @override_settings(REQUIRE_TWO_FACTOR_FOR_SUPERUSERS=False)
@@ -89,6 +95,57 @@ class AutomaticUpdateRuleListViewTests(TestCase):
         request.user = self.user
         request.role = self.test_role
         return request
+
+
+class XFormManagementPostTests(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'xform-mgmt-test'
+        cls.blob_db = TemporaryFilesystemBlobDB()
+        cls.addClassCleanup(cls.blob_db.close)
+
+    def test_post_creates_and_queues_job(self):
+        request = RequestFactory().post(
+            '/x', {'mode': 'archive', 'xform_ids': ['form-1', 'form-2']})
+        request.couch_user = WebUser(username='someone')
+        request.can_access_all_locations = True
+
+        view = XFormManagementView()
+        view.request = request
+        view.args = ()
+        view.kwargs = {'domain': self.domain}
+
+        with patch(
+            'corehq.apps.data_interfaces.views.bulk_form_action_async.delay'
+        ) as mock_delay:
+            response = view.post(request)
+
+        assert response.status_code == 302
+        job = BulkAsyncJob.objects.get(domain=self.domain)
+        assert job.model is XFormInstance
+        assert job.action == BulkAsyncJob.Action.ARCHIVE
+        assert job.requested_count == 2
+        assert job.get_requested_ids() == ['form-1', 'form-2']
+        mock_delay.assert_called_once_with(job.id.hex, self.domain)
+        # the redirect (poll) url includes the job id
+        assert job.id.hex in response['Location']
+
+    def test_post_with_no_forms_is_rejected(self):
+        request = RequestFactory().post('/x', {'mode': 'archive'})
+        request.couch_user = WebUser(username='someone')
+        request.can_access_all_locations = True
+
+        view = XFormManagementView()
+        view.request = request
+        view.args = ()
+        view.kwargs = {'domain': self.domain}
+
+        response = view.post(request)
+
+        assert response.status_code == 400
+        assert not BulkAsyncJob.objects.filter(domain=self.domain).exists()
 
 
 class DeduplicationRuleCreateViewTests(TestCase):

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -24,7 +24,7 @@ from no_exceptions.exceptions import Http403
 
 from dimagi.utils.logging import notify_exception
 from soil.exceptions import TaskFailedError
-from soil.util import expose_cached_download, get_download_context
+from soil.util import get_download_context
 
 from corehq import privileges, toggles
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
@@ -56,6 +56,7 @@ from corehq.apps.data_interfaces.forms import (
     DedupeCaseFilterForm,
     UpdateCaseGroupForm,
 )
+from corehq.apps.data_interfaces.bulk_form_actions import create_bulk_form_job
 from corehq.apps.data_interfaces.models import (
     AutomaticUpdateRule,
     CaseDeduplicationActionDefinition,
@@ -63,7 +64,7 @@ from corehq.apps.data_interfaces.models import (
     DomainCaseRuleRun,
 )
 from corehq.apps.data_interfaces.tasks import (
-    bulk_form_management_async,
+    bulk_form_action_async,
     bulk_upload_cases_to_group,
 )
 from corehq.apps.domain.decorators import login_and_domain_required
@@ -455,6 +456,8 @@ class XFormManagementView(DataInterfaceSection):
 
     def post(self, request, *args, **kwargs):
         form_ids = self.get_xform_ids(request)
+        if not form_ids:
+            return HttpResponseBadRequest(_("No forms were supplied."))
         if not self.request.can_access_all_locations:
             inaccessible_forms_accessed = self.inaccessible_forms_accessed(
                 form_ids, self.domain, request.couch_user)
@@ -463,19 +466,13 @@ class XFormManagementView(DataInterfaceSection):
                     "Inaccessible forms accessed. Id(s): %s " % ','.join(inaccessible_forms_accessed))
 
         mode = self.request.POST.get('mode')
-        task_ref = expose_cached_download(payload=None, expiry=1 * 60 * 60, file_extension=None)
-        task = bulk_form_management_async.delay(
-            mode,
-            self.domain,
-            self.request.couch_user,
-            form_ids
-        )
-        task_ref.set_task(task)
-
+        job = create_bulk_form_job(
+            self.domain, FormManagementMode.bulk_action(mode), self.request.couch_user.username, form_ids)
+        bulk_form_action_async.delay(job.id.hex, self.domain)
         return HttpResponseRedirect(
             reverse(
                 XFormManagementStatusView.urlname,
-                args=[self.domain, mode, task_ref.download_id]
+                args=[self.domain, mode, job.id.hex]
             )
         )
 

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -3,6 +3,7 @@ import uuid
 
 from django.contrib import messages
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.http import (
     Http404,
@@ -59,6 +60,7 @@ from corehq.apps.data_interfaces.forms import (
 from corehq.apps.data_interfaces.bulk_form_actions import create_bulk_form_job
 from corehq.apps.data_interfaces.models import (
     AutomaticUpdateRule,
+    BulkAsyncJob,
     CaseDeduplicationActionDefinition,
     CaseDuplicateNew,
     DomainCaseRuleRun,
@@ -553,8 +555,21 @@ class XFormManagementStatusView(DataInterfaceSection):
 @require_can_edit_data
 @require_form_management_privilege
 def xform_management_job_poll(request, domain, download_id,
-                              template="data_interfaces/partials/xform_management_status.html"):
+                              template="data_interfaces/partials/xform_management_status_new.html"):
     mode = FormManagementMode(request.GET.get('mode'), validate=True)
+    if download_id.startswith('dl-'):
+        return _legacy_xform_management_job_poll(request, domain, download_id, mode)
+    try:
+        job = BulkAsyncJob.objects.get(id=download_id, domain=domain)
+    except (BulkAsyncJob.DoesNotExist, ValueError, ValidationError):
+        raise Http404()
+    context = _xform_management_job_context(job, mode)
+    return render(request, template, context)
+
+
+def _legacy_xform_management_job_poll(request, domain, download_id, mode):
+    """Supports the legacy soil download_id. To be removed in followup PR"""
+    legacy_template = 'data_interfaces/partials/xform_management_status.html'
     try:
         context = get_download_context(download_id)
     except TaskFailedError:
@@ -566,7 +581,29 @@ def xform_management_job_poll(request, domain, download_id,
         'form_management_url': reverse(EditDataInterfaceDispatcher.name(),
                                        args=[domain, BulkFormManagementInterface.slug])
     })
-    return render(request, template, context)
+    return render(request, legacy_template, context)
+
+
+def _job_percent(job):
+    if not job.requested_count:
+        return 0
+    return int(100 * job.processed_count / job.requested_count)
+
+
+def _xform_management_job_context(job, mode):
+    """Build the soil-compatible poll context for ``job``."""
+    return {
+        'download_id': job.id.hex,
+        'is_done': job.is_done,
+        'has_failed': job.status == BulkAsyncJob.Status.FAILED,
+        'succeeded_count': job.succeeded_count,
+        'skipped': job.get_skipped() if job.is_done and job.skipped_ids_blob_key else {},
+        'progress': {'percent': _job_percent(job)},
+        'on_complete_short': mode.complete_short,
+        'mode': mode,
+        'form_management_url': reverse(EditDataInterfaceDispatcher.name(),
+                                       args=[job.domain, BulkFormManagementInterface.slug]),
+    }
 
 
 class BulkCaseActionSatusView(DataInterfaceSection):

--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -255,10 +255,19 @@ def _delete_data_files(domain_name):
 
 def _delete_bulk_async_jobs(domain_name):
     from corehq.apps.data_interfaces.models import BulkAsyncJob
-    get_blob_db().bulk_delete(metas=list(BlobMeta.objects.partitioned_query(domain_name).filter(
-        parent_id=domain_name,
-        type_code=CODES.bulk_async_job,
-    )))
+
+    blob_db = get_blob_db()
+    query = BulkAsyncJob.objects.filter(domain=domain_name)
+    for job_id in query.values_list('id', flat=True):
+        parent_id = job_id.hex
+        blob_db.bulk_delete(
+            metas=list(
+                BlobMeta.objects.partitioned_query(parent_id).filter(
+                    parent_id=parent_id,
+                    type_code=CODES.bulk_async_job,
+                )
+            )
+        )
     BulkAsyncJob.objects.filter(domain=domain_name).delete()
 
 

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -618,44 +618,43 @@ class TestDeleteDomain(TestCase):
         self._assert_export_counts(self.domain2.name, 1)
 
     def test_bulk_async_job_blobs_delete(self):
+        from corehq.blobs.models import BlobMeta
         blobdb = get_blob_db()
         keys = {}
+        parent_ids = {}
         for domain_name in [self.domain.name, self.domain2.name]:
-            requested_meta = blobdb.put(
-                BytesIO((domain_name + " ids").encode('utf-8')),
-                domain=domain_name,
-                parent_id=domain_name,
-                type_code=CODES.bulk_async_job,
-            )
-            skipped_meta = blobdb.put(
-                BytesIO((domain_name + " skipped").encode('utf-8')),
-                domain=domain_name,
-                parent_id=domain_name,
-                type_code=CODES.bulk_async_job,
-            )
-            keys[domain_name] = [requested_meta.key, skipped_meta.key]
-            BulkAsyncJob.objects.create(
+            obj = BulkAsyncJob(
                 domain=domain_name,
                 model=XFormInstance,
                 action=BulkAsyncJob.Action.ARCHIVE,
                 requested_by='user@example.com',
-                requested_ids_blob_key=requested_meta.key,
-                skipped_ids_blob_key=skipped_meta.key,
             )
+            obj.set_requested_ids(['a', 'b', 'c'])
+            obj.set_skipped({"skipped": ['a', 'b', 'c']})
+            obj.save()
+            keys[domain_name] = [obj.requested_ids_blob_key, obj.skipped_ids_blob_key]
+            parent_ids[domain_name] = obj.id.hex
 
         self.domain.delete()
 
         deleted_requested_key, deleted_skipped_key = keys[self.domain.name]
-        with self.assertRaises(NotFound):
-            blobdb.get(key=deleted_requested_key, type_code=CODES.bulk_async_job)
-        with self.assertRaises(NotFound):
-            blobdb.get(key=deleted_skipped_key, type_code=CODES.bulk_async_job)
+        deleted_parent_id = parent_ids[self.domain.name]
+        with self.assertRaises(BlobMeta.DoesNotExist):
+            blobdb.metadb.get(key=deleted_requested_key, parent_id=deleted_parent_id)
+
+        with self.assertRaises(BlobMeta.DoesNotExist):
+            blobdb.metadb.get(key=deleted_skipped_key, parent_id=deleted_parent_id)
+        assert not blobdb.exists(deleted_requested_key)
+        assert not blobdb.exists(deleted_skipped_key)
 
         remaining_requested_key, remaining_skipped_key = keys[self.domain2.name]
-        with blobdb.get(key=remaining_requested_key, type_code=CODES.bulk_async_job) as f:
-            self.assertEqual(f.read(), (self.domain2.name + " ids").encode('utf-8'))
-        with blobdb.get(key=remaining_skipped_key, type_code=CODES.bulk_async_job) as f:
-            self.assertEqual(f.read(), (self.domain2.name + " skipped").encode('utf-8'))
+        remaining_parent_id = parent_ids[self.domain2.name]
+        requested_meta = blobdb.metadb.get(key=remaining_requested_key, parent_id=remaining_parent_id)
+        skipped_meta = blobdb.metadb.get(key=remaining_skipped_key, parent_id=remaining_parent_id)
+        with blobdb.get(meta=requested_meta) as f:
+            self.assertEqual(f.read(), b'["a", "b", "c"]')
+        with blobdb.get(meta=skipped_meta) as f:
+            self.assertEqual(f.read(), b'{"skipped": ["a", "b", "c"]}')
 
         self.assertEqual(
             BulkAsyncJob.objects.filter(domain=self.domain.name).count(), 0)

--- a/corehq/blobs/metadata.py
+++ b/corehq/blobs/metadata.py
@@ -14,6 +14,9 @@ from . import CODES
 
 from .models import BlobMeta
 
+# Blob type codes whose contents are always gzipped.
+ALWAYS_COMPRESSED_CODES = (CODES.form_xml, CODES.bulk_async_job)
+
 
 class MetaDB(object):
     """Blob metadata database interface
@@ -35,7 +38,7 @@ class MetaDB(object):
                     "keyword arguments are incompatible with `meta` argument")
             return blob_meta_args["meta"]
         timeout = blob_meta_args.pop("timeout", None)
-        if blob_meta_args.get('type_code') == CODES.form_xml:
+        if blob_meta_args.get('type_code') in ALWAYS_COMPRESSED_CODES:
             blob_meta_args['compressed_length'] = -1
         meta = BlobMeta(**blob_meta_args)
         if not meta.domain:

--- a/corehq/sql_db/fields.py
+++ b/corehq/sql_db/fields.py
@@ -39,6 +39,11 @@ class ModelClassField(CharField):
             return value
         return self._slug_by_model[value]
 
+    def pre_save(self, model_instance, add):
+        # Override pre_save to ensure the slug value is returned, which is
+        # ultimately what is saved to the database.
+        return self.get_prep_value(getattr(model_instance, self.attname))
+
 
 class CharIdField(CharField):
     """CharField that does not create varchar_pattern_ops index

--- a/corehq/sql_db/tests/test_fields.py
+++ b/corehq/sql_db/tests/test_fields.py
@@ -76,3 +76,15 @@ def has_pattern_ops_index(statements):
 def test_ModelClassField_slugs_are_unique():
     slugs = list(ModelClassField()._slug_by_model.values())
     assert len(slugs) == len(set(slugs)), f"Duplicate slugs: {slugs}"
+
+
+def test_ModelClassField_pre_save_returns_slug_for_class():
+    from corehq.form_processor.models import XFormInstance
+
+    @unregistered_django_model
+    class Test(models.Model):
+        model = ModelClassField()
+
+    field = {f.name: f for f in Test._meta.fields}["model"]
+    obj = Test(model=XFormInstance)
+    assert field.pre_save(obj, add=False) == 'xform'


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->


### Known limitation — job may not reach a terminal state on hard worker loss

`bulk_form_action_async` marks its `BulkAsyncJob` failed via a `task_failure` signal receiver, which covers uncaught errors and lock exhaustion (retries exhausted). It does **not** cover a hard worker kill (SIGKILL / OOM / eviction): no in-process handler runs, so the job is left in `PENDING`/`RUNNING` and the status page polls indefinitely. A periodic reaper that fails stale non-terminal jobs is the planned follow-up.

Relatedly, for very large jobs the per-domain serial-task lock TTL (currently 1h) must exceed the run duration, or the per-domain serialization can lapse mid-run.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [ ] The migrations in this code can be safely applied first independently of the code. Pay particular attention to _backward incompatible_ operations like `RemoveField`, `RenameField`, `RemoveConstraint`, and [others described here](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md) that can cause errors when migrations are applied to a live database.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

