### PR TITLE
Disable button to preview payload for succeeded and empty repeat records

### DIFF
--- a/corehq/motech/repeaters/tests/test_views.py
+++ b/corehq/motech/repeaters/tests/test_views.py
@@ -1,3 +1,4 @@
+import pytest
 from django.urls import reverse
 
 from testil import assert_raises
@@ -5,7 +6,9 @@ from testil import assert_raises
 from corehq import privileges
 from corehq.motech.dhis2.tests.test_views import BaseViewTest
 from corehq.motech.models import ConnectionSettings
-from corehq.motech.repeaters.models import FormRepeater
+from corehq.motech.repeaters.const import State
+from corehq.motech.repeaters.models import FormRepeater, RepeatRecord
+from corehq.motech.repeaters.views.repeat_records import DomainForwardingRepeatRecords
 from corehq.util.test_utils import privilege_enabled
 
 
@@ -81,3 +84,19 @@ class TestRepeaterViews(BaseViewTest):
         }
         response = self.client.get(reverse('edit_repeater', kwargs=url_kwargs))
         assert response.status_code == 404
+
+
+def _render_payload_button(state):
+    record = RepeatRecord(domain='test', state=state)
+    # The method uses no instance state, so call it unbound with a dummy self.
+    return DomainForwardingRepeatRecords._make_view_payload_button(None, record)
+
+
+@pytest.mark.parametrize('state', [State.Success, State.Empty])
+def test_payload_button_disabled_for_succeeded_records(state):
+    assert 'disabled' in _render_payload_button(state)
+
+
+@pytest.mark.parametrize('state', [State.Pending, State.Fail, State.Cancelled])
+def test_payload_button_active_for_non_succeeded_records(state):
+    assert 'disabled' not in _render_payload_button(state)

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -8,6 +8,7 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 from django.views.generic import View
@@ -67,7 +68,17 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
             self.domain, toggles.NAMESPACE_DOMAIN
         ) and toggles.BACKOFF_REPEATERS.enabled(self.domain, toggles.NAMESPACE_DOMAIN)
 
-    def _make_view_payload_button(self, record_id):
+    def _make_view_payload_button(self, record):
+        if record.succeeded:
+            return mark_safe('''
+            <a
+                class="btn btn-default disabled"
+                role="button"
+                aria-disabled="true">
+                <i class="fa fa-search"></i>
+                Payload
+            </a>
+            ''')  # nosec: static markup, no interpolation
         return format_html('''
         <a
             class="btn btn-default"
@@ -78,7 +89,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
             <i class="fa fa-search"></i>
             Payload
         </a>
-        ''', record_id)
+        ''', record.id)
 
     def _make_view_attempts_button(self, record_id):
         return format_html('''
@@ -179,7 +190,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
             display.remote_service,
             display.next_check,
             self._make_view_attempts_button(record.id),
-            self._make_view_payload_button(record.id),
+            self._make_view_payload_button(record),
         ]
 
         if toggles.SUPPORT.enabled_for_request(self.request):


### PR DESCRIPTION
## Product Description
In the Data Forwarding report (Repeat Records report), the **Payload** button on each row opens a modal previewing the payload that would be sent to the remote service. The preview regenerates the payload from *current* data each time it is opened.

For records that have already been sent successfully, this preview can be misleading since it might differ from what was actually sent. This PR renders the **Payload** button greyed-out and non-clickable for successful records.

"Succeeded" here means `RepeatRecord.succeeded`, i.e. state `Success` **or** `Empty` (an empty payload means a prior attempt found nothing to send.)

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-20095

- `_make_view_payload_button` now takes the `record` (instead of just `record_id`) so it can read `record.succeeded`.
- When succeeded, it renders an `<a>` with Bootstrap's `disabled` class + `aria-disabled="true"` and omits the `data-toggle`/`data-target` attributes, so the preview modal can no longer be opened. The static disabled markup uses `mark_safe` to avoid the Django 6.0 no-args `format_html` deprecation.
- A single Python method feeds both the Bootstrap 3 and Bootstrap 5 templates, so both reports are covered with no template or JS changes.

## Feature Flag
N/A

## Safety Assurance

### Safety story
Low risk, UI-only change. It only affects the rendering of one button in the repeat record report; the payload-preview endpoint itself is unchanged and remains reachable for non-succeeded records. No data is modified.

### Automated test coverage
Added parametrized unit tests on `_make_view_payload_button`: `Success`/`Empty` states render the disabled button; `Pending`/`Fail`/`Cancelled` render the active button.

### QA Plan
None. Covered by automated tests and the change is UI-only.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
