### PR TITLE
Catch NoCredentialsError from botocore when attempting to forward repeat records

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1552,6 +1552,11 @@ class RepeatRecord(models.Model):
         return self.add_payload_rejected_attempt(message, traceback_str)
 
     def handle_generate_payload_error(self, message, traceback_str=''):
+        notify_exception(
+            None,
+            f'Error generating payload: {message}',
+            details={'domain': self.domain},
+        )
         log_repeater_error_in_datadog(self.domain, status_code=None, repeater_type=self.repeater_type)
         return self.add_error_generating_payload_attempt(message, traceback_str)
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -91,6 +91,7 @@ from jsonfield import JSONField
 from memoized import memoized
 from requests.exceptions import ConnectionError, RequestException, Timeout
 
+from botocore.exceptions import NoCredentialsError
 from casexml.apps.case.const import CASE_INDEX_EXTENSION
 from casexml.apps.case.xml import LEGAL_VERSIONS, V2
 from couchforms.const import DEVICE_LOG_XMLNS
@@ -1462,7 +1463,7 @@ class RepeatRecord(models.Model):
         if force_send or not self.succeeded:
             try:
                 self.repeater.fire_for_record(self, timing_context=timing_context)
-            except OSError as e:
+            except (NoCredentialsError, OSError) as e:
                 self.handle_exception(str(e))
                 raise
             except Exception as e:


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-20085

We know that users with FormRepeaters have seen repeat records marked as "error generating payload" with the error "Unable to locate credentials", and that is it.

I presume the error comes when fetching the payload [here](https://github.com/dimagi/commcare-hq/blob/b776133f64904e70605d6304c0ef6cf8987e8b48/corehq/motech/repeaters/repeater_generators.py#L206-L207). 
I found a similar error in [celery](https://dimagi.sentry.io/issues/trace/9cd62d0abc914d2e80287e599d2e0172/?groupId=7250906392&node=error-29ae6203fd0841f082d72559b5d4f79d&pageEnd=2026-07-27T19%3A58%3A06.385&pageStart=2026-07-26T19%3A58%3A06.385&referrer=issue-stream&source=issue_details&timestamp=1785139086.292) that I _believe_ to be the same error we've seen in data forwarding based on the "Unable to locate credentials" message seen there as well. I'm proposing catching the `NoCredentialsError` from botocore in this PR.

This change _only_ handles improving this one case where run into this unexpected/intermittent botocore exception, similar to the [OSError](https://github.com/dimagi/commcare-hq/pull/35461) encountered previously.

There is a larger question of how to better distinguish between payload errors caused by user/project configuration and errors that are entirely due to our infrastructure and should be retried. If we deem we cannot meaningfully distinguish between these, then we should default to retrying instead of the current code which defaults to cancelling.

Additionally this starts logging payload generation exceptions to sentry.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Small blast radius since this only adds an additional error to catch and treat as an "internal" error that we should retry.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
