### PR TITLE
Fix Case API v2 bulk fetch docs

### DIFF
--- a/docs/api/cases-v2.rst
+++ b/docs/api/cases-v2.rst
@@ -354,9 +354,10 @@ Exclude specific fields:
 
     GET /a/<domain>/api/case/v2/<case_id>?exclude=case_name&exclude.properties=husband_name
 
-These parameters work on all GET endpoints and on the case object returned
-by POST/PUT (create/update) endpoints. For list and bulk responses, the
-filtering applies to each individual case object; envelope fields
+These parameters work on all GET endpoints, on the bulk fetch endpoint (as
+URL query parameters alongside the POST body), and on the case object
+returned by POST/PUT (create/update) endpoints. For list and bulk responses,
+the filtering applies to each individual case object; envelope fields
 (``matching_records``, ``next``) are not affected.
 
 Field filtering is preserved across paginated requests.
@@ -464,22 +465,22 @@ endpoint.
 2. POST request using Case IDs or External IDs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Interface - ``POST /a/<domain>/api/case/v2/bulk_fetch/``
+Interface - ``POST /a/<domain>/api/case/v2/bulk-fetch/``
 
 A more flexible approach to fetching cases in bulk is to use a POST
 request where the case IDs are supplied in the POST body.  You may also
 specify external IDs in this way.
 
-Body must have one or both of the ‘case_id’, ‘external_id’ fields.
+Body must have one or both of the ‘case_ids’, ‘external_ids’ fields.
 
 .. code-block:: json
 
     {
-      "case_id": [
+      "case_ids": [
         "30ad22bd-f828-4e3f-8287-a67a180cff4f",
         "d5e5962a-c5f1-483c-a58a-590167d594a9"
       ],
-      "external_id": [
+      "external_ids": [
         "id1",
         "id2"
       ]
@@ -487,6 +488,11 @@ Body must have one or both of the ‘case_id’, ‘external_id’ fields.
 
 **Note**: This endpoint allows you to pull data about specific cases by
 ID or external ID.
+
+The ``fields`` and ``exclude`` parameters described in
+"`Limiting Response Fields`_" may be passed as URL query parameters to
+limit which fields are returned for each case, e.g.
+``POST /a/<domain>/api/case/v2/bulk-fetch/?fields=case_id&fields.properties=dob``.
 
 Response format (cases truncated for clarity)
 


### PR DESCRIPTION
## Product Description
Documentation-only fixes to the Case API v2 page (https://commcare-hq.readthedocs.io/api/cases-v2.html). No product changes.

## Technical Summary
Three fixes to `docs/api/cases-v2.rst`, each verified against the code on master:

1. The bulk fetch interface line said `POST /a/<domain>/api/case/v2/bulk_fetch/`. The registered URL is `bulk-fetch` with a hyphen (`corehq/apps/api/urls.py`); the underscore version never reaches the bulk fetch handler (it matches the case-by-ID route instead and fails; verified live with a 405 on POST). The endpoint table elsewhere on the page already uses the hyphen.
2. The request body description and example used `case_id` / `external_id` keys. The view requires `case_ids` / `external_ids` (`_handle_bulk_fetch` in `corehq/apps/hqcase/views.py`); the documented payload is rejected with a 400.
3. The "Limiting Response Fields" section only mentioned GET and create/update endpoints. The bulk fetch handler also applies `fields`/`exclude` from the URL query string (`get_fields_filter_fn(request.GET)` in `_get_bulk_cases`), so this is now stated in that section and in the bulk fetch section with an example.

## Safety Assurance

### Safety story
Docs-only change, verified against `urls.py`, `views.py`, and `corehq/apps/hqcase/api/field_filters.py`, plus live requests against production confirming: the hyphenated URL with plural body keys and field filtering returns 200 with the filtered response, the underscore URL fails (405), and the singular body keys fail (400).

### Automated test coverage
None; documentation only. The documented behavior is covered by existing tests in `corehq/apps/hqcase/tests/test_field_filters.py`.

### QA Plan
No QA needed.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

