### PR TITLE
Fix typos in API docs

### DIFF
--- a/docs/api/application-structure.rst
+++ b/docs/api/application-structure.rst
@@ -57,7 +57,7 @@ The API response includes an ``objects`` field, which is a list of configuration
       "objects": [
         {
           "id": "app uuid",
-          "build_on": null,
+          "built_on": null,
           "build_comment": null,
           "is_released": false,
           "version": 16,
@@ -94,7 +94,7 @@ The API response includes an ``objects`` field, which is a list of configuration
               "versions": [
                 {
                   "id": "app version uuid",
-                  "build_on": "2017-01-30T19:53:20",
+                  "built_on": "2017-01-30T19:53:20",
                   "build_comment": "",
                   "is_released": true,
                   "version": 16

--- a/docs/api/det-exports.rst
+++ b/docs/api/det-exports.rst
@@ -36,7 +36,7 @@ export_format:
     very large volumes of data.
 
 is_deidentified:
-    Whether personal ideintifiers are excluded from the export data.
+    Whether personal identifiers are excluded from the export data.
 
 case_type:
     (Case exports only) The case type of exported cases.

--- a/docs/api/fixture.rst
+++ b/docs/api/fixture.rst
@@ -304,7 +304,7 @@ Edit or Delete Lookup Table
         "fields": [
             {"field_name": "name", "properties": ["lang"]},
             {"field_name": "price", "properties": []}
-        ],
+        ]
     }
 
 

--- a/docs/api/locations-v2.rst
+++ b/docs/api/locations-v2.rst
@@ -1,7 +1,7 @@
 Location API v2
 ===============
 
-V2 of the Location API updates the serilization used in v1 and adds the ability
+V2 of the Location API updates the serialization used in v1 and adds the ability
 to create and update locations, one at a time or in bulk.
 
 Data format

--- a/docs/api/messaging-events.rst
+++ b/docs/api/messaging-events.rst
@@ -77,7 +77,7 @@ These are the filter parameters that the API call can use. Examples of how to us
      - event.status
      - ``status=error``
    * - error_code
-     - Filter on the event error code (e.g. NO_PHONE_NUMBER, NO_RECIPIENT, NO_MESSAGE-sent )
+     - Filter on the event error code (e.g. NO_PHONE_NUMBER, NO_RECIPIENT, NO_MESSAGE)
      - event.error_code
      - ``error_code=NO_MESSAGE``
    * - phone_number

--- a/docs/api/ota-api-restore.rst
+++ b/docs/api/ota-api-restore.rst
@@ -62,6 +62,6 @@ using HTTP basic authentication with the CHW's username and password.
     https://www.commcarehq.org/a/DEMO_DOMAIN/phone/restore/?version=2.0
 
 In this example, we are on domain "DEMO_DOMAIN", our CHW's username is ``jason``, and his password is 1988.
-You'll note that the username, instead of being just ``jason`` is the much longer ``jason@demo.commcarehq.org``. This is to distinguish him from any other ``jason``'s on any other domain.
+You'll note that the username, instead of being just ``jason`` is the much longer ``jason@DEMO_DOMAIN.commcarehq.org``. This is to distinguish him from any other ``jason``'s on any other domain.
 
 The format for the full-length username is:   ``{username}@{domain}.commcarehq.org``


### PR DESCRIPTION
## Product Description
Typo and copy fixes in the API documentation pages (rendered at commcare-hq.readthedocs.io/api/). Docs only, no behavior claims changed.

## Technical Summary
Six fixes across six files in `docs/api/`:

1. `det-exports.rst`: "ideintifiers" -> "identifiers".
2. `locations-v2.rst`: "serilization" -> "serialization".
3. `messaging-events.rst`: the error-code example "NO_MESSAGE-sent )" is garbled; the real code is `NO_MESSAGE` (`ERROR_NO_MESSAGE = 'NO_MESSAGE'`, `corehq/apps/sms/models.py:1090`).
4. `fixture.rst`: removed a trailing comma that made the "Edit or Delete Lookup Table" sample request body invalid JSON.
5. `ota-api-restore.rst`: the prose restated the curl example's username as `jason@demo.commcarehq.org` while the example and its URL use `DEMO_DOMAIN`; aligned to `DEMO_DOMAIN`.
6. `application-structure.rst`: sample JSON showed `build_on`; the API returns `built_on` (`corehq/apps/api/resources/v0_4.py:338,353`; confirmed against a live response).

## Safety Assurance

### Safety story
Documentation-only. Field-name and error-code fixes were verified against the code (references above) and the `built_on` fix against a live API response.

### Automated test coverage
None; documentation only.

### QA Plan
No QA needed.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
