### PR TITLE
Add missing trailing slashes to detail URLs in API docs

### DIFF
--- a/docs/api/application-structure.rst
+++ b/docs/api/application-structure.rst
@@ -11,7 +11,7 @@ Overview
 
 .. code-block:: text
 
-    https://www.commcarehq.org/a/[domain]/api/application/v1/[app_id]
+    https://www.commcarehq.org/a/[domain]/api/application/v1/[app_id]/
 
 *Omit* ``app_id`` *in the URL to retrieve a list of applications.*
 

--- a/docs/api/fixture.rst
+++ b/docs/api/fixture.rst
@@ -290,7 +290,7 @@ Edit or Delete Lookup Table
 
 .. code-block:: text
 
-    https://www.commcarehq.org/a/[domain]/api/lookup_table/v1/[lookup_table_id]
+    https://www.commcarehq.org/a/[domain]/api/lookup_table/v1/[lookup_table_id]/
 
 **HTTP Method**
     PUT, DELETE
@@ -431,7 +431,7 @@ Edit or Delete Lookup Table Row
 
 .. code-block:: text
 
-    https://www.commcarehq.org/a/[domain]/api/lookup_table_item/v1/[lookup_table_item_id]
+    https://www.commcarehq.org/a/[domain]/api/lookup_table_item/v1/[lookup_table_item_id]/
 
 **HTTP Method**
     PUT, DELETE

--- a/docs/api/location-types.rst
+++ b/docs/api/location-types.rst
@@ -53,7 +53,7 @@ Retrieves details for a specific location type.
 
 .. code-block:: text
 
-    GET https://www.commcarehq.org/a/[domain]/api/location_type/v1/[id]
+    GET https://www.commcarehq.org/a/[domain]/api/location_type/v1/[id]/
 
 
 **Sample JSON Output**

--- a/docs/api/locations-v1.rst
+++ b/docs/api/locations-v1.rst
@@ -84,6 +84,6 @@ Location Details
 
 .. code-block:: text
 
-    GET https://www.commcarehq.org/a/[domain]/api/location/v1/[location_id]
+    GET https://www.commcarehq.org/a/[domain]/api/location/v1/[location_id]/
 
 This will output the same information displayed above, but for a single location

--- a/docs/api/locations-v2.rst
+++ b/docs/api/locations-v2.rst
@@ -105,7 +105,7 @@ Location Details
 
 .. code-block:: text
 
-    GET https://www.commcarehq.org/a/[domain]/api/location/v2/[location_id]
+    GET https://www.commcarehq.org/a/[domain]/api/location/v2/[location_id]/
 
 
 Create Location (Individual)
@@ -170,7 +170,7 @@ Allows editing an individual location.
 
 .. code-block:: text
 
-    PUT https://www.commcarehq.org/a/[domain]/api/location/v2/[location_id]
+    PUT https://www.commcarehq.org/a/[domain]/api/location/v2/[location_id]/
 
 **Editable Fields**
 


### PR DESCRIPTION
## Product Description
Documentation-only: add the trailing slash to seven detail-endpoint URLs in the API docs (fixture, locations v1/v2, location types, application structure).

## Technical Summary
The tastypie detail route only matches with a trailing slash (`api_dispatch_detail` pattern `r"^(?P<pk>.*?)/$"`, `corehq/apps/api/resources/__init__.py`). URLs copied from these docs work for GET only via Django's APPEND_SLASH 301 redirect, which plain curl does not follow, and a PUT/DELETE built from the docs receives the 301 and never reaches the API. Every changed line adds one character.

## Safety Assurance

### Safety story
Docs-only; the route pattern cited above is the whole story.

### Automated test coverage
None; documentation only.

### QA Plan
No QA needed.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
