### PR TITLE
Correct parameter names and values in API docs

### DIFF
--- a/docs/api/bulk-upload-cases.rst
+++ b/docs/api/bulk-upload-cases.rst
@@ -95,7 +95,7 @@ JSON output with following Parameters. Note that a success code indicates that t
      - Description
      - Example
    * - code
-     - 200: Success, 402: Warning, 500: Fail
+     - 200: Success, 500: Fail
      - ``500``
    * - message
      - Warning or Failure message

--- a/docs/api/list-forms.rst
+++ b/docs/api/list-forms.rst
@@ -152,7 +152,7 @@ The forms can be filtered using the following parameters, which also control pag
           },
           "id": "f959449c-8776-42ac-b776-3f564fafc331",
           "initial_processing_complete": true,
-          "is_phone_submission": "2.0",
+          "is_phone_submission": false,
           "metadata": {
             "appVersion": "CommCare Android, version \"2.31.0\"(423345). App v18. CommCare Version 2.31. Build 423345, built on: 2016-11-02",
             "app_build_version": 18,

--- a/docs/api/list-groups.rst
+++ b/docs/api/list-groups.rst
@@ -42,10 +42,10 @@ Request & Response Details
    * - Name
      - Description
      - Example
-   * - ``group_id``
+   * - ``id``
      - Group UUID
      - ``ac9d34ff59cf6388e4f5804b12276d8a``
-   * - ``group_name``
+   * - ``name``
      - Group name (e.g., health district)
      - ``Senahú``
 

--- a/docs/api/list-webusers.rst
+++ b/docs/api/list-webusers.rst
@@ -36,9 +36,9 @@ Request & Response Details
    * - Name
      - Description
      - Example
-   * - ``username``
+   * - ``web_username``
      - Filter list by username
-     - ``username=bob@example.com``
+     - ``web_username=bob@example.com``
 
 **Output Parameters**
 

--- a/docs/api/locations-v2.rst
+++ b/docs/api/locations-v2.rst
@@ -50,8 +50,8 @@ Locations can be filtered by the following attributes as request parameters:
      - Description
      - Example
    * - ``format``
-     - Data format returned, defaults to xml
-     - ```?format=json``
+     - Data format returned, defaults to json
+     - ``?format=json``
    * - ``site_code``
      - Site code for the location
      - ``?site_code=boston``

--- a/docs/api/messaging-events.rst
+++ b/docs/api/messaging-events.rst
@@ -41,7 +41,7 @@ These are the filter parameters that the API call can use. Examples of how to us
      - Filters On
      - Example
    * - limit
-     - Number of records to return (Defaults to 20, maximum 5000)
+     - Number of records to return (Defaults to 20, maximum 1000)
      -
      - ``limit=100``
    * - cursor
@@ -103,10 +103,6 @@ These sorting parameters can be applied to the existing search results alongside
 
    * - Sort Parameter
      - Description
-   * - order_by=date
-     - Order data by ``event.date`` (ascending)
-   * - order_by=-date
-     - Order data by ``event.date`` (descending)
    * - order_by=date_last_activity
      - Order data by ``event.date_last_activity`` (ascending)
    * - order_by=-date_last_activity
@@ -239,11 +235,11 @@ API Fields and Data Structure
    * - domain
      - The Project Space this event belongs to.
    * - content_type
-     - Type of the event (e.g. sms, email, sms_survey)
+     - Type of the event (e.g. sms, email, sms-survey)
    * - case_id
      - ID of the case if this event is related to one.
    * - status
-     - Status of this event (e.g. error, completed, in_progress)
+     - Status of this event (e.g. error, completed, in-progress)
 
 .. list-table:: **Source (Nested Object)**
    :widths: 20 40
@@ -265,7 +261,7 @@ API Fields and Data Structure
    * - Field
      - Note
    * - type
-     - Recipient type (web_user, case, or mobile_user)
+     - Recipient type (case, mobile-worker, or web-user)
    * - recipient_id
      - Case ID / User ID
    * - name

--- a/docs/api/mobile-worker.rst
+++ b/docs/api/mobile-worker.rst
@@ -91,7 +91,7 @@ Request & Response Details
    * - Name
      - Description
      - Example
-   * - ``user_id``
+   * - ``id``
      - User UUID
      - ``3c5a623af057e23a32ae4000cf291339``
 

--- a/docs/api/webuser.rst
+++ b/docs/api/webuser.rst
@@ -341,13 +341,13 @@ Endpoint Specifications
 
 .. code-block:: text
 
-    https://www.commcarehq.org/a/[domain]/api/web-user/v1/[id]/enable
+    https://www.commcarehq.org/a/[domain]/api/web-user/v1/[id]/activate/
 
 and
 
 .. code-block:: text
 
-    https://www.commcarehq.org/a/[domain]/api/web-user/v1/[id]/disable
+    https://www.commcarehq.org/a/[domain]/api/web-user/v1/[id]/deactivate/
 
 **Method**
 


### PR DESCRIPTION
## Product Description
Documentation-only: correct eleven parameter names, values, and enum spellings in the API docs. Each hunk aligns one documented name or value with a single constant, field, or serializer in the code.

## Technical Summary
Per-hunk evidence:

1. `list-webusers.rst`: filter param `username` -> `web_username` — the view reads `request.GET.get('web_username')` (`corehq/apps/api/resources/v0_1.py:162`). Confirmed live: `?username=x` is ignored, `?web_username=x` filters.
2. `webuser.rst`: `[id]/enable` -> `[id]/activate/`, `[id]/disable` -> `[id]/deactivate/` — the registered routes (`WebUserResource.prepend_urls`, `v0_5.py:598-603`).
3. `messaging-events.rst`: limit "maximum 5000" -> "maximum 1000" — `get_limit_offset(..., max_value=1000)` (`messaging_event/pagination.py:15`). Confirmed live: `?limit=5000` returns `"limit": 1000`.
4. `messaging-events.rst`: removed `order_by=date`/`-date` rows — only `date_last_activity`/`-date_last_activity` are accepted; anything else raises BadRequest (`messaging_event/utils.py:44-46`). Confirmed live: `?order_by=date` returns 400.
5. `messaging-events.rst`: `sms_survey` -> `sms-survey` (`CONTENT_TYPE_SLUGS`, `corehq/apps/sms/models.py:1049`), `in_progress` -> `in-progress` (`STATUS_SLUGS`, models.py:973), recipient types `web_user`/`mobile_user` -> `web-user`/`mobile-worker` (`RECIPIENT_SLUGS`, models.py:1650-1651).
6. `locations-v2.rst`: format "defaults to xml" -> "defaults to json" — no XML default is configured; the shared meta sets `default_format = 'application/json'` (`corehq/apps/api/resources/meta.py:80`). Confirmed live. Also removed a stray backtick in the same table cell.
7. `list-forms.rst`: sample `"is_phone_submission": "2.0"` -> `false` — the dehydrate method returns a boolean (`v0_4.py:124-130`). Confirmed live.
8. `mobile-worker.rst`: create response key `user_id` -> `id` — `data = {'id': data.obj._id}` (`v0_5.py:252-255`).
9. `list-groups.rst`: field names `group_id`/`group_name` -> `id`/`name` — `GroupResource` fields (`v0_4.py:234-237`); the doc's own JSON sample already uses `id`/`name`.
10. `bulk-upload-cases.rst`: removed "402: Warning" — the view returns only `{"code": 200, ...}` or `{"code": 500, ...}` (`corehq/apps/case_importer/views.py:482,551`); no 402 exists in the app.

## Safety Assurance

### Safety story
Docs-only. Every change is backed by the code reference beside it; items 1, 3, 4, 6, and 7 were additionally verified with live API calls.

### Automated test coverage
None; documentation only.

### QA Plan
No QA needed.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
