### PR TITLE
 Update pricing link in API docs to official CommCare pricing page

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -12,7 +12,7 @@ integration.
 
     This feature is only available to CommCare users with a
     **Standard Plan or above**. For more details, please see the
-    `CommCare Pricing Overview <https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2420015134/CommCare+Pricing+Overview>`_
+    `CommCare Pricing Overview <https://commcare.dimagi.com/pricing/>`_
 
 
 Table of contents


### PR DESCRIPTION
## Product Description
This PR updates the pricing link in the documentation to point to the official CommCare pricing page (https://commcare.dimagi.com/pricing/) instead of the confluence page

## Technical Summary
https://dimagi.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/custom/4/SUPPORT-27838

## Feature Flag
NA

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->NA

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->NA


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
