### PR TITLE
Update CommCare pricing URLs

### DIFF
--- a/corehq/apps/accounting/emails.py
+++ b/corehq/apps/accounting/emails.py
@@ -234,8 +234,7 @@ def _ending_reminder_context(subscription, days_left):
         'base_url': get_site_domain(),
         'invoicing_contact_email': settings.INVOICING_CONTACT_EMAIL,
         'sales_email': settings.SALES_EMAIL,
-        'plan_info_url': ('https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2420015134/'
-                          'CommCare+Pricing+Overview#Detailed-Software-Plan-%26-Feature-Comparisons')
+        'plan_info_url': 'https://commcare.dimagi.com/pricing/#plans'
     }
 
     subject = _(

--- a/corehq/apps/domain/templates/domain/partials/enable_auto_renew.html
+++ b/corehq/apps/domain/templates/domain/partials/enable_auto_renew.html
@@ -39,9 +39,9 @@
   {% blocktrans %}
     For more information about CommCare software plans, visit
     <a
-      href="https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2420015134/CommCare+Pricing+Overview#Detailed-Software-Plan-%26-Feature-Comparisons"
+      href="https://commcare.dimagi.com/pricing/#plans"
       target="_blank"
-      >our help site</a
+      >our pricing page</a
     >.
   {% endblocktrans %}
 </p>

--- a/corehq/apps/export/templates/export/paywall.html
+++ b/corehq/apps/export/templates/export/paywall.html
@@ -24,7 +24,7 @@
             higher software plans.
           {% endblocktrans %}
         </p>
-        <a class="btn btn-outline-primary" href="{% prelogin_url "go_to_pricing" %}">
+        <a class="btn btn-outline-primary" href="{% prelogin_url "public_pricing" %}">
           {% trans "Learn More About Pricing Plans" %}
         </a>
         <a class="btn btn-primary float-end" href="{% url "domain_select_plan" domain %}">

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -430,7 +430,7 @@ def prelogin_url(urlname):
         'go_to_pricing': 'https://commcare.dimagi.com/pricing/',
         'public_pricing': 'https://commcare.dimagi.com/pricing/',
     }
-    return urlname_to_url.get(urlname, 'https://dimagi.com/commcare/')
+    return urlname_to_url.get(urlname, 'https://commcare.dimagi.com/')
 
 
 @register.tag

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -427,9 +427,8 @@ def prelogin_url(urlname):
     Fetches the correct dimagi.com url for a "prelogin" view.
     """
     urlname_to_url = {
-        'go_to_pricing': 'https://dimagi.com/commcare-pricing/',
-        'public_pricing': 'https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2420015134/CommCare+Pricing+Overview',  # noqa: E501
-
+        'go_to_pricing': 'https://commcare.dimagi.com/pricing/',
+        'public_pricing': 'https://commcare.dimagi.com/pricing/',
     }
     return urlname_to_url.get(urlname, 'https://dimagi.com/commcare/')
 

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -426,11 +426,9 @@ def prelogin_url(urlname):
     """
     Fetches the correct dimagi.com url for a "prelogin" view.
     """
-    urlname_to_url = {
-        'go_to_pricing': 'https://commcare.dimagi.com/pricing/',
-        'public_pricing': 'https://commcare.dimagi.com/pricing/',
-    }
-    return urlname_to_url.get(urlname, 'https://commcare.dimagi.com/')
+    if urlname == 'public_pricing':
+        return 'https://commcare.dimagi.com/pricing/'
+    return 'https://commcare.dimagi.com/'
 
 
 @register.tag

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -3343,8 +3343,7 @@ class DeactivateMobileWorkerTrigger(models.Model):
 
 
 def check_and_send_limit_email(domain, plan_limit, user_count, prev_count):
-    ADDITIONAL_USERS_PRICING = ("https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/"
-                                "2420015134/CommCare+Pricing+Overview#Additional-Mobile-Users-Fees")
+    ADDITIONAL_USERS_PRICING = 'https://commcare.dimagi.com/pricing/#add-ons'
     ENTERPRISE_LIMIT = -1
     if plan_limit == ENTERPRISE_LIMIT:
         return


### PR DESCRIPTION
## Product Description

Replaces links to the Confluence wiki pricing page and the old CommCare page on dimagi.com with the new CommCare website's pricing page.

All pricing references have been moved and combined in one place: <https://commcare.dimagi.com/pricing/>

## Technical Summary

For context, see [SUPPORT-27838](https://dimagi.atlassian.net/browse/SUPPORT-27838) and [SAAS-20126](https://dimagi.atlassian.net/browse/SAAS-20126)

This PR replaces PRs https://github.com/dimagi/commcare-hq/pull/37973 and https://github.com/dimagi/commcare-hq/pull/37975

## Safety Assurance

### Safety story

Non-code change.

### Automated test coverage

N/A

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

fyi @akhanduja1 

[SUPPORT-27838]: https://dimagi.atlassian.net/browse/SUPPORT-27838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-20126]: https://dimagi.atlassian.net/browse/SAAS-20126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ