### PR TITLE
Fix module name being logged to google analytics

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/collections.js
@@ -31,6 +31,7 @@ var MenuSelect = Backbone.Collection.extend({
         'selections',
         'tiles',
         'title',
+        'menuTitle',
         'type',
         'noItemsText',
         'dynamicSearch',

--- a/corehq/apps/cloudcare/static/cloudcare/js/gtx.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/gtx.js
@@ -44,9 +44,13 @@ const logNavigateMenu = function (menuResponse) {
 
 const logCaseList = function (menuResponse, searchFieldList) {
     const selections = extractSelections(menuResponse);
+    let moduleName = menuResponse.title;
+    if (menuResponse.queryResponse) {
+        moduleName = menuResponse.queryResponse.title;
+    }
     let gtxEventData = {
         selections: selections,
-        moduleName: menuResponse.title,
+        moduleName: moduleName,
     };
     if (searchFieldList.length > 0) {
         let searchFieldData = formatSearchFieldData(searchFieldList);

--- a/corehq/apps/cloudcare/static/cloudcare/js/gtx.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/gtx.js
@@ -45,9 +45,10 @@ const logNavigateMenu = function (menuResponse) {
 const logCaseList = function (menuResponse, searchFieldList) {
     const selections = extractSelections(menuResponse);
     let moduleName = menuResponse.title;
-    if (menuResponse.queryResponse) {
-        moduleName = menuResponse.queryResponse.title;
+    if (menuResponse.menuTitle) {
+        moduleName = menuResponse.menuTitle;
     }
+    console.log(`moduleName: ${moduleName}`);
     let gtxEventData = {
         selections: selections,
         moduleName: moduleName,

--- a/corehq/apps/cloudcare/static/cloudcare/js/gtx.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/gtx.js
@@ -44,11 +44,7 @@ const logNavigateMenu = function (menuResponse) {
 
 const logCaseList = function (menuResponse, searchFieldList) {
     const selections = extractSelections(menuResponse);
-    let moduleName = menuResponse.title;
-    if (menuResponse.menuTitle) {
-        moduleName = menuResponse.menuTitle;
-    }
-    console.log(`moduleName: ${moduleName}`);
+    const moduleName = menuResponse.menuTitle || menuResponse.title;
     let gtxEventData = {
         selections: selections,
         moduleName: moduleName,
@@ -61,7 +57,7 @@ const logCaseList = function (menuResponse, searchFieldList) {
     if (selections !== lastCaseListSelections) {
         lastCaseListSelections = selections;
         lastCaseListTimeMs = Date.now();
-        lastCaseListModuleName = menuResponse.title;
+        lastCaseListModuleName = moduleName;
     }
     gtx.sendEvent("web_apps_viewed_case_list", gtxEventData);
 };


### PR DESCRIPTION


## Product Description

The query screen from formplayer does not up the module name into the top level field "title". But it is present in queryResponse.title. If queryrResponse exists use it to get the menu name for logging to google analytics

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6605

## Feature Flag

SYNC_SEARCH_CASE_CLAIM

## Safety Assurance

### Safety story

Tested on staging using Google Tag manager to check the value send to Google Analytics.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
