### PR TITLE
Allow API clients to use the app import API without a CSRF token

### DIFF
--- a/corehq/apps/app_manager/tests/test_app_import_api.py
+++ b/corehq/apps/app_manager/tests/test_app_import_api.py
@@ -14,6 +14,8 @@ from corehq.apps.app_manager.views.app_import_api import (
     _handle_import_app,
     _handle_multimedia_status,
     _handle_upload_multimedia,
+    import_app_api,
+    upload_multimedia_api,
 )
 
 DOMAIN = 'test-domain'
@@ -62,6 +64,14 @@ def _json(response):
 
 def _app_json():
     return json.dumps({'doc_type': 'Application'}).encode()
+
+
+@pytest.mark.parametrize('view', [import_app_api, upload_multimedia_api])
+def test_post_api_views_are_csrf_exempt(view):
+    # API clients authenticate with API keys and can't supply a CSRF
+    # token; csrf_exempt must be the outermost decorator to survive
+    # the rest of the decorator stack.
+    assert getattr(view, 'csrf_exempt', False)
 
 
 # --- import_app_api ---

--- a/corehq/apps/app_manager/views/app_import_api.py
+++ b/corehq/apps/app_manager/views/app_import_api.py
@@ -3,6 +3,7 @@ import zipfile
 
 from django.contrib.messages import get_messages
 from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
 
 from couchdbkit.exceptions import ResourceNotFound
@@ -17,11 +18,14 @@ from corehq.apps.domain.decorators import api_auth
 from corehq.apps.hqmedia.cache import BulkMultimediaStatusCache
 from corehq.apps.hqmedia.tasks import process_bulk_upload_zip
 from corehq.apps.hqmedia.utils import save_multimedia_upload
+from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
 from corehq.util.view_utils import json_error
 
 
+@waf_allow('XSS_BODY')
+@csrf_exempt
 @json_error
 @require_permission(HqPermissions.edit_apps, login_decorator=api_auth())
 @api_throttle
@@ -57,6 +61,8 @@ def _handle_import_app(request, domain):
     return JsonResponse(response, status=201)
 
 
+@waf_allow('XSS_BODY')
+@csrf_exempt
 @json_error
 @require_permission(HqPermissions.edit_apps, login_decorator=api_auth())
 @api_throttle


### PR DESCRIPTION
## Product Description
No user-facing UI changes. Makes the recently added app import API (`POST /a/<domain>/apps/api/import_app/`) and its companion multimedia upload endpoint actually usable by API clients — previously any POST with API-key auth was rejected with a 403 CSRF failure page.

## Technical Summary
The endpoints added in 9292f3636da (import app API) are authenticated via `api_auth()` (API key / basic / digest / OAuth), but were missing `@csrf_exempt`. API clients have no way to obtain or send a CSRF token, so Django's CSRF middleware rejected every POST before it reached the view. Verified against staging: a correctly authenticated curl got the `csrf_failure` "Cookies are disabled" page; the same request passed once a CSRF cookie/token was manually scraped and attached, confirming CSRF was the only blocker.

This applies the established pattern from other API-key-authenticated upload endpoints (`upload_fixture_api`, `bulk_case_upload_api`, `bulk_location_upload_api`): `@waf_allow('XSS_BODY')` + `@csrf_exempt` as the outermost decorators. `waf_allow` matters on production because app source JSON embeds XForm XML, which trips the WAF's XSS body rules. The GET status endpoint is untouched since CSRF only applies to unsafe methods.

## Feature Flag
None.

## Safety Assurance

### Safety story
The change only removes CSRF enforcement from two endpoints that cannot be invoked with session auth from a browser form flow in practice — they are API endpoints guarded by `api_auth()` + `require_permission(edit_apps)` + `api_throttle`, identical in shape to the existing exempted upload APIs. Manually verified the failure mode and the fix logic against staging.

### Automated test coverage
`corehq/apps/app_manager/tests/test_app_import_api.py` — new parametrized test asserting both POST views are `csrf_exempt` (also catches decorator-ordering regressions, since `csrf_exempt` must be outermost to survive the stack). Existing tests exercise the handler logic; the new test covers the decorator layer they bypass.

### QA Plan
No QA ticket — a successful authenticated curl against staging after deploy is sufficient verification.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
