### PR TITLE
Retire quarterly and yearly invoicing plans

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -58,7 +58,6 @@ from corehq.apps.accounting.models import (
     FormSubmittingMobileWorkerHistory,
     FundingSource,
     Invoice,
-    InvoicingPlan,
     PaymentType,
     PreOrPostPay,
     ProBonoStatus,
@@ -129,10 +128,6 @@ class BillingAccountBasicForm(forms.Form):
         required=False,
         help_text='ex: dimagi.com, commcarehq.org',
     )
-    invoicing_plan = forms.ChoiceField(
-        label="Invoicing Plan",
-        required=False
-    )
     active_accounts = forms.IntegerField(
         label=gettext_lazy("Transfer Subscriptions To"),
         help_text=gettext_lazy(
@@ -193,7 +188,6 @@ class BillingAccountBasicForm(forms.Form):
                 'is_sms_billable_report_visible': account.is_sms_billable_report_visible,
                 'enterprise_admin_emails': account.enterprise_admin_emails,
                 'enterprise_restricted_signup_domains': ','.join(account.enterprise_restricted_signup_domains),
-                'invoicing_plan': account.invoicing_plan,
                 'dimagi_contact': account.dimagi_contact,
                 'entry_point': account.entry_point,
                 'last_payment_method': account.last_payment_method,
@@ -208,12 +202,10 @@ class BillingAccountBasicForm(forms.Form):
                 'entry_point': EntryPoint.CONTRACTED,
                 'last_payment_method': PaymentType.NONE,
                 'pre_or_post_pay': PreOrPostPay.POSTPAY,
-                'invoicing_plan': InvoicingPlan.MONTHLY
             }
         super(BillingAccountBasicForm, self).__init__(*args, **kwargs)
         self.fields['currency'].choices =\
             [(cur.code, cur.code) for cur in Currency.objects.order_by('code')]
-        self.fields['invoicing_plan'].choices = InvoicingPlan.CHOICES
         self.helper = FormHelper()
         self.helper.form_id = "account-form"
         self.helper.form_class = "form-horizontal"
@@ -238,7 +230,6 @@ class BillingAccountBasicForm(forms.Form):
             ))
             additional_fields.append(
                 crispy.Div(
-                    'invoicing_plan',
                     crispy.Field(
                         'enterprise_admin_emails',
                         css_class='input-xxlarge accounting-email-select2',
@@ -429,7 +420,6 @@ class BillingAccountBasicForm(forms.Form):
         account.is_sms_billable_report_visible = self.cleaned_data['is_sms_billable_report_visible']
         account.enterprise_admin_emails = self.cleaned_data['enterprise_admin_emails']
         account.enterprise_restricted_signup_domains = self.cleaned_data['enterprise_restricted_signup_domains']
-        account.invoicing_plan = self.cleaned_data['invoicing_plan']
         account.block_hubspot_data_for_all_users = self.cleaned_data['block_hubspot_data_for_all_users']
         account.bill_web_user = self.cleaned_data['bill_web_user']
         account.require_auto_pay = self.cleaned_data['require_auto_pay']
@@ -2213,7 +2203,7 @@ class TriggerCustomerInvoiceForm(forms.Form):
         month = int(self.cleaned_data['month'])
         try:
             account = BillingAccount.objects.get(name=self.cleaned_data['customer_account'])
-            invoice_start, invoice_end = self.get_invoice_dates(account, year, month)
+            invoice_start, invoice_end = get_first_last_days(year, month)
             self.clean_previous_invoices(invoice_start, invoice_end, account)
             invoice_factory = CustomerAccountInvoiceFactory(
                 date_start=invoice_start,
@@ -2255,35 +2245,6 @@ class TriggerCustomerInvoiceForm(forms.Form):
         month = int(self.cleaned_data['month'])
         if (year, month) >= (today.year, today.month):
             raise ValidationError('Statement period must be in the past')
-
-    def get_invoice_dates(self, account, year, month):
-        if account.invoicing_plan == InvoicingPlan.YEARLY:
-            if month == 12:
-                # Set invoice start date to January 1st
-                return datetime.date(year, 1, 1), datetime.date(year, 12, 31)
-            else:
-                raise InvoiceError(
-                    "%s is set to be invoiced yearly, and you may not invoice in this month. "
-                    "You must select December in the year for which you are triggering an annual invoice."
-                    % self.cleaned_data['customer_account']
-                )
-        if account.invoicing_plan == InvoicingPlan.QUARTERLY:
-            if month == 3:
-                return datetime.date(year, 1, 1), datetime.date(year, 3, 31)    # Quarter 1
-            if month == 6:
-                return datetime.date(year, 4, 1), datetime.date(year, 6, 30)    # Quarter 2
-            if month == 9:
-                return datetime.date(year, 7, 1), datetime.date(year, 9, 30)    # Quarter 3
-            if month == 12:
-                return datetime.date(year, 10, 1), datetime.date(year, 12, 31)  # Quarter 4
-            else:
-                raise InvoiceError(
-                    "%s is set to be invoiced quarterly, and you may not invoice in this month. "
-                    "You must select the last month of a quarter to trigger a quarterly invoice."
-                    % self.cleaned_data['customer_account']
-                )
-        else:
-            return get_first_last_days(year, month)
 
 
 class TriggerBookkeeperEmailForm(forms.Form):

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -39,7 +39,6 @@ from corehq.apps.accounting.models import (
     FeatureType,
     FormSubmittingMobileWorkerHistory,
     Invoice,
-    InvoicingPlan,
     LineItem,
     SoftwarePlanEdition,
     Subscriber,
@@ -54,7 +53,6 @@ from corehq.apps.accounting.utils import (
     ensure_domain_instance,
     log_accounting_error,
     log_accounting_info,
-    get_first_day_x_months_later,
 )
 from corehq.apps.accounting.utils.invoicing import (
     get_flagged_pay_annually_prepay_invoice,
@@ -681,24 +679,7 @@ class ProductLineItemFactory(LineItemFactory):
     def quantity(self):
         if self.is_prorated:
             return self.num_prorated_days
-        if self.invoice.is_customer_invoice:
-            if self.invoice.account.invoicing_plan == InvoicingPlan.QUARTERLY:
-                return self.months_product_active_over_period(3)
-            elif self.invoice.account.invoicing_plan == InvoicingPlan.YEARLY:
-                return self.months_product_active_over_period(12)
         return 1
-
-    def months_product_active_over_period(self, num_months):
-        # Calculate the number of months out of num_months the subscription was active
-        quantity = 0
-        date_start = get_first_day_x_months_later(self.invoice.date_end, -(num_months - 1))
-        while date_start < self.invoice.date_end:
-            if self.subscription.date_end and self.subscription.date_end <= date_start:
-                continue
-            elif self.subscription.date_start <= date_start:
-                quantity += 1
-            date_start = date_start + relativedelta(months=1)
-        return quantity
 
     @property
     def plan_name(self):

--- a/corehq/apps/accounting/migrations/0121_invoicing_plan_monthly.py
+++ b/corehq/apps/accounting/migrations/0121_invoicing_plan_monthly.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+from corehq.util.django_migrations import skip_on_fresh_install
+
+# Spelled out rather than imported from InvoicingPlan, which is losing its
+# other members in this same change. Migrations must not depend on the
+# current state of the code.
+MONTHLY = 'MONTHLY'
+
+
+@skip_on_fresh_install
+def _set_invoicing_plan_to_monthly(apps, schema_editor):
+    """
+    Normalize quarterly and yearly accounts ahead of removing those options.
+
+    Nothing was ever billed on a quarterly or yearly customer invoice, so
+    there is no charge to reconcile — only the setting to clear.
+    """
+    BillingAccount = apps.get_model('accounting', 'BillingAccount')
+    BillingAccount.objects.exclude(invoicing_plan=MONTHLY).update(invoicing_plan=MONTHLY)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0120_billingaccountdomainhistory'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _set_invoicing_plan_to_monthly,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/corehq/apps/accounting/migrations/0122_stop_declaring_invoicing_plan.py
+++ b/corehq/apps/accounting/migrations/0122_stop_declaring_invoicing_plan.py
@@ -1,0 +1,45 @@
+from django.db import migrations
+
+# The column is NOT NULL and Django keeps field defaults in Python, so once the
+# model stops declaring the field every INSERT would omit it and violate the
+# constraint. Hand the default to the database for as long as the column lives.
+SET_DEFAULT = (
+    'ALTER TABLE "accounting_billingaccount"'
+    ' ALTER COLUMN "invoicing_plan" SET DEFAULT \'MONTHLY\';'
+)
+DROP_DEFAULT = (
+    'ALTER TABLE "accounting_billingaccount"'
+    ' ALTER COLUMN "invoicing_plan" DROP DEFAULT;'
+)
+
+
+class Migration(migrations.Migration):
+    """
+    Stop declaring ``BillingAccount.invoicing_plan``, leaving the column in place.
+
+    Deploys run the new code's migrations and only then switch servers over to
+    it, so dropping the column here would leave the still-running previous
+    release selecting a column that no longer exists. Removing the field from
+    migration state alone keeps every deploy state valid: the column is present
+    throughout, and only the new code stops asking for it. A later migration
+    drops the column, once no deployed code declares the field.
+
+    Neither statement here rewrites the table; both are catalog-only.
+    """
+
+    dependencies = [
+        ('accounting', '0121_invoicing_plan_monthly'),
+    ]
+
+    operations = [
+        migrations.RunSQL(SET_DEFAULT, reverse_sql=DROP_DEFAULT),
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name='billingaccount',
+                    name='invoicing_plan',
+                ),
+            ],
+            database_operations=[],
+        ),
+    ]

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -118,17 +118,6 @@ class BillingAccountType(object):
     )
 
 
-class InvoicingPlan(object):
-    MONTHLY = "MONTHLY"
-    QUARTERLY = "QUARTERLY"
-    YEARLY = "YEARLY"
-    CHOICES = (
-        (MONTHLY, "Monthly"),
-        (QUARTERLY, "Quarterly"),
-        (YEARLY, "Yearly")
-    )
-
-
 class FeatureType(object):
     USER = "User"
     SMS = "SMS"
@@ -412,11 +401,6 @@ class BillingAccount(ValidateModelMixin, models.Model):
     is_sms_billable_report_visible = models.BooleanField(default=False)
     enterprise_admin_emails = ArrayField(models.EmailField(), default=list, blank=True)
     enterprise_restricted_signup_domains = ArrayField(models.CharField(max_length=128), default=list, blank=True)
-    invoicing_plan = models.CharField(
-        max_length=25,
-        default=InvoicingPlan.MONTHLY,
-        choices=InvoicingPlan.CHOICES
-    )
     entry_point = models.CharField(
         max_length=25,
         default=EntryPoint.NOT_SET,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -3132,18 +3132,14 @@ class InvoicePdf(BlobMixin, SafeSaveDocument):
                 line_items = LineItem.objects.filter(subscription_invoice=invoice)
             for line_item in line_items:
                 is_unit = line_item.unit_description is not None
-                is_quarterly = line_item.invoice.is_customer_invoice and \
-                    line_item.invoice.account.invoicing_plan != InvoicingPlan.MONTHLY
                 unit_cost = line_item.subtotal
                 if is_unit:
                     unit_cost = line_item.unit_cost
-                if is_quarterly and line_item.base_description is not None:
-                    unit_cost = line_item.product_rate.monthly_fee
                 description = line_item.base_description or line_item.unit_description
                 if line_item.quantity > 0:
                     template.add_item(
                         description,
-                        line_item.quantity if is_unit or is_quarterly else 1,
+                        line_item.quantity if is_unit else 1,
                         unit_cost,
                         line_item.subtotal,
                         line_item.applied_credit,
@@ -3233,9 +3229,6 @@ class LineItem(models.Model):
 
     @property
     def subtotal(self):
-        if self.customer_invoice and self.customer_invoice.account.invoicing_plan != InvoicingPlan.MONTHLY:
-            return self.base_cost * self.quantity + self.unit_cost * self.quantity
-
         return self.base_cost + self.unit_cost * self.quantity
 
     @property

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -52,7 +52,6 @@ from corehq.apps.accounting.models import (
     DomainUserHistory,
     FeatureType,
     FormSubmittingMobileWorkerHistory,
-    InvoicingPlan,
     SoftwarePlanEdition,
     Subscription,
     SubscriptionAdjustment,
@@ -328,15 +327,9 @@ def generate_invoices_based_on_date(invoice_date):
     all_customer_billing_accounts = BillingAccount.objects.filter(is_customer_billing_account=True)
     for account in all_customer_billing_accounts:
         try:
-            if account.invoicing_plan == InvoicingPlan.QUARTERLY:
-                customer_invoice_start = invoice_start - relativedelta(months=2)
-            elif account.invoicing_plan == InvoicingPlan.YEARLY:
-                customer_invoice_start = invoice_start - relativedelta(months=11)
-            else:
-                customer_invoice_start = invoice_start
             invoice_factory = CustomerAccountInvoiceFactory(
                 account=account,
-                date_start=customer_invoice_start,
+                date_start=invoice_start,
                 date_end=invoice_end
             )
             invoice_factory.create_invoice()

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -4,7 +4,6 @@ from decimal import Decimal
 
 from django.test import TestCase
 
-from dateutil import relativedelta
 from unittest.mock import Mock
 
 from dimagi.utils.dates import add_months_to_date
@@ -15,9 +14,7 @@ from corehq.apps.accounting.models import (
     CreditLine,
     CustomerInvoice,
     DefaultProductPlan,
-    DomainUserHistory,
     FeatureType,
-    InvoicingPlan,
     SoftwarePlanEdition,
     Subscription,
 )
@@ -36,7 +33,6 @@ from corehq.apps.smsbillables.models import (
 from corehq.apps.smsbillables.tests.generator import (
     arbitrary_sms_billables_for_domain,
 )
-from corehq.util.dates import get_previous_month_date_range
 from corehq.apps.domain.shortcuts import create_domain
 
 
@@ -208,46 +204,6 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
                          'One month of CommCare Advanced Edition - Pay Monthly Software Plan.')
         product_cost = product_line_item.base_cost
         self.assertEqual(product_cost, self.product_rate.monthly_fee)
-
-    def test_product_line_items_in_quarterly_invoice(self):
-        self.account.invoicing_plan = InvoicingPlan.QUARTERLY
-        self.account.save()
-        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start, 14)
-        for months_before_invoice_date in range(3):
-            user_date = date(invoice_date.year, invoice_date.month, 1)
-            user_date -= relativedelta.relativedelta(months=months_before_invoice_date)
-            calculate_users_in_all_domains(user_date)
-        tasks.generate_invoices_based_on_date(invoice_date)
-
-        self.assertEqual(CustomerInvoice.objects.count(), 1)
-        invoice = CustomerInvoice.objects.first()
-        self.assertEqual(invoice.balance, Decimal('3600.0000'))
-        self.assertEqual(invoice.account, self.account)
-
-        num_product_line_item = invoice.lineitem_set.get_products().count()
-        self.assertEqual(num_product_line_item, 1)
-        product_line_item = invoice.lineitem_set.get_products().first()
-        self.assertEqual(product_line_item.quantity, 3)
-
-    def test_product_line_items_in_yearly_invoice(self):
-        self.account.invoicing_plan = InvoicingPlan.YEARLY
-        self.account.save()
-        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start, 14)
-        for months_before_invoice_date in range(12):
-            user_date = date(invoice_date.year, invoice_date.month, 1)
-            user_date -= relativedelta.relativedelta(months=months_before_invoice_date)
-            calculate_users_in_all_domains(user_date)
-        tasks.generate_invoices_based_on_date(invoice_date)
-
-        self.assertEqual(CustomerInvoice.objects.count(), 1)
-        invoice = CustomerInvoice.objects.first()
-        self.assertEqual(invoice.balance, Decimal('14400.0000'))
-        self.assertEqual(invoice.account, self.account)
-
-        num_product_line_items = invoice.lineitem_set.get_products()
-        self.assertEqual(num_product_line_items.count(), 1)
-        product_line_item = invoice.lineitem_set.get_products().first()
-        self.assertEqual(product_line_item.quantity, 12)
 
     def test_account_level_product_credits(self):
         CreditLine.add_credit(
@@ -576,144 +532,6 @@ class TestSmsLineItem(BaseCustomerInvoiceCase):
         SmsGatewayFeeCriteria.objects.all().delete()
         SmsUsageFee.objects.all().delete()
         SmsUsageFeeCriteria.objects.all().delete()
-
-
-class TestQuarterlyInvoicing(BaseCustomerInvoiceCase):
-
-    is_using_test_plans = True
-
-    def setUp(self):
-        super(TestQuarterlyInvoicing, self).setUp()
-        self.user_rate = self.main_subscription.plan_version.feature_rates \
-            .filter(feature__feature_type=FeatureType.USER).get()
-        self.initialize_domain_user_history_objects()
-        self.sms_rate = self.main_subscription.plan_version.feature_rates.filter(
-            feature__feature_type=FeatureType.SMS
-        ).get()
-        self.invoice_date = utils.get_first_day_x_months_later(
-            self.main_subscription.date_start, random.randint(3, self.non_main_subscription_length)
-        )
-        self.sms_date = utils.get_first_day_x_months_later(self.invoice_date, -1)
-
-    def initialize_domain_user_history_objects(self):
-        record_dates = []
-        month_end = self.main_subscription.date_end
-        while month_end > self.main_subscription.date_start:
-            record_dates.append(month_end)
-            _, month_end = get_previous_month_date_range(month_end)
-
-        self.num_users = self.user_rate.monthly_limit + 1
-        for record_date in record_dates:
-            DomainUserHistory.objects.create(
-                domain=self.main_domain,
-                num_users=self.num_users,
-                record_date=record_date
-            )
-
-        for record_date in record_dates:
-            DomainUserHistory.objects.create(
-                domain=self.non_main_domain1,
-                num_users=self.num_users,
-                record_date=record_date
-            )
-
-        for record_date in record_dates:
-            DomainUserHistory.objects.create(
-                domain=self.non_main_domain2,
-                num_users=0,
-                record_date=record_date
-            )
-
-    def test_user_over_limit_in_quarterly_invoice(self):
-        self.account.invoicing_plan = InvoicingPlan.QUARTERLY
-        self.account.save()
-        tasks.generate_invoices_based_on_date(self.invoice_date)
-        self.assertEqual(CustomerInvoice.objects.count(), 1)
-
-        invoice = CustomerInvoice.objects.first()
-        user_line_items = invoice.lineitem_set.get_feature_by_type(FeatureType.USER)
-        num_excess_users_quarterly = (self.num_users * 2 - self.user_rate.monthly_limit) * 3
-        self.assertEqual(user_line_items.count(), 1)
-        for user_line_item in user_line_items:
-            self.assertEqual(user_line_item.quantity, num_excess_users_quarterly)
-
-    def test_user_over_limit_in_yearly_invoice(self):
-        self.account.invoicing_plan = InvoicingPlan.YEARLY
-        self.account.save()
-        invoice_date = utils.get_first_day_x_months_later(self.main_subscription.date_start, 14)
-        tasks.generate_invoices_based_on_date(invoice_date)
-        self.assertEqual(CustomerInvoice.objects.count(), 1)
-
-        invoice = CustomerInvoice.objects.first()
-        user_line_items = invoice.lineitem_set.get_feature_by_type(FeatureType.USER)
-        num_excess_users_quarterly = (self.num_users * 2 - self.user_rate.monthly_limit) * 12
-        self.assertEqual(user_line_items.count(), 1)
-        for user_line_item in user_line_items:
-            self.assertEqual(user_line_item.quantity, num_excess_users_quarterly)
-
-    def test_sms_over_limit_in_quarterly_invoice(self):
-        num_sms = random.randint(self.sms_rate.monthly_limit + 1, self.sms_rate.monthly_limit + 2)
-        billables_main_domain = arbitrary_sms_billables_for_domain(
-            self.main_domain, self.sms_date, num_sms
-        )
-        billables_non_main_domain1 = arbitrary_sms_billables_for_domain(
-            self.non_main_domain1, self.sms_date, num_sms
-        )
-
-        tasks.generate_invoices_based_on_date(self.invoice_date)
-        self.assertEqual(CustomerInvoice.objects.count(), 1)
-        invoice = CustomerInvoice.objects.first()
-
-        sms_line_items = invoice.lineitem_set.get_feature_by_type(FeatureType.SMS)
-        self.assertEqual(sms_line_items.count(), 1)
-        for sms_line_item in sms_line_items:
-            self.assertIsNone(sms_line_item.base_description)
-            self.assertEqual(sms_line_item.base_cost, Decimal('0.0000'))
-            self.assertEqual(sms_line_item.quantity, 1)
-
-            sms_cost = sum(
-                billable.gateway_charge + billable.usage_charge
-                for billable in (
-                    billables_non_main_domain1[self.sms_rate.monthly_limit:]
-                    + billables_main_domain
-                ))
-            self.assertEqual(sms_line_item.unit_cost, sms_cost)
-            self.assertEqual(sms_line_item.total, sms_cost)
-
-    def test_sms_over_limit_in_yearly_invoice(self):
-        num_sms = random.randint(self.sms_rate.monthly_limit + 1, self.sms_rate.monthly_limit + 2)
-        billables_main_domain = arbitrary_sms_billables_for_domain(
-            self.main_domain, self.sms_date, num_sms
-        )
-        billables_non_main_domain1 = arbitrary_sms_billables_for_domain(
-            self.non_main_domain1, self.sms_date, num_sms
-        )
-
-        tasks.generate_invoices_based_on_date(self.invoice_date)
-        self.assertEqual(CustomerInvoice.objects.count(), 1)
-        invoice = CustomerInvoice.objects.first()
-
-        sms_line_items = invoice.lineitem_set.get_feature_by_type(FeatureType.SMS)
-        self.assertEqual(sms_line_items.count(), 1)
-        for sms_line_item in sms_line_items:
-            self.assertIsNone(sms_line_item.base_description)
-            self.assertEqual(sms_line_item.base_cost, Decimal('0.0000'))
-            self.assertEqual(sms_line_item.quantity, 1)
-
-            sms_cost = sum(
-                billable.gateway_charge + billable.usage_charge
-                for billable in (
-                    billables_non_main_domain1[self.sms_rate.monthly_limit:]
-                    + billables_main_domain
-                ))
-            self.assertEqual(sms_line_item.unit_cost, sms_cost)
-            self.assertEqual(sms_line_item.total, sms_cost)
-
-    def _create_sms_line_items_for_quarter(self):
-        tasks.generate_invoices_based_on_date(self.invoice_date)
-        self.assertEqual(CustomerInvoice.objects.count(), 1)
-        invoice = CustomerInvoice.objects.first()
-        return invoice.lineitem_set.get_feature_by_type(FeatureType.SMS)
 
 
 class TestDomainsInLineItemForCustomerInvoicing(TestCase):

--- a/migrations.lock
+++ b/migrations.lock
@@ -140,6 +140,7 @@ accounting
  0118_vellum_save_to_case_priv
  0119_public_webforms_priv
  0120_billingaccountdomainhistory
+ 0121_invoicing_plan_monthly
 admin
  0001_initial
  0002_logentry_remove_auto_add

--- a/migrations.lock
+++ b/migrations.lock
@@ -141,6 +141,7 @@ accounting
  0119_public_webforms_priv
  0120_billingaccountdomainhistory
  0121_invoicing_plan_monthly
+ 0122_stop_declaring_invoicing_plan
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
## Product Description

Ops no longer see an "Invoicing Plan" control on customer billing accounts, and every customer invoice covers one calendar month. Nothing was ever billed on a quarterly or yearly invoice, so there is no customer-facing change.

## Technical Summary

Removes `QUARTERLY` and `YEARLY`, every use of `BillingAccount.invoicing_plan`, the field, and the `InvoicingPlan` enum. #37971 has the audit: quarterly set on zero accounts in any environment, yearly on 8 internal or dormant ones, every invoice they produced $0.00. The commits carry the two bugs that made keeping either untenable.

This does **not** remove annual contracts. Those are an annual software plan (`SoftwarePlan.is_annual_plan`) over a twelve month subscription, invoiced monthly — one audited account runs that way with `invoicing_plan = MONTHLY` today. What goes is a broken second mechanism that duplicated it.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Every removed branch was reachable only when `invoicing_plan != MONTHLY`, so the monthly path is unchanged by construction — and monthly is every account that has ever been billed.

One consequence worth flagging: `LineItem.subtotal` is computed at read time, so the subtotal *rendered* for the 69 historical multi-month invoices changes. Stored balances don't, the PDFs are already frozen in blob storage, and all 69 are $0.00 — but it is the one place this alters existing records.

### Automated test coverage

`corehq/apps/accounting/tests/`: 273 passed, 30 skipped, against a rebuilt database. Rebuilt matters — a reused one already has the column dropped by a later migration, which hides the `NOT NULL` problem `0122` handles.

### QA Plan

Worth an ops check that the billing account edit page still saves with the field gone. No other user-facing surface.

### Migrations

- [x] The migrations in this code can be safely applied first independently of the code.

Neither migration drops anything and both are catalog-only. `0122` removes the field from migration state but leaves the column, because a deploy runs migrations *before* switching servers over ([migrations_in_practice](https://github.com/dimagi/commcare-hq/blob/dbfb5f3d448/docs/migrations_in_practice.rst#L47-L51)); its docstring has the reasoning.

#37984 drops the column and must not be merged until this is deployed everywhere.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

The column is still present and still populated. `0121` doesn't restore the 8 previous values in reverse, but nothing was billed under them.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
