### PR TITLE
Drop the leftover invoicing plan column

### DIFF
--- a/corehq/apps/accounting/migrations/0123_drop_invoicing_plan_column.py
+++ b/corehq/apps/accounting/migrations/0123_drop_invoicing_plan_column.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+# Matches the SQL Django itself emits for RemoveField, including CASCADE.
+DROP_COLUMN = 'ALTER TABLE "accounting_billingaccount" DROP COLUMN "invoicing_plan" CASCADE;'
+
+# Restores what 0122 left behind, database default included. Reversing only this
+# migration lands back in 0122's world, where the model does not declare the
+# field and the database is what satisfies NOT NULL — so unlike a reversed
+# RemoveField, this must not drop the default. Reversing 0122 does that.
+ADD_COLUMN = (
+    'ALTER TABLE "accounting_billingaccount"'
+    ' ADD COLUMN "invoicing_plan" varchar(25) DEFAULT \'MONTHLY\' NOT NULL;'
+)
+
+
+class Migration(migrations.Migration):
+    """
+    Drop the ``invoicing_plan`` column, undeclared in model state since 0122.
+
+    Raw SQL rather than ``RemoveField`` because the field is already out of
+    migration state; there is nothing left to remove from it.
+
+    Must not be merged until 0122 is deployed everywhere. If both land in one
+    deploy, migrations run while the release that still declares the field is
+    serving, and every ``BillingAccount`` query fails until the code switch.
+    """
+
+    dependencies = [
+        ('accounting', '0122_stop_declaring_invoicing_plan'),
+    ]
+
+    operations = [
+        migrations.RunSQL(DROP_COLUMN, reverse_sql=ADD_COLUMN),
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -142,6 +142,7 @@ accounting
  0120_billingaccountdomainhistory
  0121_invoicing_plan_monthly
  0122_stop_declaring_invoicing_plan
+ 0123_drop_invoicing_plan_column
 admin
  0001_initial
  0002_logentry_remove_auto_add


### PR DESCRIPTION
Stacked on #37982. **Do not merge until 6 weeks after #37982 is merged** so it has time to be deployed everywhere — see Migrations. Audit: #37971.

## Product Description

No user-visible change. #37982 stopped the code declaring `BillingAccount.invoicing_plan`; this drops the leftover column.

## Technical Summary

Migration only, no code. Raw SQL rather than `RemoveField` because the field is already out of migration state — the statements match what Django emitted for this column, `CASCADE` included, in both directions.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Once #37982 is live nothing declares the field, so no query selects the column. `DROP COLUMN` is catalog-only in Postgres — no rewrite of ~110k rows.

### Automated test coverage

`corehq/apps/accounting/tests/`: 273 passed, 30 skipped, against a rebuilt database. No behaviour to cover; this deletes a column nothing references.

### QA Plan

None needed.

### Migrations

- [x] The migrations in this code can be safely applied first independently of the code.

Trivially so — there is no code here for them to be out of step with. The real constraint is between PRs. Deploys run migrations before switching servers over, so if this lands in the same deploy as #37982, `0123` drops the column while the release that still declares the field is serving. Being stacked stops it merging *before* #37982, not *with* it: merge #37982, let it deploy everywhere, then merge this.

Third parties who deploy infrequently could still pick up both at once and reinstate that window. [Spacing the merges](https://github.com/dimagi/commcare-hq/blob/dbfb5f3d448/docs/migrations_in_practice.rst#L211-L219) is the mitigation.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

Reversing `0123` re-adds the column as `varchar(25) NOT NULL DEFAULT 'MONTHLY'`, which is what every row held. There is no code to revert.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] It has been 6 weeks since #37982 was merged: it is Sept 23, 2026 or later
