### PR TITLE
Find payload errors and empty records from the Record Status filter

### DIFF
--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import List, Literal, Optional  # noqa: F401
+from typing import List, Literal, Optional, Sequence  # noqa: F401
 
 from django.conf import settings
 from django.core.cache import cache
@@ -220,10 +220,12 @@ def task_generate_ids_and_operate_on_payloads(
     repeater_id: Optional[str],
     domain: str,
     action: Literal['resend', 'cancel', 'requeue'],
-    state: Literal[None, State.Pending, State.Cancelled] = None,
+    state: Optional[Sequence[State]] = None,
 ) -> dict:
+    # Backwards compatibility with already queued tasks.
+    states = [state] if isinstance(state, State) else state
     repeat_record_ids = RepeatRecord.objects.get_repeat_record_ids(
-        domain, repeater_id=repeater_id, state=state, payload_id=payload_id,
+        domain, repeater_id=repeater_id, states=states, payload_id=payload_id,
     )
     return operate_on_payloads(repeat_record_ids, domain, action,
                                task=task_generate_ids_and_operate_on_payloads)

--- a/corehq/apps/data_interfaces/tests/test_utils.py
+++ b/corehq/apps/data_interfaces/tests/test_utils.py
@@ -40,7 +40,7 @@ class TestTasks(TestCase):
 
         mock_get_repeat_record_ids.assert_called_once()
         mock_get_repeat_record_ids.assert_called_with(
-            'test_domain', repeater_id='deadbeef', state=None, payload_id='c0ffee')
+            'test_domain', repeater_id='deadbeef', states=None, payload_id='c0ffee')
 
         mock_operate_on_payloads.assert_called_once()
         mock_operate_on_payloads.assert_called_with(

--- a/corehq/apps/reports/filters/select.py
+++ b/corehq/apps/reports/filters/select.py
@@ -137,14 +137,14 @@ class RepeatRecordStateFilter(BaseSingleOptionFilter):
 
     @property
     def options(self):
-        return [(s.name.upper(), s.label) for s in [
-            State.Success,  # Includes Empty
-            State.Pending,
-            State.Cancelled,
-            State.Fail,
-            State.PayloadRejected,  # Includes ErrorGeneratingPayload
-            # See templates/repeaters/partials/repeater_row.html
-        ]]
+        # Keys are the groups in STATE_GROUPS
+        return [
+            ('SUCCESS', State.Success.label),  # Includes Empty
+            ('PENDING', State.Pending.label),
+            ('CANCELLED', State.Cancelled.label),
+            ('FAIL', State.Fail.label),
+            ('PAYLOADERROR', gettext_lazy('Payload Error')),
+        ]
 
 
 class UCRRebuildStatusFilter(BaseSingleOptionFilter):

--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -37,12 +37,6 @@ class State(IntegerChoices):
     PayloadRejected = 32, _('Payload Rejected')  # Implies Cancelled.
     ErrorGeneratingPayload = 64, _('Error Generating Payload')  # Unsent like Empty, but implies Cancelled
 
-    @staticmethod
-    def state_for_key(key):
-        # Keys match RepeatRecordStateFilter.options[*][0]
-        state_map = {s.name.upper(): s for s in State}
-        return state_map.get(key.upper() if key else None)
-
 
 STATE_GROUPS = {
     'SUCCESS': (State.Success, State.Empty),

--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -44,6 +44,19 @@ class State(IntegerChoices):
         return state_map.get(key.upper() if key else None)
 
 
+STATE_GROUPS = {
+    'SUCCESS': (State.Success, State.Empty),
+    'PENDING': (State.Pending,),
+    'CANCELLED': (State.Cancelled,),
+    'FAIL': (State.Fail,),
+    'PAYLOADERROR': (State.PayloadRejected, State.ErrorGeneratingPayload),
+}
+
+
+def states_for_key(key):
+    return STATE_GROUPS.get(key.upper() if key else None)
+
+
 RECORD_QUEUED_STATES = (State.Pending, State.Fail)
 RECORD_FAILED_STATES = (
     State.Fail,

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1202,7 +1202,7 @@ class RepeatRecordManager(models.Manager):
             where &= models.Q(state=state)
         return paginate_query(db, self.model, where, query_size=chunk_size)
 
-    def page(self, domain, skip, limit, repeater_id=None, state=None):
+    def page(self, domain, skip, limit, repeater_id=None, states=None):
         """Get a page of repeat records
 
         WARNING this is inefficient for large skip values.
@@ -1210,8 +1210,8 @@ class RepeatRecordManager(models.Manager):
         queryset = self.filter(domain=domain)
         if repeater_id:
             queryset = queryset.filter(repeater__id=repeater_id)
-        if state is not None:
-            queryset = queryset.filter(state=state)
+        if states:
+            queryset = queryset.filter(state__in=states)
         return (queryset.order_by('-registered_at')[skip:skip + limit]
                 .select_related('repeater')
                 .prefetch_related('attempt_set'))
@@ -1237,12 +1237,12 @@ class RepeatRecordManager(models.Manager):
     def get_domains_with_records(self):
         return self.order_by().values_list("domain", flat=True).distinct()
 
-    def get_repeat_record_ids(self, domain, repeater_id=None, state=None, payload_id=None):
+    def get_repeat_record_ids(self, domain, repeater_id=None, states=None, payload_id=None):
         where = models.Q(domain=domain)
         if repeater_id:
             where &= models.Q(repeater__id=repeater_id)
-        if state:
-            where &= models.Q(state=state)
+        if states:
+            where &= models.Q(state__in=states)
         if payload_id:
             where &= models.Q(payload_id=payload_id)
 

--- a/corehq/motech/repeaters/templates/repeaters/partials/repeater_row.html
+++ b/corehq/motech/repeaters/templates/repeaters/partials/repeater_row.html
@@ -11,27 +11,27 @@
     </td>
     <td>
         <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=PENDING">
-            {{ repeater.count_State.Pending }}
+            {{ repeater.state_group_counts.PENDING }}
         </a>
     </td>
     <td>
         <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=FAIL">
-            {{ repeater.count_State.Fail }}
+            {{ repeater.state_group_counts.FAIL }}
         </a>
     </td>
     <td>
         <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=PAYLOADERROR">
-            {{ repeater.count_State.ErrorGeneratingPayloadOrRejected }}
+            {{ repeater.state_group_counts.PAYLOADERROR }}
         </a>
     </td>
     <td>
         <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=CANCELLED">
-            {{ repeater.count_State.Cancelled }}
+            {{ repeater.state_group_counts.CANCELLED }}
         </a>
     </td>
     <td>
         <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=SUCCESS">
-            {{ repeater.count_State.EmptyOrSuccess }}
+            {{ repeater.state_group_counts.SUCCESS }}
         </a>
     </td>
     <td>

--- a/corehq/motech/repeaters/templates/repeaters/partials/repeater_row.html
+++ b/corehq/motech/repeaters/templates/repeaters/partials/repeater_row.html
@@ -20,7 +20,7 @@
         </a>
     </td>
     <td>
-        <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=PAYLOADREJECTED">
+        <a href="{% url 'domain_report_dispatcher' domain report %}?repeater={{ repeater.repeater_id }}&amp;record_state=PAYLOADERROR">
             {{ repeater.count_State.ErrorGeneratingPayloadOrRejected }}
         </a>
     </td>

--- a/corehq/motech/repeaters/tests/test_const.py
+++ b/corehq/motech/repeaters/tests/test_const.py
@@ -1,0 +1,20 @@
+import pytest
+
+from corehq.motech.repeaters.const import STATE_GROUPS, State, states_for_key
+
+
+@pytest.mark.parametrize('key, expected', [
+    (None, None),
+    ('', None),
+    ('NOT_A_GROUP', None),
+    ('PENDING', (State.Pending,)),
+    ('PAYLOADERROR', (State.PayloadRejected, State.ErrorGeneratingPayload)),
+    ('payloaderror', (State.PayloadRejected, State.ErrorGeneratingPayload)),
+])
+def test_states_for_key(key, expected):
+    assert states_for_key(key) == expected
+
+
+def test_every_state_belongs_to_exactly_one_group():
+    grouped_states = [s for states in STATE_GROUPS.values() for s in states]
+    assert sorted(grouped_states) == sorted(State)

--- a/corehq/motech/repeaters/tests/test_dbaccessors.py
+++ b/corehq/motech/repeaters/tests/test_dbaccessors.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from django.test import TestCase
 
-from corehq.motech.repeaters.const import State
+from corehq.motech.repeaters.const import State, states_for_key
 from corehq.motech.repeaters.models import ConnectionSettings, FormRepeater, RepeatRecord
 
 
@@ -115,8 +115,13 @@ class TestRepeatRecordDBAccessors(TestCase):
         self.assertEqual(len(records), 1)
 
     def test_get_paged_repeat_records_with_state(self):
-        records = RepeatRecord.objects.page(self.domain, 0, 10, state=State.Pending)
+        records = RepeatRecord.objects.page(self.domain, 0, 10, states=[State.Pending])
         self.assertEqual(len(records), 3)
+
+    def test_get_paged_repeat_records_with_state_group(self):
+        records = RepeatRecord.objects.page(
+            self.domain, 0, 10, states=states_for_key('SUCCESS'))
+        self.assertEqual(len(records), 2)  # one Success, one Empty
 
     def test_get_paged_repeat_records_wrong_domain(self):
         records = RepeatRecord.objects.page('wrong-domain', 0, 2)

--- a/corehq/motech/repeaters/tests/test_models.py
+++ b/corehq/motech/repeaters/tests/test_models.py
@@ -26,6 +26,7 @@ from ..const import (
     MAX_BACKOFF_ATTEMPTS,
     RECORD_QUEUED_STATES,
     State,
+    states_for_key,
 )
 from ..models import (
     HTTP_STATUS_BACK_OFF,
@@ -810,8 +811,17 @@ class TestRepeatRecordManager(RepeaterTestCase):
     def test_get_repeat_record_ids_for_state(self):
         cancelled = self.new_record(state=State.Cancelled, next_check=None)
         self.new_record(state=State.Success, next_check=None)
-        ids = RepeatRecord.objects.get_repeat_record_ids(DOMAIN, state=State.Cancelled)
+        ids = RepeatRecord.objects.get_repeat_record_ids(DOMAIN, states=[State.Cancelled])
         assert Counter([cancelled.id]) == Counter(ids)
+
+    def test_get_repeat_record_ids_for_state_group(self):
+        rejected = self.new_record(state=State.PayloadRejected, next_check=None)
+        error = self.new_record(state=State.ErrorGeneratingPayload, next_check=None)
+        self.new_record(state=State.Cancelled, next_check=None)
+        ids = RepeatRecord.objects.get_repeat_record_ids(
+            DOMAIN, states=states_for_key('PAYLOADERROR')
+        )
+        assert Counter([rejected.id, error.id]) == Counter(ids)
 
     def test_get_repeat_record_ids_for_payload(self):
         actual = self.new_record(payload_id="waldo")
@@ -829,7 +839,7 @@ class TestRepeatRecordManager(RepeaterTestCase):
         self.new_record_for_repeater(non_default_repeater, state=State.Fail, payload_id="not-waldo")
         self.new_record_for_repeater(self.repeater, state=State.Fail, payload_id="waldo")
         ids = RepeatRecord.objects.get_repeat_record_ids(
-            DOMAIN, repeater_id=non_default_repeater.id, state=State.Fail, payload_id="waldo"
+            DOMAIN, repeater_id=non_default_repeater.id, states=[State.Fail], payload_id="waldo"
         )
         assert Counter([actual.id]) == Counter(ids)
 

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -38,7 +38,7 @@ from corehq.motech.models import RequestLog
 from corehq.motech.utils import pformat_json
 from corehq.util.xml_utils import indent_xml
 
-from ..const import State
+from ..const import states_for_key
 from ..exceptions import BulkActionMissingParameters
 from ..models import RepeatRecord
 from .repeat_record_display import RepeatRecordDisplay
@@ -97,8 +97,8 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
         query = RepeatRecord.objects.filter(domain=self.domain)
         if self.repeater_id:
             query = query.filter(repeater_id=self.repeater_id)
-        if self.state:
-            query = query.filter(state=self.state)
+        if self.states:
+            query = query.filter(state__in=self.states)
         return query.count()
 
     @property
@@ -117,8 +117,8 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
         )
         if self.repeater_id:
             query = query.filter(repeater_id=self.repeater_id)
-        if self.state:
-            query = query.filter(state=self.state)
+        if self.states:
+            query = query.filter(state__in=self.states)
         return list(query)
 
     @property
@@ -130,8 +130,14 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
         return self.request.GET.get('repeater', None)
 
     @property
-    def state(self):
-        return State.state_for_key(self.request.GET.get('record_state'))
+    def state_group(self):
+        """The STATE_GROUPS key selected in the Record Status filter"""
+        key = self.request.GET.get('record_state')
+        return key.upper() if states_for_key(key) else None
+
+    @property
+    def states(self):
+        return states_for_key(self.state_group)
 
     @property
     def rows(self):
@@ -144,7 +150,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
                 self.pagination.start,
                 self.pagination.count,
                 repeater_id=self.repeater_id,
-                states=[self.state] if self.state else None,
+                states=self.states,
             )
         rows = [self._make_row(record) for record in records]
         return rows
@@ -213,15 +219,15 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
             where &= Q(repeater_id=self.repeater_id)
         if self.payload_id:
             where &= Q(payload_id=self.payload_id)
-        if self.state:
-            where &= Q(state=self.state)
+        if self.states:
+            where &= Q(state__in=self.states)
         total = RepeatRecord.objects.filter(where).count()
 
         context.update(
             total=total,
             payload_id=self.payload_id,
             repeater_id=self.repeater_id,
-            state=self.state.name.upper() if self.state else None,
+            state=self.state_group,
         )
         return context
 
@@ -350,14 +356,14 @@ def _get_record_ids_from_request(request):
     return record_ids.strip().split()
 
 
-def _get_state(request: HttpRequest) -> str:
+def _get_states(request: HttpRequest) -> tuple | None:
     state_from_request = request.POST.get('state')
     if not state_from_request:
         return None
-    state = State.state_for_key(state_from_request)
-    if not state:
-        raise KeyError(f"{state_from_request} is not a valid option for RepeatRecord.State")
-    return state
+    states = states_for_key(state_from_request)
+    if not states:
+        raise KeyError(f"{state_from_request} does not name a group in STATE_GROUPS")
+    return states
 
 
 def _schedule_task_with_state(
@@ -370,9 +376,9 @@ def _schedule_task_with_state(
     repeater_id = request.POST.get('repeater_id', None)
     if not any([repeater_id, payload_id]):
         raise BulkActionMissingParameters
-    state = _get_state(request)
+    states = _get_states(request)
     task = task_generate_ids_and_operate_on_payloads.delay(
-        payload_id, repeater_id, domain, action, state=state)
+        payload_id, repeater_id, domain, action, state=states)
     task_ref.set_task(task)
 
 

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -144,7 +144,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
                 self.pagination.start,
                 self.pagination.count,
                 repeater_id=self.repeater_id,
-                state=self.state
+                states=[self.state] if self.state else None,
             )
         rows = [self._make_row(record) for record in records]
         return rows

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -24,7 +24,7 @@ from corehq.apps.users.models import HqPermissions
 from corehq.motech.const import PASSWORD_PLACEHOLDER
 from corehq.motech.models import ConnectionSettings
 
-from ..const import RECORD_QUEUED_STATES, State
+from ..const import RECORD_QUEUED_STATES, STATE_GROUPS
 from ..forms import CaseRepeaterForm, FormRepeaterForm, GenericRepeaterForm
 from ..models import (
     Repeater,
@@ -52,16 +52,11 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
         def get_repeaters_with_state_counts(repeater_class):
             repeaters = repeater_class.objects.by_domain(self.domain)
             for repeater in repeaters:
-                assert not hasattr(repeater, "count_State"), repeater.count_State
-                repeater.count_State = {s.name: state_counts[repeater.id][s] for s in State}
-                repeater.count_State['EmptyOrSuccess'] = (
-                    repeater.count_State[State.Empty.name]
-                    + repeater.count_State[State.Success.name]
-                )
-                repeater.count_State['ErrorGeneratingPayloadOrRejected'] = (
-                    repeater.count_State[State.ErrorGeneratingPayload.name]
-                    + repeater.count_State[State.PayloadRejected.name]
-                )
+                assert not hasattr(repeater, "state_group_counts"), repeater.state_group_counts
+                repeater.state_group_counts = {
+                    key: sum(state_counts[repeater.id][state] for state in states)
+                    for key, states in STATE_GROUPS.items()
+                }
             return repeaters
 
         return [

--- a/corehq/motech/repeaters/views/tests/test_repeat_records.py
+++ b/corehq/motech/repeaters/views/tests/test_repeat_records.py
@@ -72,26 +72,45 @@ class TestDomainForwardingOptionsView(TestCase):
             next_check=datetime.utcnow(),
         )
 
-    def test_get_repeater_types_info(self):
+    def _get_repeater_with_counts(self):
         class view:
             domain = "test"
         state_counts = RepeatRecord.objects.count_by_repeater_and_state("test")
         infos = repeaters.DomainForwardingOptionsView.get_repeater_types_info(view, state_counts)
         repeater, = {i.class_name: i for i in infos}['FormRepeater'].instances
+        return repeater
 
-        self.assertEqual(repeater.count_State, {
-            # templates that reference `count_State` may need to be
-            # updated if the keys in this dict change
-            'Cancelled': 0,
-            'Empty': 0,
-            'EmptyOrSuccess': 0,
-            'ErrorGeneratingPayload': 0,
-            'ErrorGeneratingPayloadOrRejected': 0,
-            'Fail': 0,
-            'PayloadRejected': 0,
-            'Pending': 1,
-            'Success': 0
+    def test_get_repeater_types_info(self):
+        repeater = self._get_repeater_with_counts()
+
+        self.assertEqual(repeater.state_group_counts, {
+            # templates that reference `state_group_counts` may need to
+            # be updated if the keys in this dict change
+            'SUCCESS': 0,
+            'PENDING': 1,
+            'CANCELLED': 0,
+            'FAIL': 0,
+            'PAYLOADERROR': 0,
         })
+
+    def test_counts_include_every_state_in_a_group(self):
+        for state in (
+            State.Success,
+            State.Empty,
+            State.PayloadRejected,
+            State.ErrorGeneratingPayload,
+        ):
+            self.repeater.repeat_records.create(
+                domain=self.repeater.domain,
+                payload_id="3978e5d2bc2346fe958b933870c5b28a",
+                registered_at=datetime.utcnow(),
+                state=state,
+            )
+
+        repeater = self._get_repeater_with_counts()
+
+        assert repeater.state_group_counts['SUCCESS'] == 2
+        assert repeater.state_group_counts['PAYLOADERROR'] == 2
 
 
 class TestRepeatRecordView(TestCase):

--- a/corehq/motech/repeaters/views/tests/test_repeat_records.py
+++ b/corehq/motech/repeaters/views/tests/test_repeat_records.py
@@ -33,21 +33,25 @@ class TestUtilities(SimpleTestCase):
             records_ids = repeat_records._get_record_ids_from_request(mock_request)
             self.assertEqual(records_ids, expected_result)
 
-    def test__get_state(self):
+    def test__get_states(self):
         mock_request = Mock()
-        state_values = [None, 'PENDING']
-        expected_results = [None, State.Pending]
+        state_values = [None, '', 'PENDING', 'PAYLOADERROR']
+        expected_results = [
+            None,
+            None,
+            (State.Pending,),
+            (State.PayloadRejected, State.ErrorGeneratingPayload),
+        ]
         for value, expected_result in zip(state_values, expected_results):
             mock_request.POST.get.return_value = value
-            result = repeat_records._get_state(mock_request)
+            result = repeat_records._get_states(mock_request)
             assert result == expected_result
 
-    def test__get_state_raises_key_error(self):
+    def test__get_states_raises_key_error(self):
         mock_request = Mock()
-        state_values = ['', 'ALL']
-        for value in state_values:
-            with self.assertRaises(KeyError):
-                repeat_records._get_state(mock_request)
+        mock_request.POST.get.return_value = 'ALL'
+        with self.assertRaises(KeyError):
+            repeat_records._get_states(mock_request)
 
 
 class TestDomainForwardingOptionsView(TestCase):


### PR DESCRIPTION
## Product Description

There was a bug with the record status filter on the repeat record report. In code, it mentioned that the success and empty states were combined in the UI, as were the payload rejected and error generating payload states. However in the backend this was not the case, and only one of the two states was included in the filter.

Picking "Payload Rejected" used to return only records in the `PayloadRejected` state, even though the count it was linked from on the Data Forwarding page ("Invalid") also included records whose payload could not be generated. The count and the report it linked to disagreed.

The option is now called **Payload Error** and covers both payload-rejected and payload-generation-failure records. "Succeeded" covers empty records.
<img width="1404" height="803" alt="image" src="https://github.com/user-attachments/assets/ecfda188-b29d-4f1a-87de-b7750c02ed25" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-20085

`STATE_GROUPS` in `repeaters/const.py` maps user-facing record status groups to the backend states it includes. The filter's option keys, the `record_state` URL param, and the per-status counts on Data Forwarding all derive from it, so a count and the report it links to can no longer drift  apart which is what produced this bug. Queries moved from `state=` to `state__in=`.

Two things to know about the diff:

- Bookmarked report URLs with `record_state=PAYLOADREJECTED` no longer name a group and fall back to Show All. Similarly, stale POSTs for bulk actions would raise an error rather than  widening the target since the payload error state string changed.
- `task_generate_ids_and_operate_on_payloads` keeps its `state` kwarg name and normalizes a single `State` into a list. That's deliberate as it means a bulk action queued by the previous release doesn't hit an unexpected-kwarg failure after a deploy. It can be dropped once those tasks have drained.


## Feature Flag

n/a

## Safety Assurance

### Safety story

Read-only reporting change. No migrations, no data touched. The only non-report surface is the bulk resend/cancel/requeue task, whose selection query widened from one state to a group.

### Automated test coverage

- `repeaters/tests/test_const.py` — `states_for_key`, plus an invariant that every `State` belongs to exactly one group. That invariant is the bug. A state in no group is unreachable from the filter, which is exactly what happened to `ErrorGeneratingPayload` and `Empty`.
- Data Forwarding counts sum every state in a group (`SUCCESS` = Success + Empty, `PAYLOADERROR` = PayloadRejected + ErrorGeneratingPayload).

### QA Plan

Tested on staging

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

One caveat rather than a blocker: a bulk-action task queued by this release and still in the queue at rollback would carry a sequence where the old code expects a single state, and would fail. The blast radius is a failed bulk action inside the rollback window with no permanent issues, but would need to manually re-run the task.

### Labels & Review

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
