### PR TITLE
Enforce the six-year retention policy on audit records

### DIFF
--- a/corehq/apps/auditcare/README.md
+++ b/corehq/apps/auditcare/README.md
@@ -81,6 +81,16 @@ If all 5,001 rows fall within the same minute (making minute-boundary trimming
 impossible), the report shows the first 5,000 rows with a warning that
 additional events in that minute are not displayed.
 
+## Retention
+
+Audit records are kept for `AUDITCARE_RETENTION_YEARS` (default 6, overridable
+per environment in `localsettings`). A monthly Celery task,
+`prune_auditcare_tables`, drops whole monthly partitions once every record in
+them is older than that cutoff.
+
+Searches beyond the retention window therefore return no results even for
+periods when activity did occur.
+
 ## Underlying models
 
 **`NavigationEventAudit`** — Records HTTP requests. Key fields: `user`,

--- a/corehq/apps/auditcare/README.md
+++ b/corehq/apps/auditcare/README.md
@@ -84,9 +84,10 @@ additional events in that minute are not displayed.
 ## Retention
 
 Audit records are kept for `AUDITCARE_RETENTION_YEARS` (default 6, overridable
-per environment in `localsettings`). A monthly Celery task,
-`prune_auditcare_tables`, drops whole monthly partitions once every record in
-them is older than that cutoff.
+per environment in `localsettings`). The pruning task enforces a floor of
+`MINIMUM_RETENTION_YEARS` (6), so the setting can lengthen the retention window
+but never shorten it. A monthly Celery task, `prune_auditcare_tables`, drops
+whole monthly partitions once every record in them is older than that cutoff.
 
 Searches beyond the retention window therefore return no results even for
 periods when activity did occur.

--- a/corehq/apps/auditcare/README.md
+++ b/corehq/apps/auditcare/README.md
@@ -84,10 +84,13 @@ additional events in that minute are not displayed.
 ## Retention
 
 Audit records are kept for `AUDITCARE_RETENTION_YEARS` (default 6, overridable
-per environment in `localsettings`). The pruning task enforces a floor of
-`MINIMUM_RETENTION_YEARS` (6), so the setting can lengthen the retention window
-but never shorten it. A monthly Celery task, `prune_auditcare_tables`, drops
-whole monthly partitions once every record in them is older than that cutoff.
+per environment in `localsettings`). A monthly Celery task,
+`prune_auditcare_tables`, drops whole monthly partitions once every record in
+them is older than that cutoff.
+
+The task enforces a floor of `MINIMUM_RETENTION_YEARS` (6), so the setting can
+lengthen the retention window but never shorten it. Setting it to `None`
+disables pruning entirely, and audit data is kept indefinitely.
 
 Searches beyond the retention window therefore return no results even for
 periods when activity did occur.

--- a/corehq/apps/auditcare/tasks.py
+++ b/corehq/apps/auditcare/tasks.py
@@ -1,11 +1,3 @@
-"""Prune auditcare tables outside of retention window defined in
-``settings.AUDITCARE_RETENTION_YEARS``
-
-``NavigationEventAudit`` and ``AccessAudit`` are partitioned by month on
-``event_date``, and each monthly table carries a ``CHECK`` constraint
-bounding it to that month. Therefore the month in a partition's name is
-enough to prove every row it holds predates the retention cutoff.
-"""
 import logging
 import re
 from datetime import UTC, date, datetime

--- a/corehq/apps/auditcare/tasks.py
+++ b/corehq/apps/auditcare/tasks.py
@@ -16,7 +16,7 @@ from django.db import connections, router
 from celery.schedules import crontab
 from dateutil.relativedelta import relativedelta
 
-from dimagi.utils.logging import notify_exception
+from dimagi.utils.logging import notify_error, notify_exception
 
 from corehq.apps.celery import periodic_task
 from corehq.util.metrics import metrics_gauge
@@ -89,6 +89,14 @@ def _drop_expired_partitions(model, cutoff):
     to_drop = _get_partitions_to_drop(partitioned_tables, base_table, cutoff)
     dropped = 0
     for table_name in sorted(to_drop):
+        newest = _get_newest_event_date(db, table_name)
+        if newest is not None and newest.date() >= cutoff:
+            notify_error(
+                f'Refusing to drop auditcare partition {table_name}: its name '
+                f'says it predates the {cutoff} retention cutoff but it holds '
+                f'rows up to {newest}'
+            )
+            continue
         with connections[db].cursor() as cursor:
             cursor.execute(f'DROP TABLE IF EXISTS "{table_name}"')
         log.info(
@@ -98,3 +106,10 @@ def _drop_expired_partitions(model, cutoff):
         )
         dropped += 1
     return dropped
+
+
+def _get_newest_event_date(db, table_name):
+    """Return the newest ``event_date`` in the partition, or None if it is empty"""
+    with connections[db].cursor() as cursor:
+        cursor.execute(f'SELECT MAX(event_date) FROM "{table_name}"')
+        return cursor.fetchone()[0]

--- a/corehq/apps/auditcare/tasks.py
+++ b/corehq/apps/auditcare/tasks.py
@@ -30,6 +30,9 @@ MINIMUM_RETENTION_YEARS = 6
 def prune_auditcare_tables():
     """Drop partitions older than the retention window."""
     cutoff = _get_cutoff_date()
+    if cutoff is None:
+        log.info('Auditcare pruning is disabled by AUDITCARE_RETENTION_YEARS')
+        return
     for model in MODELS_TO_PRUNE:
         try:
             dropped = _drop_expired_partitions(model, cutoff)
@@ -50,14 +53,19 @@ def prune_auditcare_tables():
 
 
 def _get_cutoff_date():
-    """Return the date before which audit records may be pruned
+    """Return the date before which audit records may be pruned, or
+    ``None`` if pruning is disabled
 
-    ``settings.AUDITCARE_RETENTION_YEARS`` can only lengthen the
-    retention window, never shorten it below
-    ``MINIMUM_RETENTION_YEARS``.
+    Setting ``AUDITCARE_RETENTION_YEARS`` to ``None`` turns pruning off.
+    Any other value can only lengthen the retention window, never
+    shorten it below ``MINIMUM_RETENTION_YEARS``.
     """
-    years = max(MINIMUM_RETENTION_YEARS, settings.AUDITCARE_RETENTION_YEARS)
-    return datetime.now(UTC).date() - relativedelta(years=years)
+    years = settings.AUDITCARE_RETENTION_YEARS
+    if years is None:
+        return None
+    return datetime.now(UTC).date() - relativedelta(
+        years=max(MINIMUM_RETENTION_YEARS, years)
+    )
 
 
 def _get_partitions_for_base_table(db, base_table):
@@ -87,7 +95,10 @@ def _get_partitions_to_drop(existing_table_names, base_table, cutoff_date):
 
 
 def _drop_expired_partitions(model, cutoff):
-    if cutoff > _get_cutoff_date():
+    latest_allowed_cutoff = _get_cutoff_date()
+    if latest_allowed_cutoff is None:
+        raise ValueError('Refusing to prune auditcare: pruning is disabled')
+    if cutoff > latest_allowed_cutoff:
         raise ValueError(
             f'Refusing to prune auditcare with cutoff {cutoff}: it is inside '
             f'the retention window'

--- a/corehq/apps/auditcare/tasks.py
+++ b/corehq/apps/auditcare/tasks.py
@@ -1,0 +1,100 @@
+"""Prune auditcare tables outside of retention window defined in
+``settings.AUDITCARE_RETENTION_YEARS``
+
+``NavigationEventAudit`` and ``AccessAudit`` are partitioned by month on
+``event_date``, and each monthly table carries a ``CHECK`` constraint
+bounding it to that month. Therefore the month in a partition's name is
+enough to prove every row it holds predates the retention cutoff.
+"""
+import logging
+import re
+from datetime import UTC, date, datetime
+
+from django.conf import settings
+from django.db import connections, router
+
+from celery.schedules import crontab
+from dateutil.relativedelta import relativedelta
+
+from dimagi.utils.logging import notify_exception
+
+from corehq.apps.celery import periodic_task
+from corehq.util.metrics import metrics_gauge
+
+from .models import AccessAudit, NavigationEventAudit
+
+log = logging.getLogger(__name__)
+
+MODELS_TO_PRUNE = [NavigationEventAudit, AccessAudit]
+
+
+@periodic_task(
+    run_every=crontab(hour=2, minute=0, day_of_month='1'),
+    queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'),
+)
+def prune_auditcare_tables():
+    """Drop partitions older than ``AUDITCARE_RETENTION_YEARS``."""
+    cutoff = datetime.now(UTC).date() - relativedelta(
+        years=settings.AUDITCARE_RETENTION_YEARS
+    )
+    for model in MODELS_TO_PRUNE:
+        try:
+            dropped = _drop_expired_partitions(model, cutoff)
+        except Exception:
+            notify_exception(
+                None,
+                'Error pruning auditcare partitions',
+                details={
+                    'model': model.__name__,
+                },
+            )
+        else:
+            metrics_gauge(
+                'commcare.auditcare.partitions_dropped',
+                dropped,
+                tags={'model': model.__name__},
+            )
+
+
+def _get_partitions_for_base_table(db, base_table):
+    """Return the names of ``base_table``'s partitions from Postgres"""
+    with connections[db].cursor() as cursor:
+        cursor.execute(
+            'SELECT tablename FROM pg_tables WHERE tablename LIKE %s',
+            [f'{base_table}_y%m%'],
+        )
+        return [row[0] for row in cursor.fetchall()]
+
+
+def _get_partitions_to_drop(existing_table_names, base_table, cutoff_date):
+    """Return partitioned tables whose month and year is older than ``cutoff_date``"""
+    table_name_pattern = re.compile(
+        rf'^{re.escape(base_table)}_y(\d{{4}})m(\d{{2}})$'
+    )
+    cutoff_month = date(cutoff_date.year, cutoff_date.month, 1)
+
+    def is_expired(match):
+        year, month = int(match.group(1)), int(match.group(2))
+        # only strictly older months are dropped
+        return date(year, month, 1) < cutoff_month
+
+    matches = (table_name_pattern.match(name) for name in existing_table_names)
+    return [match.group(0) for match in matches if match and is_expired(match)]
+
+
+def _drop_expired_partitions(model, cutoff):
+    db = router.db_for_write(model)
+    base_table = model._meta.db_table
+    partitioned_tables = _get_partitions_for_base_table(db, base_table)
+    to_drop = _get_partitions_to_drop(partitioned_tables, base_table, cutoff)
+    dropped = 0
+    for table_name in sorted(to_drop):
+        with connections[db].cursor() as cursor:
+            cursor.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+        log.info(
+            'Dropped expired auditcare partition %s (retention cutoff %s)',
+            table_name,
+            cutoff,
+        )
+        dropped += 1
+    return dropped

--- a/corehq/apps/auditcare/tasks.py
+++ b/corehq/apps/auditcare/tasks.py
@@ -20,16 +20,16 @@ log = logging.getLogger(__name__)
 
 MODELS_TO_PRUNE = [NavigationEventAudit, AccessAudit]
 
+MINIMUM_RETENTION_YEARS = 6
+
 
 @periodic_task(
     run_every=crontab(hour=2, minute=0, day_of_month='1'),
     queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'),
 )
 def prune_auditcare_tables():
-    """Drop partitions older than ``AUDITCARE_RETENTION_YEARS``."""
-    cutoff = datetime.now(UTC).date() - relativedelta(
-        years=settings.AUDITCARE_RETENTION_YEARS
-    )
+    """Drop partitions older than the retention window."""
+    cutoff = _get_cutoff_date()
     for model in MODELS_TO_PRUNE:
         try:
             dropped = _drop_expired_partitions(model, cutoff)
@@ -47,6 +47,17 @@ def prune_auditcare_tables():
                 dropped,
                 tags={'model': model.__name__},
             )
+
+
+def _get_cutoff_date():
+    """Return the date before which audit records may be pruned
+
+    ``settings.AUDITCARE_RETENTION_YEARS`` can only lengthen the
+    retention window, never shorten it below
+    ``MINIMUM_RETENTION_YEARS``.
+    """
+    years = max(MINIMUM_RETENTION_YEARS, settings.AUDITCARE_RETENTION_YEARS)
+    return datetime.now(UTC).date() - relativedelta(years=years)
 
 
 def _get_partitions_for_base_table(db, base_table):
@@ -76,6 +87,11 @@ def _get_partitions_to_drop(existing_table_names, base_table, cutoff_date):
 
 
 def _drop_expired_partitions(model, cutoff):
+    if cutoff > _get_cutoff_date():
+        raise ValueError(
+            f'Refusing to prune auditcare with cutoff {cutoff}: it is inside '
+            f'the retention window'
+        )
     db = router.db_for_write(model)
     base_table = model._meta.db_table
     partitioned_tables = _get_partitions_for_base_table(db, base_table)

--- a/corehq/apps/auditcare/tasks.py
+++ b/corehq/apps/auditcare/tasks.py
@@ -7,6 +7,7 @@ from django.db import connections, router
 
 from celery.schedules import crontab
 from dateutil.relativedelta import relativedelta
+from psycopg2 import sql
 
 from dimagi.utils.logging import notify_error, notify_exception
 
@@ -90,7 +91,11 @@ def _drop_expired_partitions(model, cutoff):
             )
             continue
         with connections[db].cursor() as cursor:
-            cursor.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+            cursor.execute(
+                sql.SQL('DROP TABLE IF EXISTS {}').format(
+                    sql.Identifier(table_name)
+                )
+            )
         log.info(
             'Dropped expired auditcare partition %s (retention cutoff %s)',
             table_name,
@@ -103,5 +108,9 @@ def _drop_expired_partitions(model, cutoff):
 def _get_newest_event_date(db, table_name):
     """Return the newest ``event_date`` in the partition, or None if it is empty"""
     with connections[db].cursor() as cursor:
-        cursor.execute(f'SELECT MAX(event_date) FROM "{table_name}"')
+        cursor.execute(
+            sql.SQL('SELECT MAX(event_date) FROM {}').format(
+                sql.Identifier(table_name)
+            )
+        )
         return cursor.fetchone()[0]

--- a/corehq/apps/auditcare/tests/test_tasks.py
+++ b/corehq/apps/auditcare/tests/test_tasks.py
@@ -39,6 +39,17 @@ def test_setting_can_only_lengthen_the_retention_window(retention_years, expecte
     assert cutoff == expected
 
 
+def test_setting_of_none_disables_pruning():
+    with override_settings(AUDITCARE_RETENTION_YEARS=None):
+        assert _get_cutoff_date() is None
+
+
+def test_refuses_to_drop_partitions_when_pruning_is_disabled():
+    with override_settings(AUDITCARE_RETENTION_YEARS=None):
+        with pytest.raises(ValueError, match='pruning is disabled'):
+            _drop_expired_partitions(AccessAudit, date(2015, 3, 1))
+
+
 def test_no_partitions_means_nothing_to_drop():
     partitions_to_drop = _get_partitions_to_drop([], BASE_TABLE, date(2030, 1, 1))
     assert partitions_to_drop == []
@@ -179,6 +190,15 @@ class TestPruneAuditcarePartitions(AuditcareTest):
         self.insert_row(table_name, datetime.utcnow())
 
         prune_auditcare_tables()
+
+        assert table_name in self.get_partition_tables(AccessAudit)
+
+    def test_keeps_an_expired_partition_when_pruning_is_disabled(self):
+        table_name = f'{BASE_TABLE}_y2015m03'
+        self.create_partition_without_check_constraint(table_name)
+
+        with override_settings(AUDITCARE_RETENTION_YEARS=None):
+            prune_auditcare_tables()
 
         assert table_name in self.get_partition_tables(AccessAudit)
 

--- a/corehq/apps/auditcare/tests/test_tasks.py
+++ b/corehq/apps/auditcare/tests/test_tasks.py
@@ -7,6 +7,7 @@ from django.db import connections, router
 
 from corehq.util.metrics.tests.utils import capture_metrics
 
+from ..models import AccessAudit
 from ..tasks import (
     MODELS_TO_PRUNE,
     _get_partitions_to_drop,
@@ -140,6 +141,46 @@ class TestPruneAuditcarePartitions(AuditcareTest):
             assert metrics.sum(
                 'commcare.auditcare.partitions_dropped', model=model.__name__
             ) == len(dropped)
+
+    def test_drops_an_expired_partition_holding_no_rows(self):
+        table_name = f'{BASE_TABLE}_y2015m03'
+        self.create_partition_without_check_constraint(table_name)
+
+        prune_auditcare_tables()
+
+        assert table_name not in self.get_partition_tables(AccessAudit)
+
+    def test_keeps_an_expired_partition_holding_rows_within_retention(self):
+        """This should be impossible in practice using architect, so
+        reaching it means an error with architect's configuration to
+        ensure data is only saved to its relevant partition
+        """
+        table_name = f'{BASE_TABLE}_y2015m03'
+        self.create_partition_without_check_constraint(table_name)
+        self.insert_row(table_name, datetime.utcnow())
+
+        prune_auditcare_tables()
+
+        assert table_name in self.get_partition_tables(AccessAudit)
+
+    def create_partition_without_check_constraint(self, table_name):
+        db = router.db_for_write(AccessAudit)
+        with connections[db].cursor() as cursor:
+            cursor.execute(
+                f'CREATE TABLE "{table_name}" '
+                f'(LIKE "{BASE_TABLE}" INCLUDING DEFAULTS) '
+                f'INHERITS ("{BASE_TABLE}")'
+            )
+
+    def insert_row(self, table_name, event_date):
+        db = router.db_for_write(AccessAudit)
+        with connections[db].cursor() as cursor:
+            cursor.execute(
+                f'INSERT INTO "{table_name}" '
+                f'(id, event_date, access_type, path, ip_address) '
+                f'VALUES (%s, %s, %s, %s, %s)',
+                [1, event_date, 'i', '/a/block/login', '127.0.0.1'],
+            )
 
     def get_partition_tables(self, model):
         db = router.db_for_write(model)

--- a/corehq/apps/auditcare/tests/test_tasks.py
+++ b/corehq/apps/auditcare/tests/test_tasks.py
@@ -1,0 +1,157 @@
+from datetime import date, datetime
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.db import connections, router
+
+from corehq.util.metrics.tests.utils import capture_metrics
+
+from ..tasks import (
+    MODELS_TO_PRUNE,
+    _get_partitions_to_drop,
+    prune_auditcare_tables,
+)
+from .testutils import AuditcareTest
+
+BASE_TABLE = 'auditcare_accessaudit'
+
+
+def test_no_partitions_means_nothing_to_drop():
+    partitions_to_drop = _get_partitions_to_drop([], BASE_TABLE, date(2030, 1, 1))
+    assert partitions_to_drop == []
+
+
+@pytest.mark.parametrize(
+    'table_name',
+    [
+        BASE_TABLE,  # the parent table itself
+        'auditcare_navigationeventaudit_y2020m01',  # the other model's partition
+        'phone_synclogsql_y2020w01',  # an unrelated partitioned table
+        f'{BASE_TABLE}_y2020m1',  # month not zero padded
+        f'{BASE_TABLE}_y20m01',  # two digit year
+        f'{BASE_TABLE}_y2020m01_backup',  # a manual copy of a partition
+        f'{BASE_TABLE}_y2020w01',  # weekly rather than monthly
+        f'{BASE_TABLE}_null',  # architect's partition for null event_date
+    ],
+)
+def test_ignores_tables_that_are_not_monthly_partitions(table_name):
+    partitions_to_drop = _get_partitions_to_drop([table_name], BASE_TABLE, date(2030, 1, 1))
+    assert partitions_to_drop == []
+
+
+def test_partition_containing_the_cutoff_is_kept():
+    existing = [f'{BASE_TABLE}_y2020m06']
+    partitions_to_drop = _get_partitions_to_drop(existing, BASE_TABLE, date(2020, 6, 15))
+    assert partitions_to_drop == []
+
+
+def test_partition_containing_the_cutoff_is_kept_when_cutoff_is_first_of_month():
+    existing = [f'{BASE_TABLE}_y2020m06']
+    partitions_to_drop = _get_partitions_to_drop(existing, BASE_TABLE, date(2020, 6, 1))
+    assert partitions_to_drop == []
+
+
+def test_partition_one_month_before_the_cutoff_is_dropped():
+    existing = [f'{BASE_TABLE}_y2020m05']
+    partitions_to_drop = _get_partitions_to_drop(existing, BASE_TABLE, date(2020, 6, 15))
+    assert partitions_to_drop == [f'{BASE_TABLE}_y2020m05']
+
+
+def test_partition_one_month_after_the_cutoff_is_kept():
+    existing = [f'{BASE_TABLE}_y2020m07']
+    partitions_to_drop = _get_partitions_to_drop(existing, BASE_TABLE, date(2020, 6, 15))
+    assert partitions_to_drop == []
+
+
+def test_cutoff_in_january_drops_the_previous_december():
+    existing = [
+        f'{BASE_TABLE}_y2019m12',
+        f'{BASE_TABLE}_y2020m01',
+    ]
+    partitions_to_drop = _get_partitions_to_drop(existing, BASE_TABLE, date(2020, 1, 10))
+    assert partitions_to_drop == [f'{BASE_TABLE}_y2019m12']
+
+
+def test_drops_every_month_older_than_the_cutoff():
+    existing = [
+        f'{BASE_TABLE}_y2018m11',
+        f'{BASE_TABLE}_y2018m12',
+        f'{BASE_TABLE}_y2019m01',
+        f'{BASE_TABLE}_y2019m06',
+        f'{BASE_TABLE}_y2019m07',  # the cutoff month
+        f'{BASE_TABLE}_y2019m08',
+        f'{BASE_TABLE}_y2020m01',
+    ]
+    partitions_to_drop = _get_partitions_to_drop(existing, BASE_TABLE, date(2019, 7, 20))
+    assert partitions_to_drop == [
+        f'{BASE_TABLE}_y2018m11',
+        f'{BASE_TABLE}_y2018m12',
+        f'{BASE_TABLE}_y2019m01',
+        f'{BASE_TABLE}_y2019m06',
+    ]
+
+
+def test_matches_partitions_of_the_model_it_was_given():
+    existing = [
+        'auditcare_navigationeventaudit_y2018m01',
+        f'{BASE_TABLE}_y2018m01',
+    ]
+    base_table = 'auditcare_navigationeventaudit'
+    partitions_to_drop = _get_partitions_to_drop(existing, base_table, date(2026, 1, 1))
+    assert partitions_to_drop == ['auditcare_navigationeventaudit_y2018m01']
+
+
+class TestPruneAuditcarePartitions(AuditcareTest):
+    def test_drops_only_partitions_older_than_the_retention_period(self):
+        cutoff = date.today() - relativedelta(
+            years=settings.AUDITCARE_RETENTION_YEARS
+        )
+        # two expired dates, so the task has to drop more than one partition
+        expired_dates = [
+            datetime(cutoff.year - 3, 1, 15),
+            datetime(cutoff.year - 1, 7, 15),
+        ]
+        retained_date = datetime.utcnow()
+        for model in MODELS_TO_PRUNE:
+            model.objects.bulk_create(
+                [
+                    model(user='melvin@test.com', event_date=event_date)
+                    for event_date in expired_dates + [retained_date]
+                ]
+            )
+        tables_before = {
+            model: self.get_partition_tables(model)
+            for model in MODELS_TO_PRUNE
+        }
+
+        with capture_metrics() as metrics:
+            prune_auditcare_tables()
+
+        for model in MODELS_TO_PRUNE:
+            remaining = self.get_partition_tables(model)
+            dropped = tables_before[model] - remaining
+            assert self.partitions_for(model, expired_dates) == dropped
+            assert self.partitions_for(model, [retained_date]) == remaining
+            assert model.objects.filter(event_date=retained_date).exists()
+            assert not model.objects.filter(
+                event_date__in=expired_dates
+            ).exists()
+            assert metrics.sum(
+                'commcare.auditcare.partitions_dropped', model=model.__name__
+            ) == len(dropped)
+
+    def get_partition_tables(self, model):
+        db = router.db_for_write(model)
+        with connections[db].cursor() as cursor:
+            cursor.execute(
+                'SELECT tablename FROM pg_tables WHERE tablename LIKE %s',
+                [f'{model._meta.db_table}_%'],
+            )
+            return {row[0] for row in cursor.fetchall()}
+
+    def partitions_for(self, model, event_dates):
+        return {
+            f'{model._meta.db_table}_y{d.year}m{d.month:02d}'
+            for d in event_dates
+        }

--- a/corehq/apps/auditcare/tests/test_tasks.py
+++ b/corehq/apps/auditcare/tests/test_tasks.py
@@ -1,21 +1,42 @@
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 
 import pytest
 from dateutil.relativedelta import relativedelta
-from django.conf import settings
 from django.db import connections, router
+from django.test import override_settings
 
 from corehq.util.metrics.tests.utils import capture_metrics
 
 from ..models import AccessAudit
 from ..tasks import (
+    MINIMUM_RETENTION_YEARS,
     MODELS_TO_PRUNE,
+    _drop_expired_partitions,
+    _get_cutoff_date,
     _get_partitions_to_drop,
     prune_auditcare_tables,
 )
 from .testutils import AuditcareTest
 
 BASE_TABLE = 'auditcare_accessaudit'
+
+
+@pytest.mark.parametrize(
+    'retention_years, expected_years',
+    [
+        (0, MINIMUM_RETENTION_YEARS),
+        (-1, MINIMUM_RETENTION_YEARS),
+        (MINIMUM_RETENTION_YEARS - 1, MINIMUM_RETENTION_YEARS),
+        (MINIMUM_RETENTION_YEARS, MINIMUM_RETENTION_YEARS),
+        (MINIMUM_RETENTION_YEARS + 1, MINIMUM_RETENTION_YEARS + 1),
+        (25, 25),
+    ],
+)
+def test_setting_can_only_lengthen_the_retention_window(retention_years, expected_years):
+    with override_settings(AUDITCARE_RETENTION_YEARS=retention_years):
+        cutoff = _get_cutoff_date()
+    expected = datetime.now(UTC).date() - relativedelta(years=expected_years)
+    assert cutoff == expected
 
 
 def test_no_partitions_means_nothing_to_drop():
@@ -105,9 +126,7 @@ def test_matches_partitions_of_the_model_it_was_given():
 
 class TestPruneAuditcarePartitions(AuditcareTest):
     def test_drops_only_partitions_older_than_the_retention_period(self):
-        cutoff = date.today() - relativedelta(
-            years=settings.AUDITCARE_RETENTION_YEARS
-        )
+        cutoff = _get_cutoff_date()
         # two expired dates, so the task has to drop more than one partition
         expired_dates = [
             datetime(cutoff.year - 3, 1, 15),
@@ -160,6 +179,16 @@ class TestPruneAuditcarePartitions(AuditcareTest):
         self.insert_row(table_name, datetime.utcnow())
 
         prune_auditcare_tables()
+
+        assert table_name in self.get_partition_tables(AccessAudit)
+
+    def test_refuses_a_cutoff_inside_the_retention_window(self):
+        table_name = f'{BASE_TABLE}_y2015m03'
+        self.create_partition_without_check_constraint(table_name)
+        cutoff_one_day_too_recent = _get_cutoff_date() + relativedelta(days=1)
+
+        with pytest.raises(ValueError, match='inside the retention window'):
+            _drop_expired_partitions(AccessAudit, cutoff_one_day_too_recent)
 
         assert table_name in self.get_partition_tables(AccessAudit)
 

--- a/settings.py
+++ b/settings.py
@@ -787,6 +787,7 @@ AUDIT_ALL_VIEWS = False
 AUDIT_VIEWS = []
 AUDIT_MODULES = []
 AUDIT_ADMIN_VIEWS = False
+AUDITCARE_RETENTION_YEARS = 6
 
 # Don't use google analytics unless overridden in localsettings
 ANALYTICS_IDS = {


### PR DESCRIPTION
## Product Description

Auditcare records older than six years are now deleted. The User Audit Report will return no results for periods beyond that window even where activity did occur, so an empty result set is no longer evidence that nothing happened. The auditcare README documents this so investigators aren't misled by it, though no change was made to display this in the report itself.

## Technical Summary

https://dimagi.atlassian.net/browse/SAAS-20045

This enforces the data retention policy we already have which is that audit records over 6 years old may be deleted. The window is now defined in `settings.AUDITCARE_RETENTION_YEARS`.

`NavigationEventAudit` and `AccessAudit` are partitioned by month on `event_date` via `architect`, so expired data can be reclaimed by dropping partitions instead of issuing row-level `DELETE`s.

We already prune a similar table in `prune_synclogs`, which decides which tables to drop via `Min('date')`. I took a similar approach here, though the implementation differs a bit. I start by fetching the partitions that are eligible to be dropped based on name, and then confirm they are safe to drop by looking at the max `event_date` in the partition. Since we have an index on `event_date`, that is a cheap lookup.

I'd like to followup this work by sharing this code with the `prune_synclogs` function to consolidate slightly duplicated code, and make it is easier to add pruning to any partitioned tables in the future. I created https://dimagi.atlassian.net/browse/SAAS-20147 for this.

## Feature Flag

N/A

## Safety Assurance

### Safety story

This permanently destroys compliance-relevant data, so the destructive decision is isolated in `_get_partitions_to_drop` and an additional check is performed to ensure the partition doesn't contain data newer than the retention cutoff.

### Automated test coverage

All in `corehq/apps/auditcare/tests/test_tasks.py`.

### QA Plan
Tested against local database:
```
     table                                         result    verdict why
     --------------------------------------------------------------------------------------------------------------
     auditcare_accessaudit_y2015m03                DROPPED   ok      expected drop: expired and empty
     auditcare_accessaudit_y2019m08                DROPPED   ok      expected drop: a year before the cutoff month
     auditcare_accessaudit_y2020m07                DROPPED   ok      expected drop: the month right before the cutoff
     auditcare_navigationeventaudit_y2019m08       DROPPED   ok      expected drop: a year before the cutoff month
     auditcare_navigationeventaudit_y2020m07       DROPPED   ok      expected drop: the month right before the cutoff
     auditcare_accessaudit_y2016m04                KEPT      ok      expected keep: name says expired but it holds a row inside the window (content guard)
     auditcare_accessaudit_y2020m08                KEPT      ok      expected keep: the cutoff month: its row predates the cutoff but the month straddles it
     auditcare_accessaudit_y2026m08                KEPT      ok      expected keep: the current month
     auditcare_navigationeventaudit_y2020m08       KEPT      ok      expected keep: the cutoff month: its row predates the cutoff but the month straddles it
     auditcare_navigationeventaudit_y2026m08       KEPT      ok      expected keep: the current month
```

### Rollback instructions
None

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
