### PR TITLE
Public Webforms: Create a public webform

### DIFF
--- a/corehq/apps/app_manager/const.py
+++ b/corehq/apps/app_manager/const.py
@@ -125,3 +125,13 @@ ANDROID_LOGO_PROPERTY_MAPPING = {
 
 LATEST_APK_VALUE = 'latest'
 LATEST_APP_VALUE = 0
+
+NON_BUILD_APP_KEYS = (
+    '_id',
+    '_rev',
+    '_attachments',
+    'external_blobs',
+    'short_odk_url',
+    'short_odk_media_url',
+    'recipients',
+)

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -183,8 +183,13 @@ class CommCareFeatureSupportMixin(object):
 
     @property
     def supports_session_endpoints(self):
+        # _force_session_endpoints lets a build emit endpoints regardless of the
+        # domain toggle (set transiently for public webform endpoint builds).
         return (
-            toggles.SESSION_ENDPOINTS.enabled(self.domain)
+            (
+                getattr(self, '_force_session_endpoints', False)
+                or toggles.SESSION_ENDPOINTS.enabled(self.domain)
+            )
             and self._require_minimum_version('2.51')
         )
 

--- a/corehq/apps/app_manager/models/applications.py
+++ b/corehq/apps/app_manager/models/applications.py
@@ -61,6 +61,7 @@ from corehq.apps.app_manager.const import (
     ANDROID_LOGO_PROPERTY_MAPPING,
     LATEST_APK_VALUE,
     LATEST_APP_VALUE,
+    NON_BUILD_APP_KEYS,
 )
 from corehq.apps.app_manager.dbaccessors import (
     domain_has_apps,
@@ -695,12 +696,9 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
             copy = copies[0]
         else:
             copy = deepcopy(self.to_json())
-            bad_keys = ('_id', '_rev', '_attachments', 'external_blobs',
-                        'short_odk_url', 'short_odk_media_url', 'recipients')
-
-            for bad_key in bad_keys:
-                if bad_key in copy:
-                    del copy[bad_key]
+            for key in NON_BUILD_APP_KEYS:
+                if key in copy:
+                    del copy[key]
 
             copy = cls.wrap(copy)
             copy.convert_app_to_build(self._id, user_id, comment)

--- a/corehq/apps/public_webforms/app_builds.py
+++ b/corehq/apps/public_webforms/app_builds.py
@@ -1,6 +1,4 @@
-"""Create the session endpoint a public webform navigates to.
-
-Public webforms deep-link into a form via a session endpoint in a build's
+"""Public webforms deep-link into a form via a session endpoint in a build's
 suite. Each webform gets its own build, generated from the app's latest
 released build with an endpoint added to the target form.
 
@@ -19,7 +17,7 @@ BUILD_COMMENT = "Automatically created for a public webform"
 PUBLIC_WEBFORM_COPY_OF_SUFFIX = "__public_webform"
 
 
-def create_public_webform_endpoint(domain, app_id, form_unique_id):
+def create_public_webform_build(domain, app_id, form_unique_id):
     """Return ``(app_build_id, endpoint_id)`` for the target form.
 
     An endpoint is generated rather than reusing one the form may already

--- a/corehq/apps/public_webforms/endpoints.py
+++ b/corehq/apps/public_webforms/endpoints.py
@@ -11,7 +11,7 @@ build lineage (version history, latest build, releases, revert).
 from copy import deepcopy
 from uuid import uuid4
 
-from corehq.apps.app_manager.dbaccessors import get_latest_released_app
+from corehq.apps.app_manager.dbaccessors import get_app, get_latest_released_app
 
 BUILD_COMMENT = "Automatically created for a public webform"
 STRIPPED_BUILD_KEYS = (
@@ -41,6 +41,13 @@ def create_public_webform_endpoint(domain, app_id, form_unique_id):
     new_build.create_build_files()
     new_build.save()
     return new_build._id, endpoint_id
+
+
+def delete_public_webform_build(domain, app_build_id):
+    """Delete a build that was generated explicitly for a public webform."""
+    build = get_app(domain, app_build_id)
+    build.delete_app()
+    build.save(increment_version=False)
 
 
 def _public_webform_copy_of(app_id):

--- a/corehq/apps/public_webforms/endpoints.py
+++ b/corehq/apps/public_webforms/endpoints.py
@@ -1,0 +1,56 @@
+"""Create the session endpoint a public webform navigates to.
+
+Public webforms deep-link into a form via a session endpoint in a build's
+suite. Each webform gets its own build, generated from the app's latest
+released build with an endpoint added to the target form.
+
+The generated build is "detached": its ``copy_of`` is a sentinel rather than
+the canonical app id, so it is served by build id but stays out of the app's
+build lineage (version history, latest build, releases, revert).
+"""
+from copy import deepcopy
+from uuid import uuid4
+
+from corehq.apps.app_manager.dbaccessors import get_latest_released_app
+
+BUILD_COMMENT = "Automatically created for a public webform"
+STRIPPED_BUILD_KEYS = (
+    '_id', '_rev', '_attachments', 'external_blobs',
+    'short_odk_url', 'short_odk_media_url', 'recipients',
+)
+
+
+def create_public_webform_endpoint(domain, app_id, form_unique_id):
+    """Return ``(app_build_id, endpoint_id)`` for the target form.
+
+    An endpoint is generated rather than reusing one the form may already
+    have, so that a webform never depends on a build someone can delete.
+    """
+    released_build = get_latest_released_app(domain, app_id)
+    endpoint_id = uuid4().hex
+    new_build = _copy_for_build(released_build)
+    new_build._force_session_endpoints = True
+    new_build.get_form(form_unique_id).session_endpoint_id = endpoint_id
+    new_build.convert_app_to_build(
+        _public_webform_copy_of(released_build.copy_of),
+        user_id=None,
+        comment=BUILD_COMMENT,
+    )
+    new_build.copy_attachments(released_build)
+    new_build._id = uuid4().hex
+    new_build.create_build_files()
+    new_build.save()
+    return new_build._id, endpoint_id
+
+
+def _public_webform_copy_of(app_id):
+    """A traceable, non-canonical ``copy_of``: keeps the doc a build (``copy_of``
+    stays truthy) and out of the app's lineage, while recording its origin."""
+    return f'{app_id}__public_webform'
+
+
+def _copy_for_build(released_build):
+    doc = deepcopy(released_build.to_json())
+    for key in STRIPPED_BUILD_KEYS:
+        doc.pop(key, None)
+    return type(released_build).wrap(doc)

--- a/corehq/apps/public_webforms/endpoints.py
+++ b/corehq/apps/public_webforms/endpoints.py
@@ -13,8 +13,10 @@ from uuid import uuid4
 
 from corehq.apps.app_manager.const import NON_BUILD_APP_KEYS
 from corehq.apps.app_manager.dbaccessors import get_app, get_latest_released_app
+from corehq.blobs import get_blob_db
 
 BUILD_COMMENT = "Automatically created for a public webform"
+PUBLIC_WEBFORM_COPY_OF_SUFFIX = "__public_webform"
 
 
 def create_public_webform_endpoint(domain, app_id, form_unique_id):
@@ -41,16 +43,24 @@ def create_public_webform_endpoint(domain, app_id, form_unique_id):
 
 
 def delete_public_webform_build(domain, app_build_id):
-    """Delete a build that was generated explicitly for a public webform."""
+    """Hard-delete a build that was generated explicitly for a public webform.
+    """
     build = get_app(domain, app_build_id)
-    build.delete_app()
-    build.save(increment_version=False)
+    assert _is_public_webform_build(build)
+    blob_db = get_blob_db()
+    build_files = blob_db.metadb.get_for_parent(build.get_id)
+    build.delete()
+    blob_db.bulk_delete(metas=build_files)
+
+
+def _is_public_webform_build(build):
+    return build.copy_of.endswith(PUBLIC_WEBFORM_COPY_OF_SUFFIX)
 
 
 def _public_webform_copy_of(app_id):
     """A traceable, non-canonical ``copy_of``: keeps the doc a build (``copy_of``
     stays truthy) and out of the app's lineage, while recording its origin."""
-    return f'{app_id}__public_webform'
+    return f'{app_id}{PUBLIC_WEBFORM_COPY_OF_SUFFIX}'
 
 
 def _copy_for_build(released_build):

--- a/corehq/apps/public_webforms/endpoints.py
+++ b/corehq/apps/public_webforms/endpoints.py
@@ -11,13 +11,10 @@ build lineage (version history, latest build, releases, revert).
 from copy import deepcopy
 from uuid import uuid4
 
+from corehq.apps.app_manager.const import NON_BUILD_APP_KEYS
 from corehq.apps.app_manager.dbaccessors import get_app, get_latest_released_app
 
 BUILD_COMMENT = "Automatically created for a public webform"
-STRIPPED_BUILD_KEYS = (
-    '_id', '_rev', '_attachments', 'external_blobs',
-    'short_odk_url', 'short_odk_media_url', 'recipients',
-)
 
 
 def create_public_webform_endpoint(domain, app_id, form_unique_id):
@@ -58,6 +55,6 @@ def _public_webform_copy_of(app_id):
 
 def _copy_for_build(released_build):
     doc = deepcopy(released_build.to_json())
-    for key in STRIPPED_BUILD_KEYS:
+    for key in NON_BUILD_APP_KEYS:
         doc.pop(key, None)
     return type(released_build).wrap(doc)

--- a/corehq/apps/public_webforms/form_choices.py
+++ b/corehq/apps/public_webforms/form_choices.py
@@ -1,0 +1,69 @@
+from corehq.apps.app_manager.dbaccessors import (
+    get_latest_released_app,
+    get_latest_released_app_versions_by_app_id,
+)
+from corehq.apps.app_manager.exceptions import FormNotFoundException
+from corehq.apps.public_webforms.models import PublicWebformType
+
+
+def get_public_webform_choices(domain):
+    """Return the drilldown tree of applications, menus, and eligible forms
+    from latest released app builds.
+
+    The structure is ``[{'id', 'name', 'version', 'menus': [{'id', 'name',
+    'forms': [{'id', 'name', 'session_type'}]}]}]``. Menus and applications
+    with no eligible forms are omitted.
+    """
+    options = []
+    for app_id in get_latest_released_app_versions_by_app_id(domain):
+        app = get_latest_released_app(domain, app_id)
+        if app is None:
+            continue
+        menus = []
+        for module in app.get_modules():
+            if module.module_type != 'basic':
+                continue
+            forms = [
+                {
+                    'id': form.unique_id,
+                    'name': form.default_name(),
+                    'session_type': get_public_webform_type(form).value,
+                }
+                for form in module.get_forms()
+                if not form.requires_case()
+            ]
+            if forms:
+                menus.append({
+                    'id': module.unique_id,
+                    'name': module.default_name(app),
+                    'forms': forms,
+                })
+        if menus:
+            options.append({
+                'id': app_id,
+                'name': app.name,
+                'version': app.version,
+                'menus': menus,
+            })
+    return options
+
+
+def get_public_webform_eligible_form(domain, app_id, form_unique_id):
+    app = get_latest_released_app(domain, app_id)
+    if app is None:
+        return None
+    try:
+        form = app.get_form(form_unique_id)
+    except FormNotFoundException:
+        return None
+    if form.get_module().module_type != 'basic' or form.requires_case():
+        return None
+    return form
+
+
+def get_public_webform_type(form):
+    return (
+        PublicWebformType.REGISTRATION
+        if form.is_registration_form()
+        else PublicWebformType.SURVEY
+    )

--- a/corehq/apps/public_webforms/form_choices.py
+++ b/corehq/apps/public_webforms/form_choices.py
@@ -8,11 +8,8 @@ from corehq.apps.public_webforms.models import PublicWebformType
 
 def get_public_webform_choices(domain):
     """Return the drilldown tree of applications, menus, and eligible forms
-    from latest released app builds.
-
-    The structure is ``[{'id', 'name', 'version', 'menus': [{'id', 'name',
-    'forms': [{'id', 'name'}]}]}]``. Menus and applications
-    with no eligible forms are omitted.
+    from latest released app builds. Menus and applications with no eligible
+    forms are omitted.
     """
     options = []
     for app_id in get_latest_released_app_versions_by_app_id(domain):

--- a/corehq/apps/public_webforms/form_choices.py
+++ b/corehq/apps/public_webforms/form_choices.py
@@ -11,7 +11,7 @@ def get_public_webform_choices(domain):
     from latest released app builds.
 
     The structure is ``[{'id', 'name', 'version', 'menus': [{'id', 'name',
-    'forms': [{'id', 'name', 'session_type'}]}]}]``. Menus and applications
+    'forms': [{'id', 'name'}]}]}]``. Menus and applications
     with no eligible forms are omitted.
     """
     options = []
@@ -27,7 +27,6 @@ def get_public_webform_choices(domain):
                 {
                     'id': form.unique_id,
                     'name': form.default_name(),
-                    'session_type': get_public_webform_type(form).value,
                 }
                 for form in module.get_forms()
                 if not form.requires_case()
@@ -66,4 +65,4 @@ def get_public_webform_type(form):
         PublicWebformType.REGISTRATION
         if form.is_registration_form()
         else PublicWebformType.SURVEY
-    )
+    ).value

--- a/corehq/apps/public_webforms/forms.py
+++ b/corehq/apps/public_webforms/forms.py
@@ -35,7 +35,7 @@ class CreatePublicWebformForm(forms.Form):
         help_text=gettext_lazy("Identifies this public webform. Respondents will see the form's name.")
     )
     expires_at = forms.DateTimeField(
-        label=gettext_lazy("Close Requests On"),
+        label=gettext_lazy("Close Requests At"),
         help_text=gettext_lazy(
             "The public request page closes at this time. "
             "One-time links already sent can be used until they expire."

--- a/corehq/apps/public_webforms/forms.py
+++ b/corehq/apps/public_webforms/forms.py
@@ -1,0 +1,128 @@
+import json
+from datetime import datetime, timedelta
+
+from django import forms
+from django.urls import reverse
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
+
+from crispy_forms import bootstrap as twbscrispy
+from crispy_forms import layout as crispy
+
+from corehq import privileges
+from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.hqwebapp import crispy as hqcrispy
+from corehq.apps.hqwebapp.widgets import BootstrapSwitchInput
+from corehq.util.timezones.conversions import ServerTime, UserTime
+
+
+class CreatePublicWebformForm(forms.Form):
+    label = forms.CharField(
+        label=gettext_lazy("Label"),
+        help_text=gettext_lazy("Identifies this public webform. Respondents will see the form's name.")
+    )
+    expires_at = forms.DateTimeField(
+        label=gettext_lazy("Close Requests On"),
+        help_text=gettext_lazy(
+            "The public request page closes at this time. "
+            "One-time links already sent can be used until they expire."
+        ),
+    )
+    link_choices = forms.MultipleChoiceField(
+        label=gettext_lazy("How Respondents Receive Their One-time Link"),
+        choices=[],
+        initial=['allow_email'],
+        widget=forms.CheckboxSelectMultiple,
+    )
+    open_to_requests = forms.BooleanField(
+        required=False,
+        label=gettext_lazy("Open to Requests"),
+        widget=BootstrapSwitchInput(
+            inline_label=gettext_lazy(
+                "Immediately open this public webform to one-time link requests."
+            ),
+        ),
+    )
+    app_id = forms.CharField(required=False, widget=forms.HiddenInput)
+    form_unique_id = forms.CharField(required=False, widget=forms.HiddenInput)
+
+    def __init__(self, domain, timezone, *args, **kwargs):
+        self.domain = domain
+        self.timezone = timezone
+        super().__init__(*args, **kwargs)
+
+        link_choices = [(
+            'allow_email',
+            format_html(
+                '{} <div class="form-text">{}</div>',
+                _("Email"),
+                _("A branded email with a single-use link.")
+            ),
+        )]
+        if domain_has_privilege(domain, privileges.OUTBOUND_SMS):
+            link_choices.append((
+                'allow_sms',
+                format_html(
+                    '{} <div class="form-text">{}</div>',
+                    _("SMS"),
+                    _("A short text with a shortened link. Billed per message sent.")
+                ),
+            ))
+        self.fields['link_choices'].choices = link_choices
+
+        default_expires_at = (
+            ServerTime(datetime.now()).user_time(self.timezone).done()
+            + timedelta(days=30)
+        )
+        self.fields['expires_at'].initial = default_expires_at.strftime('%Y-%m-%d %H:%M:%S')
+
+        self.helper = hqcrispy.HQFormHelper()
+        self.helper.form_method = 'POST'
+
+        alpine_data_model = {
+            'expires_at': self.fields['expires_at'].initial,
+        }
+        self.helper.layout = crispy.Layout(
+            crispy.Fieldset(
+                _("New Public Webform"),
+                crispy.Field('label'),
+                crispy.Div(
+                    twbscrispy.AppendedText(
+                        'expires_at',
+                        mark_safe(  # nosec: no user input
+                            '<i class="fcc fcc-fd-datetime"></i>'
+                        ),
+                        x_datepicker=json.dumps(
+                            {
+                                'useInputGroup': True,
+                                'datetime': True,
+                            }
+                        ),
+                    ),
+                    x_data=json.dumps(alpine_data_model),
+                ),
+                crispy.Field('link_choices'),
+                twbscrispy.PrependedText('open_to_requests', ''),
+            ),
+            hqcrispy.FormActions(
+                crispy.ButtonHolder(
+                    hqcrispy.LinkButton(
+                        _("Cancel"),
+                        reverse('manage_public_webforms', args=[self.domain]),
+                        css_class='btn btn-outline-primary',
+                    ),
+                    crispy.Submit(
+                        'create_public_webform',
+                        _("Create Public Webform"),
+                        css_class='disable-on-submit',
+                    ),
+                )
+            ),
+        )
+
+    def clean_expires_at(self):
+        # The datepicker submits wall-clock time in the project's timezone; store UTC.
+        expires_at = self.cleaned_data['expires_at']
+        return UserTime(expires_at, tzinfo=self.timezone).server_time().done()

--- a/corehq/apps/public_webforms/forms.py
+++ b/corehq/apps/public_webforms/forms.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 from django import forms
 from django.template.loader import render_to_string
@@ -84,10 +84,11 @@ class CreatePublicWebformForm(forms.Form):
         self.fields['link_choices'].choices = link_choices
 
         default_expires_at = (
-            ServerTime(datetime.now()).user_time(self.timezone).done()
-            + timedelta(days=30)
+            ServerTime(datetime.now(UTC).replace(tzinfo=None) + timedelta(days=30))
+            .user_time(self.timezone)
+            .ui_string(fmt='%Y-%m-%d %H:%M:%S')
         )
-        self.fields['expires_at'].initial = default_expires_at.strftime('%Y-%m-%d %H:%M:%S')
+        self.fields['expires_at'].initial = default_expires_at
 
         self.helper = hqcrispy.HQFormHelper()
         self.helper.form_method = 'POST'

--- a/corehq/apps/public_webforms/forms.py
+++ b/corehq/apps/public_webforms/forms.py
@@ -16,8 +16,8 @@ from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import BootstrapSwitchInput
-from corehq.apps.public_webforms.endpoints import (
-    create_public_webform_endpoint,
+from corehq.apps.public_webforms.app_builds import (
+    create_public_webform_build,
     delete_public_webform_build,
 )
 from corehq.apps.public_webforms.form_choices import (
@@ -162,7 +162,7 @@ class CreatePublicWebformForm(forms.Form):
     def create_public_webform(self):
         app_id = self.cleaned_data['app_id']
         form_unique_id = self.cleaned_data['form_unique_id']
-        app_build_id, endpoint_id = create_public_webform_endpoint(
+        app_build_id, endpoint_id = create_public_webform_build(
             self.domain, app_id, form_unique_id)
         link_choices = self.cleaned_data['link_choices']
         try:

--- a/corehq/apps/public_webforms/forms.py
+++ b/corehq/apps/public_webforms/forms.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime, timedelta
 
 from django import forms
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -15,6 +16,11 @@ from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import BootstrapSwitchInput
+from corehq.apps.public_webforms.form_choices import (
+    get_public_webform_choices,
+    get_public_webform_eligible_form,
+    get_public_webform_type,
+)
 from corehq.util.timezones.conversions import ServerTime, UserTime
 
 
@@ -87,6 +93,10 @@ class CreatePublicWebformForm(forms.Form):
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 _("New Public Webform"),
+                crispy.HTML(render_to_string(
+                    'public_webforms/partials/create_form_choices.html',
+                    context={'form_choices': json.dumps(get_public_webform_choices(self.domain))},
+                )),
                 crispy.Field('label'),
                 crispy.Div(
                     twbscrispy.AppendedText(
@@ -121,6 +131,22 @@ class CreatePublicWebformForm(forms.Form):
                 )
             ),
         )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        app_id = cleaned_data.get('app_id')
+        form_unique_id = cleaned_data.get('form_unique_id')
+        if not app_id or not form_unique_id:
+            raise forms.ValidationError(_("Please select an application, menu, and form."))
+
+        form = get_public_webform_eligible_form(self.domain, app_id, form_unique_id)
+        if not form:
+            raise forms.ValidationError(_(
+                "The selected form can't be used for a public webform."
+            ))
+
+        cleaned_data['session_type'] = get_public_webform_type(form).value
+        return cleaned_data
 
     def clean_expires_at(self):
         # The datepicker submits wall-clock time in the project's timezone; store UTC.

--- a/corehq/apps/public_webforms/forms.py
+++ b/corehq/apps/public_webforms/forms.py
@@ -16,7 +16,10 @@ from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import BootstrapSwitchInput
-from corehq.apps.public_webforms.endpoints import create_public_webform_endpoint
+from corehq.apps.public_webforms.endpoints import (
+    create_public_webform_endpoint,
+    delete_public_webform_build,
+)
 from corehq.apps.public_webforms.form_choices import (
     get_public_webform_choices,
     get_public_webform_eligible_form,
@@ -161,16 +164,22 @@ class CreatePublicWebformForm(forms.Form):
         app_build_id, endpoint_id = create_public_webform_endpoint(
             self.domain, app_id, form_unique_id)
         link_choices = self.cleaned_data['link_choices']
-        return PublicWebform.objects.create(
-            domain=self.domain,
-            label=self.cleaned_data['label'],
-            app_id=app_id,
-            app_build_id=app_build_id,
-            form_unique_id=form_unique_id,
-            endpoint_id=endpoint_id,
-            session_type=self.cleaned_data['session_type'],
-            expires_at=self.cleaned_data['expires_at'],
-            allow_email='allow_email' in link_choices,
-            allow_sms='allow_sms' in link_choices,
-            is_disabled=not self.cleaned_data['open_to_requests'],
-        )
+        try:
+            return PublicWebform.objects.create(
+                domain=self.domain,
+                label=self.cleaned_data['label'],
+                app_id=app_id,
+                app_build_id=app_build_id,
+                form_unique_id=form_unique_id,
+                endpoint_id=endpoint_id,
+                session_type=self.cleaned_data['session_type'],
+                expires_at=self.cleaned_data['expires_at'],
+                allow_email='allow_email' in link_choices,
+                allow_sms='allow_sms' in link_choices,
+                is_disabled=not self.cleaned_data['open_to_requests'],
+            )
+        except Exception:
+            # The build is written to Couch and the webform to SQL; ensure we
+            # delete the build on webform create failure.
+            delete_public_webform_build(self.domain, app_build_id)
+            raise

--- a/corehq/apps/public_webforms/forms.py
+++ b/corehq/apps/public_webforms/forms.py
@@ -16,11 +16,13 @@ from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import BootstrapSwitchInput
+from corehq.apps.public_webforms.endpoints import create_public_webform_endpoint
 from corehq.apps.public_webforms.form_choices import (
     get_public_webform_choices,
     get_public_webform_eligible_form,
     get_public_webform_type,
 )
+from corehq.apps.public_webforms.models import PublicWebform
 from corehq.util.timezones.conversions import ServerTime, UserTime
 
 
@@ -152,3 +154,23 @@ class CreatePublicWebformForm(forms.Form):
         # The datepicker submits wall-clock time in the project's timezone; store UTC.
         expires_at = self.cleaned_data['expires_at']
         return UserTime(expires_at, tzinfo=self.timezone).server_time().done()
+
+    def create_public_webform(self):
+        app_id = self.cleaned_data['app_id']
+        form_unique_id = self.cleaned_data['form_unique_id']
+        app_build_id, endpoint_id = create_public_webform_endpoint(
+            self.domain, app_id, form_unique_id)
+        link_choices = self.cleaned_data['link_choices']
+        return PublicWebform.objects.create(
+            domain=self.domain,
+            label=self.cleaned_data['label'],
+            app_id=app_id,
+            app_build_id=app_build_id,
+            form_unique_id=form_unique_id,
+            endpoint_id=endpoint_id,
+            session_type=self.cleaned_data['session_type'],
+            expires_at=self.cleaned_data['expires_at'],
+            allow_email='allow_email' in link_choices,
+            allow_sms='allow_sms' in link_choices,
+            is_disabled=not self.cleaned_data['open_to_requests'],
+        )

--- a/corehq/apps/public_webforms/forms.py
+++ b/corehq/apps/public_webforms/forms.py
@@ -150,7 +150,7 @@ class CreatePublicWebformForm(forms.Form):
                 "The selected form can't be used for a public webform."
             ))
 
-        cleaned_data['session_type'] = get_public_webform_type(form).value
+        cleaned_data['session_type'] = get_public_webform_type(form)
         return cleaned_data
 
     def clean_expires_at(self):

--- a/corehq/apps/public_webforms/static/public_webforms/js/create.js
+++ b/corehq/apps/public_webforms/static/public_webforms/js/create.js
@@ -4,4 +4,21 @@ import 'hqwebapp/js/htmx_base';
 import Alpine from 'alpinejs';
 import 'hqwebapp/js/alpinejs/directives/datepicker';
 
+document.addEventListener('alpine:init', () => {
+    Alpine.data('formChoices', (initial) => ({
+        apps: initial.apps,
+        appId: '',
+        menuId: '',
+        formId: '',
+        get menus() {
+            const app = this.apps.find((app) => app.id === this.appId);
+            return app ? app.menus : [];
+        },
+        get forms() {
+            const menu = this.menus.find((menu) => menu.id === this.menuId);
+            return menu ? menu.forms : [];
+        },
+    }));
+});
+
 Alpine.start();

--- a/corehq/apps/public_webforms/static/public_webforms/js/create.js
+++ b/corehq/apps/public_webforms/static/public_webforms/js/create.js
@@ -1,0 +1,7 @@
+import 'commcarehq';
+import 'hqwebapp/js/htmx_base';
+
+import Alpine from 'alpinejs';
+import 'hqwebapp/js/alpinejs/directives/datepicker';
+
+Alpine.start();

--- a/corehq/apps/public_webforms/templates/public_webforms/create.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/create.html
@@ -1,6 +1,8 @@
 {% extends 'hqwebapp/bootstrap5/base_section.html' %}
-{% load i18n %}
+{% load crispy_forms_tags %}
+{% load hq_shared_tags %}
+{% js_entry 'public_webforms/js/create' %}
 
 {% block page_content %}
-  <h1 class="page-title">{% trans "New Public Webform" %}</h1>
+  {% crispy form %}
 {% endblock %}

--- a/corehq/apps/public_webforms/templates/public_webforms/create.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/create.html
@@ -1,0 +1,6 @@
+{% extends 'hqwebapp/bootstrap5/base_section.html' %}
+{% load i18n %}
+
+{% block page_content %}
+  <h1 class="page-title">{% trans "New Public Webform" %}</h1>
+{% endblock %}

--- a/corehq/apps/public_webforms/templates/public_webforms/manage.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/manage.html
@@ -11,4 +11,14 @@
       revoke access at any time.
     {% endblocktrans %}
   </p>
+
+  <div class="mb-3">
+    <a
+      class="btn btn-primary icon-link"
+      href="{% url 'create_public_webform' domain %}"
+    >
+      <i class="fa fa-plus"></i>
+      {% trans "New Public Webform" %}
+    </a>
+  </div>
 {% endblock %}

--- a/corehq/apps/public_webforms/templates/public_webforms/manage.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/manage.html
@@ -1,0 +1,14 @@
+{% extends 'hqwebapp/bootstrap5/base_section.html' %}
+{% load i18n %}
+
+{% block page_content %}
+  <h1 class="page-title">{% trans "Public Webforms" %}</h1>
+  <p class="lead">
+    {% blocktrans %}
+      Publish a registration or survey form to a public URL. Respondents request
+      a one-time link, pass a bot check, and complete the form once — no
+      CommCare account needed. Manage which forms are open, when they close, and
+      revoke access at any time.
+    {% endblocktrans %}
+  </p>
+{% endblock %}

--- a/corehq/apps/public_webforms/templates/public_webforms/partials/create_form_choices.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/partials/create_form_choices.html
@@ -1,0 +1,78 @@
+{% load i18n %}
+<div
+  x-data="formChoices({
+      apps: {{ form_choices }} || [],
+  })"
+>
+  <div class="row mb-3">
+    <label class="field-label" for="id_application"
+      >{% trans "Application" %}<span class="asteriskField">*</span></label
+    >
+    <div class="field-control">
+      <select
+        id="id_application"
+        name="app_id"
+        class="form-select"
+        required
+        x-model="appId"
+        @change="menuId = ''; formId = ''"
+      >
+        <option value="">{% trans "Select Application" %}</option>
+        <template x-for="app in apps" :key="app.id">
+          <option
+            :value="app.id"
+            x-text="`${app.name} (v${app.version})`"
+          ></option>
+        </template>
+      </select>
+    </div>
+  </div>
+  <div class="row mb-3">
+    <label class="field-label" for="id_public_webform_menu"
+      >{% trans "Menu" %}<span class="asteriskField">*</span></label
+    >
+    <div class="field-control">
+      <select
+        id="id_public_webform_menu"
+        class="form-select"
+        required
+        disabled
+        x-model="menuId"
+        :disabled="!appId"
+        @change="formId = ''"
+      >
+        <option value="">{% trans "Select Menu" %}</option>
+        <template x-for="menu in menus" :key="menu.id">
+          <option :value="menu.id" x-text="menu.name"></option>
+        </template>
+      </select>
+    </div>
+  </div>
+  <div class="row mb-3">
+    <label class="field-label" for="id_form"
+      >{% trans "Form" %}<span class="asteriskField">*</span></label
+    >
+    <div class="field-control">
+      <select
+        id="id_form"
+        name="form_unique_id"
+        class="form-select"
+        required
+        disabled
+        x-model="formId"
+        :disabled="!menuId"
+      >
+        <option value="">{% trans "Select Form" %}</option>
+        <template x-for="form in forms" :key="form.id">
+          <option :value="form.id" x-text="form.name"></option>
+        </template>
+      </select>
+      <div class="form-text">
+        {% blocktrans %}
+          Only <strong>registration</strong> and <strong>survey</strong> forms
+          are eligible. Forms that update existing cases can't be made public.
+        {% endblocktrans %}
+      </div>
+    </div>
+  </div>
+</div>

--- a/corehq/apps/public_webforms/tests/test_endpoints.py
+++ b/corehq/apps/public_webforms/tests/test_endpoints.py
@@ -42,7 +42,7 @@ def released_app():
             )
     finally:
         delete_all_apps()
-        domain_obj.get_db().delete_doc(domain_obj.get_id)
+        domain_obj.delete()
 
 
 @use(released_app)
@@ -58,8 +58,7 @@ class TestCreatePublicWebformEndpoint:
         # detached from the app's lineage, but traceable back to it
         assert new_build.copy_of == f'{app.app_id}__public_webform'
         suite = new_build.fetch_attachment('files/suite.xml')
-        if isinstance(suite, bytes):
-            suite = suite.decode('utf-8')
+        suite = suite.decode('utf-8')
         assert endpoint_id in suite
 
     def test_canonical_is_never_written(self):
@@ -75,12 +74,6 @@ class TestCreatePublicWebformEndpoint:
         create_public_webform_endpoint(app.domain, app.app_id, app.form_unique_id)
         # the generated build must not become the app's latest build
         assert get_latest_build_id(app.domain, app.app_id) == app.build_id
-
-    def test_released_build_is_untouched(self):
-        app = released_app()
-        create_public_webform_endpoint(app.domain, app.app_id, app.form_unique_id)
-        released = get_app(app.domain, app.build_id)
-        assert released.get_form(app.form_unique_id).session_endpoint_id is None
 
     def test_always_generates_an_endpoint(self):
         """Reusing an endpoint would pin a build a user can delete."""

--- a/corehq/apps/public_webforms/tests/test_endpoints.py
+++ b/corehq/apps/public_webforms/tests/test_endpoints.py
@@ -1,8 +1,10 @@
 from types import SimpleNamespace
 
+import pytest
 from unmagic import fixture, use
 
 from corehq.apps.app_manager.dbaccessors import get_app, get_latest_build_id
+from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import (
     delete_all_apps,
@@ -12,7 +14,9 @@ from corehq.apps.app_manager.tests.util import (
 from corehq.apps.domain.models import Domain
 from corehq.apps.public_webforms.endpoints import (
     create_public_webform_endpoint,
+    delete_public_webform_build,
 )
+from corehq.blobs import get_blob_db
 
 DOMAIN = 'public-webform-endpoints'
 
@@ -89,3 +93,26 @@ class TestCreatePublicWebformEndpoint:
 
         assert build_id != app.build_id
         assert endpoint_id != 'existing-endpoint'
+
+
+@use(released_app)
+class TestDeletePublicWebformBuild:
+
+    def test_deletes_the_build_doc_and_its_build_files(self):
+        app = released_app()
+        build_id, __ = create_public_webform_endpoint(
+            app.domain, app.app_id, app.form_unique_id)
+        assert get_blob_db().metadb.get_for_parent(build_id)
+
+        delete_public_webform_build(app.domain, build_id)
+
+        # a hard delete: no soft-deleted doc, no orphaned build files
+        assert not Application.get_db().doc_exist(build_id)
+        assert get_blob_db().metadb.get_for_parent(build_id) == []
+
+    def test_leaves_a_build_it_did_not_generate_alone(self):
+        app = released_app()
+        with pytest.raises(AssertionError):
+            delete_public_webform_build(app.domain, app.build_id)
+        assert Application.get_db().doc_exist(app.build_id)
+        assert get_blob_db().metadb.get_for_parent(app.build_id)

--- a/corehq/apps/public_webforms/tests/test_endpoints.py
+++ b/corehq/apps/public_webforms/tests/test_endpoints.py
@@ -12,8 +12,8 @@ from corehq.apps.app_manager.tests.util import (
     patch_validate_xform,
 )
 from corehq.apps.domain.models import Domain
-from corehq.apps.public_webforms.endpoints import (
-    create_public_webform_endpoint,
+from corehq.apps.public_webforms.app_builds import (
+    create_public_webform_build,
     delete_public_webform_build,
 )
 from corehq.blobs import get_blob_db
@@ -54,7 +54,7 @@ class TestCreatePublicWebformEndpoint:
 
     def test_generates_detached_build_emitting_the_endpoint(self):
         app = released_app()
-        build_id, endpoint_id = create_public_webform_endpoint(
+        build_id, endpoint_id = create_public_webform_build(
             app.domain, app.app_id, app.form_unique_id)
 
         assert build_id != app.build_id
@@ -68,14 +68,14 @@ class TestCreatePublicWebformEndpoint:
     def test_canonical_is_never_written(self):
         app = released_app()
         version_before = get_app(app.domain, app.app_id).version
-        create_public_webform_endpoint(app.domain, app.app_id, app.form_unique_id)
+        create_public_webform_build(app.domain, app.app_id, app.form_unique_id)
         canonical = get_app(app.domain, app.app_id)
         assert canonical.version == version_before
         assert canonical.get_form(app.form_unique_id).session_endpoint_id is None
 
     def test_detached_build_stays_out_of_the_lineage(self):
         app = released_app()
-        create_public_webform_endpoint(app.domain, app.app_id, app.form_unique_id)
+        create_public_webform_build(app.domain, app.app_id, app.form_unique_id)
         # the generated build must not become the app's latest build
         assert get_latest_build_id(app.domain, app.app_id) == app.build_id
 
@@ -88,7 +88,7 @@ class TestCreatePublicWebformEndpoint:
         assert get_app(app.domain, app.build_id).get_form(
             app.form_unique_id).session_endpoint_id == 'existing-endpoint'
 
-        build_id, endpoint_id = create_public_webform_endpoint(
+        build_id, endpoint_id = create_public_webform_build(
             app.domain, app.app_id, app.form_unique_id)
 
         assert build_id != app.build_id
@@ -100,7 +100,7 @@ class TestDeletePublicWebformBuild:
 
     def test_deletes_the_build_doc_and_its_build_files(self):
         app = released_app()
-        build_id, __ = create_public_webform_endpoint(
+        build_id, __ = create_public_webform_build(
             app.domain, app.app_id, app.form_unique_id)
         assert get_blob_db().metadb.get_for_parent(build_id)
 

--- a/corehq/apps/public_webforms/tests/test_endpoints.py
+++ b/corehq/apps/public_webforms/tests/test_endpoints.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+from unmagic import fixture, use
+
+from corehq.apps.app_manager.dbaccessors import get_app, get_latest_build_id
+from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.apps.app_manager.tests.util import (
+    delete_all_apps,
+    get_simple_form,
+    patch_validate_xform,
+)
+from corehq.apps.domain.models import Domain
+from corehq.apps.public_webforms.endpoints import (
+    create_public_webform_endpoint,
+)
+
+DOMAIN = 'public-webform-endpoints'
+
+
+@use('db')
+@fixture
+def released_app():
+    """A released build of an app with a basic survey form and no endpoint."""
+    domain_obj = Domain.get_or_create_with_name(DOMAIN)
+    # session endpoints require CommCare 2.51+ (feature_support)
+    factory = AppFactory(DOMAIN, name='PWF App', build_version='2.51.0')
+    __, form = factory.new_basic_module('survey', 'patient')
+    form.source = get_simple_form(xmlns=form.unique_id)
+    try:
+        # patch covers the test body too (generate rebuilds, which validates forms)
+        with patch_validate_xform():
+            app = factory.app
+            app.save()
+            build = app.make_build()
+            build.is_released = True
+            build.save()
+            yield SimpleNamespace(
+                domain=DOMAIN,
+                app_id=app.get_id,
+                build_id=build.get_id,
+                form_unique_id=form.unique_id,
+            )
+    finally:
+        delete_all_apps()
+        domain_obj.get_db().delete_doc(domain_obj.get_id)
+
+
+@use(released_app)
+class TestCreatePublicWebformEndpoint:
+
+    def test_generates_detached_build_emitting_the_endpoint(self):
+        app = released_app()
+        build_id, endpoint_id = create_public_webform_endpoint(
+            app.domain, app.app_id, app.form_unique_id)
+
+        assert build_id != app.build_id
+        new_build = get_app(app.domain, build_id)
+        # detached from the app's lineage, but traceable back to it
+        assert new_build.copy_of == f'{app.app_id}__public_webform'
+        suite = new_build.fetch_attachment('files/suite.xml')
+        if isinstance(suite, bytes):
+            suite = suite.decode('utf-8')
+        assert endpoint_id in suite
+
+    def test_canonical_is_never_written(self):
+        app = released_app()
+        version_before = get_app(app.domain, app.app_id).version
+        create_public_webform_endpoint(app.domain, app.app_id, app.form_unique_id)
+        canonical = get_app(app.domain, app.app_id)
+        assert canonical.version == version_before
+        assert canonical.get_form(app.form_unique_id).session_endpoint_id is None
+
+    def test_detached_build_stays_out_of_the_lineage(self):
+        app = released_app()
+        create_public_webform_endpoint(app.domain, app.app_id, app.form_unique_id)
+        # the generated build must not become the app's latest build
+        assert get_latest_build_id(app.domain, app.app_id) == app.build_id
+
+    def test_released_build_is_untouched(self):
+        app = released_app()
+        create_public_webform_endpoint(app.domain, app.app_id, app.form_unique_id)
+        released = get_app(app.domain, app.build_id)
+        assert released.get_form(app.form_unique_id).session_endpoint_id is None
+
+    def test_always_generates_an_endpoint(self):
+        """Reusing an endpoint would pin a build a user can delete."""
+        app = released_app()
+        released = get_app(app.domain, app.build_id)
+        released.get_form(app.form_unique_id).session_endpoint_id = 'existing-endpoint'
+        released.save(increment_version=False)
+        assert get_app(app.domain, app.build_id).get_form(
+            app.form_unique_id).session_endpoint_id == 'existing-endpoint'
+
+        build_id, endpoint_id = create_public_webform_endpoint(
+            app.domain, app.app_id, app.form_unique_id)
+
+        assert build_id != app.build_id
+        assert endpoint_id != 'existing-endpoint'

--- a/corehq/apps/public_webforms/tests/test_form_choices.py
+++ b/corehq/apps/public_webforms/tests/test_form_choices.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.apps.public_webforms import form_choices
+from corehq.apps.public_webforms.models import PublicWebformType
+
+
+def _build_app():
+    """An app with one of each relevant form: an eligible survey form, an
+    eligible registration form, an ineligible case-requiring form, and a form
+    in an advanced (non-basic) menu."""
+    factory = AppFactory(domain='pwf-test', name='Public Forms App')
+    __, survey_form = factory.new_basic_module('survey', 'patient')
+    __, registration_form = factory.new_basic_module('registration', 'patient')
+    factory.form_opens_case(registration_form, 'patient')
+    __, followup_form = factory.new_basic_module('followup', 'patient')
+    factory.form_requires_case(followup_form)
+    __, advanced_form = factory.new_advanced_module('advanced', 'patient')
+    return SimpleNamespace(
+        app=factory.app,
+        domain=factory.app.domain,
+        survey_form=survey_form,
+        registration_form=registration_form,
+        survey_form_id=survey_form.unique_id,
+        registration_form_id=registration_form.unique_id,
+        followup_form_id=followup_form.unique_id,
+        advanced_form_id=advanced_form.unique_id,
+    )
+
+
+def _patch_released_build(app):
+    """Serve ``app`` as the latest released build for a single app id."""
+    return patch.multiple(
+        form_choices,
+        get_latest_released_app_versions_by_app_id=lambda domain: {'app-1': 1},
+        get_latest_released_app=lambda domain, app_id: app,
+    )
+
+
+def test_choices_include_only_eligible_forms():
+    data = _build_app()
+    with _patch_released_build(data.app):
+        choices = form_choices.get_public_webform_choices(data.domain)
+
+    assert len(choices) == 1  # top-level (app) choices
+    assert choices[0]['id'] == 'app-1'  # the released app id, not a build id
+    assert len(choices[0]['menus']) == 2
+    forms_by_id = {
+        form['id']: form
+        for menu in choices[0]['menus']
+        for form in menu['forms']
+    }
+    assert set(forms_by_id) == {data.survey_form_id, data.registration_form_id}
+    assert forms_by_id[data.survey_form_id]['session_type'] == PublicWebformType.SURVEY.value
+
+
+def test_choices_omit_app_with_no_eligible_forms():
+    factory = AppFactory(domain='pwf-test', name='No Eligible Forms')
+    __, followup_form = factory.new_basic_module('followup', 'patient')
+    factory.form_requires_case(followup_form)
+    with _patch_released_build(factory.app):
+        choices = form_choices.get_public_webform_choices('pwf-test')
+    assert choices == []
+
+
+@pytest.mark.parametrize('form_id_attr', ['survey_form_id', 'registration_form_id'])
+def test_eligible_form_resolves_selection(form_id_attr):
+    data = _build_app()
+    with patch.object(form_choices, 'get_latest_released_app', return_value=data.app):
+        form = form_choices.get_public_webform_eligible_form(
+            data.domain, 'ignored-app-id', getattr(data, form_id_attr))
+    assert form is not None
+    assert form.unique_id == getattr(data, form_id_attr)
+
+
+@pytest.mark.parametrize('form_id_or_attr', [
+    'followup_form_id',
+    'advanced_form_id',
+    'missing-form',
+], ids=['requires-case', 'advanced-menu', 'not-in-app'])
+def test_eligible_form_rejects_invalid_selection(form_id_or_attr):
+    data = _build_app()
+    # Attribute names resolve to a real form id; anything else is used as-is
+    # (a form id that doesn't exist in the released build).
+    form_unique_id = getattr(data, form_id_or_attr, form_id_or_attr)
+    with patch.object(form_choices, 'get_latest_released_app', return_value=data.app):
+        form = form_choices.get_public_webform_eligible_form(
+            data.domain, 'ignored-app-id', form_unique_id)
+    assert form is None
+
+
+def test_eligible_form_rejects_app_without_released_build():
+    with patch.object(form_choices, 'get_latest_released_app', return_value=None):
+        form = form_choices.get_public_webform_eligible_form(
+            'pwf-test', 'unreleased-app', 'any-form')
+    assert form is None
+
+
+@pytest.mark.parametrize('form_attr, expected_type', [
+    ('survey_form', PublicWebformType.SURVEY),
+    ('registration_form', PublicWebformType.REGISTRATION),
+])
+def test_get_type_classifies_form(form_attr, expected_type):
+    data = _build_app()
+    assert form_choices.get_public_webform_type(getattr(data, form_attr)) == expected_type

--- a/corehq/apps/public_webforms/tests/test_form_choices.py
+++ b/corehq/apps/public_webforms/tests/test_form_choices.py
@@ -54,7 +54,6 @@ def test_choices_include_only_eligible_forms():
         for form in menu['forms']
     }
     assert set(forms_by_id) == {data.survey_form_id, data.registration_form_id}
-    assert forms_by_id[data.survey_form_id]['session_type'] == PublicWebformType.SURVEY.value
 
 
 def test_choices_omit_app_with_no_eligible_forms():

--- a/corehq/apps/public_webforms/tests/test_forms.py
+++ b/corehq/apps/public_webforms/tests/test_forms.py
@@ -1,24 +1,31 @@
 from datetime import datetime
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 import pytz
 
-from corehq.apps.public_webforms.forms import CreatePublicWebformForm
+from corehq.apps.public_webforms import forms
+from corehq.apps.public_webforms.models import PublicWebformType
 
 DOMAIN = 'public-webform-forms'
 TIMEZONE = pytz.timezone('America/New_York')
+SURVEY_FORM = SimpleNamespace(is_registration_form=lambda: False)
+REGISTRATION_FORM = SimpleNamespace(is_registration_form=lambda: True)
 
 
-def _form(data=None, has_sms_privilege=False):
-    """Patches the privilege check, which is the form's only database read."""
+def _form(data=None, has_sms_privilege=False, eligible_form=SURVEY_FORM):
+    """Stubs the reads that go to the database or to released builds, which the
+    accounting and form_choices tests cover."""
     args = [data] if data is not None else []
-    with patch(
-        'corehq.apps.public_webforms.forms.domain_has_privilege',
-        return_value=has_sms_privilege,
+    with patch.multiple(
+        forms,
+        domain_has_privilege=Mock(return_value=has_sms_privilege),
+        get_public_webform_choices=Mock(return_value=[]),
+        get_public_webform_eligible_form=Mock(return_value=eligible_form),
     ):
-        form = CreatePublicWebformForm(DOMAIN, TIMEZONE, *args)
-    form.is_valid()
+        form = forms.CreatePublicWebformForm(DOMAIN, TIMEZONE, *args)
+        form.is_valid()
     return form
 
 
@@ -27,6 +34,8 @@ def _post_data(**kwargs):
         'label': 'Antenatal visit',
         'expires_at': '2026-09-01 17:00:00',
         'link_choices': ['allow_email'],
+        'app_id': 'app-1',
+        'form_unique_id': 'form-1',
         **kwargs,
     }
 
@@ -59,3 +68,27 @@ def test_sms_is_offered_only_with_the_privilege(has_sms_privilege):
     rendered = dict(form.fields['link_choices'].widget.choices)
     assert ('allow_sms' in rendered) == has_sms_privilege
     assert 'allow_email' in rendered
+
+
+@pytest.mark.parametrize('eligible_form, expected_type', [
+    (SURVEY_FORM, PublicWebformType.SURVEY),
+    (REGISTRATION_FORM, PublicWebformType.REGISTRATION),
+])
+def test_session_type_comes_from_the_selected_form(eligible_form, expected_type):
+    form = _form(_post_data(), eligible_form=eligible_form)
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data['session_type'] == expected_type
+
+
+@pytest.mark.parametrize('missing', ['app_id', 'form_unique_id'])
+def test_an_application_and_form_are_required(missing):
+    form = _form(_post_data(**{missing: ''}))
+    assert not form.is_valid()
+    assert form.non_field_errors() == ["Please select an application, menu, and form."]
+
+
+def test_an_ineligible_form_is_rejected():
+    """The selection is posted from hidden inputs, so it is re-checked."""
+    form = _form(_post_data(), eligible_form=None)
+    assert not form.is_valid()
+    assert form.non_field_errors() == ["The selected form can't be used for a public webform."]

--- a/corehq/apps/public_webforms/tests/test_forms.py
+++ b/corehq/apps/public_webforms/tests/test_forms.py
@@ -6,6 +6,8 @@ import pytest
 import pytz
 from unmagic import use
 
+from django.db import DatabaseError
+
 from corehq.apps.public_webforms import forms
 from corehq.apps.public_webforms.models import PublicWebformType
 
@@ -105,6 +107,26 @@ def _create_webform(**post_data):
         return_value=('build-1', 'endpoint-1'),
     ):
         return form.create_public_webform()
+
+
+def test_create_deletes_the_generated_build_if_the_webform_is_not_saved():
+    """Otherwise the build is left behind with nothing referencing it."""
+    form = _form(_post_data())
+    assert form.is_valid(), form.errors
+    with (
+        patch.object(
+            forms, 'create_public_webform_endpoint',
+            return_value=('build-1', 'endpoint-1'),
+        ),
+        patch.object(
+            forms.PublicWebform.objects, 'create', side_effect=DatabaseError,
+        ),
+        patch.object(forms, 'delete_public_webform_build') as delete_build,
+    ):
+        with pytest.raises(DatabaseError):
+            form.create_public_webform()
+
+    delete_build.assert_called_once_with(DOMAIN, 'build-1')
 
 
 @use('db')

--- a/corehq/apps/public_webforms/tests/test_forms.py
+++ b/corehq/apps/public_webforms/tests/test_forms.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 import pytz
+from unmagic import use
 
 from corehq.apps.public_webforms import forms
 from corehq.apps.public_webforms.models import PublicWebformType
@@ -92,3 +93,43 @@ def test_an_ineligible_form_is_rejected():
     form = _form(_post_data(), eligible_form=None)
     assert not form.is_valid()
     assert form.non_field_errors() == ["The selected form can't be used for a public webform."]
+
+
+def _create_webform(**post_data):
+    """Stubs generating the endpoint, which builds a copy of a released app.
+    SMS is granted so delivery options can be exercised independently of it."""
+    form = _form(_post_data(**post_data), has_sms_privilege=True)
+    assert form.is_valid(), form.errors
+    with patch.object(
+        forms, 'create_public_webform_endpoint',
+        return_value=('build-1', 'endpoint-1'),
+    ):
+        return form.create_public_webform()
+
+
+@use('db')
+def test_create_stores_the_selection_and_generated_endpoint():
+    webform = _create_webform()
+
+    assert webform.domain == DOMAIN
+    assert webform.label == 'Antenatal visit'
+    assert webform.app_id == 'app-1'
+    assert webform.form_unique_id == 'form-1'
+    assert webform.app_build_id == 'build-1'
+    assert webform.endpoint_id == 'endpoint-1'
+    assert webform.session_type == PublicWebformType.SURVEY
+    assert webform.expires_at == datetime(2026, 9, 1, 21, 0)
+    assert webform.is_disabled
+
+
+@use('db')
+@pytest.mark.parametrize('link_choices, allow_email, allow_sms', [
+    (['allow_email'], True, False),
+    (['allow_sms'], False, True),
+    (['allow_email', 'allow_sms'], True, True),
+])
+def test_create_maps_link_choices_to_delivery_options(link_choices, allow_email, allow_sms):
+    webform = _create_webform(link_choices=link_choices)
+
+    assert webform.allow_email == allow_email
+    assert webform.allow_sms == allow_sms

--- a/corehq/apps/public_webforms/tests/test_forms.py
+++ b/corehq/apps/public_webforms/tests/test_forms.py
@@ -103,7 +103,7 @@ def _create_webform(**post_data):
     form = _form(_post_data(**post_data), has_sms_privilege=True)
     assert form.is_valid(), form.errors
     with patch.object(
-        forms, 'create_public_webform_endpoint',
+        forms, 'create_public_webform_build',
         return_value=('build-1', 'endpoint-1'),
     ):
         return form.create_public_webform()
@@ -115,7 +115,7 @@ def test_create_deletes_the_generated_build_if_the_webform_is_not_saved():
     assert form.is_valid(), form.errors
     with (
         patch.object(
-            forms, 'create_public_webform_endpoint',
+            forms, 'create_public_webform_build',
             return_value=('build-1', 'endpoint-1'),
         ),
         patch.object(

--- a/corehq/apps/public_webforms/tests/test_forms.py
+++ b/corehq/apps/public_webforms/tests/test_forms.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+import pytz
+
+from corehq.apps.public_webforms.forms import CreatePublicWebformForm
+
+DOMAIN = 'public-webform-forms'
+TIMEZONE = pytz.timezone('America/New_York')
+
+
+def _form(data=None, has_sms_privilege=False):
+    """Patches the privilege check, which is the form's only database read."""
+    args = [data] if data is not None else []
+    with patch(
+        'corehq.apps.public_webforms.forms.domain_has_privilege',
+        return_value=has_sms_privilege,
+    ):
+        form = CreatePublicWebformForm(DOMAIN, TIMEZONE, *args)
+    form.is_valid()
+    return form
+
+
+def _post_data(**kwargs):
+    return {
+        'label': 'Antenatal visit',
+        'expires_at': '2026-09-01 17:00:00',
+        'link_choices': ['allow_email'],
+        **kwargs,
+    }
+
+
+@pytest.mark.parametrize('entered, expected_utc', [
+    ('2026-09-01 17:00:00', datetime(2026, 9, 1, 21, 0)),
+    ('2026-12-01 17:00:00', datetime(2026, 12, 1, 22, 0)),
+], ids=['daylight-saving-utc-4', 'standard-time-utc-5'])
+def test_expires_at_is_stored_as_utc(entered, expected_utc):
+    form = _form(_post_data(expires_at=entered))
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data['expires_at'] == expected_utc
+
+
+def test_expires_at_defaults_to_the_datepicker_format():
+    initial = _form().fields['expires_at'].initial
+    # any other format makes the datepicker treat it as invalid and clear it
+    assert datetime.strptime(initial, '%Y-%m-%d %H:%M:%S')
+
+
+def test_a_delivery_option_is_required():
+    form = _form(_post_data(link_choices=[]))
+    assert not form.is_valid()
+    assert 'link_choices' in form.errors
+
+
+@pytest.mark.parametrize('has_sms_privilege', [True, False])
+def test_sms_is_offered_only_with_the_privilege(has_sms_privilege):
+    form = _form(has_sms_privilege=has_sms_privilege)
+    rendered = dict(form.fields['link_choices'].widget.choices)
+    assert ('allow_sms' in rendered) == has_sms_privilege
+    assert 'allow_email' in rendered

--- a/corehq/apps/public_webforms/urls.py
+++ b/corehq/apps/public_webforms/urls.py
@@ -1,7 +1,11 @@
 from django.urls import re_path as url
 
-from corehq.apps.public_webforms.views import ManagePublicWebformsView
+from corehq.apps.public_webforms.views import (
+    CreatePublicWebformView,
+    ManagePublicWebformsView,
+)
 
 urlpatterns = [
     url(r'^$', ManagePublicWebformsView.as_view(), name=ManagePublicWebformsView.urlname),
+    url(r'^create/$', CreatePublicWebformView.as_view(), name=CreatePublicWebformView.urlname),
 ]

--- a/corehq/apps/public_webforms/urls.py
+++ b/corehq/apps/public_webforms/urls.py
@@ -1,0 +1,7 @@
+from django.urls import re_path as url
+
+from corehq.apps.public_webforms.views import ManagePublicWebformsView
+
+urlpatterns = [
+    url(r'^$', ManagePublicWebformsView.as_view(), name=ManagePublicWebformsView.urlname),
+]

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -1,3 +1,5 @@
+from django.contrib import messages
+from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
@@ -41,6 +43,14 @@ class CreatePublicWebformView(BasePublicWebformsView):
     template_name = 'public_webforms/create.html'
     page_title = _("New Public Webform")
 
+    def post(self, request, *args, **kwargs):
+        if not self.form.is_valid():
+            return self.get(request, *args, **kwargs)
+        self.form.create_public_webform()
+        messages.success(request, _("Public webform created."))
+        return HttpResponseRedirect(
+            reverse(ManagePublicWebformsView.urlname, args=[self.domain]))
+
     @property
     def page_context(self):
         context = super().page_context
@@ -52,5 +62,6 @@ class CreatePublicWebformView(BasePublicWebformsView):
     @property
     @memoized
     def form(self):
+        data = [self.request.POST] if self.request.method == 'POST' else []
         return CreatePublicWebformForm(
-            self.domain, self.domain_object.get_default_timezone())
+            self.domain, self.domain_object.get_default_timezone(), *data)

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -7,6 +7,7 @@ from corehq import privileges, toggles
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.public_webforms.forms import CreatePublicWebformForm
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
 
@@ -39,3 +40,17 @@ class CreatePublicWebformView(BasePublicWebformsView):
     urlname = 'create_public_webform'
     template_name = 'public_webforms/create.html'
     page_title = _("New Public Webform")
+
+    @property
+    def page_context(self):
+        context = super().page_context
+        context.update({
+            'form': self.form,
+        })
+        return context
+
+    @property
+    @memoized
+    def form(self):
+        return CreatePublicWebformForm(
+            self.domain, self.domain_object.get_default_timezone())

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -33,3 +33,9 @@ class ManagePublicWebformsView(BasePublicWebformsView):
     urlname = 'manage_public_webforms'
     template_name = 'public_webforms/manage.html'
     page_title = _("Manage Public Webforms")
+
+
+class CreatePublicWebformView(BasePublicWebformsView):
+    urlname = 'create_public_webform'
+    template_name = 'public_webforms/create.html'
+    page_title = _("New Public Webform")

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -1,0 +1,35 @@
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.utils.translation import gettext_lazy as _
+from memoized import memoized
+
+from corehq import privileges, toggles
+from corehq.apps.accounting.decorators import requires_privilege_with_fallback
+from corehq.apps.domain.views import BaseDomainView
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.users.decorators import require_permission
+from corehq.apps.users.models import HqPermissions
+
+
+@method_decorator(
+    [
+        use_bootstrap5,
+        require_permission(HqPermissions.edit_public_webforms),
+        requires_privilege_with_fallback(privileges.PUBLIC_WEBFORMS),
+        toggles.PUBLIC_WEBFORMS.required_decorator(),
+    ],
+    name='dispatch',
+)
+class BasePublicWebformsView(BaseDomainView):
+    section_name = _("Public Webforms")
+
+    @property
+    @memoized
+    def section_url(self):
+        return reverse(ManagePublicWebformsView.urlname, args=[self.domain])
+
+
+class ManagePublicWebformsView(BasePublicWebformsView):
+    urlname = 'manage_public_webforms'
+    template_name = 'public_webforms/manage.html'
+    page_title = _("Manage Public Webforms")

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1151,7 +1151,10 @@ class ProjectDataTab(UITab):
 class ApplicationsTab(UITab):
     view = "default_new_app"
 
-    url_prefix_formats = ('/a/{domain}/apps/',)
+    url_prefix_formats = (
+        '/a/{domain}/apps/',
+        '/a/{domain}/public_webforms/',
+    )
 
     @property
     def title(self):
@@ -1199,6 +1202,40 @@ class ApplicationsTab(UITab):
                 url=(reverse('default_new_app', args=[self.domain])),
             ))
         return submenu_context
+
+    @property
+    def sidebar_items(self):
+        items = []
+        if self.public_webforms_urls:
+            items.append((_("Public Webforms"), self.public_webforms_urls))
+        return items
+
+    @property
+    def public_webforms_urls(self):
+        from corehq.apps.public_webforms.views import (
+            CreatePublicWebformView,
+            ManagePublicWebformsView,
+        )
+        if not (
+            domain_has_privilege(self.domain, privileges.PUBLIC_WEBFORMS)
+            and self.couch_user.has_permission(self.domain, HqPermissions.edit_public_webforms)
+            and toggles.PUBLIC_WEBFORMS.enabled_for_request(self._request)
+        ):
+            return []
+
+        return [{
+            'title': _(ManagePublicWebformsView.page_title),
+            'url': reverse(
+                ManagePublicWebformsView.urlname, args=[self.domain]
+            ),
+            'description': _('Create and manage public webforms.'),
+            'subpages': [
+                {
+                    'title': _(CreatePublicWebformView.page_title),
+                    'urlname': CreatePublicWebformView.urlname,
+                },
+            ],
+        }]
 
     @property
     def _is_viewable(self):

--- a/urls.py
+++ b/urls.py
@@ -77,6 +77,7 @@ domain_specific = [
     url(r'^microplanning/', include('corehq.apps.geospatial.urls')),
     url(r'^kyc/', include('corehq.apps.integration.kyc.urls')),
     url(r'^payments/', include('corehq.apps.integration.payments.urls')),
+    url(r'^public_webforms/', include('corehq.apps.public_webforms.urls')),
     url(r'^fixtures/', include('corehq.apps.fixtures.urls')),
     url(r'^importer/', include('corehq.apps.case_importer.urls')),
     url(r'^dashboard/', include('corehq.apps.dashboard.urls')),


### PR DESCRIPTION
## Product Description
Adds a stub "manage" view for public webforms and builds out the full "create" view and form:
<img width="1265" height="396" alt="image" src="https://github.com/user-attachments/assets/699a68c1-bcae-41e3-97a8-0b5177aa3ab6" />

<img width="1266" height="654" alt="image" src="https://github.com/user-attachments/assets/59e82d09-d122-416a-8188-0ca6a8592f41" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-20067
Adds the ability to create a public webform. Only registration and survey forms are eligible. For the most part, this is a straightforward model creation and UI change, with the notable exception of the session endpoints integration.

Because public webforms will use a session endpoint (part of the Application's stored XML) to navigate directly into a form, we need to create a session endpoint pointing to the form used by a public webform. On creation, a public webform will be pinned to the "latest released" build of an app - what this does is essentially create a shadow build on top of that app, adding a session endpoint and saving with a `copy_of` that doesn't point directly to the parent app, so it doesn't show up in the regular build lineage (polluting version numbers and potentially confusing editors).

As a follow-up item, we should make sure that when a Public Webform is deleted (not yet possible via UI), the shadow app build it created also gets deleted.

Code was co-authored by AI.

## Feature Flag
PUBLIC_WEBFORMS during development.

## Safety Assurance

### Safety story
Code is feature flagged and generally unreachable for the time being - there's no direct link to public webforms UI added, it essentially exists as an internal preview for those with feature flag access.

App builds created here are detached from regular builds, and we explicitly don't touch write anything on existing builds or saved Application state, only read from it.

### Automated test coverage
Yes, there is automated testing added for endpoint creation, form eligibility, and PublicWebform creation.

### QA Plan
Public Webforms will get end-to-end QA once admin and public-facing components are merged.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
