### PR TITLE
Stop npm packages from executing code on install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,9 +82,6 @@ docker/data
 fab/config.py
 extensions/
 
-# third-party js libraries
-corehq/apps/hqwebapp/static/hqwebapp/js/lib/modernizr.js
-
 # direnv
 .envrc
 .direnv

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -1038,6 +1038,18 @@ export PATH="$(yarn global bin):$PATH"
 
 More information can be found [here](https://classic.yarnpkg.com/en/docs/cli/global/)
 
+`.yarnrc` sets `ignore-scripts true` repo-wide as a supply-chain control, so no
+package's install hooks run — including puppeteer's, which is what downloads the
+Chrome build the tests drive. You'll need to install that browser explicitly,
+once:
+
+```sh
+npx puppeteer browsers install chrome
+```
+
+This is only needed to run the tests locally; CI uses the Chrome installed in
+the docker image.
+
 In order for the tests to run the **development server needs to be running on port 8000**.
 
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/main.js
@@ -1,7 +1,6 @@
 import $ from "jquery";
 import ko from "knockout";
 import _ from "underscore";
-import modernizr from "hqwebapp/js/lib/modernizr";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import alertUser from "hqwebapp/js/bootstrap3/alert_user";
 import googleAnalytics from "analytix/js/google";
@@ -409,7 +408,12 @@ $(function () {
         // We don't explicitly rely on SVG SMIL animation,
         // but it's a decent test for avoiding legacy IE.
         // TODO: Find more granular tests for what the website requires
-        return !modernizr.smil;
+        var supportsSmil = !!document.createElementNS && /SVGAnimate/.test(
+            Object.prototype.toString.call(
+                document.createElementNS("http://www.w3.org/2000/svg", "animate"),
+            ),
+        );
+        return !supportsSmil;
     }
 
     var $unsupportedBrowser = $("#unsupported-browser");

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/main.js
@@ -1,7 +1,6 @@
 import $ from "jquery";
 import ko from "knockout";
 import _ from "underscore";
-import modernizr from "hqwebapp/js/lib/modernizr";
 import initialPageData from "hqwebapp/js/initial_page_data";
 import alertUser from "hqwebapp/js/bootstrap5/alert_user";
 import googleAnalytics from "analytix/js/google";
@@ -412,7 +411,12 @@ $(function () {
         // We don't explicitly rely on SVG SMIL animation,
         // but it's a decent test for avoiding legacy IE.
         // TODO: Find more granular tests for what the website requires
-        return !modernizr.smil;
+        var supportsSmil = !!document.createElementNS && /SVGAnimate/.test(
+            Object.prototype.toString.call(
+                document.createElementNS("http://www.w3.org/2000/svg", "animate"),
+            ),
+        );
+        return !supportsSmil;
     }
 
     var $unsupportedBrowser = $("#unsupported-browser");

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/main.js.diff.txt
@@ -1,8 +1,8 @@
 --- 
 +++ 
-@@ -3,8 +3,9 @@
+@@ -2,8 +2,9 @@
+ import ko from "knockout";
  import _ from "underscore";
- import modernizr from "hqwebapp/js/lib/modernizr";
  import initialPageData from "hqwebapp/js/initial_page_data";
 -import alertUser from "hqwebapp/js/bootstrap3/alert_user";
 +import alertUser from "hqwebapp/js/bootstrap5/alert_user";
@@ -11,7 +11,7 @@
  import "hqwebapp/js/hq_extensions.jquery";
  import "jquery.cookie/jquery.cookie";
  import "jquery-textchange/jquery.textchange";
-@@ -34,11 +35,11 @@
+@@ -33,11 +34,11 @@
      wrap = wrap === undefined ? true : wrap;
      var el = $(
          '<div class="hq-help">' +
@@ -25,7 +25,7 @@
      });
      if (wrap) {
          el.hqHelp();
-@@ -93,6 +94,7 @@
+@@ -92,6 +93,7 @@
  ko.virtualElements.allowedBindings.allowDescendantBindings = true;
  
  var initBlock = function ($elem) {
@@ -33,7 +33,7 @@
      $('.submit').click(function (e) {
          var $form = $(this).closest('.form, form'),
              data = $form.find('[name]').serialize(),
-@@ -102,8 +104,6 @@
+@@ -101,8 +103,6 @@
          $.postGo(action, $.unparam(data));
      });
  
@@ -42,7 +42,7 @@
      $("input[type='text'], input[type='password'], textarea", $elem);
      $('.config', $elem).wrap('<div />').parent().addClass('container block ui-corner-all');
  
-@@ -146,7 +146,7 @@
+@@ -145,7 +145,7 @@
                  }).addClass(cssClass),
                  $saving: $('<div/>').text(SaveButton.message.SAVING).addClass('btn btn-primary disabled'),
                  $saved: $('<div/>').text(SaveButton.message.SAVED).addClass('btn btn-primary disabled'),
@@ -51,7 +51,7 @@
                  setStateWhenReady: function (state) {
                      if (this.state === 'saving') {
                          this.nextState = state;
-@@ -242,9 +242,7 @@
+@@ -241,9 +241,7 @@
                  if (lastParent) {
                      var stillAttached = lastParent.tagName.toLowerCase() === 'html';
                      if (button.state !== 'saved' && stillAttached) {
@@ -62,7 +62,7 @@
                          return options.unsavedMessage || "";
                      }
                  }
-@@ -354,7 +352,12 @@
+@@ -353,7 +351,12 @@
  $(function () {
      initBlock($("body"));
  
@@ -76,7 +76,7 @@
  
      $(document).on('click', '.track-usage-link', function (e) {
          var $link = $(e.currentTarget),
-@@ -421,8 +424,14 @@
+@@ -425,8 +428,14 @@
      // EULA modal
      var eulaCookie = "tos2025";
      if (!$.cookie(eulaCookie)) {
@@ -93,7 +93,7 @@
              $("body").addClass("has-eula");
              $("#eula-agree").click(function () {
                  $(this).disableButton();
-@@ -430,7 +439,7 @@
+@@ -434,7 +443,7 @@
                      url: initialPageData.reverse("agree_to_eula"),
                      method: "POST",
                      success: function () {
@@ -102,7 +102,7 @@
                          $("body").removeClass("has-eula");
                      },
                      error: function (xhr) {
-@@ -446,21 +455,22 @@
+@@ -450,21 +459,22 @@
                      },
                  });
              });

--- a/docs/js-guide/testing.rst
+++ b/docs/js-guide/testing.rst
@@ -23,6 +23,18 @@ npm packages:
 
    $ yarn install --frozen-lockfile
 
+``.yarnrc`` sets ``ignore-scripts true`` repo-wide as a supply-chain control,
+so no package’s install hooks run — including puppeteer’s, which is what
+downloads the Chrome build the tests drive. You’ll need to install that
+browser explicitly, once:
+
+::
+
+   $ npx puppeteer browsers install chrome
+
+This is only needed to run the tests locally; CI uses the Chrome installed in
+the docker image.
+
 It’s recommended to install grunt globally in order to use grunt from
 the command line:
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -78,4 +78,14 @@ module.exports = [
             "strict": ["warn", "global"],
         },
     },
+
+    {
+        // Build tooling runs in node, not the browser.
+        files: ['webpack/**/*.js'],
+        languageOptions: {
+            globals: {
+                ...globals.node,
+            },
+        },
+    },
 ];

--- a/modernizr-conf.json
+++ b/modernizr-conf.json
@@ -1,9 +1,0 @@
-{
-    "minify": true,
-    "options": [
-      "setClasses"
-    ],
-    "feature-detects": [
-      "test/svg/smil"
-    ]
-  }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
         "marionette.approuter": "^1.0.2",
         "marionette.templatecache": "^1.0.0",
         "markdown-it": "14.2.0",
-        "modernizr": "^3.13.1",
         "moment": "2.29.4",
         "multiselect": "0.9.12",
         "npm": "11.6.2",
@@ -87,7 +86,6 @@
         "webpack": "5.104.1",
         "webpack-cli": "5.1.4",
         "webpack-merge": "6.0.1",
-        "webpack-modernizr-loader": "5.0.0",
         "xpath": "dimagi/js-xpath#v0.0.8",
         "zxcvbn": "4.4.2"
     },
@@ -136,8 +134,6 @@
         "diff": "8.0.3"
     },
     "scripts": {
-        "postinstall": "yarn run -s build:modernizr",
-        "build:modernizr": "modernizr -c modernizr-conf.json -d corehq/apps/hqwebapp/static/hqwebapp/js/lib",
         "dev": "node webpack/generateDetails.js && webpack --mode development --config webpack/webpack.dev.js --watch",
         "test": "node webpack/generateDetails.js && webpack --mode development --config webpack/webpack.dev.js",
         "build": "node webpack/generateDetails.js --prod && webpack --config webpack/webpack.prod.js"

--- a/webpack/appPaths.js
+++ b/webpack/appPaths.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 
 const fs = require('fs');
 const path = require('path');
@@ -47,7 +46,7 @@ const hasTemplateFolder = function (dirEnt) {
     const templatePath = path.resolve(APPS_PATH, dirEnt.name, TEMPLATES_DIR);
     try {
         return fs.readdirSync(templatePath);
-    } catch (e) {
+    } catch {
         // throws an error if the templates directory does not exist
         return false;
     }

--- a/webpack/generateDetails.js
+++ b/webpack/generateDetails.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 /* eslint-disable no-useless-escape */
 // NOTE: double escapes are needed for file path delimiters in webpack regexes for cross-platform support
 
@@ -106,7 +105,7 @@ const getDetails = function (entryRegex, allAppPaths, isProdMode) {
             entryRegex,
             allAppPaths,
             details,
-            isProdMode
+            isProdMode,
         );
     }
     return details;
@@ -148,12 +147,12 @@ if (require.main === module) {
     const defaultDetails = getDetails(
         /{% js_entry ["']([\/\w\-]+)["'] %}/g,
         allAppPaths,
-        isProductionMode
+        isProductionMode,
     );
     const b3Details = getDetails(
         /{% js_entry_b3 ["']([\/\w\-]+)["'] %}/g,
         allAppPaths,
-        isProductionMode
+        isProductionMode,
     );
 
     // Directly copy the default entry point into B3.
@@ -169,15 +168,15 @@ if (require.main === module) {
             aliases: Object.assign(
                 aliases,
                 defaultDetails.aliases,
-                b3Details.aliases
+                b3Details.aliases,
             ),
             appsWithEntries: Object.assign(
                 appsWithEntries,
                 defaultDetails.appsWithEntries,
-                b3Details.appsWithEntries
+                b3Details.appsWithEntries,
             ),
             allAppPaths: allAppPaths,
-        }, null, 2)
+        }, null, 2),
     );
 }
 

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 const path = require('path');
 const fs = require('fs');
 const appPaths = require('./appPaths');
@@ -42,7 +41,7 @@ class EntryChunksPlugin {
 
             fs.writeFileSync(
                 path.join(appPaths.BUILD_ARTIFACTS_DIR, this.options.filename || 'manifest.json'),
-                JSON.stringify(manifest, null, 2)
+                JSON.stringify(manifest, null, 2),
             );
 
             callback();

--- a/webpack/utils.js
+++ b/webpack/utils.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 const path = require("path");
 const appPaths = require("./appPaths");
 const fs = require("fs");

--- a/webpack/vellumUtils.js
+++ b/webpack/vellumUtils.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 const fs = require('fs');
 const path = require('path');
 const utils = require('./utils');

--- a/webpack/webpack.b3.common.js
+++ b/webpack/webpack.b3.common.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 const commonDefault = require("./webpack.common");
 const path = require('path');
 const webpack = require('webpack');

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -9,11 +9,6 @@ const aliases = {
         'commcarehq'),
     "jquery": require.resolve('jquery'),
     "langcodes/js/langcodes": path.resolve("submodules/langcodes/static/langcodes/js/langcodes"),
-
-    // todo after completing requirejs migration,
-    //  remove this file and the yarn modernizr post-install step
-    "modernizr": "hqwebapp/js/lib/modernizr",
-
     "nvd3/nv.d3.latest.min": "nvd3-1.8.6/build/nv.d3.min",
     "popper": "@popperjs/core/dist/cjs/popper.js",
     "sentry_browser": path.resolve(utils.getStaticFolderForApp('hqwebapp'),
@@ -79,19 +74,6 @@ module.exports = {
                     {
                         test: /\.png/,
                         type: 'asset/resource',
-                    },
-
-                    {
-                        test: /modernizr\.js$/,
-                        loader: "webpack-modernizr-loader",
-                        options: {
-                            "options": [
-                                "setClasses",
-                            ],
-                            "feature-detects": [
-                                "test/svg/smil",
-                            ],
-                        },
                     },
 
                     {

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 const path = require('path');
 const webpack = require('webpack');
 const utils = require('./utils');

--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common');
 const b3Common = require('./webpack.b3.common');

--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common');
 const b3Common = require('./webpack.b3.common');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2650,11 +2650,6 @@ basic-ftp@^5.0.2:
   resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.3.1.tgz#3148ee9af43c0522514a4f973fecb1d3cbb6d71e"
   integrity sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==
 
-big.js@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
-  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
-
 biginteger@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/biginteger/-/biginteger-1.0.3.tgz#111c682070b852d0677a1621fd33452aab674607"
@@ -3010,15 +3005,6 @@ clipboard@2.0.11:
     good-listener "^1.2.2"
     select "^1.1.2"
     tiny-emitter "^2.0.0"
-
-cliui@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
-  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
-  dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
-    wrap-ansi "^6.2.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -3432,13 +3418,6 @@ diff@8.0.3, diff@^5.2.0, diff@^7.0.0, diff@^8.0.2:
   resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"
   integrity sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==
 
-doctrine@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
-  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
-  dependencies:
-    esutils "^2.0.2"
-
 dompurify@3.4.13, dompurify@^3.0.5, dompurify@^3.3.1:
   version "3.4.13"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.13.tgz#fc28949d59f92d62e28a3a764bcbeee35897a1be"
@@ -3486,11 +3465,6 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
-
-emojis-list@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
-  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
 encoding@^0.1.13:
   version "0.1.13"
@@ -3889,11 +3863,6 @@ file-entry-cache@^8.0.0:
   dependencies:
     flat-cache "^4.0.0"
 
-file@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/file/-/file-0.2.2.tgz#c3dfd8f8cf3535ae455c2b423c2e52635d76b4d3"
-  integrity sha1-w9/Y+M81Na5FXCtCPC5SY112tNM=
-
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
@@ -4115,7 +4084,7 @@ geojson-vt@^3.2.1:
   resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.2.1.tgz#f8adb614d2c1d3f6ee7c4265cad4bbf3ad60c8b7"
   integrity sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==
 
-get-caller-file@^2.0.1, get-caller-file@^2.0.5:
+get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -5084,13 +5053,6 @@ json-stringify-nice@^1.1.4:
   resolved "https://registry.yarnpkg.com/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz#2c937962b80181d3f317dd39aa323e14f5a60a67"
   integrity sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==
 
-json5@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
-  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
-  dependencies:
-    minimist "^1.2.0"
-
 json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -5359,15 +5321,6 @@ loader-runner@^4.3.1:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.1.tgz#6c76ed29b0ccce9af379208299f07f876de737e3"
   integrity sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==
 
-loader-utils@^1.0.0:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
-  integrity sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^1.0.1"
-
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -5414,7 +5367,7 @@ lodash.isequal@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
 
-lodash@4.18.1, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.21, lodash@~4.17.10, lodash@~4.17.19, lodash@~4.17.21:
+lodash@4.18.1, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.19, lodash@~4.17.10, lodash@~4.17.19, lodash@~4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
@@ -5604,7 +5557,7 @@ marionette.templatecache@^1.0.0:
   dependencies:
     backbone.marionette "^4.0.0, 4.0.0-beta.1"
 
-markdown-it@14.2.0, markdown-it@^13.0.2, markdown-it@^14.1.1:
+markdown-it@14.2.0, markdown-it@^14.1.1:
   version "14.2.0"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.2.0.tgz#06d48d9035e77d5b1c85adb315482fc8240289ef"
   integrity sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==
@@ -5723,7 +5676,7 @@ minimist-options@^4.0.2:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.6:
+minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -5807,13 +5760,6 @@ mitt@^3.0.1:
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
-mkdirp@0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
-  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
-  dependencies:
-    minimist "^1.2.6"
-
 mkdirp@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
@@ -5852,19 +5798,6 @@ mocha@11.0.1:
     yargs "^16.2.0"
     yargs-parser "^20.2.9"
     yargs-unparser "^2.0.0"
-
-modernizr@^3.13.1, modernizr@^3.7.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/modernizr/-/modernizr-3.13.1.tgz#0102882d91e7546b833a6b833677a9f1a4fd1eb5"
-  integrity sha512-jc7F04Wd8ngu+fNZYMdWmho6bdiNNnt01lAEF6WAGRay7haGzjWEj5wfBC/zNgv5BySJ+h29/ERMFX+zEcijvg==
-  dependencies:
-    doctrine "^3.0.0"
-    file "^0.2.2"
-    lodash "^4.17.21"
-    markdown-it "^13.0.2"
-    mkdirp "0.5.6"
-    requirejs "^2.3.7"
-    yargs "^15.4.1"
 
 moment-timezone@^0.4.0, moment-timezone@^0.5.35:
   version "0.5.38"
@@ -7040,16 +6973,6 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
-require-main-filename@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
-  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
-requirejs@^2.3.7:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.7.tgz#0b22032e51a967900e0ae9f32762c23a87036bd0"
-  integrity sha512-DouTG8T1WanGok6Qjg2SXuCMzszOo0eHeH9hDZ5Y4x8Je+9JB38HdTLT4/VA8OaUhBa0JPVHJ0pyBkM1z+pDsw==
-
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -7225,11 +7148,6 @@ serialize-javascript@^6.0.2, serialize-javascript@^7.0.3:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
   integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
-
-set-blocking@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -7486,7 +7404,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7504,15 +7422,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
@@ -7527,7 +7436,7 @@ string_decoder@0.10:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
   integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7540,13 +7449,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -8039,14 +7941,6 @@ webpack-merge@^5.7.3:
     flat "^5.0.2"
     wildcard "^2.0.0"
 
-webpack-modernizr-loader@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/webpack-modernizr-loader/-/webpack-modernizr-loader-5.0.0.tgz#6a7c07d3fac4b6e02964ee3be61819cf9ab811cc"
-  integrity sha512-D+FIZ03QtWNV536+cGp046qbJIcxPYEF0kGqP6YrM8Y1g6PqzXGdx8VYnK7VkfRuBdtqLL5rCerWYk1ncOSjJQ==
-  dependencies:
-    loader-utils "^1.0.0"
-    modernizr "^3.7.1"
-
 webpack-sources@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.3.3.tgz#d4bf7f9909675d7a070ff14d0ef2a4f3c982c723"
@@ -8102,11 +7996,6 @@ wgs84@0.0.0:
   resolved "https://registry.yarnpkg.com/wgs84/-/wgs84-0.0.0.tgz#34fdc555917b6e57cf2a282ed043710c049cdc76"
   integrity sha512-ANHlY4Rb5kHw40D0NJ6moaVfOCMrp9Gpd1R/AIQYg2ko4/jzcJ+TVXYYF6kXJqQwITvEZP4yEthjM7U6rYlljQ==
 
-which-module@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
-  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-
 which@^1.2.14:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -8150,25 +8039,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
-  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8215,11 +8086,6 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
-
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
@@ -8240,7 +8106,7 @@ yallist@^5.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
   integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
-yargs-parser@^18.1.2, yargs-parser@^18.1.3, yargs-parser@^20.2.2, yargs-parser@^20.2.9, yargs-parser@^21.1.1:
+yargs-parser@^18.1.3, yargs-parser@^20.2.2, yargs-parser@^20.2.9, yargs-parser@^21.1.1:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
@@ -8257,23 +8123,6 @@ yargs-unparser@^2.0.0:
     decamelize "^4.0.0"
     flat "^5.0.2"
     is-plain-obj "^2.1.0"
-
-yargs@^15.4.1:
-  version "15.4.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
-  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
-  dependencies:
-    cliui "^6.0.0"
-    decamelize "^1.2.0"
-    find-up "^4.1.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^4.2.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^18.1.2"
 
 yargs@^16.2.0:
   version "16.2.0"


### PR DESCRIPTION
## Product Description

No user-facing effects. One new step for developers who run the JS tests locally, below.

## Technical Summary

A compromised npm package can currently run arbitrary code on any machine that installs it — the mechanism the [ChainDrop worm](https://www.stepsecurity.io/blog/chaindrop-npm-worm) used to harvest credentials. `.yarnrc` now sets `ignore-scripts true`, so `yarn install` executes no package's install hooks.

Global config rather than a per-command flag, deliberately: it covers developer machines, which hold the npm and `gh` credentials worth stealing, and a workflow added later cannot forget it.

Siblings, all independent and mergeable in any order: #38004 (pinning and cooldown) and #38007 (runner egress auditing).

**The diff is bigger than the title suggests, because linting and modernizr removal come first.** We declared exactly one install hook of our own — a `postinstall` generating `modernizr.js`, which webpack bundles import. Deleting it was cheaper and better than preserving it.

<details>
<summary>

### Modernizr removal deep dive

</summary>

Modernizr has only ever answered one question here — is this browser legacy IE? — and the call site has this to say about the mechanism:

> We don't explicitly rely on SVG SMIL animation, but it's a decent test for avoiding legacy IE.

`git log` agrees: it arrived as a vendored build with a single feature detect, became a `postinstall` in 369e89d0, and was repointed from `websqldatabase` to SVG SMIL in 3db552d1 ("better detection for legacy IE"). Both feature choices were arbitrary proxies. Two dependencies, a config file, a webpack alias, a loader rule, a generated gitignored file, and an install hook computed one boolean; the first commit inlines that boolean and deletes the rest.

The repo then declares no install hooks at all, so the second commit is just `.yarnrc`. No install invocation changes and `commcare-cloud` needs nothing.

Left open deliberately: whether we should still detect a browser Microsoft retired in 2022. Removing the check would also delete both `unsupported_browser.html` partials and the dead `<!--[if lt IE 7]>` blocks in `base.html`.

</details>

### For developers

Puppeteer's browser download was a *dependency's* install hook, so running the JS tests locally now needs a one-time `npx puppeteer browsers install chrome` — documented in `docs/js-guide/testing.rst` and `DEV_SETUP.md`. CI is unaffected: `Dockerfile` sets `PUPPETEER_SKIP_DOWNLOAD=true` and `Gruntfile.js` points at the image's Chrome.

## Feature Flag

N/A

## Safety Assurance

### Safety story

The modernizr removal is behaviour-preserving by construction — the replacement is the expression from the generated bundle, copied verbatim, so `unsupportedBrowser()` and the banner it controls are unchanged.

The rest was verified by running it, since "nothing depended on that install hook" is exactly the kind of claim that reads as true and isn't. A full `yarn build` compiles with modernizr deleted, and again after a script-free `yarn install`. `yarn install --frozen-lockfile` reports `warning Ignored scripts due to flag.` and eslint is clean on both changed files. No `modernizr` reference survives outside `node_modules`, and nothing uses the `.smil` / `no-js` classes its `setClasses` option injected.

### Automated test coverage

None, and none is appropriate — config plus a three-line feature test. CI covers it: the `python-sharded-and-javascript` leg runs `yarn test`, which builds the bundles that imported modernizr.

### QA Plan

Confirm the unsupported-browser banner still does *not* appear on a modern browser. That is the only user-visible surface this touches.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
