### PR TITLE
Audit CI runner egress with harden-runner

### DIFF
--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -7,6 +7,13 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
+      # Audit-only: records egress from the runner, never fails the build.
+      # Tighten to egress-policy: block once audit logs confirm the endpoint list.
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v5
         with:
           submodules: recursive

--- a/.github/workflows/dependency-metrics.yml
+++ b/.github/workflows/dependency-metrics.yml
@@ -12,6 +12,13 @@ jobs:
       DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
     steps:
+      # Audit-only: records egress from the runner, never fails the build.
+      # Tighten to egress-policy: block once audit logs confirm the endpoint list.
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,6 +10,13 @@ jobs:
     if: ${{ github.secret_source == 'Actions' }}
     runs-on: ubuntu-latest
     steps:
+      # Audit-only: records egress from the runner, never fails the build.
+      # Tighten to egress-policy: block once audit logs confirm the endpoint list.
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@v5
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Audit-only: records egress from the runner, never fails the build.
+      # Tighten to egress-policy: block once audit logs confirm the endpoint list.
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: audit
+
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
@@ -39,6 +46,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Audit-only: records egress from the runner, never fails the build.
+      # Tighten to egress-policy: block once audit logs confirm the endpoint list.
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: audit
+
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/rebuild-staging.yml
+++ b/.github/workflows/rebuild-staging.yml
@@ -22,6 +22,13 @@ jobs:
       merged-branch: >-
         ${{ steps.check-merged.outputs.merged-branch }}
     steps:
+    # Audit-only: records egress from the runner, never fails the build.
+    # Tighten to egress-policy: block once audit logs confirm the endpoint list.
+    - name: Harden runner
+      uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+      with:
+        egress-policy: audit
+
     - name: Check if branch is in staging config
       id: check
       if: github.event_name == 'push'
@@ -68,6 +75,13 @@ jobs:
     if: needs.check-branch.outputs.is-merged-staging-branch == 'true'
     runs-on: ubuntu-latest
     steps:
+    # Audit-only: records egress from the runner, never fails the build.
+    # Tighten to egress-policy: block once audit logs confirm the endpoint list.
+    - name: Harden runner
+      uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+      with:
+        egress-policy: audit
+
     - name: Generate GitHub App token
       id: app-token
       uses: actions/create-github-app-token@v1
@@ -97,6 +111,13 @@ jobs:
     permissions:
       contents: write
     steps:
+    # Audit-only: records egress from the runner, never fails the build.
+    # Tighten to egress-policy: block once audit logs confirm the endpoint list.
+    - name: Harden runner
+      uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@v6
       with:
         ref: master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,13 @@ jobs:
       DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
       REUSE_DB: true  # do not drop databases on completion to save time
     steps:
+    # Audit-only: records egress from the runner, never fails the build.
+    # Tighten to egress-policy: block once audit logs confirm the endpoint list.
+    - name: Harden runner
+      uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@v5
       with:
         submodules: recursive

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -11,6 +11,13 @@ jobs:
     env:
       CCHQ_WITHOUT_SSO: 1
     steps:
+      # Audit-only: records egress from the runner, never fails the build.
+      # Tighten to egress-policy: block once audit logs confirm the endpoint list.
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v5
         with:
           ref: master


### PR DESCRIPTION
## Product Description

No user-facing or developer-facing effects. CI only.

## Technical Summary

Adds `step-security/harden-runner` in `audit` mode as the first step of the 10 CI jobs that either execute third-party code or hold a credential worth stealing. Audit mode records every outbound connection a runner makes and surfaces anomalies; it cannot fail a build.

Split out of the rest of the ChainDrop hardening work because it is the one piece that adds a **new third-party dependency with privileged access to our runners**, rather than riding along with mechanical pinning changes. Siblings: #38004 (pinning and cooldown) and #38006 (npm install hooks). All three are independent and can land in any order.

The motivating case: ChainDrop worked by exfiltrating harvested npm and GitHub credentials to `npm-cache.com` and an Ethereum RPC endpoint. We weren't on affected dependency versions, but had we been, nothing in our CI would have noticed. Egress auditing is the control that turns that from invisible into a log entry. The next step would be to switch from audit to block once a baseline is set, which would actually prevent the unexpected egress traffic.

### The case against, stated fairly

These are real and worth weighing before we commit to it:

- **It's a new party with visibility into our CI.** harden-runner uploads egress telemetry to StepSecurity's hosted service. They gain metadata about what our runners talk to. That is a genuine outward data flow, not a purely local control.
- **It runs privileged.** It installs an eBPF-based monitor on the runner before anything else. That's inherent to what it does, and it's why it's the first step, but it means trusting StepSecurity with the whole runner.
- **The vendor wrote the advisory.** The ChainDrop write-up motivating this work is StepSecurity's own marketing surface. That doesn't make the analysis wrong, but the recommendation is not disinterested.

Mitigations applied: pinned by commit SHA (`v2.20.1`) rather than a mutable tag, and `audit` rather than `block` so it cannot break CI while we evaluate it.

### Coverage

10 jobs across 7 workflows:

| Workflow | Why |
|---|---|
| `lint.yml` (2 jobs), `tests.yml`, `build-static.yml` | PR-triggered, install and execute npm/PyPI dependencies |
| `update-translations.yml` | GitHub App token, OpenAI key, `uv sync`, curls a transifex installer |
| `rebuild-staging.yml` (3 jobs) | contents-write App token; clones and builds Vellum; curls a remote config |
| `docker-image.yml` | Docker Hub read-write token |
| `dependency-metrics.yml` | Datadog keys, fetches from PyPI |

All three `rebuild-staging` jobs are covered individually, since each runs on its own runner and `remove-merged-branch` is the one that mints the write-scoped token.

Four jobs are left uncovered: `required-labels` (no external fetch beyond its own action), `test-docs` (fetches PyPI, no notable secret), `codeql-analysis`, and `claude-dependabot`. That last one is the weakest omission — it holds an API key and runs an action that executes model-directed code — and I'd add it if we keep this.

Note `tests.yml` runs its work inside docker via `scripts/docker`, so harden-runner's host-level monitoring only partially sees that job's egress. Treat that job's coverage as best-effort.

## Feature Flag

N/A

## Safety Assurance

### Safety story

`audit` mode cannot fail a build — that is the main safety property. The change is also pure insertion: it adds a first step to 10 jobs and modifies no existing step, `with:` block, `env:`, or matrix.

Verified programmatically rather than by eye: all 10 target jobs have harden-runner as `steps[0]` with `egress-policy: audit`; all 11 workflow files still parse; the diff touches no pre-existing `uses:` line; and the pinned SHA `b09bb98e06d4d774595224525879c09bc6e98c40` resolves to `v2.20.1`, the current latest release, confirmed through the GitHub API.

If we decide against this, reverting is a clean single-commit revert with no residue.

### Automated test coverage

None, and none is appropriate — this is CI configuration. This PR's own CI run is the test: if the step were malformed or misplaced, these workflows would fail here.

### QA Plan

None needed — no user-facing surface. The useful post-merge step is reading the audit logs on a few runs to build the endpoint allowlist that `block` mode would need.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
