### PR TITLE
Public Webforms: Manage public webforms view

### DIFF
--- a/corehq/apps/public_webforms/form_paths.py
+++ b/corehq/apps/public_webforms/form_paths.py
@@ -1,15 +1,19 @@
-from couchdbkit.exceptions import DocTypeError
-
-from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 
 from dimagi.utils.couch.database import iter_docs
 
-from corehq.apps.app_manager.dbaccessors import wrap_app
 from corehq.apps.app_manager.models import Application
+from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans
 
 
 def get_public_webform_form_paths(domain, webforms):
+    """Iterate through all apps and builds referenced by included
+    PublicWebforms to get URLs and display names.
+
+    For performance, ``webforms`` should be limited to a reasonable number,
+    e.g., 100, which is typically the max passed by a paginated table view.
+    """
     webforms = list(webforms)
     builds = _get_apps(domain, {webform.app_build_id for webform in webforms})
     apps = _get_apps(domain, {webform.app_id for webform in webforms})
@@ -28,20 +32,17 @@ def _get_apps(domain, app_ids):
     for doc in iter_docs(Application.get_db(), list(app_ids)):
         if doc.get('domain') != domain or doc['doc_type'].endswith('-Deleted'):
             continue
-        try:
-            apps[doc['_id']] = wrap_app(doc)
-        except DocTypeError:
-            pass
+        apps[doc['_id']] = doc
     return apps
 
 
 def _app_name(webform, apps, builds):
     named_app = apps.get(webform.app_id)
     if named_app:
-        return named_app.name
+        return named_app['name']
     else:
         named_build = builds.get(webform.app_build_id)
-        return "{} {}".format(named_build.name, _("(Deleted)")) if named_build else None
+        return "{} {}".format(named_build['name'], _("(Deleted)")) if named_build else None
 
 
 def _app_url(webform, apps, domain):
@@ -51,10 +52,15 @@ def _app_url(webform, apps, domain):
 
 def _app_version(webform, builds):
     build = builds.get(webform.app_build_id)
-    return build.version if build else None
+    return build['version'] if build else None
 
 
 def _form_name(webform, builds):
     build = builds.get(webform.app_build_id)
-    form = build.get_form(webform.form_unique_id) if build else None
-    return form.default_name() if form else None
+    if not build:
+        return None
+    langs = [build.get('default_language')] + build.get('langs', [])
+    for module in build.get('modules', []):
+        for form in module.get('forms', []):
+            if form.get('unique_id') == webform.form_unique_id:
+                return clean_trans(form['name'], langs)

--- a/corehq/apps/public_webforms/form_paths.py
+++ b/corehq/apps/public_webforms/form_paths.py
@@ -1,0 +1,60 @@
+from couchdbkit.exceptions import DocTypeError
+
+from django.utils.translation import gettext_lazy as _
+from django.urls import reverse
+
+from dimagi.utils.couch.database import iter_docs
+
+from corehq.apps.app_manager.dbaccessors import wrap_app
+from corehq.apps.app_manager.models import Application
+
+
+def get_public_webform_form_paths(domain, webforms):
+    webforms = list(webforms)
+    builds = _get_apps(domain, {webform.app_build_id for webform in webforms})
+    apps = _get_apps(domain, {webform.app_id for webform in webforms})
+    return {
+        webform.id: {
+            'app_name': _app_name(webform, apps, builds),
+            'app_url': _app_url(webform, apps, domain),
+            'app_version': _app_version(webform, builds),
+            'form_name': _form_name(webform, builds),
+        } for webform in webforms
+    }
+
+
+def _get_apps(domain, app_ids):
+    apps = {}
+    for doc in iter_docs(Application.get_db(), list(app_ids)):
+        if doc.get('domain') != domain or doc['doc_type'].endswith('-Deleted'):
+            continue
+        try:
+            apps[doc['_id']] = wrap_app(doc)
+        except DocTypeError:
+            pass
+    return apps
+
+
+def _app_name(webform, apps, builds):
+    named_app = apps.get(webform.app_id)
+    if named_app:
+        return named_app.name
+    else:
+        named_build = builds.get(webform.app_build_id)
+        return "{} {}".format(named_build.name, _("(Deleted)")) if named_build else None
+
+
+def _app_url(webform, apps, domain):
+    live_app = apps.get(webform.app_id)
+    return reverse('view_app', args=[domain, webform.app_id]) if live_app else None
+
+
+def _app_version(webform, builds):
+    build = builds.get(webform.app_build_id)
+    return build.version if build else None
+
+
+def _form_name(webform, builds):
+    build = builds.get(webform.app_build_id)
+    form = build.get_form(webform.form_unique_id) if build else None
+    return form.default_name() if form else None

--- a/corehq/apps/public_webforms/forms.py
+++ b/corehq/apps/public_webforms/forms.py
@@ -64,7 +64,7 @@ class PublicWebformFilterForm(forms.Form):
     }
 
     def filter(self, queryset):
-        self.is_valid()  # populates cleaned_data, dropping any invalid field
+        self.is_valid()
         for field, lookup in self.lookups.items():
             if value := self.cleaned_data.get(field):
                 queryset = queryset.filter(**{lookup: value})

--- a/corehq/apps/public_webforms/forms.py
+++ b/corehq/apps/public_webforms/forms.py
@@ -25,8 +25,55 @@ from corehq.apps.public_webforms.form_choices import (
     get_public_webform_eligible_form,
     get_public_webform_type,
 )
-from corehq.apps.public_webforms.models import PublicWebform
+from corehq.apps.public_webforms.models import (
+    PublicWebform,
+    PublicWebformStatus,
+    PublicWebformType,
+)
 from corehq.util.timezones.conversions import ServerTime, UserTime
+
+
+class PublicWebformFilterForm(forms.Form):
+
+    search = forms.CharField(
+        required=False,
+        label=gettext_lazy("Search labels"),
+        widget=forms.TextInput(attrs={
+            'type': 'search',
+            'class': 'form-control',
+            'placeholder': gettext_lazy("Search labels"),
+        }),
+    )
+    status = forms.ChoiceField(
+        required=False,
+        label=gettext_lazy("Status"),
+        choices=[('', gettext_lazy("Any status"))] + PublicWebformStatus.choices,
+        widget=forms.Select(attrs={'class': 'form-select'}),
+    )
+    session_type = forms.ChoiceField(
+        required=False,
+        label=gettext_lazy("Type"),
+        choices=[('', gettext_lazy("Any type"))] + PublicWebformType.choices,
+        widget=forms.Select(attrs={'class': 'form-select'}),
+    )
+
+    lookups = {
+        'search': 'label__icontains',
+        'status': 'status',
+        'session_type': 'session_type',
+    }
+
+    def filter(self, queryset):
+        self.is_valid()  # populates cleaned_data, dropping any invalid field
+        for field, lookup in self.lookups.items():
+            if value := self.cleaned_data.get(field):
+                queryset = queryset.filter(**{lookup: value})
+        return queryset
+
+    @property
+    def is_filtering(self):
+        self.is_valid()
+        return any(self.cleaned_data.get(field) for field in self.lookups)
 
 
 class CreatePublicWebformForm(forms.Form):

--- a/corehq/apps/public_webforms/models.py
+++ b/corehq/apps/public_webforms/models.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from casexml.apps.phone.models import OTARestoreUser
+from dimagi.utils.web import get_url_base
 
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.util import PUBLIC_USER_ID
@@ -13,6 +14,38 @@ from corehq.apps.users.util import PUBLIC_USER_ID
 class PublicWebformType(models.TextChoices):
     REGISTRATION = ('registration', _("Registration"))
     SURVEY = ('survey', _("Survey"))
+
+
+class PublicWebformStatus(models.IntegerChoices):
+    """Whether a webform is accepting requests for a one-time link.
+
+    Derived from ``expires_at`` and ``is_disabled`` rather than stored, so
+    a webform expires without anything having to write to it.
+    """
+
+    OPEN = (0, _("Open"))
+    CLOSED = (1, _("Closed"))
+    EXPIRED = (2, _("Expired"))
+
+
+class PublicWebformQuerySet(models.QuerySet):
+
+    def with_status(self):
+        """Annotate ``status``, so it can be filtered on in the database."""
+        return self.annotate(
+            status=models.Case(
+                models.When(
+                    expires_at__lt=timezone.now(),
+                    then=models.Value(PublicWebformStatus.EXPIRED),
+                ),
+                models.When(
+                    is_disabled=True,
+                    then=models.Value(PublicWebformStatus.CLOSED),
+                ),
+                default=models.Value(PublicWebformStatus.OPEN),
+                output_field=models.IntegerField(),
+            ),
+        )
 
 
 class PublicWebform(models.Model):
@@ -31,8 +64,24 @@ class PublicWebform(models.Model):
     expires_at = models.DateTimeField()
     is_disabled = models.BooleanField(default=True)
 
+    objects = PublicWebformQuerySet.as_manager()
+
     class Meta:
         indexes = [models.Index(fields=['domain', 'id'])]
+
+    @property
+    def public_url(self):
+        """The absolute link a respondent opens to request a one-time link.
+
+        Absolute because it is shared by email, SMS, and QR code, where a
+        relative URL is meaningless.
+        """
+        # TODO: point at the real public route once it exists
+        return f'{get_url_base()}/placeholder/url/{self.public_id.hex}'
+
+    @property
+    def is_expired(self):
+        return self.expires_at < timezone.now()
 
 
 class PublicFormSession(models.Model):

--- a/corehq/apps/public_webforms/models.py
+++ b/corehq/apps/public_webforms/models.py
@@ -47,6 +47,14 @@ class PublicWebformQuerySet(models.QuerySet):
             ),
         )
 
+    def with_submissions_count(self):
+        return self.annotate(
+            submissions=models.Count(
+                'publicformsession',
+                filter=models.Q(publicformsession__submitted_at__isnull=False),
+            ),
+        )
+
 
 class PublicWebform(models.Model):
 

--- a/corehq/apps/public_webforms/models.py
+++ b/corehq/apps/public_webforms/models.py
@@ -71,11 +71,7 @@ class PublicWebform(models.Model):
 
     @property
     def public_url(self):
-        """The absolute link a respondent opens to request a one-time link.
-
-        Absolute because it is shared by email, SMS, and QR code, where a
-        relative URL is meaningless.
-        """
+        """The absolute link a respondent opens to request a one-time link."""
         # TODO: point at the real public route once it exists
         return f'{get_url_base()}/placeholder/url/{self.public_id.hex}'
 

--- a/corehq/apps/public_webforms/tables.py
+++ b/corehq/apps/public_webforms/tables.py
@@ -4,6 +4,24 @@ from django.utils.translation import gettext_lazy as _
 from django_tables2 import columns, tables
 
 from corehq.apps.hqwebapp.tables.htmx import BaseHtmxTable
+from corehq.apps.public_webforms.models import (
+    PublicWebformStatus,
+    PublicWebformType,
+)
+from corehq.util.timezones.conversions import ServerTime
+
+STATUS_BADGES = {
+    PublicWebformStatus.OPEN:
+        'bg-success-subtle border border-success text-success-emphasis',
+    PublicWebformStatus.CLOSED:
+        'bg-secondary-subtle border border-secondary text-secondary-emphasis',
+    PublicWebformStatus.EXPIRED:
+        'bg-warning-subtle border border-warning text-warning-emphasis',
+}
+TYPE_BADGES = {
+    PublicWebformType.REGISTRATION: 'bg-primary-subtle text-primary-emphasis',
+    PublicWebformType.SURVEY: 'bg-info-subtle text-info-emphasis',
+}
 
 
 class PublicWebformTable(BaseHtmxTable, tables.Table):
@@ -35,8 +53,11 @@ class PublicWebformTable(BaseHtmxTable, tables.Table):
     expires_at = columns.Column(
         verbose_name=_("Closes"),
     )
-    delivery = columns.Column(
+    delivery = columns.TemplateColumn(
+        template_name='public_webforms/columns/delivery.html',
         verbose_name=_("Delivery"),
+        attrs={'td': {'class': 'text-nowrap'}},
+        empty_values=(),
     )
     public_url = columns.Column(
         verbose_name=_("Public URL"),
@@ -51,3 +72,22 @@ class PublicWebformTable(BaseHtmxTable, tables.Table):
 
     def render_label(self, value):
         return format_html('<div class="fw-semibold">{}</div>', value)
+
+    def render_session_type(self, record):
+        session_type = PublicWebformType(record.session_type)
+        return format_html(
+            '<span class="badge fs-6 {}">{}</span>',
+            TYPE_BADGES[session_type],
+            session_type.label,
+        )
+
+    def render_status(self, value):
+        status = PublicWebformStatus(value)
+        return format_html(
+            '<span class="badge fs-6 text-center rounded-pill {}">{}</span>',
+            STATUS_BADGES[status],
+            status.label,
+        )
+
+    def render_expires_at(self, value):
+        return ServerTime(value).user_time(self.timezone).ui_string()

--- a/corehq/apps/public_webforms/tables.py
+++ b/corehq/apps/public_webforms/tables.py
@@ -56,7 +56,7 @@ class PublicWebformTable(BaseHtmxTable, tables.Table):
         verbose_name=_("Submissions"),
     )
     expires_at = columns.Column(
-        verbose_name=_("Closes"),
+        verbose_name=_("Expires"),
     )
     delivery = columns.TemplateColumn(
         template_name='public_webforms/columns/delivery.html',

--- a/corehq/apps/public_webforms/tables.py
+++ b/corehq/apps/public_webforms/tables.py
@@ -64,7 +64,8 @@ class PublicWebformTable(BaseHtmxTable, tables.Table):
         attrs={'td': {'class': 'text-nowrap'}},
         empty_values=(),
     )
-    public_url = columns.Column(
+    public_url = columns.TemplateColumn(
+        template_name='public_webforms/columns/public_url.html',
         verbose_name=_("Public URL"),
     )
     actions = columns.Column(

--- a/corehq/apps/public_webforms/tables.py
+++ b/corehq/apps/public_webforms/tables.py
@@ -1,9 +1,14 @@
+from django.template.loader import render_to_string
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from django_tables2 import columns, tables
+from memoized import memoized
 
 from corehq.apps.hqwebapp.tables.htmx import BaseHtmxTable
+from corehq.apps.public_webforms.form_paths import (
+    get_public_webform_form_paths,
+)
 from corehq.apps.public_webforms.models import (
     PublicWebformStatus,
     PublicWebformType,
@@ -66,12 +71,22 @@ class PublicWebformTable(BaseHtmxTable, tables.Table):
         verbose_name=_("Actions"),
     )
 
-    def __init__(self, timezone, **kwargs):
+    def __init__(self, domain, timezone, **kwargs):
         super().__init__(**kwargs)
+        self.domain = domain
         self.timezone = timezone
 
-    def render_label(self, value):
-        return format_html('<div class="fw-semibold">{}</div>', value)
+    @property
+    @memoized
+    def form_paths(self):
+        return get_public_webform_form_paths(
+            self.domain, [row.record for row in self.paginated_rows])
+
+    def render_label(self, record, value):
+        return render_to_string('public_webforms/columns/form.html', {
+            'label': value,
+            'path': self.form_paths[record.id],
+        })
 
     def render_session_type(self, record):
         session_type = PublicWebformType(record.session_type)

--- a/corehq/apps/public_webforms/tables.py
+++ b/corehq/apps/public_webforms/tables.py
@@ -1,0 +1,53 @@
+from django.utils.html import format_html
+from django.utils.translation import gettext_lazy as _
+
+from django_tables2 import columns, tables
+
+from corehq.apps.hqwebapp.tables.htmx import BaseHtmxTable
+
+
+class PublicWebformTable(BaseHtmxTable, tables.Table):
+    """The dashboard's list of a project's public webforms."""
+
+    class Meta(BaseHtmxTable.Meta):
+        template_name = 'public_webforms/tables/public_webform.html'
+        attrs = {
+            'class': 'table table-hover px-2',
+            'thead': {'class': 'table-light text-uppercase'},
+        }
+        row_attrs = {
+            'class': 'align-middle',
+        }
+        orderable = False
+
+    label = columns.Column(
+        verbose_name=_("Form"),
+    )
+    session_type = columns.Column(
+        verbose_name=_("Type"),
+    )
+    status = columns.Column(
+        verbose_name=_("Status"),
+    )
+    submissions = columns.Column(
+        verbose_name=_("Submissions"),
+    )
+    expires_at = columns.Column(
+        verbose_name=_("Closes"),
+    )
+    delivery = columns.Column(
+        verbose_name=_("Delivery"),
+    )
+    public_url = columns.Column(
+        verbose_name=_("Public URL"),
+    )
+    actions = columns.Column(
+        verbose_name=_("Actions"),
+    )
+
+    def __init__(self, timezone, **kwargs):
+        super().__init__(**kwargs)
+        self.timezone = timezone
+
+    def render_label(self, value):
+        return format_html('<div class="fw-semibold">{}</div>', value)

--- a/corehq/apps/public_webforms/tables.py
+++ b/corehq/apps/public_webforms/tables.py
@@ -72,10 +72,11 @@ class PublicWebformTable(BaseHtmxTable, tables.Table):
         verbose_name=_("Actions"),
     )
 
-    def __init__(self, domain, timezone, **kwargs):
+    def __init__(self, domain, timezone, is_filtered=False, **kwargs):
         super().__init__(**kwargs)
         self.domain = domain
         self.timezone = timezone
+        self.is_filtered = is_filtered
 
     @property
     @memoized

--- a/corehq/apps/public_webforms/templates/public_webforms/columns/delivery.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/columns/delivery.html
@@ -1,0 +1,33 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+
+{% if record.allow_email %}
+  <span
+    class="badge fs-6 fa-regular bg-primary-subtle text-primary-emphasis"
+    title="{% trans_html_attr "Email enabled" %}"
+  >
+    <i class="fa-regular fa-envelope"></i>
+  </span>
+{% else %}
+  <span
+    class="badge fs-6 fa-regular bg-light text-body-tertiary"
+    title="{% trans_html_attr "Email disabled" %}"
+  >
+    <i class="fa-regular fa-envelope"></i>
+  </span>
+{% endif %}
+{% if record.allow_sms %}
+  <span
+    class="badge fs-6 fa-regular bg-primary-subtle text-primary-emphasis"
+    title="{% trans_html_attr "SMS enabled" %}"
+  >
+    <i class="fa-regular fa-comment"></i>
+  </span>
+{% else %}
+  <span
+    class="badge fs-6 fa-regular bg-light text-body-tertiary"
+    title="{% trans_html_attr "SMS disabled" %}"
+  >
+    <i class="fa-regular fa-comment"></i>
+  </span>
+{% endif %}

--- a/corehq/apps/public_webforms/templates/public_webforms/columns/form.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/columns/form.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+
+<div class="fw-semibold">{{ label }}</div>
+<div>
+  {% if path.app_url %}
+    <a href="{{ path.app_url }}">{{ path.app_name }}</a>
+  {% else %}
+    <span class="text-body-secondary">{{ path.app_name }}</span>
+  {% endif %}
+  <span class="text-body-secondary">v{{ path.app_version }}</span>
+  <span class="text-body-tertiary mx-1">·</span>
+  <span class="text-body-secondary">{{ path.form_name }}</span>
+</div>

--- a/corehq/apps/public_webforms/templates/public_webforms/columns/public_url.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/columns/public_url.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+
+<div class="input-group" x-data="{ copied: false }">
+  <input
+    type="text"
+    class="form-control form-control-sm"
+    aria-label="{% trans_html_attr "Public URL" %}"
+    value="{{ record.public_url }}"
+    x-ref="url"
+    readonly
+  />
+  <button
+    type="button"
+    class="btn btn-sm btn-outline-secondary"
+    title="{% trans_html_attr "Copy URL" %}"
+    @click="navigator.clipboard.writeText($refs.url.value); copied = true; setTimeout(() => copied = false, 1500)"
+  >
+    <i :class="copied ? 'fa fa-check' : 'fa-regular fa-copy'"></i>
+  </button>
+</div>

--- a/corehq/apps/public_webforms/templates/public_webforms/columns/public_url.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/columns/public_url.html
@@ -18,4 +18,13 @@
   >
     <i :class="copied ? 'fa fa-check' : 'fa-regular fa-copy'"></i>
   </button>
+  <button
+    type="button"
+    class="btn btn-sm btn-outline-secondary"
+    title="{% trans_html_attr "Show QR code" %}"
+    data-bs-toggle="modal"
+    data-bs-target="#qr-code-{{ record.id }}"
+  >
+    <i class="fa fa-qrcode"></i>
+  </button>
 </div>

--- a/corehq/apps/public_webforms/templates/public_webforms/manage.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/manage.html
@@ -1,5 +1,8 @@
 {% extends 'hqwebapp/bootstrap5/base_section.html' %}
 {% load i18n %}
+{% load hq_shared_tags %}
+{% load django_tables2 %}
+{% js_entry 'hqwebapp/js/htmx_and_alpine' %}
 
 {% block page_content %}
   <h1 class="page-title">{% trans "Public Webforms" %}</h1>
@@ -20,5 +23,29 @@
       <i class="fa fa-plus"></i>
       {% trans "New Public Webform" %}
     </a>
+    <a class="btn btn-link icon-link" href="placeholder/for/help">
+      {# TODO: real help link #}
+      <i class="fa fa-info-circle"></i>
+      {% trans "How public forms work" %}
+    </a>
   </div>
+
+  <div class="card">
+    <h4 class="card-header">{% trans "Webforms" %}</h4>
+    <div class="card-body p-0">
+      <div
+        hx-trigger="load"
+        hx-get="{% url 'public_webforms_table' domain %}{% querystring %}"
+      >
+        <div class="htmx-indicator p-3">
+          <i class="fa-solid fa-spinner fa-spin"></i> {% trans "Loading..." %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block modals %}
+  {% include "hqwebapp/htmx/error_modal.html" %}
+  {{ block.super }}
 {% endblock %}

--- a/corehq/apps/public_webforms/templates/public_webforms/manage.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/manage.html
@@ -32,7 +32,47 @@
 
   <div class="card">
     <h4 class="card-header">{% trans "Webforms" %}</h4>
-    <div class="card-body p-0">
+    <form
+      class="row g-2 p-3 pb-0"
+      hx-get="{% url 'public_webforms_table' domain %}"
+      hx-target="#PublicWebformTable"
+      hx-swap="outerHTML"
+      hx-trigger="change, input delay:300ms from:find input[type=search]"
+    >
+      <div class="col-sm-6 col-lg-4">
+        <label
+          class="visually-hidden"
+          for="{{ filter_form.search.id_for_label }}"
+        >
+          {{ filter_form.search.label }}
+        </label>
+        <div class="input-group">
+          {{ filter_form.search }}
+          <span class="input-group-text">
+            <i class="fa fa-search"></i>
+          </span>
+        </div>
+      </div>
+      <div class="col-sm-3 col-lg-2">
+        <label
+          class="visually-hidden"
+          for="{{ filter_form.session_type.id_for_label }}"
+        >
+          {{ filter_form.session_type.label }}
+        </label>
+        {{ filter_form.session_type }}
+      </div>
+      <div class="col-sm-3 col-lg-2">
+        <label
+          class="visually-hidden"
+          for="{{ filter_form.status.id_for_label }}"
+        >
+          {{ filter_form.status.label }}
+        </label>
+        {{ filter_form.status }}
+      </div>
+    </form>
+    <div class="card-body">
       <div
         hx-trigger="load"
         hx-get="{% url 'public_webforms_table' domain %}{% querystring %}"

--- a/corehq/apps/public_webforms/templates/public_webforms/partials/qr_modal.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/partials/qr_modal.html
@@ -1,0 +1,55 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+
+<div
+  id="qr-code-{{ webform.id }}"
+  class="modal fade"
+  tabindex="-1"
+  aria-labelledby="qr-code-{{ webform.id }}-title"
+  aria-hidden="true"
+>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 id="qr-code-{{ webform.id }}-title" class="modal-title">
+          {% trans "Public URL QR Code" %}
+        </h4>
+        <button
+          class="btn-close"
+          type="button"
+          aria-label="{% trans_html_attr "Close" %}"
+          data-bs-dismiss="modal"
+        ></button>
+      </div>
+      <div class="modal-body text-center">
+        <p class="fw-semibold">{{ webform.label }}</p>
+        <p>
+          {# lazily, so a page of webforms isn't a page of QR code requests #}
+          <img
+            src="{% url 'public_webform_qr_code' domain webform.id %}"
+            width="250"
+            height="250"
+            loading="lazy"
+            alt="{% trans_html_attr "QR code for this webform's public URL" %}"
+          />
+        </p>
+        <p class="text-body-secondary">
+          {% blocktrans %}
+            Respondents who scan this code open the same page as the public URL,
+            where they can request a one-time link.
+          {% endblocktrans %}
+        </p>
+        <p class="text-break"><code>{{ webform.public_url }}</code></p>
+      </div>
+      <div class="modal-footer">
+        <button
+          class="btn btn-outline-primary"
+          type="button"
+          data-bs-dismiss="modal"
+        >
+          {% trans "Close" %}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/corehq/apps/public_webforms/templates/public_webforms/tables/public_webform.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/tables/public_webform.html
@@ -3,7 +3,11 @@
 
 {% block no_results_table %}
   <p class="text-muted p-3 mb-0">
-    {% trans "No public webforms have been created yet." %}
+    {% if table.is_filtered %}
+      {% trans "No public webforms match these filters." %}
+    {% else %}
+      {% trans "No public webforms have been created yet." %}
+    {% endif %}
   </p>
 {% endblock no_results_table %}
 

--- a/corehq/apps/public_webforms/templates/public_webforms/tables/public_webform.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/tables/public_webform.html
@@ -1,0 +1,8 @@
+{% extends "hqwebapp/tables/bootstrap5_htmx.html" %}
+{% load i18n %}
+
+{% block no_results_table %}
+  <p class="text-muted p-3 mb-0">
+    {% trans "No public webforms have been created yet." %}
+  </p>
+{% endblock no_results_table %}

--- a/corehq/apps/public_webforms/templates/public_webforms/tables/public_webform.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/tables/public_webform.html
@@ -6,3 +6,11 @@
     {% trans "No public webforms have been created yet." %}
   </p>
 {% endblock no_results_table %}
+
+{% block after_table %}
+  {{ block.super }}
+  {# outside the table, so a modal doesn't inherit a cell's styling #}
+  {% for row in table.paginated_rows %}
+    {% include "public_webforms/partials/qr_modal.html" with webform=row.record domain=table.domain %}
+  {% endfor %}
+{% endblock after_table %}

--- a/corehq/apps/public_webforms/tests/test_form_paths.py
+++ b/corehq/apps/public_webforms/tests/test_form_paths.py
@@ -1,0 +1,112 @@
+from types import SimpleNamespace
+
+from unmagic import fixture, use
+
+from corehq.apps.app_manager.dbaccessors import get_app
+from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.apps.app_manager.tests.util import (
+    delete_all_apps,
+    get_simple_form,
+    patch_validate_xform,
+)
+from corehq.apps.domain.models import Domain
+from corehq.apps.public_webforms.form_paths import (
+    get_public_webform_form_paths,
+)
+from corehq.apps.public_webforms.models import PublicWebform
+
+DOMAIN = 'public-webform-form-paths'
+APP_NAME = 'Frontline Program'
+FORM_NAME = 'Cohort Registration'
+
+
+@use('db')
+@fixture
+def app_with_build():
+    """An app with one named form, and a build pinning that name."""
+    domain_obj = Domain.get_or_create_with_name(DOMAIN)
+    factory = AppFactory(DOMAIN, name=APP_NAME, build_version='2.51.0')
+    __, form = factory.new_basic_module('survey', 'patient')
+    form.name = {'en': FORM_NAME}
+    form.source = get_simple_form(xmlns=form.unique_id)
+    try:
+        with patch_validate_xform():
+            app = factory.app
+            app.save()
+            build = app.make_build()
+            build.save()
+            yield SimpleNamespace(
+                app_id=app.get_id,
+                build_id=build.get_id,
+                version=build.version,
+                form_unique_id=form.unique_id,
+            )
+    finally:
+        delete_all_apps()
+        domain_obj.delete()
+
+
+def _webform(app, webform_id=1, **kwargs):
+    return PublicWebform(**{
+        'id': webform_id,
+        'domain': DOMAIN,
+        'app_id': app.app_id,
+        'app_build_id': app.build_id,
+        'form_unique_id': app.form_unique_id,
+        **kwargs,
+    })
+
+
+def _path(*webforms):
+    paths = get_public_webform_form_paths(DOMAIN, webforms)
+    return paths[webforms[0].id] if len(webforms) == 1 else paths
+
+
+@use(app_with_build)
+class TestGetPublicWebformPaths:
+
+    def test_get_public_webform_paths(self):
+        app = app_with_build()
+
+        path = _path(_webform(app))
+
+        assert path['app_name'] == APP_NAME
+        assert path['app_version'] == app.version
+        assert path['form_name'] == FORM_NAME
+        assert path['app_url'].endswith(f'/{app.app_id}/')
+
+    def test_app_uses_current_name(self):
+        app = app_with_build()
+        canonical = get_app(DOMAIN, app.app_id)
+        canonical.name = 'Renamed Program'
+        canonical.save()
+
+        assert _path(_webform(app))['app_name'] == 'Renamed Program'
+
+    def test_form_uses_pinned_name(self):
+        app = app_with_build()
+        canonical = get_app(DOMAIN, app.app_id)
+        canonical.get_form(app.form_unique_id).name = {'en': 'Renamed Form'}
+        canonical.save()
+
+        assert _path(_webform(app))['form_name'] == FORM_NAME
+
+    def test_app_version_pinned(self):
+        app = app_with_build()
+        canonical = get_app(DOMAIN, app.app_id)
+        canonical.save()  # bumps the app's version past the build's
+
+        assert _path(_webform(app))['app_version'] == app.version
+        assert get_app(DOMAIN, app.app_id).version > app.version
+
+    def test_deleted_app_falls_back_to_build_name(self):
+        app = app_with_build()
+        canonical = get_app(DOMAIN, app.app_id)
+        canonical.delete_app()
+        canonical.save(increment_version=False)
+
+        path = _path(_webform(app))
+
+        assert path['app_name'] == f'{APP_NAME} (Deleted)'
+        assert path['app_url'] is None
+        assert path['form_name'] == FORM_NAME

--- a/corehq/apps/public_webforms/tests/test_forms.py
+++ b/corehq/apps/public_webforms/tests/test_forms.py
@@ -9,7 +9,12 @@ from unmagic import use
 from django.db import DatabaseError
 
 from corehq.apps.public_webforms import forms
-from corehq.apps.public_webforms.models import PublicWebformType
+from corehq.apps.public_webforms.models import (
+    PublicWebform,
+    PublicWebformStatus,
+    PublicWebformType,
+)
+from corehq.apps.public_webforms.tests.utils import create_webform
 
 DOMAIN = 'public-webform-forms'
 TIMEZONE = pytz.timezone('America/New_York')
@@ -17,9 +22,52 @@ SURVEY_FORM = SimpleNamespace(is_registration_form=lambda: False)
 REGISTRATION_FORM = SimpleNamespace(is_registration_form=lambda: True)
 
 
+def _filter(**params):
+    queryset = PublicWebform.objects.with_status()
+    return list(forms.PublicWebformFilterForm(params).filter(queryset))
+
+
+@use('db')
+@pytest.mark.parametrize('params', [
+    {'search': 'natal'},
+    {'status': PublicWebformStatus.CLOSED},
+    {'session_type': PublicWebformType.REGISTRATION},
+], ids=['search', 'status', 'session_type'])
+def test_each_filter_narrows_the_list(params):
+    wanted = create_webform(
+        label='Antenatal visit',
+        session_type=PublicWebformType.REGISTRATION,
+        is_disabled=True,
+    )
+    create_webform(
+        label='Household survey',
+        session_type=PublicWebformType.SURVEY,
+        is_disabled=False,
+    )
+
+    assert _filter(**params) == [wanted]
+
+
+@use('db')
+def test_a_value_that_is_not_offered_is_ignored():
+    # The query string is linkable, so a hand-edited filter must not break it.
+    webform = create_webform()
+
+    assert _filter(status='not-a-status') == [webform]
+
+
+@pytest.mark.parametrize('params, expected', [
+    ({}, False),
+    ({'search': ''}, False),
+    ({'search': 'natal'}, True),
+    ({'status': 'not-a-status'}, False),
+], ids=['unfiltered', 'blank', 'searching', 'not-offered'])
+def test_is_filtering_reports_whether_the_list_was_narrowed(params, expected):
+    assert forms.PublicWebformFilterForm(params).is_filtering is expected
+
+
 def _form(data=None, has_sms_privilege=False, eligible_form=SURVEY_FORM):
-    """Stubs the reads that go to the database or to released builds, which the
-    accounting and form_choices tests cover."""
+    """Stubs the reads that go to the database or to released builds."""
     args = [data] if data is not None else []
     with patch.multiple(
         forms,

--- a/corehq/apps/public_webforms/tests/test_models.py
+++ b/corehq/apps/public_webforms/tests/test_models.py
@@ -23,23 +23,8 @@ from corehq.apps.public_webforms.models import (
     PublicWebform,
     PublicWebformStatus,
 )
+from corehq.apps.public_webforms.tests.utils import create_webform
 from corehq.apps.users.util import PUBLIC_USER_ID
-
-
-def _create_webform(expires_at=timezone.now() + datetime.timedelta(days=30), **kwargs):
-    return PublicWebform.objects.create(
-        domain='public-forms-domain',
-        label='Antenatal visit',
-        app_id='app',
-        app_build_id='build',
-        form_unique_id='form',
-        endpoint_id='endpoint',
-        session_type='survey',
-        allow_sms=False,
-        allow_email=True,
-        expires_at=expires_at,
-        **kwargs,
-    )
 
 
 def test_public_url_is_absolute_and_keyed_on_the_public_id():
@@ -67,7 +52,7 @@ def test_is_expired(offset, expected):
 def test_with_status_derives_status_from_expiry_and_the_open_setting(
     expires_in, is_disabled, expected
 ):
-    webform = _create_webform(
+    webform = create_webform(
         expires_at=timezone.now() + expires_in, is_disabled=is_disabled)
 
     annotated = PublicWebform.objects.with_status().get(pk=webform.pk)

--- a/corehq/apps/public_webforms/tests/test_models.py
+++ b/corehq/apps/public_webforms/tests/test_models.py
@@ -2,11 +2,15 @@ import datetime
 from uuid import uuid4
 
 import pytest
+from unmagic import use
 
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, TestCase
+from django.utils import timezone
 
 from casexml.apps.phone.xml import get_registration_element_data
+from dimagi.utils.web import get_url_base
+
 from corehq.apps.public_webforms.decorators import (
     PUBLIC_FORM_SESSION_COOKIE_NAME,
     PUBLIC_FORM_SESSION_HEADER,
@@ -17,8 +21,58 @@ from corehq.apps.public_webforms.models import (
     PublicFormSession,
     PublicFormUser,
     PublicWebform,
+    PublicWebformStatus,
 )
 from corehq.apps.users.util import PUBLIC_USER_ID
+
+
+def _create_webform(expires_at=timezone.now() + datetime.timedelta(days=30), **kwargs):
+    return PublicWebform.objects.create(
+        domain='public-forms-domain',
+        label='Antenatal visit',
+        app_id='app',
+        app_build_id='build',
+        form_unique_id='form',
+        endpoint_id='endpoint',
+        session_type='survey',
+        allow_sms=False,
+        allow_email=True,
+        expires_at=expires_at,
+        **kwargs,
+    )
+
+
+def test_public_url_is_absolute_and_keyed_on_the_public_id():
+    webform = PublicWebform(public_id=uuid4())
+    # absolute because it is shared over email, SMS, and QR code
+    assert webform.public_url.startswith(get_url_base())
+    assert webform.public_id.hex in webform.public_url
+
+
+@pytest.mark.parametrize('offset, expected', [
+    (datetime.timedelta(minutes=-1), True),
+    (datetime.timedelta(minutes=1), False),
+], ids=['past', 'future'])
+def test_is_expired(offset, expected):
+    assert PublicWebform(expires_at=timezone.now() + offset).is_expired is expected
+
+
+@use('db')
+@pytest.mark.parametrize('expires_in, is_disabled, expected', [
+    (datetime.timedelta(days=1), False, PublicWebformStatus.OPEN),
+    (datetime.timedelta(days=1), True, PublicWebformStatus.CLOSED),
+    (datetime.timedelta(days=-1), False, PublicWebformStatus.EXPIRED),
+    (datetime.timedelta(days=-1), True, PublicWebformStatus.EXPIRED),
+], ids=['open', 'closed', 'expired', 'expired-and-closed'])
+def test_with_status_derives_status_from_expiry_and_the_open_setting(
+    expires_in, is_disabled, expected
+):
+    webform = _create_webform(
+        expires_at=timezone.now() + expires_in, is_disabled=is_disabled)
+
+    annotated = PublicWebform.objects.with_status().get(pk=webform.pk)
+
+    assert annotated.status == expected
 
 
 def test_public_form_session_username():

--- a/corehq/apps/public_webforms/tests/test_models.py
+++ b/corehq/apps/public_webforms/tests/test_models.py
@@ -60,6 +60,23 @@ def test_with_status_derives_status_from_expiry_and_the_open_setting(
     assert annotated.status == expected
 
 
+@use('db')
+@pytest.mark.parametrize('submitted_at, expected_submissions', [
+    (None, 0),
+    (timezone.now(), 1),
+], ids=['no-submissions', 'one-submission'])
+def test_with_submissions_count(submitted_at, expected_submissions):
+    webform = create_webform()
+    PublicFormSession.objects.create(
+        public_webform=webform,
+        expires_at=timezone.now() + datetime.timedelta(days=1),
+        submitted_at=submitted_at,
+    )
+
+    annotated = PublicWebform.objects.with_submissions_count().get(pk=webform.pk)
+    assert annotated.submissions == expected_submissions
+
+
 def test_public_form_session_username():
     webform = PublicWebform(domain='public-forms-domain')
     session = PublicFormSession(public_webform=webform)

--- a/corehq/apps/public_webforms/tests/test_tables.py
+++ b/corehq/apps/public_webforms/tests/test_tables.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+
+import pytest
+import pytz
+
+from corehq.apps.public_webforms.models import (
+    PublicWebform,
+    PublicWebformStatus,
+    PublicWebformType,
+)
+from corehq.apps.public_webforms.tables import PublicWebformTable
+
+TIMEZONE = pytz.timezone('America/New_York')
+
+
+def _table():
+    return PublicWebformTable(data=[], timezone=TIMEZONE)
+
+
+def _cells(webform):
+    table = PublicWebformTable(data=[webform], timezone=TIMEZONE)
+    [row] = table.rows
+    return {column.name: str(value) for column, value in row.items()}
+
+
+@pytest.mark.parametrize('status, expected_label', [
+    (PublicWebformStatus.OPEN, "Open"),
+    (PublicWebformStatus.CLOSED, "Closed"),
+    (PublicWebformStatus.EXPIRED, "Expired"),
+])
+def test_every_status_renders_a_labelled_badge(status, expected_label):
+    rendered = _table().render_status(status.value)
+
+    assert expected_label in rendered
+    assert 'badge' in rendered
+
+
+@pytest.mark.parametrize('session_type, expected_label', [
+    (PublicWebformType.REGISTRATION, "Registration"),
+    (PublicWebformType.SURVEY, "Survey"),
+])
+def test_every_type_renders_a_labelled_badge(session_type, expected_label):
+    rendered = _table().render_session_type(PublicWebform(session_type=session_type))
+
+    assert expected_label in rendered
+    assert 'badge' in rendered
+
+
+@pytest.mark.parametrize('stored_utc, expected', [
+    (datetime(2026, 9, 1, 21, 0), "Sep 01, 2026 17:00 EDT"),
+    (datetime(2026, 12, 1, 22, 0), "Dec 01, 2026 17:00 EST"),
+], ids=['daylight-saving-utc-4', 'standard-time-utc-5'])
+def test_closing_time_is_shown_in_the_projects_timezone(stored_utc, expected):
+    assert _table().render_expires_at(stored_utc) == expected
+
+
+@pytest.mark.parametrize('allow_email, allow_sms, expected_titles', [
+    (True, False, ["Email enabled", "SMS disabled"]),
+    (False, True, ["Email disabled", "SMS enabled"]),
+    (True, True, ["Email enabled", "SMS enabled"]),
+])
+def test_delivery_marks_each_channel_as_on_or_off(
+    allow_email, allow_sms, expected_titles
+):
+    webform = PublicWebform(allow_email=allow_email, allow_sms=allow_sms)
+
+    rendered = _cells(webform)['delivery']
+
+    for title in expected_titles:
+        assert title in rendered

--- a/corehq/apps/public_webforms/tests/test_tables.py
+++ b/corehq/apps/public_webforms/tests/test_tables.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 import pytz
@@ -74,6 +75,15 @@ def test_form_column_names_form_and_links_its_app():
     assert 'Cohort Registration' in rendered
     assert 'v3' in rendered
     assert '/apps/view/app-1/' in rendered
+
+
+def test_the_public_url_column_offers_the_url_to_copy():
+    webform = PublicWebform(id=1, public_id=uuid4())
+
+    rendered = _cells(webform)['public_url']
+
+    assert webform.public_url in rendered
+    assert 'clipboard' in rendered
 
 
 @pytest.mark.parametrize('allow_email, allow_sms, expected_titles', [

--- a/corehq/apps/public_webforms/tests/test_tables.py
+++ b/corehq/apps/public_webforms/tests/test_tables.py
@@ -1,8 +1,10 @@
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 import pytz
 
+from corehq.apps.public_webforms import tables
 from corehq.apps.public_webforms.models import (
     PublicWebform,
     PublicWebformStatus,
@@ -10,15 +12,16 @@ from corehq.apps.public_webforms.models import (
 )
 from corehq.apps.public_webforms.tables import PublicWebformTable
 
+DOMAIN = 'public-webform-tables'
 TIMEZONE = pytz.timezone('America/New_York')
 
 
 def _table():
-    return PublicWebformTable(data=[], timezone=TIMEZONE)
+    return PublicWebformTable(data=[], domain=DOMAIN, timezone=TIMEZONE)
 
 
 def _cells(webform):
-    table = PublicWebformTable(data=[webform], timezone=TIMEZONE)
+    table = PublicWebformTable(data=[webform], domain=DOMAIN, timezone=TIMEZONE)
     [row] = table.rows
     return {column.name: str(value) for column, value in row.items()}
 
@@ -52,6 +55,25 @@ def test_every_type_renders_a_labelled_badge(session_type, expected_label):
 ], ids=['daylight-saving-utc-4', 'standard-time-utc-5'])
 def test_closing_time_is_shown_in_the_projects_timezone(stored_utc, expected):
     assert _table().render_expires_at(stored_utc) == expected
+
+
+def test_form_column_names_form_and_links_its_app():
+    webform = PublicWebform(id=1, label='Antenatal visit')
+    path = {
+        'app_name': 'Frontline Program',
+        'app_url': '/apps/view/app-1/',
+        'app_version': 3,
+        'form_name': 'Cohort Registration',
+    }
+    with patch.object(
+        tables, 'get_public_webform_form_paths', return_value={1: path}
+    ):
+        rendered = _cells(webform)['label']
+
+    assert 'Antenatal visit' in rendered
+    assert 'Cohort Registration' in rendered
+    assert 'v3' in rendered
+    assert '/apps/view/app-1/' in rendered
 
 
 @pytest.mark.parametrize('allow_email, allow_sms, expected_titles', [

--- a/corehq/apps/public_webforms/tests/test_views.py
+++ b/corehq/apps/public_webforms/tests/test_views.py
@@ -1,10 +1,14 @@
 import datetime
 
+import pytz
+from time_machine import travel
 from unmagic import use
 
 from django.test import RequestFactory
 from django.utils import timezone
 
+from corehq.apps.public_webforms.models import PublicFormSession
+from corehq.apps.public_webforms.tables import PublicWebformTable
 from corehq.apps.public_webforms.tests.utils import DOMAIN, create_webform
 from corehq.apps.public_webforms.views import PublicWebformTableView
 
@@ -15,6 +19,14 @@ def _table_view(domain=DOMAIN, **params):
     view.kwargs = {}
     view.request = RequestFactory().get('/', params)
     return view
+
+
+def _create_session(webform, **kwargs):
+    return PublicFormSession.objects.create(
+        public_webform=webform,
+        expires_at=timezone.now() + datetime.timedelta(days=1),
+        **kwargs,
+    )
 
 
 @use('db')
@@ -32,3 +44,34 @@ def test_table_lists_webforms_sorted_by_expiration():
     closed = create_webform(expires_at=timezone.now() - datetime.timedelta(days=1))
 
     assert list(_table_view().get_queryset()) == [closing_later, closing_soon, closed]
+
+
+@use('db')
+def test_table_counts_webforms_submissions():
+    webform = create_webform()
+    _create_session(webform, submitted_at=timezone.now())
+    _create_session(webform)
+
+    [row] = _table_view().get_queryset()
+
+    assert row.submissions == 1
+
+
+@use('db')
+@travel('2026-08-01')
+def test_every_column_renders_from_the_queryset():
+    """The columns are fed by annotations, so they break away from the table."""
+    webform = create_webform(
+        expires_at=datetime.datetime(2026, 9, 1, 21, 0), is_disabled=False)
+    _create_session(webform, submitted_at=timezone.now())
+    table = PublicWebformTable(data=_table_view().get_queryset(), timezone=pytz.UTC)
+
+    [row] = table.rows
+    cells = {column.name: str(value) for column, value in row.items()}
+
+    assert 'Antenatal visit' in cells['label']
+    assert 'Survey' in cells['session_type']
+    assert 'Open' in cells['status']
+    assert cells['submissions'] == '1'
+    assert cells['expires_at'] == 'Sep 01, 2026 21:00 UTC'
+    assert 'fa-envelope' in cells['delivery']

--- a/corehq/apps/public_webforms/tests/test_views.py
+++ b/corehq/apps/public_webforms/tests/test_views.py
@@ -5,12 +5,21 @@ from time_machine import travel
 from unmagic import use
 
 from django.test import RequestFactory
+from django.urls import reverse
 from django.utils import timezone
 
 from corehq.apps.public_webforms.models import PublicFormSession
 from corehq.apps.public_webforms.tables import PublicWebformTable
-from corehq.apps.public_webforms.tests.utils import DOMAIN, create_webform
+from corehq.apps.public_webforms.tests.utils import (
+    DOMAIN,
+    NORMAL_USER,
+    OTHER_DOMAIN,
+    PublicWebformViewTestCase,
+    create_webform,
+)
 from corehq.apps.public_webforms.views import PublicWebformTableView
+from corehq.privileges import PUBLIC_WEBFORMS
+from corehq.util.test_utils import flag_enabled, privilege_enabled
 
 
 def _table_view(domain=DOMAIN, **params):
@@ -76,3 +85,28 @@ def test_every_column_renders_from_the_queryset():
     assert cells['submissions'] == '1'
     assert cells['expires_at'] == 'Sep 01, 2026 21:00 UTC'
     assert 'fa-envelope' in cells['delivery']
+
+
+@flag_enabled('PUBLIC_WEBFORMS')
+@privilege_enabled(PUBLIC_WEBFORMS)
+class TestPublicWebformQrCode(PublicWebformViewTestCase):
+
+    def get(self, webform, domain=DOMAIN):
+        url = reverse('public_webform_qr_code', args=[domain, webform.id])
+        return self.client.get(url)
+
+    def test_the_public_url_is_served_as_a_png(self):
+        response = self.get(create_webform())
+
+        assert response['Content-Type'] == 'image/png'
+
+    def test_another_projects_webform_is_not_found(self):
+        other = create_webform(domain=OTHER_DOMAIN)
+
+        assert self.get(other).status_code == 404
+
+    def test_a_qr_code_is_not_served_without_the_permission(self):
+        webform = create_webform()
+        self.sign_in(NORMAL_USER)
+
+        assert self.get(webform).status_code != 200

--- a/corehq/apps/public_webforms/tests/test_views.py
+++ b/corehq/apps/public_webforms/tests/test_views.py
@@ -64,7 +64,8 @@ def test_every_column_renders_from_the_queryset():
     webform = create_webform(
         expires_at=datetime.datetime(2026, 9, 1, 21, 0), is_disabled=False)
     _create_session(webform, submitted_at=timezone.now())
-    table = PublicWebformTable(data=_table_view().get_queryset(), timezone=pytz.UTC)
+    table = PublicWebformTable(
+        data=_table_view().get_queryset(), domain=DOMAIN, timezone=pytz.UTC)
 
     [row] = table.rows
     cells = {column.name: str(value) for column, value in row.items()}

--- a/corehq/apps/public_webforms/tests/test_views.py
+++ b/corehq/apps/public_webforms/tests/test_views.py
@@ -1,0 +1,34 @@
+import datetime
+
+from unmagic import use
+
+from django.test import RequestFactory
+from django.utils import timezone
+
+from corehq.apps.public_webforms.tests.utils import DOMAIN, create_webform
+from corehq.apps.public_webforms.views import PublicWebformTableView
+
+
+def _table_view(domain=DOMAIN, **params):
+    view = PublicWebformTableView()
+    view.args = (domain,)
+    view.kwargs = {}
+    view.request = RequestFactory().get('/', params)
+    return view
+
+
+@use('db')
+def test_table_lists_only_webforms_on_domain():
+    webform = create_webform()
+    create_webform(domain='another-project')
+
+    assert list(_table_view().get_queryset()) == [webform]
+
+
+@use('db')
+def test_table_lists_webforms_sorted_by_expiration():
+    closing_soon = create_webform(expires_at=timezone.now() + datetime.timedelta(days=1))
+    closing_later = create_webform(expires_at=timezone.now() + datetime.timedelta(days=90))
+    closed = create_webform(expires_at=timezone.now() - datetime.timedelta(days=1))
+
+    assert list(_table_view().get_queryset()) == [closing_later, closing_soon, closed]

--- a/corehq/apps/public_webforms/tests/utils.py
+++ b/corehq/apps/public_webforms/tests/utils.py
@@ -1,10 +1,17 @@
 import datetime
 
+from django.test import Client, TestCase
 from django.utils import timezone
 
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.public_webforms.models import PublicWebform
+from corehq.apps.users.models import HqPermissions, UserRole, WebUser
 
 DOMAIN = 'public-forms-domain'
+OTHER_DOMAIN = 'public-forms-other-domain'
+PASSWORD = 'Passw0rd!'
+ADMIN_USER = 'webform-admin@example.com'
+NORMAL_USER = 'normal-user@example.com'
 
 
 def create_webform(**kwargs):
@@ -21,3 +28,37 @@ def create_webform(**kwargs):
         'expires_at': timezone.now() + datetime.timedelta(days=30),
         **kwargs,
     })
+
+
+class PublicWebformViewTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        for domain in (DOMAIN, OTHER_DOMAIN):
+            domain_obj = create_domain(domain)
+            cls.addClassCleanup(domain_obj.delete)
+        cls.make_user(ADMIN_USER, HqPermissions(edit_public_webforms=True))
+        cls.make_user(NORMAL_USER, HqPermissions())
+
+    @classmethod
+    def make_user(cls, username, permissions):
+        role = UserRole.create(DOMAIN, username, permissions=permissions)
+        user = WebUser.create(
+            domain=DOMAIN,
+            username=username,
+            password=PASSWORD,
+            role_id=role.get_id,
+            created_by=None,
+            created_via=None,
+        )
+        cls.addClassCleanup(user.delete, DOMAIN, deleted_by=None)
+        return user
+
+    def setUp(self):
+        super().setUp()
+        self.client = Client()
+        self.sign_in(ADMIN_USER)
+
+    def sign_in(self, username):
+        self.client.login(username=username, password=PASSWORD)

--- a/corehq/apps/public_webforms/tests/utils.py
+++ b/corehq/apps/public_webforms/tests/utils.py
@@ -7,17 +7,17 @@ from corehq.apps.public_webforms.models import PublicWebform
 DOMAIN = 'public-forms-domain'
 
 
-def create_webform(expires_at=timezone.now() + datetime.timedelta(days=30), **kwargs):
-    return PublicWebform.objects.create(
-        domain=DOMAIN,
-        label='Antenatal visit',
-        app_id='app',
-        app_build_id='build',
-        form_unique_id='form',
-        endpoint_id='endpoint',
-        session_type='survey',
-        allow_sms=False,
-        allow_email=True,
-        expires_at=expires_at,
+def create_webform(**kwargs):
+    return PublicWebform.objects.create(**{
+        'domain': DOMAIN,
+        'label': 'Antenatal visit',
+        'app_id': 'app',
+        'app_build_id': 'build',
+        'form_unique_id': 'form',
+        'endpoint_id': 'endpoint',
+        'session_type': 'survey',
+        'allow_sms': False,
+        'allow_email': True,
+        'expires_at': timezone.now() + datetime.timedelta(days=30),
         **kwargs,
-    )
+    })

--- a/corehq/apps/public_webforms/tests/utils.py
+++ b/corehq/apps/public_webforms/tests/utils.py
@@ -1,0 +1,23 @@
+import datetime
+
+from django.utils import timezone
+
+from corehq.apps.public_webforms.models import PublicWebform
+
+DOMAIN = 'public-forms-domain'
+
+
+def create_webform(expires_at=timezone.now() + datetime.timedelta(days=30), **kwargs):
+    return PublicWebform.objects.create(
+        domain=DOMAIN,
+        label='Antenatal visit',
+        app_id='app',
+        app_build_id='build',
+        form_unique_id='form',
+        endpoint_id='endpoint',
+        session_type='survey',
+        allow_sms=False,
+        allow_email=True,
+        expires_at=expires_at,
+        **kwargs,
+    )

--- a/corehq/apps/public_webforms/urls.py
+++ b/corehq/apps/public_webforms/urls.py
@@ -4,10 +4,13 @@ from corehq.apps.public_webforms.views import (
     CreatePublicWebformView,
     ManagePublicWebformsView,
     PublicWebformTableView,
+    public_webform_qr_code,
 )
 
 urlpatterns = [
     url(r'^$', ManagePublicWebformsView.as_view(), name=ManagePublicWebformsView.urlname),
     url(r'^create/$', CreatePublicWebformView.as_view(), name=CreatePublicWebformView.urlname),
     url(r'^table/$', PublicWebformTableView.as_view(), name=PublicWebformTableView.urlname),
+    url(r'^(?P<webform_id>\d+)/qr_code/$', public_webform_qr_code,
+        name='public_webform_qr_code'),
 ]

--- a/corehq/apps/public_webforms/urls.py
+++ b/corehq/apps/public_webforms/urls.py
@@ -3,9 +3,11 @@ from django.urls import re_path as url
 from corehq.apps.public_webforms.views import (
     CreatePublicWebformView,
     ManagePublicWebformsView,
+    PublicWebformTableView,
 )
 
 urlpatterns = [
     url(r'^$', ManagePublicWebformsView.as_view(), name=ManagePublicWebformsView.urlname),
     url(r'^create/$', CreatePublicWebformView.as_view(), name=CreatePublicWebformView.urlname),
+    url(r'^table/$', PublicWebformTableView.as_view(), name=PublicWebformTableView.urlname),
 ]

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -74,6 +74,7 @@ class PublicWebformTableView(
 
     def get_table_kwargs(self):
         return {
+            'domain': self.domain,
             'timezone': self.domain_object.get_default_timezone(),
         }
 

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -16,7 +16,10 @@ from corehq.apps.hqwebapp.tables.pagination import (
     HtmxInvalidPageRedirectMixin,
     SelectablePaginatedTableView,
 )
-from corehq.apps.public_webforms.forms import CreatePublicWebformForm
+from corehq.apps.public_webforms.forms import (
+    CreatePublicWebformForm,
+    PublicWebformFilterForm,
+)
 from corehq.apps.public_webforms.models import PublicWebform
 from corehq.apps.public_webforms.tables import PublicWebformTable
 from corehq.apps.settings.views import get_qrcode
@@ -54,6 +57,14 @@ class ManagePublicWebformsView(BasePublicWebformsView):
     template_name = 'public_webforms/manage.html'
     page_title = _("Manage Public Webforms")
 
+    @property
+    def page_context(self):
+        context = super().page_context
+        context.update({
+            'filter_form': PublicWebformFilterForm(self.request.GET),
+        })
+        return context
+
 
 @method_decorator(PUBLIC_WEBFORMS_ACCESS, name='dispatch')
 class PublicWebformTableView(
@@ -71,21 +82,40 @@ class PublicWebformTableView(
         # a page that goes out of range is re-rendered against the dashboard
         return reverse(ManagePublicWebformsView.urlname, args=[self.domain])
 
+    def get(self, request, *args, **kwargs):
+        response = super().get(request, *args, **kwargs)
+        if 'HX-Push-Url' not in response:
+            # point the browser at the dashboard carrying the filters, rather
+            # than at this partial, so a refresh keeps them
+            query = request.GET.urlencode()
+            response['HX-Replace-Url'] = (
+                f'{self.get_host_url()}?{query}' if query else self.get_host_url()
+            )
+        return response
+
     def get_queryset(self):
-        return PublicWebform.objects.filter(
+        queryset = PublicWebform.objects.filter(
             domain=self.domain
         ).with_status().annotate(
             submissions=Count(
                 'publicformsession',
                 filter=Q(publicformsession__submitted_at__isnull=False),
             ),
-        ).order_by('-expires_at')
+        )
+        return self.filter_form.filter(queryset).order_by('-expires_at')
 
     def get_table_kwargs(self):
         return {
             'domain': self.domain,
             'timezone': self.domain_object.get_default_timezone(),
+            # an empty list reads differently when the filters are what match nothing
+            'is_filtered': self.filter_form.is_filtering,
         }
+
+    @property
+    @memoized
+    def filter_form(self):
+        return PublicWebformFilterForm(self.request.GET)
 
 
 class CreatePublicWebformView(BasePublicWebformsView):

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -7,22 +7,29 @@ from memoized import memoized
 
 from corehq import privileges, toggles
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
-from corehq.apps.domain.views import BaseDomainView
+from corehq.apps.domain.decorators import LoginAndDomainMixin
+from corehq.apps.domain.views import BaseDomainView, DomainViewMixin
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.hqwebapp.tables.pagination import (
+    HtmxInvalidPageRedirectMixin,
+    SelectablePaginatedTableView,
+)
 from corehq.apps.public_webforms.forms import CreatePublicWebformForm
+from corehq.apps.public_webforms.models import PublicWebform
+from corehq.apps.public_webforms.tables import PublicWebformTable
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
 
 
-@method_decorator(
-    [
-        use_bootstrap5,
-        require_permission(HqPermissions.edit_public_webforms),
-        requires_privilege_with_fallback(privileges.PUBLIC_WEBFORMS),
-        toggles.PUBLIC_WEBFORMS.required_decorator(),
-    ],
-    name='dispatch',
-)
+PUBLIC_WEBFORMS_ACCESS = [
+    use_bootstrap5,
+    require_permission(HqPermissions.edit_public_webforms),
+    requires_privilege_with_fallback(privileges.PUBLIC_WEBFORMS),
+    toggles.PUBLIC_WEBFORMS.required_decorator(),
+]
+
+
+@method_decorator(PUBLIC_WEBFORMS_ACCESS, name='dispatch')
 class BasePublicWebformsView(BaseDomainView):
     section_name = _("Public Webforms")
 
@@ -36,6 +43,31 @@ class ManagePublicWebformsView(BasePublicWebformsView):
     urlname = 'manage_public_webforms'
     template_name = 'public_webforms/manage.html'
     page_title = _("Manage Public Webforms")
+
+
+@method_decorator(PUBLIC_WEBFORMS_ACCESS, name='dispatch')
+class PublicWebformTableView(
+    HtmxInvalidPageRedirectMixin,
+    LoginAndDomainMixin,
+    DomainViewMixin,
+    SelectablePaginatedTableView,
+):
+    """The dashboard's table of webforms, fetched by the manage view over HTMX."""
+
+    urlname = 'public_webforms_table'
+    table_class = PublicWebformTable
+
+    def get_host_url(self):
+        # a page that goes out of range is re-rendered against the dashboard
+        return reverse(ManagePublicWebformsView.urlname, args=[self.domain])
+
+    def get_queryset(self):
+        return PublicWebform.objects.filter(domain=self.domain).order_by('-expires_at')
+
+    def get_table_kwargs(self):
+        return {
+            'timezone': self.domain_object.get_default_timezone(),
+        }
 
 
 class CreatePublicWebformView(BasePublicWebformsView):

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -1,5 +1,4 @@
 from django.contrib import messages
-from django.db.models import Count, Q
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
@@ -96,12 +95,7 @@ class PublicWebformTableView(
     def get_queryset(self):
         queryset = PublicWebform.objects.filter(
             domain=self.domain
-        ).with_status().annotate(
-            submissions=Count(
-                'publicformsession',
-                filter=Q(publicformsession__submitted_at__isnull=False),
-            ),
-        )
+        ).with_status().with_submissions_count()
         return self.filter_form.filter(queryset).order_by('-expires_at')
 
     def get_table_kwargs(self):

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.db.models import Count, Q
-from django.http import HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
@@ -18,6 +19,7 @@ from corehq.apps.hqwebapp.tables.pagination import (
 from corehq.apps.public_webforms.forms import CreatePublicWebformForm
 from corehq.apps.public_webforms.models import PublicWebform
 from corehq.apps.public_webforms.tables import PublicWebformTable
+from corehq.apps.settings.views import get_qrcode
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
 
@@ -28,6 +30,13 @@ PUBLIC_WEBFORMS_ACCESS = [
     requires_privilege_with_fallback(privileges.PUBLIC_WEBFORMS),
     toggles.PUBLIC_WEBFORMS.required_decorator(),
 ]
+
+
+def public_webforms_access(view):
+    """Apply PUBLIC_WEBFORMS_ACCESS to a function view."""
+    for decorator in reversed(PUBLIC_WEBFORMS_ACCESS):
+        view = decorator(view)
+    return view
 
 
 @method_decorator(PUBLIC_WEBFORMS_ACCESS, name='dispatch')
@@ -106,3 +115,11 @@ class CreatePublicWebformView(BasePublicWebformsView):
         data = [self.request.POST] if self.request.method == 'POST' else []
         return CreatePublicWebformForm(
             self.domain, self.domain_object.get_default_timezone(), *data)
+
+
+@public_webforms_access
+def public_webform_qr_code(request, domain, webform_id):
+    """Serve the public URL as a QR code PNG, as ``odk_qr_code`` does for app
+    installs, so the dashboard can show one without embedding image data."""
+    webform = get_object_or_404(PublicWebform, domain=domain, id=webform_id)
+    return HttpResponse(get_qrcode(webform.public_url), content_type='image/png')

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -1,4 +1,5 @@
 from django.contrib import messages
+from django.db.models import Count, Q
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -62,7 +63,14 @@ class PublicWebformTableView(
         return reverse(ManagePublicWebformsView.urlname, args=[self.domain])
 
     def get_queryset(self):
-        return PublicWebform.objects.filter(domain=self.domain).order_by('-expires_at')
+        return PublicWebform.objects.filter(
+            domain=self.domain
+        ).with_status().annotate(
+            submissions=Count(
+                'publicformsession',
+                filter=Q(publicformsession__submitted_at__isnull=False),
+            ),
+        ).order_by('-expires_at')
 
     def get_table_kwargs(self):
         return {


### PR DESCRIPTION
## Product Description

Adds Manage Public Webforms table view, which can be filtered by webform label, status, or type, and includes a modal to get the QR code for a public webform's link:
<img width="1265" height="673" alt="image" src="https://github.com/user-attachments/assets/a7b274cd-8d51-4ca0-bf26-5ae63ff47096" />

<img width="504" height="546" alt="image" src="https://github.com/user-attachments/assets/333bb2a3-a57b-48af-b288-8c1f2bf92bd0" />

## Technical Summary
[SAAS-20068](https://dimagi.atlassian.net/browse/SAAS-20068) / [SAAS-19924](https://dimagi.atlassian.net/browse/SAAS-19924)

Adds a new view and table to list public webforms. The table follows much of the HTMX + django-tables2 setup used by newer apps like `data_cleaning`. This table shows:

- The user-defined label for this public webform, used internally for identification and search.
- A link back to the Application the webform is based on. This is intentionally not a link to the form, because the form may be deleted from the app but the webform will still work - because it is pinned to a specific app build.
- Status showing one of:
  - Expired (past its closing date, no requests to complete the webform are allowed)
  - Closed (within its closing date but the webform is set to disabled)
  - Open (accepting requests to complete the webform)
- Number of submissions, based on completed `PublicFormSession`s
- Closing date shown in the project's timezone
- Delivery options (email or SMS) and whether they are enabled or disabled
- Public URL (currently a placeholder until the public webform landing page is implemented)
  - "Copy" button here that runs a short Alpine snippet
  - QR code button to launch a modal to get a QR code for the public URL
- Actions, not implemented here, a placeholder for Open/Close and Edit buttons. 

Code and this PR description co-authored by AI.

## Feature Flag

`PUBLIC_WEBFORMS`

## Safety Assurance

### Safety story

**Everything in this PR is a read path.** It adds two GET views and a set of model helpers; nothing writes. Tested locally against a project with several webforms across two apps, including a webform whose app had been deleted.

### Automated test coverage

- `tests/test_models.py`
- `tests/test_views.py`
- `tests/test_tables.py`
- `tests/test_form_paths.py`
- `tests/test_forms.py`


### QA Plan
Public Webforms will get end-to-end QA before release.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-20068]: https://dimagi.atlassian.net/browse/SAAS-20068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-19924]: https://dimagi.atlassian.net/browse/SAAS-19924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ