### PR TITLE
Public Webforms: Edit a public webform

### DIFF
--- a/corehq/apps/public_webforms/form_paths.py
+++ b/corehq/apps/public_webforms/form_paths.py
@@ -18,13 +18,19 @@ def get_public_webform_form_paths(domain, webforms):
     builds = _get_apps(domain, {webform.app_build_id for webform in webforms})
     apps = _get_apps(domain, {webform.app_id for webform in webforms})
     return {
-        webform.id: {
-            'app_name': _app_name(webform, apps, builds),
-            'app_url': _app_url(webform, apps, domain),
-            'app_version': _app_version(webform, builds),
-            'menu_name': _menu_name(webform, builds),
-            'form_name': _form_name(webform, builds),
-        } for webform in webforms
+        webform.id: _form_path(webform, apps, builds, domain)
+        for webform in webforms
+    }
+
+
+def _form_path(webform, apps, builds, domain):
+    menu_name, form_name = _menu_and_form_names(webform, builds)
+    return {
+        'app_name': _app_name(webform, apps, builds),
+        'app_url': _app_url(webform, apps, domain),
+        'app_version': _app_version(webform, builds),
+        'menu_name': menu_name,
+        'form_name': form_name,
     }
 
 
@@ -56,19 +62,16 @@ def _app_version(webform, builds):
     return build['version'] if build else None
 
 
-def _menu_name(webform, builds):
-    build = builds.get(webform.app_build_id)
-    form = build.get_form(webform.form_unique_id) if build else None
-    menu = form.get_module() if form else None
-    return menu.default_name() if menu else None
-
-
-def _form_name(webform, builds):
+def _menu_and_form_names(webform, builds):
     build = builds.get(webform.app_build_id)
     if not build:
-        return None
+        return None, None
     langs = [build.get('default_language')] + build.get('langs', [])
     for module in build.get('modules', []):
         for form in module.get('forms', []):
             if form.get('unique_id') == webform.form_unique_id:
-                return clean_trans(form['name'], langs)
+                return (
+                    clean_trans(module['name'], langs),
+                    clean_trans(form['name'], langs),
+                )
+    return None, None

--- a/corehq/apps/public_webforms/form_paths.py
+++ b/corehq/apps/public_webforms/form_paths.py
@@ -22,6 +22,7 @@ def get_public_webform_form_paths(domain, webforms):
             'app_name': _app_name(webform, apps, builds),
             'app_url': _app_url(webform, apps, domain),
             'app_version': _app_version(webform, builds),
+            'menu_name': _menu_name(webform, builds),
             'form_name': _form_name(webform, builds),
         } for webform in webforms
     }
@@ -53,6 +54,13 @@ def _app_url(webform, apps, domain):
 def _app_version(webform, builds):
     build = builds.get(webform.app_build_id)
     return build['version'] if build else None
+
+
+def _menu_name(webform, builds):
+    build = builds.get(webform.app_build_id)
+    form = build.get_form(webform.form_unique_id) if build else None
+    menu = form.get_module() if form else None
+    return menu.default_name() if menu else None
 
 
 def _form_name(webform, builds):

--- a/corehq/apps/public_webforms/forms.py
+++ b/corehq/apps/public_webforms/forms.py
@@ -76,7 +76,12 @@ class PublicWebformFilterForm(forms.Form):
         return any(self.cleaned_data.get(field) for field in self.lookups)
 
 
-class CreatePublicWebformForm(forms.Form):
+class BasePublicWebformForm(forms.Form):
+
+    fieldset_title = None
+    submit_name = None
+    submit_label = None
+
     label = forms.CharField(
         label=gettext_lazy("Label"),
         help_text=gettext_lazy("Identifies this public webform. Respondents will see the form's name.")
@@ -94,17 +99,6 @@ class CreatePublicWebformForm(forms.Form):
         initial=['allow_email'],
         widget=forms.CheckboxSelectMultiple,
     )
-    open_to_requests = forms.BooleanField(
-        required=False,
-        label=gettext_lazy("Open to Requests"),
-        widget=BootstrapSwitchInput(
-            inline_label=gettext_lazy(
-                "Immediately open this public webform to one-time link requests."
-            ),
-        ),
-    )
-    app_id = forms.CharField(required=False, widget=forms.HiddenInput)
-    form_unique_id = forms.CharField(required=False, widget=forms.HiddenInput)
 
     def __init__(self, domain, timezone, *args, **kwargs):
         self.domain = domain
@@ -128,46 +122,17 @@ class CreatePublicWebformForm(forms.Form):
                     _("A short text with a shortened link. Billed per message sent.")
                 ),
             ))
+
         self.fields['link_choices'].choices = link_choices
 
-        default_expires_at = (
-            ServerTime(datetime.now(UTC).replace(tzinfo=None) + timedelta(days=30))
-            .user_time(self.timezone)
-            .ui_string(fmt='%Y-%m-%d %H:%M:%S')
-        )
-        self.fields['expires_at'].initial = default_expires_at
+        self.fields['expires_at'].initial = self.initial_expires_at()
 
         self.helper = hqcrispy.HQFormHelper()
         self.helper.form_method = 'POST'
-
-        alpine_data_model = {
-            'expires_at': self.fields['expires_at'].initial,
-        }
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
-                _("New Public Webform"),
-                crispy.HTML(render_to_string(
-                    'public_webforms/partials/create_form_choices.html',
-                    context={'form_choices': json.dumps(get_public_webform_choices(self.domain))},
-                )),
-                crispy.Field('label'),
-                crispy.Div(
-                    twbscrispy.AppendedText(
-                        'expires_at',
-                        mark_safe(  # nosec: no user input
-                            '<i class="fcc fcc-fd-datetime"></i>'
-                        ),
-                        x_datepicker=json.dumps(
-                            {
-                                'useInputGroup': True,
-                                'datetime': True,
-                            }
-                        ),
-                    ),
-                    x_data=json.dumps(alpine_data_model),
-                ),
-                crispy.Field('link_choices'),
-                twbscrispy.PrependedText('open_to_requests', ''),
+                self.fieldset_title,
+                *self.fieldset_fields(),
             ),
             hqcrispy.FormActions(
                 crispy.ButtonHolder(
@@ -177,13 +142,82 @@ class CreatePublicWebformForm(forms.Form):
                         css_class='btn btn-outline-primary',
                     ),
                     crispy.Submit(
-                        'create_public_webform',
-                        _("Create Public Webform"),
+                        self.submit_name,
+                        self.submit_label,
                         css_class='disable-on-submit',
                     ),
                 )
             ),
         )
+
+    def initial_expires_at(self):
+        """Wall-clock datetime in the project's timezone to prefill the picker."""
+        raise NotImplementedError
+
+    def fieldset_fields(self):
+        alpine_data_model = {
+            'expires_at': self.fields['expires_at'].initial,
+        }
+        return [
+            crispy.Field('label'),
+            crispy.Div(
+                twbscrispy.AppendedText(
+                    'expires_at',
+                    mark_safe(  # nosec: no user input
+                        '<i class="fcc fcc-fd-datetime"></i>'
+                    ),
+                    x_datepicker=json.dumps(
+                        {
+                            'useInputGroup': True,
+                            'datetime': True,
+                        }
+                    ),
+                ),
+                x_data=json.dumps(alpine_data_model),
+            ),
+            crispy.Field('link_choices'),
+        ]
+
+    def clean_expires_at(self):
+        # The datepicker submits wall-clock time in the project's timezone; store UTC.
+        expires_at = self.cleaned_data['expires_at']
+        return UserTime(expires_at, tzinfo=self.timezone).server_time().done()
+
+
+class CreatePublicWebformForm(BasePublicWebformForm):
+
+    fieldset_title = gettext_lazy("New Public Webform")
+    submit_name = 'create_public_webform'
+    submit_label = gettext_lazy("Create Public Webform")
+
+    open_to_requests = forms.BooleanField(
+        required=False,
+        label=gettext_lazy("Open to Requests"),
+        widget=BootstrapSwitchInput(
+            inline_label=gettext_lazy(
+                "Immediately open this public webform to one-time link requests."
+            ),
+        ),
+    )
+    app_id = forms.CharField(required=False, widget=forms.HiddenInput)
+    form_unique_id = forms.CharField(required=False, widget=forms.HiddenInput)
+
+    def initial_expires_at(self):
+        return (
+            ServerTime(datetime.now(UTC).replace(tzinfo=None) + timedelta(days=30))
+            .user_time(self.timezone)
+            .ui_string(fmt='%Y-%m-%d %H:%M:%S')
+        )
+
+    def fieldset_fields(self):
+        return [
+            crispy.HTML(render_to_string(
+                'public_webforms/partials/create_form_choices.html',
+                context={'form_choices': json.dumps(get_public_webform_choices(self.domain))},
+            )),
+            *super().fieldset_fields(),
+            twbscrispy.PrependedText('open_to_requests', ''),
+        ]
 
     def clean(self):
         cleaned_data = super().clean()
@@ -200,11 +234,6 @@ class CreatePublicWebformForm(forms.Form):
 
         cleaned_data['session_type'] = get_public_webform_type(form)
         return cleaned_data
-
-    def clean_expires_at(self):
-        # The datepicker submits wall-clock time in the project's timezone; store UTC.
-        expires_at = self.cleaned_data['expires_at']
-        return UserTime(expires_at, tzinfo=self.timezone).server_time().done()
 
     def create_public_webform(self):
         app_id = self.cleaned_data['app_id']

--- a/corehq/apps/public_webforms/forms.py
+++ b/corehq/apps/public_webforms/forms.py
@@ -1,6 +1,8 @@
 import json
 from datetime import datetime, timedelta, UTC
 
+from crispy_forms import bootstrap as twbscrispy
+from crispy_forms import layout as crispy
 from django import forms
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -8,9 +10,6 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
-
-from crispy_forms import bootstrap as twbscrispy
-from crispy_forms import layout as crispy
 
 from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
@@ -24,6 +23,9 @@ from corehq.apps.public_webforms.form_choices import (
     get_public_webform_choices,
     get_public_webform_eligible_form,
     get_public_webform_type,
+)
+from corehq.apps.public_webforms.form_paths import (
+    get_public_webform_form_paths,
 )
 from corehq.apps.public_webforms.models import (
     PublicWebform,
@@ -98,6 +100,15 @@ class BasePublicWebformForm(forms.Form):
         choices=[],
         initial=['allow_email'],
         widget=forms.CheckboxSelectMultiple,
+    )
+    open_to_requests = forms.BooleanField(
+        required=False,
+        label=gettext_lazy("Open to Requests"),
+        widget=BootstrapSwitchInput(
+            inline_label=gettext_lazy(
+                "Immediately open this public webform to one-time link requests."
+            ),
+        ),
     )
 
     def __init__(self, domain, timezone, *args, **kwargs):
@@ -176,6 +187,7 @@ class BasePublicWebformForm(forms.Form):
                 x_data=json.dumps(alpine_data_model),
             ),
             crispy.Field('link_choices'),
+            twbscrispy.PrependedText('open_to_requests', ''),
         ]
 
     def clean_expires_at(self):
@@ -190,15 +202,6 @@ class CreatePublicWebformForm(BasePublicWebformForm):
     submit_name = 'create_public_webform'
     submit_label = gettext_lazy("Create Public Webform")
 
-    open_to_requests = forms.BooleanField(
-        required=False,
-        label=gettext_lazy("Open to Requests"),
-        widget=BootstrapSwitchInput(
-            inline_label=gettext_lazy(
-                "Immediately open this public webform to one-time link requests."
-            ),
-        ),
-    )
     app_id = forms.CharField(required=False, widget=forms.HiddenInput)
     form_unique_id = forms.CharField(required=False, widget=forms.HiddenInput)
 
@@ -216,7 +219,6 @@ class CreatePublicWebformForm(BasePublicWebformForm):
                 context={'form_choices': json.dumps(get_public_webform_choices(self.domain))},
             )),
             *super().fieldset_fields(),
-            twbscrispy.PrependedText('open_to_requests', ''),
         ]
 
     def clean(self):
@@ -260,3 +262,56 @@ class CreatePublicWebformForm(BasePublicWebformForm):
             # delete the build on webform create failure.
             delete_public_webform_build(self.domain, app_build_id)
             raise
+
+
+class EditPublicWebformForm(BasePublicWebformForm):
+
+    fieldset_title = gettext_lazy("Edit Public Webform")
+    submit_name = 'edit_public_webform'
+    submit_label = gettext_lazy("Save Changes")
+
+    app_name = forms.CharField(
+        label=gettext_lazy("Application"), disabled=True, required=False)
+    menu_name = forms.CharField(
+        label=gettext_lazy("Menu"), disabled=True, required=False)
+    form_name = forms.CharField(
+        label=gettext_lazy("Form"), disabled=True, required=False)
+
+    def __init__(self, domain, timezone, webform, *args, **kwargs):
+        self.webform = webform
+        super().__init__(domain, timezone, *args, **kwargs)
+        form_paths = get_public_webform_form_paths(
+            domain, [webform])[webform.id]
+        self.initial.update({
+            'label': webform.label,
+            'open_to_requests': not webform.is_disabled,
+            'app_name': f"{form_paths['app_name']} (v{form_paths['app_version']})",
+            'menu_name': form_paths['menu_name'],
+            'form_name': form_paths['form_name'],
+            # a delivery option the project can no longer use is dropped, not kept
+            'link_choices': [
+                choice for choice, __ in self.fields['link_choices'].choices
+                if getattr(webform, choice)
+            ],
+        })
+
+    def initial_expires_at(self):
+        return ServerTime(self.webform.expires_at).user_time(self.timezone).ui_string(fmt='%Y-%m-%d %H:%M:%S')
+
+    def fieldset_fields(self):
+        return [
+            crispy.Field('app_name'),
+            crispy.Field('menu_name'),
+            crispy.Field('form_name'),
+            *super().fieldset_fields(),
+        ]
+
+    def update_public_webform(self):
+        link_choices = self.cleaned_data['link_choices']
+        self.webform.label = self.cleaned_data['label']
+        self.webform.expires_at = self.cleaned_data['expires_at']
+        self.webform.allow_email = 'allow_email' in link_choices
+        self.webform.allow_sms = 'allow_sms' in link_choices
+        self.webform.is_disabled = not self.cleaned_data['open_to_requests']
+        self.webform.save()
+        return self.webform

--- a/corehq/apps/public_webforms/static/public_webforms/js/edit.js
+++ b/corehq/apps/public_webforms/static/public_webforms/js/edit.js
@@ -1,0 +1,6 @@
+import 'commcarehq';
+
+import Alpine from 'alpinejs';
+import 'hqwebapp/js/alpinejs/directives/datepicker';
+
+Alpine.start();

--- a/corehq/apps/public_webforms/tables.py
+++ b/corehq/apps/public_webforms/tables.py
@@ -68,8 +68,7 @@ class PublicWebformTable(BaseHtmxTable, tables.Table):
         template_name='public_webforms/columns/public_url.html',
         verbose_name=_("Public URL"),
     )
-    actions = columns.TemplateColumn(
-        template_name='public_webforms/columns/actions.html',
+    actions = columns.Column(
         verbose_name=_("Actions"),
         attrs={'td': {'class': 'text-nowrap'}},
         empty_values=(),
@@ -108,6 +107,12 @@ class PublicWebformTable(BaseHtmxTable, tables.Table):
             STATUS_BADGES[status],
             status.label,
         )
+
+    def render_actions(self, record):
+        return render_to_string('public_webforms/columns/actions.html', {
+            'domain': self.domain,
+            'record': record,
+        })
 
     def render_expires_at(self, value):
         return ServerTime(value).user_time(self.timezone).ui_string()

--- a/corehq/apps/public_webforms/tables.py
+++ b/corehq/apps/public_webforms/tables.py
@@ -68,8 +68,11 @@ class PublicWebformTable(BaseHtmxTable, tables.Table):
         template_name='public_webforms/columns/public_url.html',
         verbose_name=_("Public URL"),
     )
-    actions = columns.Column(
+    actions = columns.TemplateColumn(
+        template_name='public_webforms/columns/actions.html',
         verbose_name=_("Actions"),
+        attrs={'td': {'class': 'text-nowrap'}},
+        empty_values=(),
     )
 
     def __init__(self, domain, timezone, is_filtered=False, **kwargs):

--- a/corehq/apps/public_webforms/templates/public_webforms/columns/actions.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/columns/actions.html
@@ -1,0 +1,30 @@
+{% load i18n %}
+
+{# TODO: link to the edit view #}
+<a class="btn btn-sm btn-outline-primary disabled" aria-disabled="true">
+  <i class="fa fa-pencil"></i>
+  {% trans "Edit" %}
+</a>
+{% if record.is_disabled %}
+  <button
+    type="button"
+    class="btn btn-sm btn-outline-success fw-normal"
+    data-bs-toggle="modal"
+    data-bs-target="#confirm-status-{{ record.id }}"
+    {% if record.is_expired %}disabled{% endif %}
+  >
+    <i class="fa fa-play"></i>
+    {% trans "Open" %}
+  </button>
+{% else %}
+  <button
+    type="button"
+    class="btn btn-sm btn-outline-secondary fw-normal"
+    data-bs-toggle="modal"
+    data-bs-target="#confirm-status-{{ record.id }}"
+    {% if record.is_expired %}disabled{% endif %}
+  >
+    <i class="fa fa-pause"></i>
+    {% trans "Close" %}
+  </button>
+{% endif %}

--- a/corehq/apps/public_webforms/templates/public_webforms/columns/actions.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/columns/actions.html
@@ -1,7 +1,9 @@
 {% load i18n %}
 
-{# TODO: link to the edit view #}
-<a class="btn btn-sm btn-outline-primary disabled" aria-disabled="true">
+<a
+  class="btn btn-sm btn-outline-primary"
+  href="{% url 'edit_public_webform' domain record.id %}"
+>
   <i class="fa fa-pencil"></i>
   {% trans "Edit" %}
 </a>

--- a/corehq/apps/public_webforms/templates/public_webforms/edit.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/edit.html
@@ -1,0 +1,8 @@
+{% extends 'hqwebapp/bootstrap5/base_section.html' %}
+{% load crispy_forms_tags %}
+{% load hq_shared_tags %}
+{% js_entry 'public_webforms/js/edit' %}
+
+{% block page_content %}
+  {% crispy form %}
+{% endblock %}

--- a/corehq/apps/public_webforms/templates/public_webforms/partials/status_modal.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/partials/status_modal.html
@@ -1,0 +1,75 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+{% load django_tables2 %}
+
+<div
+  id="confirm-status-{{ webform.id }}"
+  class="modal fade"
+  tabindex="-1"
+  aria-labelledby="confirm-status-{{ webform.id }}-title"
+  aria-hidden="true"
+>
+  <div class="modal-dialog">
+    <form
+      class="modal-content"
+      method="post"
+      action="{% url 'set_public_webform_status' domain webform.id %}{% querystring %}"
+    >
+      {% csrf_token %}
+      <div class="modal-header">
+        <h4 id="confirm-status-{{ webform.id }}-title" class="modal-title">
+          {% if webform.is_disabled %}
+            {% trans "Open Public Webform" %}
+          {% else %}
+            {% trans "Close Public Webform" %}
+          {% endif %}
+        </h4>
+        <button
+          class="btn-close"
+          type="button"
+          aria-label="{% trans_html_attr "Close" %}"
+          data-bs-dismiss="modal"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <p class="fw-semibold">{{ webform.label }}</p>
+        {% if webform.is_disabled %}
+          <p>
+            {% blocktrans %}
+              Respondents will be able to request a one-time link to complete
+              this form.
+            {% endblocktrans %}
+          </p>
+        {% else %}
+          <p>
+            {% blocktrans %}
+              Respondents will no longer be able to request a one-time link to
+              complete this form. Links already sent can be used until they
+              expire.
+            {% endblocktrans %}
+          </p>
+        {% endif %}
+      </div>
+      <div class="modal-footer">
+        <button
+          class="btn btn-outline-primary"
+          type="button"
+          data-bs-dismiss="modal"
+        >
+          {% trans "Cancel" %}
+        </button>
+        {% if webform.is_disabled %}
+          <input type="hidden" name="is_disabled" value="false" />
+          <button class="btn btn-primary disable-on-submit" type="submit">
+            {% trans "Open" %}
+          </button>
+        {% else %}
+          <input type="hidden" name="is_disabled" value="true" />
+          <button class="btn btn-primary disable-on-submit" type="submit">
+            {% trans "Close" %}
+          </button>
+        {% endif %}
+      </div>
+    </form>
+  </div>
+</div>

--- a/corehq/apps/public_webforms/templates/public_webforms/tables/public_webform.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/tables/public_webform.html
@@ -16,5 +16,8 @@
   {# outside the table, so a modal doesn't inherit a cell's styling #}
   {% for row in table.paginated_rows %}
     {% include "public_webforms/partials/qr_modal.html" with webform=row.record domain=table.domain %}
+    {% if not row.record.is_expired %}
+      {% include "public_webforms/partials/status_modal.html" with webform=row.record domain=table.domain %}
+    {% endif %}
   {% endfor %}
 {% endblock after_table %}

--- a/corehq/apps/public_webforms/tests/test_form_paths.py
+++ b/corehq/apps/public_webforms/tests/test_form_paths.py
@@ -17,6 +17,7 @@ from corehq.apps.public_webforms.models import PublicWebform
 
 DOMAIN = 'public-webform-form-paths'
 APP_NAME = 'Frontline Program'
+MENU_NAME = 'Patient Intake'
 FORM_NAME = 'Cohort Registration'
 
 
@@ -26,7 +27,8 @@ def app_with_build():
     """An app with one named form, and a build pinning that name."""
     domain_obj = Domain.get_or_create_with_name(DOMAIN)
     factory = AppFactory(DOMAIN, name=APP_NAME, build_version='2.51.0')
-    __, form = factory.new_basic_module('survey', 'patient')
+    menu, form = factory.new_basic_module('survey', 'patient')
+    menu.name = {'en': MENU_NAME}
     form.name = {'en': FORM_NAME}
     form.source = get_simple_form(xmlns=form.unique_id)
     try:
@@ -72,6 +74,7 @@ class TestGetPublicWebformPaths:
 
         assert path['app_name'] == APP_NAME
         assert path['app_version'] == app.version
+        assert path['menu_name'] == MENU_NAME
         assert path['form_name'] == FORM_NAME
         assert path['app_url'].endswith(f'/{app.app_id}/')
 

--- a/corehq/apps/public_webforms/tests/test_forms.py
+++ b/corehq/apps/public_webforms/tests/test_forms.py
@@ -4,9 +4,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 import pytz
-from unmagic import use
-
 from django.db import DatabaseError
+from unmagic import use
 
 from corehq.apps.public_webforms import forms
 from corehq.apps.public_webforms.models import (
@@ -203,3 +202,88 @@ def test_create_maps_link_choices_to_delivery_options(link_choices, allow_email,
 
     assert webform.allow_email == allow_email
     assert webform.allow_sms == allow_sms
+
+
+def _webform(**kwargs):
+    return PublicWebform(**{
+        'id': 1,
+        'domain': DOMAIN,
+        'label': 'Antenatal visit',
+        'expires_at': datetime(2026, 9, 1, 21, 0),
+        'allow_email': True,
+        'allow_sms': False,
+        'is_disabled': False,
+        **kwargs,
+    })
+
+
+def _edit_form(webform, data=None, has_sms_privilege=False):
+    """Stubs the build read that names the app, menu, and form."""
+    args = [data] if data is not None else []
+    with patch.multiple(
+        forms,
+        domain_has_privilege=Mock(return_value=has_sms_privilege),
+        get_public_webform_form_paths=Mock(return_value={webform.id: {
+            'app_name': 'Frontline Program',
+            'app_version': '12',
+            'menu_name': 'Registration',
+            'form_name': 'Cohort Registration',
+        }}),
+    ):
+        form = forms.EditPublicWebformForm(
+            webform.domain, TIMEZONE, webform, *args)
+        form.is_valid()
+    return form
+
+
+def _edit_data(**kwargs):
+    return {
+        'label': 'Antenatal visit',
+        'expires_at': '2026-09-01 17:00:00',
+        'link_choices': ['allow_email'],
+        **kwargs,
+    }
+
+
+def test_edit_prefills():
+    form = _edit_form(_webform())
+
+    assert form.initial['app_name'] == 'Frontline Program (v12)'
+    assert form.initial['menu_name'] == 'Registration'
+    assert form.initial['form_name'] == 'Cohort Registration'
+    assert form.initial['label'] == 'Antenatal visit'
+    # stored as UTC, offered back in the project's timezone
+    assert form.fields['expires_at'].initial == '2026-09-01 17:00:00'
+    assert form.initial['link_choices'] == ['allow_email']
+    assert form.initial['open_to_requests'] is True
+
+
+def test_edit_drops_a_delivery_option_the_project_can_no_longer_use():
+    form = _edit_form(_webform(allow_sms=True), has_sms_privilege=False)
+
+    assert form.initial['link_choices'] == ['allow_email']
+
+
+@use('db')
+def test_edit_updates_the_webform():
+    webform = create_webform()
+    form = _edit_form(
+        webform,
+        _edit_data(
+            label='Antenatal visit, round two',
+            expires_at='2026-12-01 17:00:00',
+            link_choices=['allow_sms'],
+            is_disabled=True,
+        ),
+        has_sms_privilege=True,
+    )
+    assert form.is_valid(), form.errors
+
+    updated = form.update_public_webform()
+    updated.refresh_from_db()
+
+    assert updated.label == 'Antenatal visit, round two'
+    assert updated.expires_at == datetime(2026, 12, 1, 22, 0)
+    assert not updated.allow_email
+    assert updated.allow_sms
+    assert updated.is_disabled

--- a/corehq/apps/public_webforms/tests/test_tables.py
+++ b/corehq/apps/public_webforms/tests/test_tables.py
@@ -1,9 +1,10 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
 import pytz
+from django.utils import timezone
 
 from corehq.apps.public_webforms import tables
 from corehq.apps.public_webforms.models import (
@@ -19,6 +20,10 @@ TIMEZONE = pytz.timezone('America/New_York')
 
 def _table():
     return PublicWebformTable(data=[], domain=DOMAIN, timezone=TIMEZONE)
+
+
+def _webform(**kwargs):
+    return PublicWebform(**{'id': 1, 'expires_at': timezone.now() + timedelta(days=30), **kwargs})
 
 
 def _cells(webform):
@@ -59,7 +64,7 @@ def test_closing_time_is_shown_in_the_projects_timezone(stored_utc, expected):
 
 
 def test_form_column_names_form_and_links_its_app():
-    webform = PublicWebform(id=1, label='Antenatal visit')
+    webform = _webform(label='Antenatal visit')
     path = {
         'app_name': 'Frontline Program',
         'app_url': '/apps/view/app-1/',
@@ -78,12 +83,27 @@ def test_form_column_names_form_and_links_its_app():
 
 
 def test_the_public_url_column_offers_the_url_to_copy():
-    webform = PublicWebform(id=1, public_id=uuid4())
+    webform = _webform(public_id=uuid4())
 
     rendered = _cells(webform)['public_url']
 
     assert webform.public_url in rendered
     assert 'clipboard' in rendered
+
+
+@pytest.mark.parametrize('is_disabled, expected, not_expected', [
+    (True, "Open", "Close"),
+    (False, "Close", "Open"),
+], ids=['closed', 'open'])
+def test_the_actions_column_offers_the_status_a_webform_is_not_in(
+    is_disabled, expected, not_expected
+):
+    webform = _webform(is_disabled=is_disabled)
+
+    rendered = _cells(webform)['actions']
+
+    assert expected in rendered
+    assert not_expected not in rendered
 
 
 @pytest.mark.parametrize('allow_email, allow_sms, expected_titles', [
@@ -94,7 +114,7 @@ def test_the_public_url_column_offers_the_url_to_copy():
 def test_delivery_marks_each_channel_as_on_or_off(
     allow_email, allow_sms, expected_titles
 ):
-    webform = PublicWebform(allow_email=allow_email, allow_sms=allow_sms)
+    webform = _webform(allow_email=allow_email, allow_sms=allow_sms)
 
     rendered = _cells(webform)['delivery']
 

--- a/corehq/apps/public_webforms/tests/test_views.py
+++ b/corehq/apps/public_webforms/tests/test_views.py
@@ -171,3 +171,49 @@ class TestSetPublicWebformStatus(PublicWebformViewTestCase):
         response = self.client.get(url)
 
         assert response.status_code == 405
+
+@flag_enabled('PUBLIC_WEBFORMS')
+@privilege_enabled(PUBLIC_WEBFORMS)
+class TestEditPublicWebformView(PublicWebformViewTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.webform = create_webform(is_disabled=False)
+
+    def url(self, webform=None, domain=DOMAIN):
+        return reverse(
+            'edit_public_webform', args=[domain, (webform or self.webform).id])
+
+    def post(self, webform=None, domain=DOMAIN, **fields):
+        return self.client.post(self.url(webform, domain), {
+            'label': 'Antenatal visit',
+            'expires_at': '2026-09-01 17:00:00',
+            'link_choices': ['allow_email'],
+            'open_to_requests': 'on',
+            **fields,
+        })
+
+    def test_the_webform_is_offered_for_editing(self):
+        response = self.client.get(self.url())
+
+        assert response.status_code == 200
+        assert response.context['form'].initial['label'] == 'Antenatal visit'
+
+    def test_redirects_to_dashboard_after_save(self):
+        response = self.post(label='Antenatal visit, round two')
+
+        assert response.url == reverse('manage_public_webforms', args=[DOMAIN])
+
+    def test_another_projects_webform_is_not_found(self):
+        other = create_webform(domain=OTHER_DOMAIN, label='Not yours')
+
+        assert self.client.get(self.url(other)).status_code == 404
+        assert self.post(webform=other).status_code == 404
+
+    def test_webform_cannot_be_edited_without_permission(self):
+        self.sign_in(NORMAL_USER)
+
+        assert self.client.get(self.url()).status_code != 200
+        self.post(label='Renamed by a non-admin useur')
+        self.webform.refresh_from_db()
+        assert self.webform.label == 'Antenatal visit'

--- a/corehq/apps/public_webforms/tests/test_views.py
+++ b/corehq/apps/public_webforms/tests/test_views.py
@@ -110,3 +110,64 @@ class TestPublicWebformQrCode(PublicWebformViewTestCase):
         self.sign_in(NORMAL_USER)
 
         assert self.get(webform).status_code != 200
+
+
+@flag_enabled('PUBLIC_WEBFORMS')
+@privilege_enabled(PUBLIC_WEBFORMS)
+class TestSetPublicWebformStatus(PublicWebformViewTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.webform = create_webform(is_disabled=True)
+
+    def post(self, is_disabled, webform=None, domain=DOMAIN, query=''):
+        webform = webform or self.webform
+        url = reverse('set_public_webform_status', args=[domain, webform.id])
+        return self.client.post(f'{url}{query}', {'is_disabled': is_disabled})
+
+    def test_a_closed_webform_can_be_opened(self):
+        self.post(is_disabled='false')
+
+        self.webform.refresh_from_db()
+        assert not self.webform.is_disabled
+
+    def test_an_open_webform_can_be_closed(self):
+        self.webform.is_disabled = False
+        self.webform.save()
+
+        self.post(is_disabled='true')
+
+        self.webform.refresh_from_db()
+        assert self.webform.is_disabled
+
+    def test_the_dashboard_is_returned_to_as_it_was_left(self):
+        """Closing a webform from a filtered page shouldn't reset the filters."""
+        response = self.post(is_disabled='true', query='?status=0&page=2')
+
+        dashboard = reverse('manage_public_webforms', args=[DOMAIN])
+        assert response.url == f'{dashboard}?status=0&page=2'
+
+    def test_another_projects_webform_is_not_found(self):
+        other = create_webform(domain='public-forms-other-domain')
+
+        response = self.post(is_disabled='false', webform=other)
+
+        assert response.status_code == 404
+        other.refresh_from_db()
+        assert other.is_disabled
+
+    def test_status_cannot_be_changed_without_the_permission(self):
+        self.sign_in(NORMAL_USER)
+
+        response = self.post(is_disabled='false')
+
+        assert response.status_code != 302
+        self.webform.refresh_from_db()
+        assert self.webform.is_disabled
+
+    def test_status_cannot_be_changed_by_a_get(self):
+        url = reverse('set_public_webform_status', args=[DOMAIN, self.webform.id])
+
+        response = self.client.get(url)
+
+        assert response.status_code == 405

--- a/corehq/apps/public_webforms/urls.py
+++ b/corehq/apps/public_webforms/urls.py
@@ -5,6 +5,7 @@ from corehq.apps.public_webforms.views import (
     ManagePublicWebformsView,
     PublicWebformTableView,
     public_webform_qr_code,
+    set_public_webform_status,
 )
 
 urlpatterns = [
@@ -13,4 +14,6 @@ urlpatterns = [
     url(r'^table/$', PublicWebformTableView.as_view(), name=PublicWebformTableView.urlname),
     url(r'^(?P<webform_id>\d+)/qr_code/$', public_webform_qr_code,
         name='public_webform_qr_code'),
+    url(r'^(?P<webform_id>\d+)/status/$', set_public_webform_status,
+        name='set_public_webform_status'),
 ]

--- a/corehq/apps/public_webforms/urls.py
+++ b/corehq/apps/public_webforms/urls.py
@@ -2,6 +2,7 @@ from django.urls import re_path as url
 
 from corehq.apps.public_webforms.views import (
     CreatePublicWebformView,
+    EditPublicWebformView,
     ManagePublicWebformsView,
     PublicWebformTableView,
     public_webform_qr_code,
@@ -12,6 +13,8 @@ urlpatterns = [
     url(r'^$', ManagePublicWebformsView.as_view(), name=ManagePublicWebformsView.urlname),
     url(r'^create/$', CreatePublicWebformView.as_view(), name=CreatePublicWebformView.urlname),
     url(r'^table/$', PublicWebformTableView.as_view(), name=PublicWebformTableView.urlname),
+    url(r'^(?P<webform_id>\d+)/edit/$', EditPublicWebformView.as_view(),
+        name=EditPublicWebformView.urlname),
     url(r'^(?P<webform_id>\d+)/qr_code/$', public_webform_qr_code,
         name='public_webform_qr_code'),
     url(r'^(?P<webform_id>\d+)/status/$', set_public_webform_status,

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -18,6 +18,7 @@ from corehq.apps.hqwebapp.tables.pagination import (
 )
 from corehq.apps.public_webforms.forms import (
     CreatePublicWebformForm,
+    EditPublicWebformForm,
     PublicWebformFilterForm,
 )
 from corehq.apps.public_webforms.models import PublicWebform
@@ -140,6 +141,49 @@ class CreatePublicWebformView(BasePublicWebformsView):
         data = [self.request.POST] if self.request.method == 'POST' else []
         return CreatePublicWebformForm(
             self.domain, self.domain_object.get_default_timezone(), *data)
+
+
+class EditPublicWebformView(BasePublicWebformsView):
+    urlname = 'edit_public_webform'
+    template_name = 'public_webforms/edit.html'
+    page_title = _("Edit Public Webform")
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, args=[self.domain, self.webform.id])
+
+    def post(self, request, *args, **kwargs):
+        if not self.form.is_valid():
+            return self.get(request, *args, **kwargs)
+        self.form.update_public_webform()
+        messages.success(request, _("Public webform updated."))
+        return HttpResponseRedirect(
+            reverse(ManagePublicWebformsView.urlname, args=[self.domain]))
+
+    @property
+    def page_context(self):
+        context = super().page_context
+        context.update({
+            'form': self.form,
+        })
+        return context
+
+    @property
+    @memoized
+    def webform(self):
+        return get_object_or_404(
+            PublicWebform, domain=self.domain, id=self.kwargs['webform_id'])
+
+    @property
+    @memoized
+    def form(self):
+        data = [self.request.POST] if self.request.method == 'POST' else []
+        return EditPublicWebformForm(
+            self.domain,
+            self.domain_object.get_default_timezone(),
+            self.webform,
+            *data,
+        )
 
 
 @public_webforms_access

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -138,9 +138,9 @@ class CreatePublicWebformView(BasePublicWebformsView):
     @property
     @memoized
     def form(self):
-        data = [self.request.POST] if self.request.method == 'POST' else []
+        data = self.request.POST if self.request.method == 'POST' else None
         return CreatePublicWebformForm(
-            self.domain, self.domain_object.get_default_timezone(), *data)
+            self.domain, self.domain_object.get_default_timezone(), data)
 
 
 class EditPublicWebformView(BasePublicWebformsView):
@@ -177,12 +177,12 @@ class EditPublicWebformView(BasePublicWebformsView):
     @property
     @memoized
     def form(self):
-        data = [self.request.POST] if self.request.method == 'POST' else []
+        data = self.request.POST if self.request.method == 'POST' else None
         return EditPublicWebformForm(
             self.domain,
             self.domain_object.get_default_timezone(),
             self.webform,
-            *data,
+            data,
         )
 
 

--- a/corehq/apps/public_webforms/views.py
+++ b/corehq/apps/public_webforms/views.py
@@ -4,6 +4,7 @@ from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
+from django.views.decorators.http import require_POST
 from memoized import memoized
 
 from corehq import privileges, toggles
@@ -147,3 +148,23 @@ def public_webform_qr_code(request, domain, webform_id):
     installs, so the dashboard can show one without embedding image data."""
     webform = get_object_or_404(PublicWebform, domain=domain, id=webform_id)
     return HttpResponse(get_qrcode(webform.public_url), content_type='image/png')
+
+
+@require_POST
+@public_webforms_access
+def set_public_webform_status(request, domain, webform_id):
+    """Open or close a webform to requests for a one-time link."""
+    webform = get_object_or_404(PublicWebform, domain=domain, id=webform_id)
+    webform.is_disabled = request.POST.get('is_disabled') == 'true'
+    webform.save()
+    messages.success(request, _("Public webform closed to new requests.")
+                     if webform.is_disabled
+                     else _("Public webform opened to new requests."))
+    return HttpResponseRedirect(_dashboard_url(request, domain))
+
+
+def _dashboard_url(request, domain):
+    """The dashboard as the admin left it, filters and page included."""
+    url = reverse(ManagePublicWebformsView.urlname, args=[domain])
+    query = request.GET.urlencode()
+    return f'{url}?{query}' if query else url

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1225,6 +1225,7 @@ class ApplicationsTab(UITab):
     def public_webforms_urls(self):
         from corehq.apps.public_webforms.views import (
             CreatePublicWebformView,
+            EditPublicWebformView,
             ManagePublicWebformsView,
         )
         if not (
@@ -1244,6 +1245,10 @@ class ApplicationsTab(UITab):
                 {
                     'title': _(CreatePublicWebformView.page_title),
                     'urlname': CreatePublicWebformView.urlname,
+                },
+                {
+                    'title': _(EditPublicWebformView.page_title),
+                    'urlname': EditPublicWebformView.urlname,
                 },
             ],
         }]


### PR DESCRIPTION
## Product Description
Adds the Edit Public Webform view and form, as well as filling in the "actions" column in the Manage Public Webforms view:
<img width="1265" height="626" alt="image" src="https://github.com/user-attachments/assets/0d82187b-6f17-40f5-8dae-b13dcfbeee3f" />


<img width="125" height="141" alt="image" src="https://github.com/user-attachments/assets/4270116a-f0db-4b71-ad2e-454b499d7830" />


## Technical Summary
[SAAS-20180](https://dimagi.atlassian.net/browse/SAAS-20180)

Adds a form and view to edit public webforms, based directly on the "create" form and view but with the app/menu/form fields disabled. All other fields from the create form can be edited and saved.

Enables opening and closing a public webform from the dashboard view, which sets `is_disabled` on the model instance. This, along with closing date, will be used to determine whether a public webform should be currently available to one-time link requests or not.

Code in this PR co-authored by AI.

## Feature Flag
`PUBLIC_WEBFORMS`

## Safety Assurance

### Safety story
Privilege and feature-flag gated. Consideration is given to get only public webforms belonging to the domain currently accessed and fails more gracefully (404 rather than 500) if a user tries to access something they shouldn't. Tested locally and with thorough automated testing.

### Automated test coverage
Tests are added in `test_forms`, `test_tables`, and `test_views`.

### QA Plan
Public Webforms will get end-to-end QA before release.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-20180]: https://dimagi.atlassian.net/browse/SAAS-20180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ