### PR TITLE
Allow accounting admin access without superuser status

### DIFF
--- a/corehq/apps/accounting/decorators.py
+++ b/corehq/apps/accounting/decorators.py
@@ -1,14 +1,37 @@
 from functools import wraps
 
-from django.http import HttpResponse, JsonResponse
-
-from django_prbac.decorators import requires_privilege
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.urls import reverse
+from django_prbac.decorators import (
+    requires_privilege,
+    requires_privilege_raise404,
+)
 from django_prbac.exceptions import PermissionDenied
 
 from corehq import privileges
 from corehq.apps.accounting.models import DefaultProductPlan
+from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 from corehq.const import USER_DATE_FORMAT
 from corehq.toggles import domain_has_privilege_from_toggle
+
+
+def accounting_admin_required(view_func):
+    """Require a logged-in user with the ACCOUNTING_ADMIN privilege.
+
+    Sessions authenticated via SSO are rejected: accounting pages
+    historically required superuser status, whose decorator blocked SSO
+    sessions, and dropping the superuser requirement should not open
+    these pages to externally-managed logins.
+    """
+    @wraps(view_func)
+    def _inner(request, *args, **kwargs):
+        if is_request_using_sso(request):
+            return HttpResponseRedirect(reverse("no_permissions"))
+        return view_func(request, *args, **kwargs)
+    return login_required(
+        requires_privilege_raise404(privileges.ACCOUNTING_ADMIN)(_inner)
+    )
 
 
 def requires_privilege_with_fallback(slug, **assignment):
@@ -51,7 +74,9 @@ def requires_privilege_with_fallback(slug, **assignment):
                 )
             except PermissionDenied:
                 request.show_trial_notice = False
-                from corehq.apps.domain.views.accounting import SubscriptionUpgradeRequiredView
+                from corehq.apps.domain.views.accounting import (
+                    SubscriptionUpgradeRequiredView,
+                )
                 return SubscriptionUpgradeRequiredView().get(
                     request, request.domain, slug
                 )

--- a/corehq/apps/accounting/dispatcher.py
+++ b/corehq/apps/accounting/dispatcher.py
@@ -1,9 +1,6 @@
 from django.utils.decorators import method_decorator
 
-from django_prbac.decorators import requires_privilege_raise404
-
-from corehq import privileges
-from corehq.apps.domain.decorators import require_superuser
+from corehq.apps.accounting.decorators import accounting_admin_required
 from corehq.apps.reports.dispatcher import ReportDispatcher
 
 
@@ -11,7 +8,6 @@ class AccountingAdminInterfaceDispatcher(ReportDispatcher):
     prefix = 'accounting_admin_interface'
     map_name = "ACCOUNTING_ADMIN_INTERFACES"
 
-    @method_decorator(require_superuser)
-    @method_decorator(requires_privilege_raise404(privileges.ACCOUNTING_ADMIN))
+    @method_decorator(accounting_admin_required)
     def dispatch(self, request, *args, **kwargs):
         return super(AccountingAdminInterfaceDispatcher, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -2772,9 +2772,9 @@ class CreateAdminForm(forms.Form):
                 "User '%s' does not exist" % username
             )
         web_user = WebUser.get_by_username(username)
-        if not web_user or not web_user.is_superuser:
+        if not web_user:
             raise CreateAccountingAdminError(
-                "The user '%s' is not a superuser." % username,
+                "The user '%s' is not a web user." % username,
             )
         try:
             user_role = UserRole.objects.get(user=user)

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -89,6 +89,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.users.models import WebUser
+from corehq.apps.users.util import is_dimagi_email
 from corehq.util.dates import get_first_last_days
 
 
@@ -2775,6 +2776,10 @@ class CreateAdminForm(forms.Form):
         if not web_user:
             raise CreateAccountingAdminError(
                 "The user '%s' is not a web user." % username,
+            )
+        if settings.IS_DIMAGI_ENVIRONMENT and not is_dimagi_email(username):
+            raise CreateAccountingAdminError(
+                "The user '%s' does not have a Dimagi email address." % username,
             )
         try:
             user_role = UserRole.objects.get(user=user)

--- a/corehq/apps/accounting/tests/test_forms.py
+++ b/corehq/apps/accounting/tests/test_forms.py
@@ -2,18 +2,26 @@ import datetime
 import random
 from unittest.mock import patch
 
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from dateutil.relativedelta import relativedelta
+from django_prbac.models import Grant, Role
 
-from corehq.apps.accounting.exceptions import InvoiceError
+from corehq import privileges
+from corehq.apps.accounting.exceptions import (
+    CreateAccountingAdminError,
+    InvoiceError,
+)
 from corehq.apps.accounting.forms import (
     AdjustBalanceForm,
+    CreateAdminForm,
     PlanContactForm,
     SubscriptionForm,
     TriggerInvoiceForm,
 )
+from corehq.apps.accounting.utils import is_accounting_admin
 from corehq.apps.accounting.models import (
     BillingAccount,
     CreditAdjustmentReason,
@@ -481,3 +489,41 @@ class TestPlanContactForm(TestCase):
         expected_subject = f'[{request_type}] {self.domain.name}'
         self.assertEqual(subject, expected_subject)
         self.assertTrue(all(value in text_content for value in data.values()))
+
+
+class TestCreateAdminForm(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        ops_role, _ = Role.objects.get_or_create(
+            slug=privileges.OPERATIONS_TEAM, defaults={'name': 'Ops'}
+        )
+        accounting_role, _ = Role.objects.get_or_create(
+            slug=privileges.ACCOUNTING_ADMIN, defaults={'name': 'Accounting'}
+        )
+        Grant.objects.get_or_create(from_role=ops_role, to_role=accounting_role)
+        Role.update_cache()
+
+    def test_can_grant_accounting_admin_to_non_superuser(self):
+        user = WebUser.create(None, 'new-admin@dimagi.com', 'password', None, None)
+        self.addCleanup(user.delete, None, None)
+
+        form = CreateAdminForm({'username': user.username})
+        assert form.is_valid()
+        django_user = form.add_admin_user()
+
+        Role.update_cache()
+        assert is_accounting_admin(django_user)
+
+    def test_rejects_nonexistent_user(self):
+        form = CreateAdminForm({'username': 'nobody@dimagi.com'})
+        assert form.is_valid()
+        with self.assertRaises(CreateAccountingAdminError):
+            form.add_admin_user()
+
+    def test_rejects_user_without_web_user(self):
+        User.objects.create(username='django-only@dimagi.com')
+        form = CreateAdminForm({'username': 'django-only@dimagi.com'})
+        assert form.is_valid()
+        with self.assertRaises(CreateAccountingAdminError):
+            form.add_admin_user()

--- a/corehq/apps/accounting/tests/test_forms.py
+++ b/corehq/apps/accounting/tests/test_forms.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from dateutil.relativedelta import relativedelta
 from django_prbac.models import Grant, Role
@@ -527,3 +527,25 @@ class TestCreateAdminForm(TestCase):
         assert form.is_valid()
         with self.assertRaises(CreateAccountingAdminError):
             form.add_admin_user()
+
+    @override_settings(IS_DIMAGI_ENVIRONMENT=True)
+    def test_rejects_non_dimagi_email_on_dimagi_environment(self):
+        user = WebUser.create(None, 'outsider@example.com', 'password', None, None)
+        self.addCleanup(user.delete, None, None)
+
+        form = CreateAdminForm({'username': user.username})
+        assert form.is_valid()
+        with self.assertRaises(CreateAccountingAdminError):
+            form.add_admin_user()
+
+    @override_settings(IS_DIMAGI_ENVIRONMENT=False)
+    def test_allows_non_dimagi_email_off_dimagi_environment(self):
+        user = WebUser.create(None, 'partner@example.com', 'password', None, None)
+        self.addCleanup(user.delete, None, None)
+
+        form = CreateAdminForm({'username': user.username})
+        assert form.is_valid()
+        django_user = form.add_admin_user()
+
+        Role.update_cache()
+        assert is_accounting_admin(django_user)

--- a/corehq/apps/accounting/tests/test_views.py
+++ b/corehq/apps/accounting/tests/test_views.py
@@ -1,0 +1,85 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.urls import reverse
+from django_prbac.models import Grant, Role, UserRole
+
+from corehq import privileges
+from corehq.apps.accounting.views import ManageAccountingAdminsView
+from corehq.apps.users.models import WebUser
+
+
+def _grant_accounting_admin(django_user):
+    # privileges.ACCOUNTING_ADMIN is applied via OPERATIONS_TEAM role
+    ops_role, _ = Role.objects.get_or_create(slug=privileges.OPERATIONS_TEAM, defaults={'name': 'Ops'})
+    accounting_role, _ = Role.objects.get_or_create(
+        slug=privileges.ACCOUNTING_ADMIN, defaults={'name': 'Accounting'}
+    )
+    Grant.objects.get_or_create(from_role=ops_role, to_role=accounting_role)
+    user_privs = Role.objects.create(slug=f"{django_user.username}_privs", name="Test user privileges")
+    UserRole.objects.create(user=django_user, role=user_privs)
+    Grant.objects.create(from_role=user_privs, to_role=ops_role)
+    Role.update_cache()
+
+
+class TestAccountingAdminAccess(TestCase):
+    """Accounting pages require the ACCOUNTING_ADMIN privilege, but not
+    superuser status."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.accounting_admin = WebUser.create(
+            None, "acct-admin@dimagi.com", "password", None, None
+        )
+        cls.addClassCleanup(cls.accounting_admin.delete, None, None)
+        _grant_accounting_admin(cls.accounting_admin.get_django_user())
+
+        cls.plain_user = WebUser.create(
+            None, "plain@dimagi.com", "password", None, None
+        )
+        cls.addClassCleanup(cls.plain_user.delete, None, None)
+
+        cls.superuser_without_privilege = WebUser.create(
+            None, "superuser@dimagi.com", "password", None, None, is_superuser=True
+        )
+        cls.addClassCleanup(cls.superuser_without_privilege.delete, None, None)
+
+        cls.default_url = reverse('accounting_default')
+        cls.section_url = reverse(ManageAccountingAdminsView.urlname)
+
+    def test_non_superuser_accounting_admin_can_access_default_view(self):
+        self.client.login(username=self.accounting_admin.username, password='password')
+        response = self.client.get(self.default_url)
+        assert response.status_code == 302
+        assert response.url != reverse('no_permissions')
+
+    def test_non_superuser_accounting_admin_can_access_section_view(self):
+        self.client.login(username=self.accounting_admin.username, password='password')
+        response = self.client.get(self.section_url)
+        assert response.status_code == 200
+
+    def test_user_without_privilege_gets_404(self):
+        self.client.login(username=self.plain_user.username, password='password')
+        response = self.client.get(self.default_url)
+        assert response.status_code == 404
+
+    def test_superuser_without_privilege_gets_404(self):
+        self.client.login(username=self.superuser_without_privilege.username, password='password')
+        response = self.client.get(self.default_url)
+        assert response.status_code == 404
+
+    def test_anonymous_user_is_redirected_to_login(self):
+        response = self.client.get(self.default_url)
+        assert response.status_code == 302
+        assert response.url.startswith('/accounts/login/')
+
+    def test_sso_authenticated_session_is_blocked(self):
+        self.client.login(username=self.accounting_admin.username, password='password')
+        with patch(
+            'corehq.apps.accounting.decorators.is_request_using_sso',
+            return_value=True,
+        ):
+            response = self.client.get(self.default_url)
+        assert response.status_code == 302
+        assert response.url == reverse('no_permissions')

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -24,7 +24,6 @@ from django.utils.translation import gettext_noop
 from django.views.generic import View
 
 from couchdbkit import ResourceNotFound
-from django_prbac.decorators import requires_privilege_raise404
 from django_prbac.models import Grant, Role
 from memoized import memoized
 
@@ -46,6 +45,7 @@ from corehq.apps.accounting.async_handlers import (
     SubscriberFilterAsyncHandler,
     SubscriptionFilterAsyncHandler,
 )
+from corehq.apps.accounting.decorators import accounting_admin_required
 from corehq.apps.accounting.exceptions import (
     CreateAccountingAdminError,
     CreditLineError,
@@ -117,7 +117,6 @@ from corehq.apps.accounting.utils.invoicing import (
     get_oldest_overdue_invoice_over_threshold,
 )
 from corehq.apps.accounting.utils.unpaid_invoice import Downgrade
-from corehq.apps.domain.decorators import require_superuser
 from corehq.apps.domain.views.accounting import DomainBillingStatementsView
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.views import (
@@ -128,8 +127,7 @@ from corehq.apps.sso.tasks import auto_deactivate_removed_sso_users
 from corehq.toggles import ACCOUNTING_TESTING_TOOLS
 
 
-@require_superuser
-@requires_privilege_raise404(privileges.ACCOUNTING_ADMIN)
+@accounting_admin_required
 def accounting_default(request):
     return HttpResponseRedirect(AccountingInterface.get_url())
 
@@ -141,8 +139,7 @@ class AccountingSectionView(BaseSectionPageView):
     def section_url(self):
         return reverse('accounting_default')
 
-    @method_decorator(require_superuser)
-    @method_decorator(requires_privilege_raise404(privileges.ACCOUNTING_ADMIN))
+    @method_decorator(accounting_admin_required)
     def dispatch(self, request, *args, **kwargs):
         return super(AccountingSectionView, self).dispatch(request, *args, **kwargs)
 
@@ -1207,8 +1204,7 @@ class AccountingSingleOptionResponseView(View, AsyncHandlerMixin):
         InvoiceBalanceAsyncHandler,
     ]
 
-    @method_decorator(require_superuser)
-    @method_decorator(requires_privilege_raise404(privileges.ACCOUNTING_ADMIN))
+    @method_decorator(accounting_admin_required)
     def dispatch(self, request, *args, **kwargs):
         return super(AccountingSingleOptionResponseView, self).dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
## Product Description

Accounting admin pages are now accessible to any user holding the `ACCOUNTING_ADMIN` privilege — superuser status is no longer also required. Correspondingly, the "Add Admin" form can grant the privilege to non-superusers (restricted to `@dimagi.com` addresses on Dimagi environments, matching the superuser management form).

## Technical Summary

Stacked on #38024. That PR made accounting admins auditable at offboarding in their own right; this one removes the superuser coupling itself, so the privilege can be granted and revoked independently.

A new `accounting_admin_required` decorator replaces the `require_superuser` + `requires_privilege_raise404(ACCOUNTING_ADMIN)` pairs at all four gates (the admin-interface dispatcher, `accounting_default`, `AccountingSectionView`, and `AccountingSingleOptionResponseView`; the SSO IdP admin views inherit from `AccountingSectionView`). Two properties of `require_superuser` are deliberately preserved rather than dropped with it:

- **SSO-authenticated sessions remain blocked** — removing the superuser requirement should not silently open billing pages to externally-managed logins.
- **Unauthenticated requests are still turned away**, now with a login redirect rather than a no-permissions redirect.

Grant-time, the form check that required the target to already be a superuser is replaced by the same Dimagi-email guard used for superuser grants (`is_dimagi_email` under `IS_DIMAGI_ENVIRONMENT`), since the superuser prerequisite was previously what carried that restriction implicitly.

Note the resulting model: accounting admins can grant/revoke accounting admin to other (Dimagi-email) web users without being superusers. Offboarding via the superuser-management page continues to strip the privilege, and the offboarding list (per #38024) now surfaces holders directly.

## Feature Flag

None.

## Safety Assurance

### Safety story

Access can only narrow or stay equal for any existing user: every current accounting admin is a superuser (grants required it), so nobody gains access they lacked; superusers without the privilege were already 404'd. The behavior change is prospective — future grants no longer require superuser status.

A security review of the branch was run (decorator composition order, missed gates, privilege-escalation surface, query construction); no findings.

### Automated test coverage

`TestAccountingAdminAccess` covers the new access matrix end-to-end: non-superuser admin can reach the section and default views; privilege-less users and superusers-without-privilege get 404; anonymous requests redirect to login; SSO sessions are rejected. `TestCreateAdminForm` covers granting to a non-superuser, the Dimagi-email restriction on/off `IS_DIMAGI_ENVIRONMENT`, and the retained existence checks.

### QA Plan

None — covered by automated tests.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
