### PR TITLE
fix(case_search): reset query builder state in place

### DIFF
--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -9,6 +9,7 @@ import {
     cloneWithNewIds,
     normalizeRoot,
     removeChild,
+    resetQuery,
 } from "case_search/js/endpoint_tree";
 
 // Input-slot type sentinels. These MUST stay in sync with the constants in
@@ -91,7 +92,7 @@ Alpine.data("endpointForm", () => {
         },
 
         onCasetypeChange() {
-            this.query = { type: "all", children: [] };
+            resetQuery(this.query);
         },
 
         addParameter() {

--- a/corehq/apps/case_search/static/case_search/js/endpoint_tree.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_tree.js
@@ -32,6 +32,11 @@ export function normalizeRoot(node) {
     return { type: "all", children: (node && node.children) || [] };
 }
 
+export function resetQuery(query) {
+    query.type = "all";
+    query.children = [];
+}
+
 // Remove `node` from `parent.children` by identity, returning true if found.
 // Identity rather than index because the builder's x-for is keyed by `_id` and
 // Alpine does not re-run a child's scope after the list mutates, so a captured

--- a/corehq/apps/case_search/static/case_search/spec/endpoint_tree.spec.js
+++ b/corehq/apps/case_search/static/case_search/spec/endpoint_tree.spec.js
@@ -3,6 +3,7 @@ import {
     cloneWithNewIds,
     normalizeRoot,
     removeChild,
+    resetQuery,
 } from "case_search/js/endpoint_tree";
 
 const component = (extra = {}) => ({ type: "component", ...extra });
@@ -113,6 +114,23 @@ describe("endpoint_tree", function () {
             const result = normalizeRoot({ type: "legacy", children });
             assert.equal(result.type, "all");
             assert.deepEqual(result.children, children);
+        });
+    });
+
+    describe("resetQuery", function () {
+        it("resets type and children", function () {
+            const query = group("any", [component({ field: "a" })]);
+            resetQuery(query);
+            assert.equal(query.type, "all");
+            assert.deepEqual(query.children, []);
+        });
+
+        it("is visible through any other reference to the same object", function () {
+            const query = group("all", [component()]);
+            const node = query;
+            resetQuery(query);
+            assert.equal(node.type, "all");
+            assert.deepEqual(node.children, []);
         });
     });
 


### PR DESCRIPTION
## Product Description

onCasetypeChange reassigned `this.query` to a new object on a new endpoint's first case-type pick. The query builder tree captures a reference to that object once via `x-data="{ node: query }"` at page load, so the reassignment silently orphaned it — the visible form kept working off the stale reference, while the hidden query field, JSON preview, and test button read the reassigned one and stayed frozen at an empty query no matter what conditions were added afterward.

resetQuery() in endpoint_tree.js mutates type/children in place instead.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag

CASE_SEARCH_ENDPOINTS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
