### PR TITLE
Read and update a single form without re-importing the whole app

### DIFF
--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -51,6 +51,7 @@ from corehq.apps.api.resources.v0_5 import (
     DomainUsernames,
     UserDomainsResource,
 )
+from corehq.apps.app_manager.views.single_form_api import SingleFormApiView
 from corehq.apps.zapier.api.v0_5 import ZapierUserDomains
 from corehq.apps.commtrack.resources.v0_1 import ProductResource
 from corehq.apps.fixtures import resources as fixtures
@@ -193,6 +194,8 @@ urlpatterns = [
     v1_0.CommCareAnalyticsUserResource.get_urlpattern('v1'),
     v1_0.InvitationResource.get_urlpattern('v1'),
     v1_0.DETExportInstanceResource.get_urlpattern('v1'),
+    url(r'^apps/v1/(?P<app_id>[\w-]+)/modules/(?P<module_id>[\w-]+)/forms/(?P<form_id>[\w-]+)/$',
+        SingleFormApiView.as_view(), name='single_form_api'),
 ]
 
 
@@ -250,3 +253,7 @@ user_urlpatterns = [
 ]
 
 waf_allow('XSS_BODY', hard_code_pattern=r'^/a/([\w\.:-]+)/api/v([\d\.]+)/form/$')
+waf_allow(
+    'XSS_BODY',
+    hard_code_pattern=r'^/a/([\w\.:-]+)/api/apps/v1/[\w-]+/modules/[\w-]+/forms/[\w-]+/$',
+)

--- a/corehq/apps/app_manager/tests/test_single_form_api.py
+++ b/corehq/apps/app_manager/tests/test_single_form_api.py
@@ -109,6 +109,9 @@ class SingleFormApiViewTests(TestCase):
                 self._url(), data=json.dumps({}), content_type='application/json',
             ).status_code == 404
 
+    def test_head_matches_get_etag(self):
+        assert self.client.head(self._url())['ETag'] == self.client.get(self._url())['ETag']
+
     def test_head_returns_404_for_missing_app(self):
         response = self.client.head(self._url(app_id='missing-app'))
         assert response.status_code == 404
@@ -117,6 +120,12 @@ class SingleFormApiViewTests(TestCase):
     # asserting on the content proves nothing. Content-Length still reports
     # the body the view built, which is the thing that must stay empty --
     # neither Django nor gunicorn strips it in production.
+    def test_head_builds_no_body(self):
+        assert self.client.head(self._url())['Content-Length'] == '0'
+
+    def test_head_builds_no_body_for_an_error(self):
+        assert self.client.head(self._url(form_id='missing-form'))['Content-Length'] == '0'
+
     def test_get_returns_bare_resource(self):
         response = self.client.get(self._url())
         assert response.status_code == 200
@@ -162,6 +171,9 @@ class SingleFormApiViewTests(TestCase):
         client = Client()
         client.login(username=self.non_admin_username, password=self.non_admin_password)
         assert client.get(self._url()).status_code != 200
+
+    def test_head_reports_the_content_type_get_would_send(self):
+        assert self.client.head(self._url())['Content-Type'] == 'application/json'
 
     def test_missing_form_says_the_form_is_missing(self):
         response = self.client.get(self._url(form_id='missing-form'))

--- a/corehq/apps/app_manager/tests/test_single_form_api.py
+++ b/corehq/apps/app_manager/tests/test_single_form_api.py
@@ -1,14 +1,32 @@
+import hashlib
+import json
+from unittest import mock
+from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import Client, TestCase
+from django.urls import reverse
 
 from corehq.apps.app_manager.models import (
     Application,
     Module,
+    RemoteApp,
 )
 from corehq.apps.app_manager.tests.util import get_simple_form
 from corehq.apps.app_manager.views.single_form_api import (
+    FORM_API_APP_NOT_FOUND,
+    FORM_API_FORM_NOT_FOUND,
+    FORM_API_MODULE_NOT_FOUND,
+    ApiError,
     FormResource,
     _form_resource_dict,
+    get_form_for_api,
+)
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import WebUser
+from corehq.util.test_utils import (
+    flag_disabled,
+    flag_enabled,
+    has_permissions,
 )
 
 ENTITY_XML = (
@@ -17,6 +35,217 @@ ENTITY_XML = (
     '<h:html xmlns:h="http://www.w3.org/1999/xhtml"><h:head>'
     '<h:title>&xxe;</h:title></h:head><h:body/></h:html>'
 )
+
+
+@flag_enabled('SINGLE_FORM_API')
+class SingleFormApiViewTests(TestCase):
+    username = 'single-form-api-user'
+    password = 'correct-horse-battery-staple'
+    non_admin_username = 'single-form-api-non-admin'
+    non_admin_password = 'another-horse-battery-staple'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = create_domain('single-form-view-domain')
+        cls.user = WebUser.create(
+            cls.domain.name,
+            cls.username,
+            cls.password,
+            created_by=None,
+            created_via=None,
+            is_active=True,
+        )
+        cls.user.is_superuser = True
+        cls.user.save()
+
+        cls.non_admin_user = WebUser.create(
+            cls.domain.name,
+            cls.non_admin_username,
+            cls.non_admin_password,
+            created_by=None,
+            created_via=None,
+            is_active=True,
+        )
+
+        cls.throttle_patcher = patch(
+            'corehq.apps.api.resources.meta.HQThrottle.should_be_throttled', return_value=False
+        )
+        cls.throttle_patcher.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.throttle_patcher.stop()
+        cls.non_admin_user.delete(cls.domain.name, deleted_by=None)
+        cls.user.delete(cls.domain.name, deleted_by=None)
+        cls.domain.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.app = Application.new_app(self.domain.name, 'Test App')
+        module = self.app.add_module(Module.new_module('Module One', lang='en'))
+        form = module.new_form('Form One', lang='en', attachment=get_simple_form(xmlns='xmlns-1'))
+        self.module_id = module.unique_id
+        self.form_id = form.unique_id
+        self.app.save()
+        self.addCleanup(self.app.delete)
+
+        self.client = Client()
+        self.client.login(username=self.username, password=self.password)
+
+    def _url(self, app_id=None, module_id=None, form_id=None):
+        return reverse('single_form_api', kwargs={
+            'domain': self.domain.name,
+            'app_id': app_id or self.app._id,
+            'module_id': module_id or self.module_id,
+            'form_id': form_id or self.form_id,
+        })
+
+    def test_endpoint_is_absent_without_the_feature_flag(self):
+        with flag_disabled('SINGLE_FORM_API'):
+            assert self.client.get(self._url()).status_code == 404
+            assert self.client.head(self._url()).status_code == 404
+            assert self.client.patch(
+                self._url(), data=json.dumps({}), content_type='application/json',
+            ).status_code == 404
+
+    def test_head_returns_404_for_missing_app(self):
+        response = self.client.head(self._url(app_id='missing-app'))
+        assert response.status_code == 404
+
+    # The test client discards HEAD content the way a web server would, so
+    # asserting on the content proves nothing. Content-Length still reports
+    # the body the view built, which is the thing that must stay empty --
+    # neither Django nor gunicorn strips it in production.
+    def test_get_returns_bare_resource(self):
+        response = self.client.get(self._url())
+        assert response.status_code == 200
+        body = response.json()
+        assert body['unique_id'] == self.form_id
+        assert 'source' in body
+        assert 'errors' not in body
+        assert response['ETag']
+
+    def test_etag_is_the_hash_of_the_bytes_that_were_sent(self):
+        # The contract a client relies on to recompute the ETag itself,
+        # rather than treating it as an opaque token.
+        response = self.client.get(self._url())
+        digest = hashlib.sha256(response.content).hexdigest()
+        assert response['ETag'] == f'"{digest}"'
+
+    def test_response_body_is_canonical_json(self):
+        body = self.client.get(self._url()).content
+        assert body == json.dumps(
+            json.loads(body), sort_keys=True, separators=(',', ':'), ensure_ascii=False
+        ).encode('utf-8')
+
+    def test_get_returns_404_for_missing_app(self):
+        response = self.client.get(self._url(app_id='missing-app'))
+        assert response.status_code == 404
+        assert response.json()['errors'][0]['error'] == 'app_not_found'
+
+    def test_get_returns_404_for_missing_module(self):
+        response = self.client.get(self._url(module_id='missing-module'))
+        assert response.status_code == 404
+        assert response.json()['errors'][0]['error'] == 'module_not_found'
+
+    def test_get_returns_404_for_missing_form(self):
+        response = self.client.get(self._url(form_id='missing-form'))
+        assert response.status_code == 404
+        assert response.json()['errors'][0]['error'] == 'form_not_found'
+
+    def test_get_rejects_unauthenticated_request(self):
+        assert Client().get(self._url()).status_code != 200
+
+    @has_permissions(view_apps=False, edit_apps=False)
+    def test_get_rejects_user_without_view_apps_permission(self):
+        client = Client()
+        client.login(username=self.non_admin_username, password=self.non_admin_password)
+        assert client.get(self._url()).status_code != 200
+
+    def test_missing_form_says_the_form_is_missing(self):
+        response = self.client.get(self._url(form_id='missing-form'))
+        assert 'missing-form' in response.json()['errors'][0]['message']
+
+    def test_throttling_does_not_run_before_authentication(self):
+        with patch('corehq.apps.api.resources.meta.HQThrottle.should_be_throttled') as throttle:
+            Client().get(self._url())
+        assert not throttle.called
+
+    def test_rejects_put_method(self):
+        response = self.client.put(self._url(), data=json.dumps({}), content_type='application/json')
+        assert response.status_code == 405
+
+    # --- round-trip ---
+
+
+class GetFormForApiTests(TestCase):
+    def setUp(self):
+        self.domain = create_domain('form-api-get-domain')
+        self.addCleanup(self.domain.delete)
+        self.app = Application.new_app(self.domain.name, 'Test App')
+        module = self.app.add_module(Module.new_module('Module One', lang='en'))
+        self.form = module.new_form('Form One', lang='en', attachment=get_simple_form(xmlns='xmlns-1'))
+        self.module_id = module.unique_id
+        self.form_id = self.form.unique_id
+        self.app.save()
+        self.addCleanup(self.app.delete)
+
+    def test_returns_form_on_success(self):
+        form, result = get_form_for_api(self.domain.name, self.app._id, self.module_id, self.form_id)
+
+        assert result.success is True
+        assert result.errors == []
+        assert form.unique_id == self.form_id
+
+    def test_treats_missing_app_as_not_found(self):
+        form, result = get_form_for_api(self.domain.name, 'missing-app', self.module_id, self.form_id)
+
+        assert result.success is False
+        assert result.errors == [ApiError(FORM_API_APP_NOT_FOUND, mock.ANY)]
+
+    def test_treats_saved_build_as_not_found(self):
+        build = self.app.make_build()
+        build.save()
+        self.addCleanup(build.delete)
+
+        form, result = get_form_for_api(self.domain.name, build._id, self.module_id, self.form_id)
+
+        assert result.success is False
+        assert result.errors == [ApiError(FORM_API_APP_NOT_FOUND, mock.ANY)]
+
+    def test_treats_a_deleted_app_as_not_found(self):
+        self.app.delete_app()
+        self.app.save()
+
+        form, result = get_form_for_api(
+            self.domain.name, self.app._id, self.module_id, self.form_id
+        )
+
+        assert result.errors == [ApiError(FORM_API_APP_NOT_FOUND, mock.ANY)]
+
+    def test_treats_a_remote_app_as_not_found(self):
+        remote = RemoteApp.new_app(self.domain.name, 'Remote App')
+        remote.save()
+        self.addCleanup(remote.delete)
+
+        form, result = get_form_for_api(
+            self.domain.name, remote._id, self.module_id, self.form_id
+        )
+
+        assert result.errors == [ApiError(FORM_API_APP_NOT_FOUND, mock.ANY)]
+
+    def test_returns_module_not_found(self):
+        form, result = get_form_for_api(self.domain.name, self.app._id, 'missing-module', self.form_id)
+
+        assert result.success is False
+        assert result.errors == [ApiError(FORM_API_MODULE_NOT_FOUND, mock.ANY)]
+
+    def test_returns_form_not_found(self):
+        form, result = get_form_for_api(self.domain.name, self.app._id, self.module_id, 'missing-form')
+
+        assert result.success is False
+        assert result.errors[0].error == FORM_API_FORM_NOT_FOUND
 
 
 class FormResourceEtagTests(TestCase):

--- a/corehq/apps/app_manager/tests/test_single_form_api.py
+++ b/corehq/apps/app_manager/tests/test_single_form_api.py
@@ -1,25 +1,37 @@
 import hashlib
 import json
+import os
 from unittest import mock
 from unittest.mock import patch
 
-from django.test import Client, TestCase
+from couchdbkit.exceptions import ResourceConflict
+from django.test import Client, SimpleTestCase, TestCase
 from django.urls import reverse
 
+from corehq import privileges
 from corehq.apps.app_manager.models import (
+    AdvancedModule,
     Application,
     Module,
     RemoteApp,
 )
 from corehq.apps.app_manager.tests.util import get_simple_form
+from corehq.apps.app_manager.util import save_xform
 from corehq.apps.app_manager.views.single_form_api import (
     FORM_API_APP_NOT_FOUND,
+    FORM_API_CONFLICT,
+    FORM_API_FIELD_NOT_PATCHABLE,
     FORM_API_FORM_NOT_FOUND,
+    FORM_API_INVALID_FIELD_VALUE,
     FORM_API_MODULE_NOT_FOUND,
+    FORM_API_PRECONDITION_FAILED,
+    FORM_API_PRECONDITION_REQUIRED,
     ApiError,
     FormResource,
     _form_resource_dict,
     get_form_for_api,
+    merge_patch,
+    patch_form_for_api,
 )
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
@@ -27,6 +39,7 @@ from corehq.util.test_utils import (
     flag_disabled,
     flag_enabled,
     has_permissions,
+    privilege_enabled,
 )
 
 ENTITY_XML = (
@@ -101,6 +114,9 @@ class SingleFormApiViewTests(TestCase):
             'form_id': form_id or self.form_id,
         })
 
+    def _etag(self):
+        return self.client.get(self._url())['ETag']
+
     def test_endpoint_is_absent_without_the_feature_flag(self):
         with flag_disabled('SINGLE_FORM_API'):
             assert self.client.get(self._url()).status_code == 404
@@ -172,6 +188,169 @@ class SingleFormApiViewTests(TestCase):
         client.login(username=self.non_admin_username, password=self.non_admin_password)
         assert client.get(self._url()).status_code != 200
 
+    def test_patch_updates_only_specified_field(self):
+        etag = self._etag()
+        response = self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'Updated'}}),
+            content_type='application/json', HTTP_IF_MATCH=etag,
+        )
+        assert response.status_code == 200
+        assert response.json()['name']['en'] == 'Updated'
+
+        app = Application.get(self.app._id)
+        module = app.get_module_by_unique_id(self.module_id)
+        assert module.get_form_by_unique_id(self.form_id).name['en'] == 'Updated'
+
+    def test_patch_applies_source(self):
+        etag = self._etag()
+        new_xml = get_simple_form(xmlns='updated-xmlns')
+        response = self.client.patch(
+            self._url(), data=json.dumps({'source': new_xml}),
+            content_type='application/json', HTTP_IF_MATCH=etag,
+        )
+        assert response.status_code == 200
+        app = Application.get(self.app._id)
+        module = app.get_module_by_unique_id(self.module_id)
+        assert module.get_form_by_unique_id(self.form_id).source == new_xml
+
+    def test_patch_accepts_the_whole_resource_it_returned(self):
+        get = self.client.get(self._url())
+        response = self.client.patch(
+            self._url(), data=get.content,
+            content_type='application/json', HTTP_IF_MATCH=get['ETag'],
+        )
+        assert response.status_code == 200, response.content
+
+    def test_patch_merges_into_a_dict_instead_of_replacing_it(self):
+        self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'English', 'fr': 'French'}}),
+            content_type='application/json', HTTP_IF_MATCH=self._etag(),
+        )
+        self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'Updated'}}),
+            content_type='application/json', HTTP_IF_MATCH=self._etag(),
+        )
+        assert self.client.get(self._url()).json()['name'] == {
+            'en': 'Updated', 'fr': 'French',
+        }
+
+    def test_patch_null_deletes_a_key(self):
+        self.client.patch(
+            self._url(), data=json.dumps({'comment': 'a comment'}),
+            content_type='application/json', HTTP_IF_MATCH=self._etag(),
+        )
+        self.client.patch(
+            self._url(), data=json.dumps({'comment': None}),
+            content_type='application/json', HTTP_IF_MATCH=self._etag(),
+        )
+        assert not self.client.get(self._url()).json()['comment']
+
+    def _patch_source(self, xml):
+        return self.client.patch(
+            self._url(), data=json.dumps({'source': xml}),
+            content_type='application/json', HTTP_IF_MATCH=self._etag(),
+        )
+
+    def test_patch_rejects_a_source_that_is_not_xml(self):
+        response = self._patch_source('not xml at all')
+        assert response.status_code == 400
+        assert response.json()['errors'][0]['error'] == 'invalid_field_value'
+
+    def test_patch_rejects_an_empty_source(self):
+        assert self._patch_source('').status_code == 400
+
+    def test_patch_rejects_a_source_declaring_entities(self):
+        # Entities are refused by the parser; the point here is that the
+        # refusal reaches the client as a 4xx rather than a crash.
+        response = self._patch_source(ENTITY_XML)
+        assert response.status_code == 400
+
+    def test_a_rejected_source_leaves_the_form_alone(self):
+        before = self.client.get(self._url()).json()
+        self._patch_source('not xml at all')
+        after = self.client.get(self._url()).json()
+        assert after['xmlns'] == before['xmlns']
+        assert after['source'] == before['source']
+
+    def test_patch_rejects_an_explicit_null_source(self):
+        # RFC 7396 says null deletes; a form cannot exist without XML, so
+        # this has to be refused rather than silently ignored.
+        response = self.client.patch(
+            self._url(), data=json.dumps({'source': None}),
+            content_type='application/json', HTTP_IF_MATCH=self._etag(),
+        )
+        assert response.status_code == 400
+
+    def test_if_match_accepts_a_list_of_tags(self):
+        etag = self._etag()
+        response = self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'Updated'}}),
+            content_type='application/json', HTTP_IF_MATCH=f'"nomatch", {etag}',
+        )
+        assert response.status_code == 200
+
+    def test_if_match_rejects_a_weak_validator(self):
+        # RFC 9110 requires strong comparison for If-Match, so a weak tag
+        # never matches, even one derived from the current ETag.
+        etag = self._etag()
+        response = self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'Updated'}}),
+            content_type='application/json', HTTP_IF_MATCH=f'W/{etag}',
+        )
+        assert response.status_code == 412
+
+    def test_no_field_can_be_deleted_into_a_crash(self):
+        # RFC 7396 makes every field deletable, which is the corner these
+        # keep failing in, so sweep the whole resource rather than guessing.
+        for field in sorted(self.client.get(self._url()).json()):
+            with self.subTest(field=field):
+                response = self.client.patch(
+                    self._url(), data=json.dumps({field: None}),
+                    content_type='application/json', HTTP_IF_MATCH=self._etag(),
+                )
+                assert response.status_code < 500, response.content
+
+    def test_patch_returns_the_updated_representation(self):
+        response = self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'Updated'}}),
+            content_type='application/json', HTTP_IF_MATCH=self._etag(),
+        )
+        assert response.json()['name']['en'] == 'Updated'
+
+    def test_the_patch_response_etag_hashes_the_patch_response(self):
+        response = self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'Updated'}}),
+            content_type='application/json', HTTP_IF_MATCH=self._etag(),
+        )
+        digest = hashlib.sha256(response.content).hexdigest()
+        assert response['ETag'] == f'"{digest}"'
+
+    def test_patch_rejects_a_field_outside_the_allowlist(self):
+        response = self.client.patch(
+            self._url(), data=json.dumps({'auto_gps_capture': True}),
+            content_type='application/json', HTTP_IF_MATCH=self._etag(),
+        )
+        assert response.status_code == 400, response.content
+        assert response.json()['errors'][0]['error'] == 'field_not_patchable'
+
+    def test_patch_ignores_an_unchanged_field_outside_the_allowlist(self):
+        # A client handing back a GET response must not be punished for the
+        # fields it did not touch.
+        get = self.client.get(self._url())
+        response = self.client.patch(
+            self._url(), data=get.content,
+            content_type='application/json', HTTP_IF_MATCH=get['ETag'],
+        )
+        assert response.status_code == 200, response.content
+
+    def test_if_match_star_is_accepted(self):
+        # RFC 9110: "*" matches any current representation.
+        response = self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'Updated'}}),
+            content_type='application/json', HTTP_IF_MATCH='*',
+        )
+        assert response.status_code == 200
+
     def test_head_reports_the_content_type_get_would_send(self):
         assert self.client.head(self._url())['Content-Type'] == 'application/json'
 
@@ -184,11 +363,259 @@ class SingleFormApiViewTests(TestCase):
             Client().get(self._url())
         assert not throttle.called
 
+    def test_patch_etag_is_accepted_by_the_next_patch(self):
+        first = self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'First'}}),
+            content_type='application/json', HTTP_IF_MATCH=self._etag(),
+        )
+        # no GET in between: the previous response carried the new ETag
+        second = self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'Second'}}),
+            content_type='application/json', HTTP_IF_MATCH=first['ETag'],
+        )
+        assert second.status_code == 200
+
+    def test_patch_requires_if_match(self):
+        response = self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'x'}}), content_type='application/json'
+        )
+        assert response.status_code == 428
+        assert response.json()['errors'][0]['error'] == 'precondition_required'
+
+    def test_patch_rejects_stale_if_match(self):
+        response = self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'x'}}),
+            content_type='application/json', HTTP_IF_MATCH='"stale"',
+        )
+        assert response.status_code == 412
+        assert response.json()['errors'][0]['error'] == 'precondition_failed'
+
+    def test_patch_returns_invalid_json_for_bad_body(self):
+        response = self.client.patch(
+            self._url(), data='not json', content_type='application/json', HTTP_IF_MATCH=self._etag()
+        )
+        assert response.status_code == 400
+        assert response.json()['errors'][0]['error'] == 'invalid_json'
+
+    def test_patch_returns_404_for_missing_app(self):
+        response = self.client.patch(
+            self._url(app_id='missing-app'), data=json.dumps({}),
+            content_type='application/json', HTTP_IF_MATCH='"anything"',
+        )
+        assert response.status_code == 404
+
+    def test_patch_returns_404_for_saved_build(self):
+        build = self.app.make_build()
+        build.save()
+        self.addCleanup(build.delete)
+        response = self.client.patch(
+            self._url(app_id=build._id), data=json.dumps({'name': {'en': 'x'}}),
+            content_type='application/json', HTTP_IF_MATCH='"anything"',
+        )
+        assert response.status_code == 404
+
+    def test_patch_returns_conflict_on_concurrent_write(self):
+        etag = self._etag()
+        with patch.object(Application, 'save', side_effect=ResourceConflict):
+            response = self.client.patch(
+                self._url(), data=json.dumps({'name': {'en': 'x'}}),
+                content_type='application/json', HTTP_IF_MATCH=etag,
+            )
+        assert response.status_code == 409
+        assert response.json()['errors'][0]['error'] == 'conflict'
+
+    def test_patch_rejects_unauthenticated_request(self):
+        response = Client().patch(
+            self._url(), data=json.dumps({}), content_type='application/json', HTTP_IF_MATCH='"x"'
+        )
+        assert response.status_code != 200
+
+    @has_permissions(edit_apps=False)
+    def test_patch_rejects_user_without_edit_apps_permission(self):
+        client = Client()
+        client.login(username=self.non_admin_username, password=self.non_admin_password)
+        response = client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'x'}}),
+            content_type='application/json', HTTP_IF_MATCH='"x"',
+        )
+        assert response.status_code != 200
+
     def test_rejects_put_method(self):
         response = self.client.put(self._url(), data=json.dumps({}), content_type='application/json')
         assert response.status_code == 405
 
     # --- round-trip ---
+
+    def test_get_then_patch_with_its_etag_then_reject_reuse(self):
+        etag = self._etag()
+        first = self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'First'}}),
+            content_type='application/json', HTTP_IF_MATCH=etag,
+        )
+        assert first.status_code == 200
+
+        second = self.client.patch(
+            self._url(), data=json.dumps({'name': {'en': 'Second'}}),
+            content_type='application/json', HTTP_IF_MATCH=etag,  # stale now
+        )
+        assert second.status_code == 412
+
+
+class UpdateFormForApiTests(TestCase):
+    domain = 'form-api-patch-domain'
+    username = 'form-api-patch-user'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(cls.domain)
+        cls.user = WebUser.create(
+            cls.domain, cls.username, 'correct-horse-battery-staple',
+            created_by=None, created_via=None, is_active=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(cls.domain, deleted_by=None)
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.app = Application.new_app(self.domain, 'Test App')
+        self.module = self.app.add_module(Module.new_module('Module One', lang='en'))
+        self.form = self.module.new_form('Form One', lang='en', attachment=get_simple_form(xmlns='xmlns-1'))
+        self.form.comment = 'original comment'
+        self.module_id = self.module.unique_id
+        self.form_id = self.form.unique_id
+        self.app.save()
+        self.addCleanup(self.app.delete)
+
+    def _etag(self):
+        form, _ = get_form_for_api(
+            self.domain, self.app._id, self.module_id, self.form_id
+        )
+        return FormResource(form).get_etag()
+
+    def test_updates_only_specified_fields(self):
+        form, result = patch_form_for_api(
+            self.domain, self.app._id, self.module_id, self.form_id,
+            {'name': {'en': 'Renamed'}}, self._etag(), self.user
+        )
+
+        assert result.success is True
+        assert form.name['en'] == 'Renamed'
+        assert form.comment == 'original comment'  # untouched
+
+    def test_bumps_app_version(self):
+        old_version = self.app.version
+        patch_form_for_api(
+            self.domain, self.app._id, self.module_id, self.form_id,
+            {'name': {'en': 'Renamed'}}, self._etag(), self.user
+        )
+        assert Application.get(self.app._id).version > old_version
+
+    def test_applies_source_via_save_xform(self):
+        new_xml = get_simple_form(xmlns='xmlns-2')
+        form, result = patch_form_for_api(
+            self.domain, self.app._id, self.module_id, self.form_id,
+            {'source': new_xml}, self._etag(), self.user
+        )
+        assert result.success is True
+        assert form.source == new_xml
+
+    def test_leaves_xml_untouched_when_source_absent(self):
+        original_source = self.form.source
+        form, result = patch_form_for_api(
+            self.domain, self.app._id, self.module_id, self.form_id,
+            {'name': {'en': 'Renamed'}}, self._etag(), self.user
+        )
+        assert form.source == original_source
+
+    def test_a_spoofed_unique_id_is_refused(self):
+        form, result = patch_form_for_api(
+            self.domain, self.app._id, self.module_id, self.form_id,
+            {'unique_id': 'spoofed-id', 'name': {'en': 'Renamed'}}, self._etag(), self.user
+        )
+        assert result.errors[0].error == FORM_API_FIELD_NOT_PATCHABLE
+
+    def test_a_spoofed_xmlns_is_refused(self):
+        form, result = patch_form_for_api(
+            self.domain, self.app._id, self.module_id, self.form_id,
+            {'xmlns': 'spoofed-xmlns', 'name': {'en': 'Renamed'}}, self._etag(), self.user
+        )
+        assert result.errors[0].error == FORM_API_FIELD_NOT_PATCHABLE
+
+    def test_returns_invalid_field_value_for_wrong_type(self):
+        form, result = patch_form_for_api(
+            self.domain, self.app._id, self.module_id, self.form_id,
+            {'name': 'not-a-dict'}, self._etag(), self.user
+        )
+        assert result.success is False
+        assert result.errors[0].error == FORM_API_INVALID_FIELD_VALUE
+
+    def test_returns_precondition_required_when_if_match_missing(self):
+        form, result = patch_form_for_api(
+            self.domain, self.app._id, self.module_id, self.form_id,
+            {'name': {'en': 'x'}}, None, self.user
+        )
+        assert result.success is False
+        assert result.errors[0].error == FORM_API_PRECONDITION_REQUIRED
+
+    def test_returns_precondition_failed_for_stale_if_match(self):
+        form, result = patch_form_for_api(
+            self.domain, self.app._id, self.module_id, self.form_id,
+            {'name': {'en': 'x'}}, '"stale-etag"', self.user
+        )
+        assert result.success is False
+        assert result.errors[0].error == FORM_API_PRECONDITION_FAILED
+
+    def test_propagates_a_failed_lookup(self):
+        form, result = patch_form_for_api(
+            self.domain, self.app._id, 'missing-module', self.form_id, {}, None, self.user
+        )
+        assert result.errors[0].error == FORM_API_MODULE_NOT_FOUND
+
+    def test_does_not_save_on_any_failure(self):
+        old_version = self.app.version
+        patch_form_for_api(
+            self.domain, self.app._id, self.module_id, self.form_id,
+            {'not_a_real_field': 'x'}, self._etag(), self.user
+        )
+        assert Application.get(self.app._id).version == old_version
+
+    def test_returns_conflict_when_save_hits_concurrent_write(self):
+        etag = self._etag()
+        with patch.object(Application, 'save', side_effect=ResourceConflict):
+            form, result = patch_form_for_api(
+                self.domain, self.app._id, self.module_id, self.form_id,
+                {'name': {'en': 'x'}}, etag, self.user,
+            )
+
+        assert result.success is False
+        assert result.errors[0].error == FORM_API_CONFLICT
+
+    def test_a_losing_write_leaves_the_xml_untouched(self):
+        # save_xform only stages the XML, and app.save() writes the blob and
+        # the doc inside one rollback scope, so losing the save race must
+        # not leave the new XML behind without the fields that go with it.
+        original_source = self.form.source
+        etag = self._etag()
+
+        def commit_a_conflicting_change(app, form, xml, **kw):
+            other = Application.get(app._id)
+            other.name = 'Renamed By Someone Else'
+            other.save()
+            return save_xform(app, form, xml, **kw)
+
+        with patch(f'{patch_form_for_api.__module__}.save_xform',
+                   side_effect=commit_a_conflicting_change):
+            form, result = patch_form_for_api(
+                self.domain, self.app._id, self.module_id, self.form_id,
+                {'source': get_simple_form(xmlns='xmlns-clobber')}, etag, self.user,
+            )
+
+        assert result.errors[0].error == FORM_API_CONFLICT
+        assert Application.get(self.app._id).get_form(self.form_id).source == original_source
 
 
 class GetFormForApiTests(TestCase):
@@ -260,6 +687,29 @@ class GetFormForApiTests(TestCase):
         assert result.errors[0].error == FORM_API_FORM_NOT_FOUND
 
 
+class MergePatchTests(SimpleTestCase):
+    """RFC 7396 semantics, which the API adopts wholesale."""
+
+    def test_merges_nested_objects_rather_than_replacing_them(self):
+        merged = merge_patch({'a': {'x': 1, 'y': 2}}, {'a': {'y': 3}})
+        assert merged == {'a': {'x': 1, 'y': 3}}
+
+    def test_null_deletes_a_key(self):
+        assert merge_patch({'a': 1, 'b': 2}, {'a': None}) == {'b': 2}
+
+    def test_null_for_an_absent_key_is_a_noop(self):
+        assert merge_patch({'b': 2}, {'a': None}) == {'b': 2}
+
+    def test_lists_replace_wholesale(self):
+        assert merge_patch({'a': [1, 2, 3]}, {'a': [9]}) == {'a': [9]}
+
+    def test_a_scalar_replaces_an_object(self):
+        assert merge_patch({'a': {'x': 1}}, {'a': 'flat'}) == {'a': 'flat'}
+
+    def test_leaves_untouched_keys_alone(self):
+        assert merge_patch({'a': 1, 'b': 2}, {'a': 9}) == {'a': 9, 'b': 2}
+
+
 class FormResourceEtagTests(TestCase):
     def setUp(self):
         self.app = Application.new_app('form-etag-domain', 'Test App')
@@ -314,3 +764,135 @@ LOCKED_BIND = '<bind nodeset="/data/question2" type="xsd:string" vellum:lock="al
 EDITED_LOCKED_BIND = (
     '<bind nodeset="/data/question2" type="xsd:string" constraint="0" vellum:lock="all" />'
 )
+
+
+@flag_enabled('SINGLE_FORM_API')
+class LockedQuestionApiTests(TestCase):
+    """A locked question must be no more editable through this API than it is
+    in the form builder, which rejects the edit unless the user holds
+    ``edit_locked_questions_in_apps``.
+    """
+
+    username = 'locked-question-user'
+    password = 'correct-horse-battery-staple'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = create_domain('locked-question-domain')
+        cls.user = WebUser.create(
+            cls.domain.name, cls.username, cls.password,
+            created_by=None, created_via=None, is_active=True,
+        )
+        cls.throttle_patcher = patch(
+            'corehq.apps.api.resources.meta.HQThrottle.should_be_throttled', return_value=False
+        )
+        cls.throttle_patcher.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.throttle_patcher.stop()
+        cls.user.delete(cls.domain.name, deleted_by=None)
+        cls.domain.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        path = os.path.join(os.path.dirname(__file__), 'data', 'case_in_form.xml')
+        with open(path, encoding='utf-8') as f:
+            source = f.read()
+        self.app = Application.new_app(self.domain.name, 'Test App')
+        module = self.app.add_module(Module.new_module('Module One', lang='en'))
+        module.case_type = 'test'
+        form = module.new_form('Form One', lang='en', attachment=source)
+        self.module_id = module.unique_id
+        self.form_id = form.unique_id
+        self.app.save()
+        self.addCleanup(self.app.delete)
+
+        self.client = Client()
+        self.client.login(username=self.username, password=self.password)
+
+    def _url(self):
+        return reverse('single_form_api', kwargs={
+            'domain': self.domain.name,
+            'app_id': self.app._id,
+            'module_id': self.module_id,
+            'form_id': self.form_id,
+        })
+
+    def _edit_the_locked_question(self):
+        get = self.client.get(self._url())
+        edited = get.json()['source'].replace(LOCKED_BIND, EDITED_LOCKED_BIND)
+        assert edited != get.json()['source'], 'fixture no longer locks question2'
+        return self.client.patch(
+            self._url(), data=json.dumps({'source': edited}),
+            content_type='application/json', HTTP_IF_MATCH=get['ETag'],
+        )
+
+    def test_patch_cannot_edit_a_locked_question_without_the_permission(self):
+        with privilege_enabled(privileges.LOCKED_ADMIN_QUESTIONS), \
+                has_permissions(view_apps=True, edit_apps=True):
+            assert self._edit_the_locked_question().status_code == 403
+
+    def test_patch_can_edit_a_locked_question_with_the_permission(self):
+        with privilege_enabled(privileges.LOCKED_ADMIN_QUESTIONS), \
+                has_permissions(view_apps=True, edit_apps=True,
+                                edit_locked_questions_in_apps=True):
+            assert self._edit_the_locked_question().status_code == 200
+
+
+@flag_enabled('SINGLE_FORM_API')
+class ShadowFormApiTests(TestCase):
+    """A shadow form derives its XML and actions from the form it shadows,
+    so neither is settable; patching them must fail cleanly rather than
+    crash on the missing setter."""
+
+    domain = 'shadow-form-domain'
+    username = 'shadow-form-user'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(cls.domain)
+        cls.user = WebUser.create(
+            cls.domain, cls.username, 'correct-horse-battery-staple',
+            created_by=None, created_via=None, is_active=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete(cls.domain, deleted_by=None)
+        cls.domain_obj.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.app = Application.new_app(self.domain, 'Test App')
+        module = self.app.add_module(AdvancedModule.new_module('Module One', lang='en'))
+        module.new_form('Real Form', lang='en', attachment=get_simple_form(xmlns='xmlns-1'))
+        shadow = module.new_shadow_form('Shadow Form', lang='en')
+        self.module_id = module.unique_id
+        self.form_id = shadow.unique_id
+        self.app.save()
+        self.addCleanup(self.app.delete)
+
+    def _patch(self, body):
+        form, _ = get_form_for_api(self.domain, self.app._id, self.module_id, self.form_id)
+        etag = FormResource(form).get_etag()
+        return patch_form_for_api(
+            self.domain, self.app._id, self.module_id, self.form_id, body, etag, self.user,
+        )
+
+    def test_etag_is_stable_between_identical_reads(self):
+        # Without this a shadow form is unwritable: its regenerated source
+        # changes the hash, so If-Match can never match.
+        first, _ = get_form_for_api(self.domain, self.app._id, self.module_id, self.form_id)
+        second, _ = get_form_for_api(self.domain, self.app._id, self.module_id, self.form_id)
+        assert FormResource(first).get_etag() == FormResource(second).get_etag()
+
+    def test_rejects_a_source_patch(self):
+        form, result = self._patch({'source': get_simple_form(xmlns='xmlns-2')})
+        assert result.errors[0].error == FORM_API_INVALID_FIELD_VALUE
+
+    def test_allows_an_ordinary_field(self):
+        form, result = self._patch({'comment': 'a comment'})
+        assert result.success is True, result.errors

--- a/corehq/apps/app_manager/tests/test_single_form_api.py
+++ b/corehq/apps/app_manager/tests/test_single_form_api.py
@@ -1,0 +1,75 @@
+
+from django.test import TestCase
+
+from corehq.apps.app_manager.models import (
+    Application,
+    Module,
+)
+from corehq.apps.app_manager.tests.util import get_simple_form
+from corehq.apps.app_manager.views.single_form_api import (
+    FormResource,
+    _form_resource_dict,
+)
+
+ENTITY_XML = (
+    '<?xml version="1.0"?>\n'
+    '<!DOCTYPE root [ <!ENTITY xxe SYSTEM "file:///etc/passwd"> ]>\n'
+    '<h:html xmlns:h="http://www.w3.org/1999/xhtml"><h:head>'
+    '<h:title>&xxe;</h:title></h:head><h:body/></h:html>'
+)
+
+
+class FormResourceEtagTests(TestCase):
+    def setUp(self):
+        self.app = Application.new_app('form-etag-domain', 'Test App')
+        module = self.app.add_module(Module.new_module('Module One', lang='en'))
+        self.form = module.new_form('Form One', lang='en', attachment=get_simple_form(xmlns='xmlns-1'))
+        self.app.save()
+        self.addCleanup(self.app.delete)
+
+    def test_stable_across_reloading_unchanged_form(self):
+        reloaded = Application.get(self.app._id).get_form(self.form.unique_id)
+        assert FormResource(self.form).get_etag() == FormResource(reloaded).get_etag()
+
+    def test_changes_when_form_content_changes(self):
+        before = FormResource(self.form).get_etag()
+        self.form.name = {'en': 'Renamed'}
+        after = FormResource(self.form).get_etag()
+        assert before != after
+
+    def test_is_a_quoted_string(self):
+        etag = FormResource(self.form).get_etag()
+        assert etag.startswith('"') and etag.endswith('"')
+
+
+class FormResourceDictTests(TestCase):
+    def setUp(self):
+        app = Application.new_app('form-resource-dict-domain', 'Test App')
+        module = app.add_module(Module.new_module('Module One', lang='en'))
+        self.form = module.new_form('Form One', lang='en', attachment=get_simple_form(xmlns='xmlns-1'))
+
+    def test_includes_source_key(self):
+        resource = _form_resource_dict(self.form)
+        assert resource['source'] == self.form.source
+
+    def test_does_not_include_validation_cache(self):
+        # Assigning validation_cache also writes a dynamic property onto
+        # the document, so every in-memory form carries the key while one
+        # reloaded from Couch has it stripped by FormBase.wrap. Leaving it
+        # in the resource would give one unchanged form two ETags.
+        self.form.set_validation_cache('some cached value')
+        resource = _form_resource_dict(self.form)
+        assert 'validation_cache' not in resource
+
+    def test_includes_form_json_fields(self):
+        resource = _form_resource_dict(self.form)
+        assert resource['unique_id'] == self.form.unique_id
+        assert resource['name'] == self.form.name
+
+
+# ``case_in_form`` locks /data/question2; changing its bind changes the
+# question's signature, which is what the locked-question check compares.
+LOCKED_BIND = '<bind nodeset="/data/question2" type="xsd:string" vellum:lock="all" />'
+EDITED_LOCKED_BIND = (
+    '<bind nodeset="/data/question2" type="xsd:string" constraint="0" vellum:lock="all" />'
+)

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -233,7 +233,7 @@ def edit_advanced_form_actions(request, domain, app_id, form_unique_id):
     actions = AdvancedFormActions.wrap(json_loads)
 
     try:
-        _apply_advanced_form_actions_change(request, domain, form, actions)
+        _apply_advanced_form_actions_change(request.couch_user, domain, form, actions)
     except LockedQuestionError:
         return HttpResponseForbidden(_LOCKED_QUESTION_MAPPING_ERROR)
 
@@ -258,7 +258,7 @@ def edit_form_actions(request, domain, app_id, form_unique_id):
     diff_json = request.POST.get('case_mapping_diff')
     diff = json.loads(diff_json) if diff_json else {}
     try:
-        _apply_form_actions_change(request, domain, form, actions_json, diff)
+        _apply_form_actions_change(request.couch_user, domain, form, actions_json, diff)
     except LockedQuestionError:
         return HttpResponseForbidden(_LOCKED_QUESTION_MAPPING_ERROR)
 
@@ -284,14 +284,14 @@ def edit_form_actions(request, domain, app_id, form_unique_id):
     return json_response(response_json)
 
 
-def _apply_advanced_form_actions_change(request, domain, form, new_actions):
+def _apply_advanced_form_actions_change(couch_user, domain, form, new_actions):
     """Assign ``new_actions`` to ``form.actions`` (or ``form.extra_actions``
     for shadow forms).
 
     :raises LockedQuestionError: if the change would add, remove, or
         repoint a case-property mapping bound to a locked question.
     """
-    locked_paths = _locked_paths_to_protect(request, domain, form)
+    locked_paths = _locked_paths_to_protect(domain, form)
     current = form.extra_actions if form.form_type == 'shadow_form' else form.actions
     if (
         collect_locked_advanced_mappings(current, locked_paths)
@@ -305,20 +305,20 @@ def _apply_advanced_form_actions_change(request, domain, form, new_actions):
         form.actions = new_actions
 
 
-def _apply_form_actions_change(request, domain, form, actions_json, diff):
+def _apply_form_actions_change(couch_user, domain, form, actions_json, diff):
     """Apply ``actions_json`` and ``diff`` to ``form.actions``.
 
     :raises LockedQuestionError: if the change would add, remove, or
         repoint a case-property mapping bound to a locked question.
     """
-    locked_paths = _locked_paths_to_protect(request, domain, form)
+    locked_paths = _locked_paths_to_protect(domain, form)
     before = collect_locked_mappings(form.actions, locked_paths)
     update_form_actions(form.actions, actions_json, diff)
     if collect_locked_mappings(form.actions, locked_paths) != before:
         raise LockedQuestionError
 
 
-def _locked_paths_to_protect(request, domain, form):
+def _locked_paths_to_protect(domain, form):
     """Set of locked question paths whose case-property mappings must be
     preserved on this request, or empty set if the feature is off.
     """
@@ -327,7 +327,7 @@ def _locked_paths_to_protect(request, domain, form):
     return form.wrapped_xform().locked_question_paths
 
 
-def _check_case_mapping_diff_does_not_touch_locked(request, domain, form, case_mapping_diff):
+def _check_case_mapping_diff_does_not_touch_locked(couch_user, domain, form, case_mapping_diff):
     """Reject a save whose ``case_mapping_diff`` would change a case-property
     mapping bound to a question that is locked.
 
@@ -339,11 +339,11 @@ def _check_case_mapping_diff_does_not_touch_locked(request, domain, form, case_m
     """
     if (
         not case_mapping_diff
-        or request.couch_user.can_edit_locked_questions_in_apps(domain)
+        or couch_user.can_edit_locked_questions_in_apps(domain)
     ):
         return
 
-    locked_paths = _locked_paths_to_protect(request, domain, form)
+    locked_paths = _locked_paths_to_protect(domain, form)
     if not locked_paths:
         return
 
@@ -354,7 +354,7 @@ def _check_case_mapping_diff_does_not_touch_locked(request, domain, form, case_m
         raise LockedQuestionError
 
 
-def _check_locked_questions_unmodified(request, domain, form, new_xml):
+def check_locked_questions_unmodified(couch_user, domain, form, new_xml):
     """Reject a save that changes anything about a locked question.
 
     For every path that was locked in the old form, the question's signature
@@ -366,9 +366,9 @@ def _check_locked_questions_unmodified(request, domain, form, new_xml):
 
     :raises LockedQuestionError: if a locked question changed.
     """
-    if request.couch_user.can_edit_locked_questions_in_apps(domain):
+    if couch_user.can_edit_locked_questions_in_apps(domain):
         return
-    old_locked = _locked_paths_to_protect(request, domain, form)
+    old_locked = _locked_paths_to_protect(domain, form)
     if not old_locked:
         return
     old_xform = form.wrapped_xform()
@@ -480,7 +480,7 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
 
     if has_xform:
         if "xform" in request.FILES and not _allow_xform_upload(
-            request, domain, form.wrapped_xform().has_locked_questions
+            request.couch_user, domain, form.wrapped_xform().has_locked_questions
         ):
             error = _("You do not have permission to upload an XForm for a form "
                       "that contains locked questions.")
@@ -504,12 +504,12 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
                     xform = xform.encode('utf-8')
                 case_mapping_diff = _get_case_mapping_diff(request)
                 try:
-                    _check_locked_questions_unmodified(request, domain, form, xform)
+                    check_locked_questions_unmodified(request.couch_user, domain, form, xform)
                 except LockedQuestionError:
                     raise Exception(_LOCKED_QUESTION_CONTENT_ERROR)
                 try:
                     _check_case_mapping_diff_does_not_touch_locked(
-                        request, domain, form, case_mapping_diff,
+                        request.couch_user, domain, form, case_mapping_diff,
                     )
                 except LockedQuestionError:
                     raise Exception(_LOCKED_QUESTION_MAPPING_ERROR)
@@ -719,9 +719,9 @@ def patch_xform(request, domain, app_id, form_unique_id):
     case_mapping_diff = _get_case_mapping_diff(request)
 
     try:
-        _check_locked_questions_unmodified(request, domain, form, new_xml)
+        check_locked_questions_unmodified(request.couch_user, domain, form, new_xml)
         _check_case_mapping_diff_does_not_touch_locked(
-            request, domain, form, case_mapping_diff,
+            request.couch_user, domain, form, case_mapping_diff,
         )
     except LockedQuestionError:
         return HttpResponseForbidden()
@@ -1043,7 +1043,7 @@ def get_form_view_context(
         'xform_validation_errored': xform_validation_errored,
         'xform_validation_missing': xform_validation_missing,
         'allow_form_copy': isinstance(form, (Form, AdvancedForm)),
-        'allow_xform_upload': _allow_xform_upload(request, domain, has_locked_questions),
+        'allow_xform_upload': _allow_xform_upload(request.couch_user, domain, has_locked_questions),
         'allow_form_filtering': not form_has_schedule,
         'allow_usercase': allow_usercase,
         'is_module_filter_enabled': app.enable_module_filtering,
@@ -1133,10 +1133,10 @@ def get_form_view_context(
     return context
 
 
-def _allow_xform_upload(request, domain, has_locked_questions):
+def _allow_xform_upload(couch_user, domain, has_locked_questions):
     if not domain_has_privilege(domain, "locked_admin_questions"):
         return True
-    if request.couch_user.can_edit_locked_questions_in_apps(domain):
+    if couch_user.can_edit_locked_questions_in_apps(domain):
         return True
     return not has_locked_questions
 

--- a/corehq/apps/app_manager/views/single_form_api.py
+++ b/corehq/apps/app_manager/views/single_form_api.py
@@ -3,10 +3,24 @@ import hashlib
 import json
 from dataclasses import dataclass
 
+from couchdbkit.exceptions import ResourceNotFound
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse, JsonResponse
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from django.views.generic import View
 from memoized import memoized
 
+from corehq import toggles
+from corehq.apps.api.decorators import api_throttle
+from corehq.apps.app_manager.dbaccessors import get_app_doc, wrap_app
+from corehq.apps.app_manager.exceptions import (
+    ModuleNotFoundException,
+)
+from corehq.apps.domain.decorators import api_auth
+from corehq.apps.users.decorators import require_permission
+from corehq.apps.users.models import HqPermissions
+from corehq.util.view_utils import json_error
 
 # ApiError.error codes
 FORM_API_APP_NOT_FOUND = 'app_not_found'
@@ -46,6 +60,29 @@ class ApiError:
 
     def to_json(self):
         return dataclasses.asdict(self)
+
+
+@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(json_error, name='dispatch')
+class SingleFormApiView(View):
+    """HEAD/GET/PATCH a single form's JSON fields and XForm XML."""
+
+    def dispatch(self, request, *args, **kwargs):
+        # Rolling out by domain. Until this is generally available the flag
+        # also bounds who can reach an endpoint that does not yet check
+        # access_api, unlike the rest of the APIs here.
+        if not toggles.SINGLE_FORM_API.enabled(kwargs.get('domain')):
+            return HttpResponse(status=404)
+        return super().dispatch(request, *args, **kwargs)
+
+    @method_decorator(require_permission(HqPermissions.view_apps, login_decorator=api_auth()))
+    @method_decorator(api_throttle)
+    def get(self, request, domain, app_id, module_id, form_id):
+        form, result = get_form_for_api(domain, app_id, module_id, form_id)
+        if not result.success:
+            return _errors_response(result)
+
+        return FormResource(form).get_response()
 
 
 def _errors_response(result):
@@ -99,6 +136,37 @@ class FormResource:
             ensure_ascii=False,
             cls=DjangoJSONEncoder,
         ).encode('utf-8')
+
+
+def get_form_for_api(domain, app_id, module_id, form_id):
+    try:
+        app_doc = get_app_doc(domain, app_id)
+    except ResourceNotFound:
+        app_doc = None
+
+    # Only a live, editable Application is addressable. A saved build is a
+    # frozen copy; a deleted app is 'Application-Deleted'; a RemoteApp has no
+    # modules at all; a LinkedApplication is overwritten by its next sync.
+    # None of them is any more addressable than an app that does not exist.
+    if (
+        app_doc is None
+        or app_doc.get('copy_of')
+        or app_doc.get('doc_type') != 'Application'
+    ):
+        return None, ApiResult.error(FORM_API_APP_NOT_FOUND, f"Application ({app_id}) not found")
+
+    app = wrap_app(app_doc)
+
+    try:
+        module = app.get_module_by_unique_id(module_id)
+    except ModuleNotFoundException:
+        return None, ApiResult.error(FORM_API_MODULE_NOT_FOUND, f"Module ({module_id}) not found")
+
+    form = module.get_form_by_unique_id(form_id)
+    if form is None:
+        return None, ApiResult.error(FORM_API_FORM_NOT_FOUND, f"Form ({form_id}) not found")
+
+    return form, ApiResult()
 
 
 def _form_resource_dict(form):

--- a/corehq/apps/app_manager/views/single_form_api.py
+++ b/corehq/apps/app_manager/views/single_form_api.py
@@ -3,20 +3,26 @@ import hashlib
 import json
 from dataclasses import dataclass
 
-from couchdbkit.exceptions import ResourceNotFound
+from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
+from jsonobject.exceptions import BadValueError
 from memoized import memoized
 
 from corehq import toggles
 from corehq.apps.api.decorators import api_throttle
 from corehq.apps.app_manager.dbaccessors import get_app_doc, wrap_app
 from corehq.apps.app_manager.exceptions import (
+    DangerousXmlException,
+    LockedQuestionError,
     ModuleNotFoundException,
 )
+from corehq.apps.app_manager.util import save_xform
+from corehq.apps.app_manager.views.forms import check_locked_questions_unmodified
+from corehq.apps.app_manager.xform import XForm, XFormException
 from corehq.apps.domain.decorators import api_auth
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import HqPermissions
@@ -26,6 +32,20 @@ from corehq.util.view_utils import json_error
 FORM_API_APP_NOT_FOUND = 'app_not_found'
 FORM_API_MODULE_NOT_FOUND = 'module_not_found'
 FORM_API_FORM_NOT_FOUND = 'form_not_found'
+FORM_API_FIELD_NOT_PATCHABLE = 'field_not_patchable'
+FORM_API_INVALID_FIELD_VALUE = 'invalid_field_value'
+FORM_API_PRECONDITION_REQUIRED = 'precondition_required'
+FORM_API_PRECONDITION_FAILED = 'precondition_failed'
+FORM_API_CONFLICT = 'conflict'
+FORM_API_INVALID_JSON = 'invalid_json'
+FORM_API_LOCKED_QUESTION = 'locked_question'
+
+# Only these may be changed. Every other field of a form carries an
+# invariant the schema does not express -- a derived value, a uniqueness
+# rule, a dependency on a sibling field, a paid-feature gate -- and each
+# would need its own guard here. ``source`` is on the list but travels
+# its own path, since it is an attachment rather than a schema property.
+PATCHABLE_FIELDS = frozenset({'name', 'comment', 'source'})
 
 ETAG = 'etag'
 
@@ -33,6 +53,13 @@ _ERROR_TO_STATUS_CODE = {
     FORM_API_APP_NOT_FOUND: 404,
     FORM_API_MODULE_NOT_FOUND: 404,
     FORM_API_FORM_NOT_FOUND: 404,
+    FORM_API_FIELD_NOT_PATCHABLE: 400,
+    FORM_API_INVALID_FIELD_VALUE: 400,
+    FORM_API_PRECONDITION_REQUIRED: 428,
+    FORM_API_PRECONDITION_FAILED: 412,
+    FORM_API_CONFLICT: 409,
+    FORM_API_INVALID_JSON: 400,
+    FORM_API_LOCKED_QUESTION: 403,
 }
 
 
@@ -97,6 +124,28 @@ class SingleFormApiView(View):
 
         return FormResource(form).get_response()
 
+    @method_decorator(require_permission(HqPermissions.edit_apps, login_decorator=api_auth()))
+    @method_decorator(api_throttle)
+    def patch(self, request, domain, app_id, module_id, form_id):
+        try:
+            source = json.loads(request.body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            source = None
+        if not isinstance(source, dict):
+            return _errors_response(
+                ApiResult.error(FORM_API_INVALID_JSON, 'Invalid JSON body')
+            )
+
+        if_match = request.headers.get('If-Match')
+
+        form, result = patch_form_for_api(
+            domain, app_id, module_id, form_id, source, if_match, request.couch_user
+        )
+        if not result.success:
+            return _errors_response(result)
+
+        return FormResource(form).get_response()
+
 
 def _errors_response(result):
     return JsonResponse(
@@ -151,6 +200,104 @@ class FormResource:
         ).encode('utf-8')
 
 
+def patch_form_for_api(domain, app_id, module_id, form_id, source, if_match, couch_user):
+    form, result = get_form_for_api(domain, app_id, module_id, form_id)
+    if not result.success:
+        return None, result
+
+    errors = []
+    if if_match is None:
+        errors.append(ApiError(
+            FORM_API_PRECONDITION_REQUIRED, 'If-Match header is required.'
+        ))
+    elif not if_match_is_satisfied(if_match, FormResource(form).get_etag()):
+        errors.append(ApiError(
+            FORM_API_PRECONDITION_FAILED, 'If-Match does not match the current ETag.'
+        ))
+
+    source_xml = source.get('source')
+    if 'source' in source and source_xml is None:
+        errors.append(ApiError(
+            FORM_API_INVALID_FIELD_VALUE, 'source cannot be deleted'
+        ))
+    elif source_xml is not None and not isinstance(source_xml, str):
+        errors.append(ApiError(
+            FORM_API_INVALID_FIELD_VALUE, 'source must be a string'
+        ))
+    elif source_xml is not None and form.form_type == 'shadow_form':
+        errors.append(ApiError(
+            FORM_API_INVALID_FIELD_VALUE,
+            'a shadow form takes its XML from the form it shadows',
+        ))
+    elif source_xml is not None:
+        # save_xform swallows a parse failure and stores the string anyway,
+        # which would leave the form with no xmlns and break submission
+        # routing, so the XML has to be rejected before it gets that far.
+        try:
+            xform = XForm(source_xml.encode('utf-8'), domain=domain)
+            if not xform.exists():
+                raise XFormException('the document contains no XForm')
+            xform.data_node  # what save_xform reads; fail here instead, cleanly
+        except (XFormException, DangerousXmlException) as e:
+            errors.append(ApiError(
+                FORM_API_INVALID_FIELD_VALUE, f'source is not a valid XForm: {e}'
+            ))
+
+    resource = _form_resource_dict(form)
+    resource.pop('source', None)  # an attachment, not a schema property
+
+    patch = {}
+    for key, value in source.items():
+        if key == 'source':
+            continue  # an attachment; applied through save_xform below
+        elif key in PATCHABLE_FIELDS:
+            patch[key] = value
+        elif value == resource.get(key):
+            continue  # sent back unchanged, so nothing to refuse
+        else:
+            errors.append(ApiError(
+                FORM_API_FIELD_NOT_PATCHABLE, f"'{key}' cannot be changed"
+            ))
+
+    if errors:
+        return None, ApiResult(errors)
+
+    if source_xml is not None:
+        try:
+            check_locked_questions_unmodified(
+                couch_user, domain, form, source_xml.encode('utf-8')
+            )
+        except LockedQuestionError:
+            return None, ApiResult.error(
+                FORM_API_LOCKED_QUESTION,
+                'This form contains locked questions that you may not modify.',
+            )
+
+    try:
+        patched = type(form).wrap(merge_patch(resource, patch))
+    except (ValueError, BadValueError) as e:
+        return None, ApiResult.error(FORM_API_INVALID_FIELD_VALUE, str(e))
+
+    module = form.get_module()
+    module.forms[form.id] = patched
+    # re-read it through the getter, which is what parents the form to
+    # its module -- ``source`` and ``get_app`` both need that link
+    patched = module.get_form(form.id)
+
+    app = patched.get_app()
+    if source_xml is not None:
+        save_xform(app, patched, source_xml.encode('utf-8'))
+
+    try:
+        app.save()
+    except ResourceConflict:
+        return None, ApiResult.error(
+            FORM_API_CONFLICT, 'Application was concurrently modified, please retry'
+        )
+
+    return patched, ApiResult()
+
+
 def get_form_for_api(domain, app_id, module_id, form_id):
     try:
         app_doc = get_app_doc(domain, app_id)
@@ -180,6 +327,37 @@ def get_form_for_api(domain, app_id, module_id, form_id):
         return None, ApiResult.error(FORM_API_FORM_NOT_FOUND, f"Form ({form_id}) not found")
 
     return form, ApiResult()
+
+
+def if_match_is_satisfied(if_match, current_etag):
+    """Whether ``If-Match`` permits the write, per RFC 9110 section 13.1.1.
+
+    The header carries a list of entity tags, or ``*`` for any current
+    representation. Comparison is strong, so a weak validator never
+    matches.
+    """
+    if if_match.strip() == '*':
+        return True
+    return any(tag.strip() == current_etag for tag in if_match.split(','))
+
+
+def merge_patch(target, patch):
+    """Apply ``patch`` to ``target`` per RFC 7396 JSON Merge Patch.
+
+    Objects merge key by key, a ``null`` removes its key, and anything
+    else -- including a list -- replaces what was there.
+    """
+    if not isinstance(patch, dict):
+        return patch
+    if not isinstance(target, dict):
+        target = {}
+    merged = dict(target)
+    for key, value in patch.items():
+        if value is None:
+            merged.pop(key, None)
+        else:
+            merged[key] = merge_patch(merged.get(key), value)
+    return merged
 
 
 def _form_resource_dict(form):

--- a/corehq/apps/app_manager/views/single_form_api.py
+++ b/corehq/apps/app_manager/views/single_form_api.py
@@ -1,0 +1,123 @@
+import dataclasses
+import hashlib
+import json
+from dataclasses import dataclass
+
+from django.core.serializers.json import DjangoJSONEncoder
+from django.http import HttpResponse, JsonResponse
+from memoized import memoized
+
+
+# ApiError.error codes
+FORM_API_APP_NOT_FOUND = 'app_not_found'
+FORM_API_MODULE_NOT_FOUND = 'module_not_found'
+FORM_API_FORM_NOT_FOUND = 'form_not_found'
+
+ETAG = 'etag'
+
+_ERROR_TO_STATUS_CODE = {
+    FORM_API_APP_NOT_FOUND: 404,
+    FORM_API_MODULE_NOT_FOUND: 404,
+    FORM_API_FORM_NOT_FOUND: 404,
+}
+
+
+@dataclass
+class ApiResult:
+    """The outcome of an API operation. Functions that also produce a
+    value return it alongside one of these, rather than through it.
+    """
+
+    errors: 'list[ApiError]' = dataclasses.field(default_factory=list)
+
+    @property
+    def success(self):
+        return not self.errors
+
+    @classmethod
+    def error(cls, code, message):
+        return cls([ApiError(code, message)])
+
+
+@dataclass
+class ApiError:
+    error: str
+    message: str
+
+    def to_json(self):
+        return dataclasses.asdict(self)
+
+
+def _errors_response(result):
+    return JsonResponse(
+        {'errors': [error.to_json() for error in result.errors]},
+        status=_status_for_result(result),
+    )
+
+
+def _status_for_result(result):
+    return _ERROR_TO_STATUS_CODE[result.errors[0].error]
+
+
+class FormResource:
+    """A form's API representation: the exact bytes sent to clients, and
+    an ETag over those same bytes.
+
+    The bytes are canonical JSON -- keys sorted, no whitespace between
+    tokens, non-ASCII left unescaped, encoded as UTF-8 -- so a client can
+    recompute the ETag from a response it holds rather than treat it as
+    opaque.
+
+    Each accessor is memoized and they build on one another, so a caller
+    that needs only the ETag does the serialization once and a caller
+    that needs the whole response does not repeat it. An instance must
+    not outlive a change to ``form``, or it will serve the memoized
+    representation of the older version -- build one where it is needed
+    rather than passing it around.
+    """
+
+    def __init__(self, form):
+        self.form = form
+
+    def get_response(self, status=200):
+        response = HttpResponse(
+            self.get_body(), status=status, content_type='application/json'
+        )
+        response[ETAG] = self.get_etag()
+        return response
+
+    @memoized
+    def get_etag(self):
+        return '"{}"'.format(hashlib.sha256(self.get_body()).hexdigest())
+
+    @memoized
+    def get_body(self):
+        return json.dumps(
+            _form_resource_dict(self.form),
+            sort_keys=True,
+            separators=(',', ':'),
+            ensure_ascii=False,
+            cls=DjangoJSONEncoder,
+        ).encode('utf-8')
+
+
+def _form_resource_dict(form):
+    """The single-form-API's resource representation of ``form`` -- its
+    JSON fields plus its XForm XML under ``source``.
+
+    ``validation_cache`` is dropped. Assigning that attribute writes a
+    dynamic property onto the document as well as to the Django cache it
+    is declared against, so every in-memory form carries the key, while
+    one reloaded from Couch has it stripped by ``FormBase.wrap``.
+    Leaving it in would make the ETag depend on where the form was
+    obtained rather than on its content.
+    """
+    resource = form.to_json()
+    resource.pop('validation_cache', None)
+    if form.form_type != 'shadow_form':
+        # A shadow form has no XML of its own: ``source`` regenerates it from
+        # the form it shadows on every read, so including it would make the
+        # ETag differ between two identical GETs and no PATCH could ever
+        # satisfy If-Match.
+        resource['source'] = form.source
+    return resource

--- a/corehq/apps/app_manager/views/single_form_api.py
+++ b/corehq/apps/app_manager/views/single_form_api.py
@@ -77,6 +77,19 @@ class SingleFormApiView(View):
 
     @method_decorator(require_permission(HqPermissions.view_apps, login_decorator=api_auth()))
     @method_decorator(api_throttle)
+    def head(self, request, domain, app_id, module_id, form_id):
+        form, result = get_form_for_api(domain, app_id, module_id, form_id)
+        if not result.success:
+            return HttpResponse(
+                status=_status_for_result(result), content_type='application/json'
+            )
+
+        response = HttpResponse(status=200, content_type='application/json')
+        response[ETAG] = FormResource(form).get_etag()
+        return response
+
+    @method_decorator(require_permission(HqPermissions.view_apps, login_decorator=api_auth()))
+    @method_decorator(api_throttle)
     def get(self, request, domain, app_id, module_id, form_id):
         form, result = get_form_for_api(domain, app_id, module_id, form_id)
         if not result.success:

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -2083,6 +2083,17 @@ SAVE_ONLY_EDITED_FORM_FIELDS = FeatureRelease(
     """
 )
 
+SINGLE_FORM_API = StaticToggle(
+    slug='single_form_api',
+    label='Read and update a single form of an application over the API',
+    tag=TAG_GA_PATH,
+    namespaces=[NAMESPACE_DOMAIN],
+    description="""
+    Enables HEAD/GET/PATCH on an individual form within an application,
+    rather than having to re-import the whole application to change one form.
+    """,
+)
+
 APP_DEPENDENCIES = StaticToggle(
     slug='app-dependencies',
     label='Set Android app dependencies that must be installed before using a CommCare app',

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -227,6 +227,7 @@ class privilege_enabled:
         'corehq.apps.app_manager.tasks.domain_has_privilege',
         'corehq.apps.app_manager.util.domain_has_privilege',
         'corehq.apps.app_manager.views.formdesigner.domain_has_privilege',
+        'corehq.apps.app_manager.views.forms.domain_has_privilege',
         'corehq.apps.callcenter.sync_usercase.domain_has_privilege',
         'corehq.apps.callcenter.tasks.domain_has_privilege',
         'corehq.apps.case_importer.do_import.domain_has_privilege',


### PR DESCRIPTION
## Product Description

Adds a new API that lets clients read and update one form at a time in app, rather than having to fetch and overwrite the whole app to do so.

```
HEAD|GET|PATCH /a/<domain>/api/apps/v1/<app_id>/modules/<module_id>/forms/<form_id>/
```

The editable fields are currently
- name
- comment
- the form's XML source

## Technical Summary

- **The endpoint supports normal Etag / If-Match semantics** to prevent clobbering a concurrent write from elsewhere. (The Etag is a hash of the full form content.)

- **Only `name`, `comment` and `source` may be patched.** Many other fields are more complex to implement so I want to keep it simple for now.
- **Within those fields, PATCH follows JSON Merge Patch (RFC 7396).** Objects merge, arrays replace, and `null` deletes a key — after which `wrap` restores the schema default, so deleting means resetting. The patch is merged into the form's own JSON and the result re-wrapped rather than assigned field by field.
- **Only works with live `Application`s** — not a build, a deleted app, a `RemoteApp`, or a linked app. A shadow form has no XML of its own, so the `source` field is excluded from its representation, and not editable.
- **Locked questions are as protected here as in the form builder.** Editing one, or unlocking it, needs `edit_locked_questions_in_apps`, using the same check the other write paths use. `source` is also parsed before it is stored, because `save_xform` swallows a parse failure and would leave the form with no xmlns.
- **PATCH is atomic**. `save_xform` and `app.save()` may not look atomic, but they are. `save_xform` only stages the attachment in memory, and `app.save()` commits the blob and the document inside one rollback scope, so losing the save race leaves the stored XML untouched rather than half-applied. Nothing at the call site says so, hence the test.

## Feature Flag

`SINGLE_FORM_API`, per domain. This is to allow internal testing while it's being developed and potentially changed.

## Safety Assurance

### Safety story

It's gated by the feature flag, but also has the same auth decorators as import_app_api. The only other changes are the pretty straightforward and well-tested refactor in the first commit.

### Automated test coverage

There are a bunch of new tests in `corehq/apps/app_manager/tests/test_single_form_api.py`.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change



