### PR TITLE
Revise security policy and reporting procedures

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,7 @@ When you report, please include as much of the following as you can:
 
 ## What to expect
 
-- We aim to acknowledge your report within **5 business days**.
+- We aim to acknowledge your report as fast as reasonably possible.
 - We follow **coordinated disclosure**: we ask that you give us a reasonable
   opportunity to release a fix before any public disclosure. With your
   permission, we are glad to credit you in the resulting advisory.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected security vulnerabilities **privately**. Do not open a
+public GitHub issue or pull request, and do not post details to the CommCare
+forum, for a security issue.
+
+Email your report to **`support@dimagi.com`**.
+
+When you report, please include as much of the following as you can:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof of concept.
+- The affected component(s), endpoint(s), or file(s), and the commit or
+  deployment you tested against.
+- Any suggested remediation, if you have one.
+
+## What to expect
+
+- We aim to acknowledge your report within **5 business days**.
+- We follow **coordinated disclosure**: we ask that you give us a reasonable
+  opportunity to release a fix before any public disclosure. With your
+  permission, we are glad to credit you in the resulting advisory.
+
+For confirmed vulnerabilities we publish a fix and, where appropriate, a
+[GitHub Security Advisory](https://github.com/dimagi/commcare-hq/security/advisories).
+
+## Supported versions
+
+CommCare HQ is continuously delivered: it is deployed from the `master` branch,
+and there are no long-term maintenance branches. Security fixes are applied to
+`master`. Self-hosted operators should track `master` and deploy updates
+regularly so that security fixes are picked up promptly through their normal
+deploy process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Dimagi, the maker of CommCare, takes the security of our software products and services seriously. 
 
-For more information about CommCare’s security policies, please visit the Dimagi Trust Center.
+For more information about CommCare’s security policies, please visit the [Dimagi Trust Center](https://dimagi.safebase.us/).
 
 ## Reporting a vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,16 +20,17 @@ When you report, please include as much of the following as you can:
 - Steps to reproduce, or a proof of concept.
 - The affected component(s), endpoint(s), or file(s), and the commit or
   deployment you tested against.
-- Any suggested remediation, if you have one.
 
 ## What to expect
 
 - We aim to acknowledge your report as fast as reasonably possible.
-- We follow **coordinated disclosure**: we ask that you give us a reasonable
-  opportunity to release a fix before any public disclosure. With your
-  permission, we are glad to credit you in the resulting advisory.
+- We follow **coordinated disclosure**. Accordingly we request that 
+  you provide us a reasonable opportunity to release a fix and protect
+  covered surfaces before any public disclosure, and notify us of intent
+  to publish. With your permission, we are glad to credit individuals who
+  have discovered vulnerabilities.
 
-For confirmed vulnerabilities we publish a fix and, where appropriate, a
+Where appropriate for confirmed vulnerabilities, we publish a 
 [GitHub Security Advisory](https://github.com/dimagi/commcare-hq/security/advisories).
 
 ## Supported versions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,11 @@
 # Security Policy
 
+## About
+
+Dimagi, the maker of CommCare, takes the security of our software products and services seriously. 
+
+For more information about CommCare’s security policies, please visit the Dimagi Trust Center.
+
 ## Reporting a vulnerability
 
 Please report suspected security vulnerabilities **privately**. Do not open a


### PR DESCRIPTION
## Product Description
None

## Technical Summary
Updated the security policy to include reporting guidelines and expectations for vulnerability disclosure.

This is a standard piece of public-facing project documentation that github displays at https://github.com/dimagi/commcare-hq/security (visit with incognito tab to make sure you see the public view). 

## Safety Assurance

### Safety story
Project-level documentation only

### Automated test coverage

N/A

### Migrations
N/A

### Rollback instructions

N/A

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
