### PR TITLE
Make the documented dev setup work on a current Mac, and script it

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -11,6 +11,23 @@ an Ubuntu virtual machine.
 Once your environment is up and running, bookmark the [dev FAQ](https://github.com/dimagi/commcare-hq/blob/master/DEV_FAQ.md)
 for common issues encountered in day-to-day HQ development.
 
+## Automated setup (macOS)
+
+On macOS, `scripts/setup-dev.sh` performs the steps below for you. It is safe to
+re-run, since each step checks its own precondition and skips work that is
+already done:
+
+```sh
+scripts/setup-dev.sh           # set up, prompting before installing anything
+scripts/setup-dev.sh --check   # report what is missing, change nothing
+```
+
+`--check` is also useful on an environment that has stopped working, since it
+reports the state of every prerequisite and service in one place.
+
+The rest of this document is the reference, and is worth reading either way. If
+you are on Linux, follow it directly; the script does not support Linux yet.
+
 ## (Optional) Copying data from an existing HQ install
 
 If you're setting up HQ on a new computer, you may have an old, functional
@@ -117,6 +134,12 @@ NOTE: Developers on Mac OS have additional prerequisites. See the [Supplementary
     brew install postgresql
     ```
 
+    `postgresql` aliases a versioned, keg-only formula (currently `postgresql@18`), so
+    Homebrew does not link `psql`, `createdb`, etc. onto your `PATH`. Add the keg's `bin`
+    directory (`brew --prefix postgresql` prints it) to `PATH` in your shell profile. If you
+    only want the client tools, `brew install libpq` is a smaller alternative that is
+    keg-only for the same reason.
+
     Possible alternative to installing postgres (from [this SO answer](https://stackoverflow.com/a/39800677)).
     Do this prior to `uv` commands (outlined later in this doc):
 
@@ -167,6 +190,13 @@ git-hooks/install.sh
     already exist. To activate the environment:
     ```sh
     source .venv/bin/activate
+    ```
+
+    Commands below are written as `./manage.py ...`, which assumes an activated
+    environment. Prefixing with `uv run` instead uses the project environment
+    without activating anything, which is handy in a fresh terminal:
+    ```sh
+    uv run ./manage.py runserver localhost:8000
     ```
 
     For convenience, you can create an alias to activate virtual environments in
@@ -247,8 +277,11 @@ needs of most developers.
 
 1. Install docker packages.
 
-  - **Mac**: see [Install Docker Desktop on Mac](https://docs.docker.com/docker-for-mac/install/)
-    for docker installation and setup.
+  - **Mac**: you need a container engine, and there is more than one option. Docker
+    Desktop is one, but it requires a paid subscription for larger organizations, so it
+    may not be the right choice for you. See
+    [Container engines](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP_MAC.md#container-engines)
+    in the Supplementary Guide to pick one and set it up.
   - **Linux**:
 
     ```sh
@@ -267,7 +300,10 @@ needs of most developers.
     ```
 
 2. Install `docker compose`
-  - **Mac**: comes with Docker Desktop
+  - **Mac**: depends on the engine you chose. Docker Desktop and OrbStack bundle it;
+    with Colima you install and register it yourself. Either way, confirm with
+    `docker compose version` — see
+    [Container engines](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP_MAC.md#container-engines).
   - **Linux**:
     ```sh
     sudo apt install docker-compose-plugin
@@ -504,15 +540,9 @@ populate them with any data that's in the database.
 
 #### Install Dart Sass
 
-We are transitioning to using `sass`/`scss` for our stylesheets. In order to compile `*.scss`,
-Dart Sass is required.
-
-We recommend using `npm` to install this globally with:
-```
-npm install -g sass
-```
-
-You can also [follow the instructions here](https://sass-lang.com/install) if you encounter issues with this method.
+We are transitioning to using `sass`/`scss` for our stylesheets, so compiling `*.scss`
+requires Dart Sass. See [Requirements: Install Dart Sass](#requirements-install-dart-sass)
+under Step 8, which covers the installation options.
 
 
 #### Installing Yarn
@@ -572,15 +602,20 @@ At present, we are undergoing a migration from Bootstrap 3 to 5. Bootstrap 3 use
 as its CSS precompiler, and Bootstrap 5 using SASS / SCSS. You will need both installed.
 
 LESS is already taken care of by `package.json` when you run `yarn install`. In order to
-compile SASS, we need Dart Sass. There is a `sass` npm package that can be installed globally with
-`npm install -g sass`, however this installs the pure javascript version without a binary. For speed in a
-development environment, it is recommended to install `sass` with homebrew:
+compile SASS, we need Dart Sass. Installing it globally via `npm` works on any platform:
 
 ```sh
-brew install sass/sass/sass
+npm install -g sass
 ```
 
-You can also view [alternative installation instructions](https://sass-lang.com/install/) if homebrew doesn't work for you.
+This is the pure JavaScript build, which compiles more slowly than the native binary. If you
+want the native build:
+
+- **macOS**: see [Dart Sass](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP_MAC.md#dart-sass)
+  in the Supplementary Guide — the Homebrew formula needs extra steps and fails quietly
+  without them.
+- Otherwise, follow the [installation instructions](https://sass-lang.com/install/) for your
+  platform.
 
 #### Option 1: Compile CSS on page-load without compression
 
@@ -680,10 +715,45 @@ in docker, it will of course fail. Don't worry about celery for now.
 Then run the django server with the following command:
 
 ```sh
-./manage.py runserver localhost:8000
+uv run ./manage.py runserver localhost:8000
 ```
 
 You should now be able to load CommCare HQ in a browser at [http://localhost:8000](http://localhost:8000).
+
+#### Running the dev processes
+
+Day to day you need the Webpack watcher, a Celery worker and Formplayer running
+alongside Django. `Procfile.dev` in the repo root defines those three, and
+[honcho](https://github.com/nickstenning/honcho) runs them as a group, so two
+terminals are enough:
+
+```sh
+# terminal 1: supporting processes
+uvx honcho start -f Procfile.dev
+
+# terminal 2: the app
+uv run ./manage.py runserver localhost:8000
+```
+
+`uvx` runs honcho without installing it into the project. Output from each
+process is prefixed with its name, and Ctrl-C stops all of them.
+
+Django is kept out of the Procfile on purpose. honcho passes its terminal through
+to child processes, but they all share it, so an interactive prompt competes with
+Webpack and Celery output and keystrokes cannot be aimed at one process. Running
+Django separately gives `breakpoint()`/`pdb` a terminal to itself, keeps request
+logs readable, and lets you restart the app without cycling everything else. To
+break inside a Celery task, use `celery.contrib.rdb` rather than `breakpoint()`.
+
+Note that honcho stops every process as soon as *any* one of them exits, so if
+the group dies immediately, read the message from the first process that failed.
+
+The worker runs with `-B`, which embeds the Celery beat scheduler in the worker so
+it does not need its own process. That is convenient for development but is wrong
+anywhere you run more than one worker, since each would run its own scheduler.
+
+The backing services are not included, since they run in containers: start those
+with `./scripts/docker up -d` first.
 
 #### Troubleshooting Javascript Errors
 
@@ -703,18 +773,21 @@ useful background and tips.
 
 Formplayer is a Java service that allows us to use applications on the web  instead of on a mobile device.
 
-In `localsettings.py`:
+No `localsettings.py` changes are needed for this — all three settings this used to ask for
+are already defaults: `FORMPLAYER_URL` in `settings.py`, and
+`FORMPLAYER_INTERNAL_AUTH_KEY` plus `django_extensions` in `LOCAL_APPS` in
+`dev_settings.py`.
 
-```python
-FORMPLAYER_URL = 'http://localhost:8080'
-FORMPLAYER_INTERNAL_AUTH_KEY = "secretkey"
-LOCAL_APPS += ('django_extensions',)
-```
-
-**IMPORTANT:** When running HQ, be sure to use `runserver_plus`
+Run HQ as usual:
 
 ```sh
-./manage.py runserver_plus localhost:8000
+uv run ./manage.py runserver localhost:8000
+```
+
+If you want the Werkzeug debugger, `runserver_plus` (from `django-extensions`) works too:
+
+```sh
+uv run ./manage.py runserver_plus localhost:8000
 ```
 
 Then you need to have Formplayer running.
@@ -829,6 +902,10 @@ If you want to run periodic tasks you would need to start `beat` service along w
 ```sh
 celery -A corehq beat
 ```
+
+Note that `./manage.py check_services` reports celery queues as "blocked as long as we can
+see" until `beat` is running, because the queue heartbeats it checks are written by periodic
+tasks. A worker on its own is not enough to make that check pass.
 
 ## Running Formdesigner (Vellum) in Development mode
 

--- a/DEV_SETUP_MAC.md
+++ b/DEV_SETUP_MAC.md
@@ -82,6 +82,25 @@
 
   [oracle_jdk17]: https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 
+## Dart Sass
+
+`npm install -g sass` (see [Step 8 in the Main Developer Setup
+Guide](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md#step-8-configure-css-precompilers-2-options))
+is the simplest option and needs nothing extra. Homebrew provides the faster native binary,
+but the formula lives in a third-party tap and declares a build dependency on another one,
+so both must be trusted first:
+
+```sh
+brew tap dart-lang/dart
+brew trust dart-lang/dart   # Homebrew refuses to load formulae from untrusted taps
+brew install sass/sass/sass
+```
+
+Only do this if you are comfortable trusting those taps. Without the `brew trust` step the
+install fails with `Refusing to load formula dart-lang/dart/dart from untrusted tap` — and it
+exits 0 having installed nothing, so confirm with `command -v sass`.
+
+
 ## Issues With `uv sync`
 
 - `psycopg2` may complain
@@ -100,6 +119,9 @@
   ```
 
 - `uv pip install xmlsec` gives `ImportError`
+
+  This is no longer expected — `uv sync` installs a prebuilt `xmlsec` wheel that needs none of
+  the steps below. Only reach for this if you actually hit the `ImportError`.
 
   Due to issues with recent versions of `libxmlsec1` (v1.3 and after) `uv pip install xmlsec` may be broken.
   This is a workaround. This solution also assumes your `homebrew` version is greater than `4.0.13`*:
@@ -128,18 +150,64 @@ and [thread](https://github.com/xmlsec/python-xmlsec/issues/254) are good starti
 
 ## Docker
 
+### Container engines
+
+macOS cannot run Linux containers directly, so you need an engine that provides a
+Docker-compatible daemon in a VM. Any of these work for HQ's services:
+
+| Engine | Notes |
+| --- | --- |
+| [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/) | GUI app. Bundles `docker compose`. Requires a paid subscription for larger organizations, so check whether yours is covered. |
+| [Colima](https://github.com/abiosoft/colima) | CLI only, no licensing question. Needs `docker compose` installed and registered separately (below). |
+| [OrbStack](https://orbstack.dev/) | Fast on Apple Silicon. Bundles `docker compose`. Free for personal use, paid for commercial. |
+
+Whichever you pick, `docker` on its own is only the client — it needs one of the above behind
+it, or every command fails with `Cannot connect to the Docker daemon`.
+
+#### Colima
+
+```sh
+brew install colima docker docker-compose
+colima start --cpu 4 --memory 8 --disk 60 --vm-type vz --vz-rosetta
+```
+
+`--vm-type vz --vz-rosetta` enables Rosetta translation, which matters because two of HQ's
+images are amd64-only (see [Image architectures](#image-architectures)).
+
+Homebrew's `docker-compose` is not automatically visible to the Docker CLI, so `docker
+compose` (and therefore `./scripts/docker`) will not resolve until you point the CLI at it.
+Add the plugin directory to `~/.docker/config.json`, merging with whatever is already in
+that file:
+
+```json
+{
+  "cliPluginsExtraDirs": ["/opt/homebrew/lib/docker/cli-plugins"]
+}
+```
+
+That path is for Apple Silicon; on Intel it is `/usr/local/lib/docker/cli-plugins`. JSON has
+no shell expansion, so the literal path is required — `brew --prefix` prints yours. Verify
+with `docker compose version`.
+
+### Image architectures
+
 Docker images that will not run on Mac OS (Intel or M1):
 
 - `formplayer` (See section on Running Formplayer Outside of Docker in the [Main Developer Setup Guide](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md))
 
-Docker images that may not run on Mac OS (as of 11.x Big Sur and above):
+Images published only for `amd64`, which therefore run emulated on Apple Silicon:
 
-- `elasticsearch6` (Image is not optimized for arm but can run on apple silicon)
+- `elasticsearch6`
+- `postgres` (`dimagi/docker-postgresql`)
+
+Emulation makes these noticeably slower but they do work. Rosetta translation is much
+faster than QEMU, so enable it if your container engine supports it — with Colima that
+means `colima start --vm-type vz --vz-rosetta`.
 
 ### M1 (OS 11.x and above) Recommended Docker Up Command
 
 ```sh
-./scripts/docker up -d postgres couch redis zookeeper kafka minio
+./scripts/docker up -d postgres couch redis elasticsearch6 zookeeper kafka minio
 ```
 
 Note: `kafka` will be very cranky on start up. You might have to restart it if you see `kafka` errors.
@@ -148,6 +216,10 @@ Note: `kafka` will be very cranky on start up. You might have to restart it if y
 ```
 
 ### Installing and running Elasticsearch 6.8.23 outside of Docker
+
+You should not need this — `elasticsearch6` runs fine in Docker on Apple Silicon. Keep it as
+a fallback if the container gives you trouble, or if you want to avoid the emulation
+overhead.
 
 First, ensure that you have Java 17 running. `java -version` should output something like `openjdk version "17.0.7" 2023-04-18 LTS"`.
 Use `sdkman` or `jenv` to manage your local java versions.
@@ -158,12 +230,13 @@ Download the `tar` file for elasticsearch 6.8.23
 curl https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.8.23.tar.gz --output elasticsearch-6.8.23.tar.gz
 ```
 
-Un-tar and put the folder somewhere you can find it. Take note of that path (`pwd`) and add the following to your `~/.zshrc`:
+Un-tar it and put the folder somewhere you can find it:
 
 ```sh
 tar -xvzf elasticsearch-6.8.23.tar.gz
 ```
 
+Take note of that path (`pwd`), then add the following to your `~/.zshrc`:
 
 ```sh
 export PATH="/path/to/elasticsearch-6.8.23/bin:$PATH"
@@ -187,7 +260,7 @@ sed -i '' '/10-:-XX:UseAVX=2/ s/^/# /' config/jvm.options
 - In `config/elasticsearch.yml`, add xpack.ml.enabled: false
 
 ```sh
-echo "xpack.ml.enabled: false" | sudo tee -a config/elasticsearch.yml
+echo "xpack.ml.enabled: false" >> config/elasticsearch.yml
 ```
 
 After this you can open a new terminal window and run elasticsearch with `elasticsearch`.

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,33 @@
+# Long-running support processes for local development. Run them with:
+#
+#     uvx honcho start -f Procfile.dev
+#
+# Django is deliberately not included. Run it in its own terminal:
+#
+#     ./manage.py runserver localhost:8000
+#
+# honcho does pass its terminal through to child processes, but they all share
+# it, so an interactive prompt competes with webpack and celery output and there
+# is no way to direct keystrokes at one process. Keeping Django separate gives
+# breakpoint()/pdb a terminal to itself, keeps request logs readable, and lets
+# you restart the app without cycling everything else. To debug inside a celery
+# task, use celery.contrib.rdb rather than breakpoint().
+#
+# Ctrl-C stops every process. Note that honcho also stops them all as soon as one
+# of them exits, so if the group dies immediately, read the message from the
+# first process that failed.
+#
+# The backing services (postgres, couch, redis, elasticsearch, kafka, zookeeper,
+# minio) run in containers, not here: start them with `./scripts/docker up -d`.
+#
+# `uv run` is used so each process finds the project virtualenv without you
+# having to activate it first. formplayer needs a JDK, and sdkman keeps its JDKs
+# off PATH unless sdkman-init.sh has been sourced, so that location is added
+# here; a nonexistent directory in PATH is ignored, leaving any system java to be
+# found as usual.
+js: yarn dev
+# The queue list is long on purpose: `check_services` reports a queue as blocked
+# when nothing consumes it, so a worker on only the default queue leaves celery
+# permanently red even while it is running. These are the queues it watches.
+worker: uv run celery -A corehq worker -B -l info -Q celery,analytics_queue,async_restore_queue,background_queue,case_import_queue,email_queue,export_download_queue,malt_generation_queue,reminder_case_update_queue,reminder_queue,reminder_rule_queue,repeat_record_queue,saved_exports_queue,send_report_throttled,sms_queue,submission_reprocessing_queue,sumologic_logs_queue
+formplayer: sh -c 'PATH="$HOME/.sdkman/candidates/java/current/bin:$PATH"; exec java -jar ./formplayer.jar'

--- a/docker/README.rst
+++ b/docker/README.rst
@@ -12,13 +12,18 @@ Install `Docker`_. You should `manage Docker as a non-root user`_.
 MacOS
 ~~~~
 
-Install `Docker Desktop`_. It is available for Mac with Intel, and Mac
-with Apple silicon.
+Install a container engine. `Docker Desktop`_ is one option, available for
+Mac with Intel and Mac with Apple silicon, but it requires a paid
+subscription for larger organizations. Colima and OrbStack also work. See
+`Container engines`_ in the macOS supplementary guide for the options and
+their setup, including the extra step Colima needs before ``docker
+compose`` resolves.
 
 .. _Docker: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 .. _manage Docker as a non-root user: https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user
 .. _Docker Compose: https://docs.docker.com/compose/install/
 .. _Docker Desktop: https://docs.docker.com/desktop/install/mac-install/
+.. _Container engines: https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP_MAC.md#container-engines
 
 
 Running only services in Docker

--- a/docker/files/Dockerfile.es.6
+++ b/docker/files/Dockerfile.es.6
@@ -1,3 +1,12 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.23
 
 RUN bin/elasticsearch-plugin install --silent analysis-phonetic
+
+# HQ uses no machine learning features. Drop X-Pack ML's bundled native controller so
+# Elasticsearch does not try to exec it at startup. ES 6.x spawns any native controller
+# found on disk regardless of `xpack.ml.enabled`, and the binary is linux-x86_64 only, so
+# on arm64 hosts (Apple Silicon) the emulated JVM fails to spawn it and the node dies:
+#   Cannot run program ".../modules/x-pack-ml/platform/linux-x86_64/bin/controller":
+#   error=0, Failed to exec spawn helper
+# Spawner skips the module when no controller file is present.
+RUN rm -rf modules/x-pack-ml/platform

--- a/docker/files/elasticsearch_6.yml
+++ b/docker/files/elasticsearch_6.yml
@@ -4,6 +4,11 @@ http.port: 9200
 
 discovery.type: single-node
 
+# HQ does not use machine learning features. Note this setting alone does not stop ES 6.x
+# from spawning X-Pack ML's native controller at startup, which breaks arm64 hosts; see the
+# `rm -rf modules/x-pack-ml/platform` step in Dockerfile.es.6 for that.
+xpack.ml.enabled: false
+
 # dev-only setting to allow client-side ES front-ends
 http.cors.allow-origin: "*"
 http.cors.enabled: true

--- a/scripts/docker
+++ b/scripts/docker
@@ -334,6 +334,11 @@ elif [ "$CMD" == "rebuild" ]; then
     fi
 else
     docker compose $CMD "$@"
+    # Remember this before anything else runs, and exit with it at the end.
+    # Without that, the trailing `if` below becomes the last command evaluated and
+    # its status (0, when TEARDOWN is unset) is what the script returns, hiding
+    # every docker compose failure from callers and from CI.
+    compose_status=$?
     if [ "$TEARDOWN" == "yes" ]; then
         if [ "$COMPOSE_PROJECT_NAME" == "hqservice" ]; then
             echo "THIS WILL DELETE ALL SERVICE DATA"
@@ -341,7 +346,7 @@ else
             echo
             if [[ ! $REPLY =~ ^[Yy]$ ]]; then
                 echo "Volumes not deleted."
-                exit
+                exit $compose_status
             fi
         fi
         docker volume rm \
@@ -355,4 +360,5 @@ else
             ${VOLUME_PREFIX}minio-data \
             ${VOLUME_PREFIX}zookeeper
     fi
+    exit $compose_status
 fi

--- a/scripts/docker
+++ b/scripts/docker
@@ -116,7 +116,7 @@ compose_os_prefix='hq-compose-os-'
 if [ -n "$COMPOSE_OS_FILE" ]; then
     # Allow overriding in the local shell env to bypass OS detection logic.
     here=$(dirname "$0")
-    dockerdir=$(python -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "${here}/../docker")
+    dockerdir=$(cd "${here}/../docker" && pwd)
     if ! [ -f "$COMPOSE_OS_FILE" ] && ! [ -f "${dockerdir}/${COMPOSE_OS_FILE}" ]; then
         echo "ERROR: invalid compose OS file: $COMPOSE_OS_FILE"
         echo "Please specify a valid YAML file, or consider using an existing one:"
@@ -125,28 +125,20 @@ if [ -n "$COMPOSE_OS_FILE" ]; then
     fi
 else
     # This exists because of M1 Macs
+    # The third field is the Darwin kernel major version, not the macOS product
+    # version: kernel 20 is macOS 11, kernel 21 is macOS 12, and so on.
     os_info=$(uname -s)-$(uname -m)-$(uname -r | cut -d. -f1)
     os_suffix='default'
     case "$os_info" in
         Darwin-arm64-20)
             os_suffix='macos-m1-11'
             ;;
-        Darwin-arm64-21)
-            os_suffix='macos-m1-12'
-            ;;
         Darwin-arm64-*)
+            # macOS 12 (kernel 21) and every later release share this configuration.
+            # If some future release needs its own, add a
+            # ${compose_os_prefix}macos-m1-<product-version>.yml file and give its
+            # kernel major version a case of its own above.
             os_suffix='macos-m1-12'
-            echo "WARNING: You are entering new territory with your new M1 Mac. Congratulations!"
-            echo "Defaulting to most recently known M1 setup: $os_suffix"
-            echo ""
-            echo "To remove this message in the future, create a new 'base OS'"
-            echo "(or copy an existing, working) docker compose configuration"
-            echo "for your OS. For example:"
-            echo ""
-            macos_version=$(sw_vers -productVersion | cut -d. -f1)
-            suggested_file="${compose_os_prefix}macos-m1-${macos_version}.yml"
-            echo "$ cp -pv ${compose_os_prefix}${os_suffix}.yml $suggested_file"
-            echo ""
             ;;
     esac
     export COMPOSE_OS_FILE="${compose_os_prefix}${os_suffix}.yml"

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -45,7 +45,11 @@ SERVICES="postgres couch redis elasticsearch6 zookeeper kafka minio"
 
 VENV_PY="$REPO_ROOT/.venv/bin/python"
 TMP_BASE="${TMPDIR:-/tmp}"
-LOG_FILE="${TMP_BASE%/}/hq-setup-dev.log"
+# Created per run by mktemp once we know we are acting. A fixed name here would be
+# predictable in a world-writable /tmp when TMPDIR is unset (as it is under
+# `sudo -i`), where a symlink planted at that path would redirect this run's
+# output into whatever it points at.
+LOG_FILE=''
 
 FORMPLAYER_JAR_URL=https://s3.amazonaws.com/dimagi-formplayer-jars/latest-successful/formplayer.jar
 FORMPLAYER_PROPS_URL=https://raw.githubusercontent.com/dimagi/formplayer/master/config/application.example.properties
@@ -197,14 +201,17 @@ if [ "$(uname -s)" != Darwin ]; then
     exit 1
 fi
 
-# Only a real run owns the log. --check must not truncate it, or inspecting an
-# environment destroys the evidence from the run you are trying to diagnose.
-acting && : >"$LOG_FILE"
+# Only a real run gets a log, and it gets a fresh one. --check writes nothing at
+# all, so inspecting an environment cannot destroy the evidence from the run you
+# are trying to diagnose.
+if acting; then
+    LOG_FILE=$(mktemp "${TMP_BASE%/}/hq-setup-dev.XXXXXX")
+fi
 
 printf '\n  %sCommCare HQ dev setup%s  %s· macOS %s · %s%s\n' \
     "$BOLD" "$RESET" "$DIM" "$(sw_vers -productVersion)" "$(uname -m)" "$RESET"
 $CHECK_ONLY && printf '  %schecking only, nothing will be changed%s\n' "$DIM" "$RESET"
-printf '  %slog: %s%s\n' "$DIM" "$LOG_FILE" "$RESET"
+[ -n "$LOG_FILE" ] && printf '  %slog: %s%s\n' "$DIM" "$LOG_FILE" "$RESET"
 
 # --- inspect: prerequisites --------------------------------------------------
 
@@ -308,7 +315,10 @@ if have sass; then
     ok sass "$(sass --version 2>/dev/null | head -1 | awk '{print $1}')"
 else
     bad sass 'not found'
-    plan_add sass 'npm install -g sass'
+    # --ignore-scripts matches the intent of .yarnrc's `ignore-scripts true`: a
+    # compromised release should not get to run install hooks as the developer.
+    # A repo .npmrc would not cover this, since npm drops project config for -g.
+    plan_add sass 'npm install -g --ignore-scripts sass'
 fi
 
 if have yarn; then
@@ -424,6 +434,10 @@ if os.path.exists(path):
 dirs = cfg.setdefault('cliPluginsExtraDirs', [])
 if sys.argv[1] not in dirs:
     dirs.append(sys.argv[1])
+# This file holds registry credentials, and docker creates it 0600. Creating it
+# at the ambient umask (0644 typically) would leave those readable. An existing
+# file keeps whatever mode its owner chose.
+os.umask(0o077)
 with open(path, 'w') as f:
     json.dump(cfg, f, indent=2)
     f.write('\n')

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,805 @@
+#!/usr/bin/env bash
+#
+# Set up a CommCare HQ development environment on macOS.
+#
+# Every step checks its own precondition before acting, so this is safe to
+# re-run: finished work is reported and skipped. That is also what makes
+# `--check` able to report an environment's state without changing it.
+#
+# Anything that installs or downloads is collected into a single plan and
+# approved with one prompt, rather than asking repeatedly part way through.
+#
+# A step that fails does not stop the run. The script does as much as it can and
+# summarises what failed at the end, because a half-built environment plus an
+# accurate list of what is missing beats stopping at the first problem.
+#
+# This automates DEV_SETUP.md and DEV_SETUP_MAC.md. Those remain the reference;
+# this is a convenience, not a replacement.
+#
+# Deliberately does not modify your shell profile. Where something needs to be
+# on PATH permanently, the script says so and adds it to its own PATH for the
+# current run only. That is also why sdkman is reported but never installed here:
+# its installer adds itself to your profile, so you run that one yourself.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$REPO_ROOT"
+
+# --- configuration -----------------------------------------------------------
+
+# Minimum front-end tool versions, per DEV_SETUP.md
+NODE_MIN_MAJOR=24
+NPM_MIN_MAJOR=11
+
+# sdkman is how HQ development manages the JDK that formplayer needs.
+JAVA_MAJOR=17
+JAVA_SDKMAN_CANDIDATE=17.0.20-zulu
+SDKMAN_INIT="$HOME/.sdkman/bin/sdkman-init.sh"
+SDKMAN_JAVA_BIN="$HOME/.sdkman/candidates/java/current/bin"
+SDKMAN_INSTALL='curl -s "https://get.sdkman.io" | zsh -o NO_NOMATCH'
+
+# formplayer is absent on purpose: its image does not run on macOS, so formplayer
+# runs from a jar instead.
+SERVICES="postgres couch redis elasticsearch6 zookeeper kafka minio"
+
+VENV_PY="$REPO_ROOT/.venv/bin/python"
+TMP_BASE="${TMPDIR:-/tmp}"
+LOG_FILE="${TMP_BASE%/}/hq-setup-dev.log"
+
+FORMPLAYER_JAR_URL=https://s3.amazonaws.com/dimagi-formplayer-jars/latest-successful/formplayer.jar
+FORMPLAYER_PROPS_URL=https://raw.githubusercontent.com/dimagi/formplayer/master/config/application.example.properties
+
+# --- options -----------------------------------------------------------------
+
+CHECK_ONLY=false
+ASSUME_YES=false
+
+usage() {
+    cat <<'EOF'
+Set up a CommCare HQ development environment on macOS.
+
+Usage: scripts/setup-dev.sh [options]
+
+  --check      Report what is missing or misconfigured, change nothing.
+               Exits non-zero if anything needs attention.
+  --yes, -y    Approve the install plan without prompting.
+  --help, -h   Show this message.
+
+Safe to re-run: each step checks its precondition and skips finished work.
+Anything that installs or downloads is approved with a single prompt, and a
+failing step is reported rather than ending the run.
+
+Automates DEV_SETUP.md and DEV_SETUP_MAC.md, which remain the reference.
+EOF
+    exit 0
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --check) CHECK_ONLY=true ;;
+        --yes|-y) ASSUME_YES=true ;;
+        --help|-h) usage ;;
+        *) echo "unknown option: $1 (try --help)" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# --- output ------------------------------------------------------------------
+
+if [ -t 1 ] && [ "${TERM:-}" != "dumb" ]; then
+    BOLD=$'\033[1m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+    RED=$'\033[31m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; CYAN=$'\033[36m'
+    CLEAR=$'\r\033[K'
+else
+    BOLD=''; DIM=''; RESET=''
+    RED=''; GREEN=''; YELLOW=''; CYAN=''
+    CLEAR=''
+fi
+ESC=$(printf '\033')
+TAB=$(printf '\t')
+
+heading() { printf '\n  %s%s%s\n' "$BOLD" "$1" "$RESET"; }
+ok()      { printf '  %s✓%s %-22s %s\n' "$GREEN" "$RESET" "$1" "${2:-}"; }
+skip()    { printf '  %s·%s %-22s %s%s%s\n' "$DIM" "$RESET" "$1" "$DIM" "${2:-already done}" "$RESET"; }
+warn()    { printf '  %s!%s %-22s %s\n' "$YELLOW" "$RESET" "$1" "${2:-}"; }
+bad()     { printf '  %s✗%s %-22s %s\n' "$RED" "$RESET" "$1" "${2:-}"; }
+info()    { printf '    %s%s%s\n' "$DIM" "$1" "$RESET"; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+acting() { ! $CHECK_ONLY; }
+strip_color() { sed "s/${ESC}\[[0-9;]*m//g"; }
+
+# --- state -------------------------------------------------------------------
+
+# PLAN holds actions that install or download, as "label<TAB>shell command".
+# They are approved together and run before anything that might depend on them.
+PLAN=''
+# PENDING/HINTS: things this script will not do, and how to do them by hand.
+PENDING=''
+HINTS=''
+# FAILED: steps that were attempted and did not work.
+FAILED=''
+
+plan_add()    { PLAN="${PLAN}${1}${TAB}${2}"$'\n'; }
+plan_count()  { printf '%s' "$PLAN" | grep -c . || true; }
+pending()     { PENDING="${PENDING}${1}"$'\n'; HINTS="${HINTS}  ${1}: ${2}"$'\n'; }
+fail_add()    { FAILED="${FAILED}  ${1}"$'\n'; }
+count_lines() { printf '%s' "$1" | grep -c . || true; }
+
+# --- running commands --------------------------------------------------------
+
+SPINNER='⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏'
+
+elapsed() {
+    local s=$((SECONDS - $1))
+    if [ "$s" -ge 60 ]; then printf '%dm%02ds' $((s / 60)) $((s % 60))
+    else printf '%ds' "$s"; fi
+}
+
+# Run a command, sending verbose output to the log. Never aborts the script: a
+# failure is reported, recorded, and execution continues with the next step.
+# Always returns 0 so callers are safe under `set -e`; use `step_ok` to test.
+STEP_OK=true
+run() {
+    local label="$1"; shift
+    local start=$SECONDS
+    STEP_OK=true
+
+    if [ -z "$CLEAR" ]; then
+        if "$@" >>"$LOG_FILE" 2>&1; then
+            ok "$label" "done in $(elapsed "$start")"
+        else
+            STEP_OK=false
+        fi
+    else
+        "$@" >>"$LOG_FILE" 2>&1 &
+        local pid=$! i=0
+        set -- $SPINNER
+        local frames=$# frame
+        while kill -0 "$pid" 2>/dev/null; do
+            eval "frame=\${$(( i % frames + 1 ))}"
+            printf '%s  %s%s%s %-22s %s%s%s' "$CLEAR" "$CYAN" "$frame" "$RESET" \
+                "$label" "$DIM" "$(elapsed "$start")" "$RESET"
+            i=$((i + 1))
+            sleep 0.1
+        done
+        if wait "$pid"; then
+            printf '%s' "$CLEAR"
+            ok "$label" "done in $(elapsed "$start")"
+        else
+            printf '%s' "$CLEAR"
+            STEP_OK=false
+        fi
+    fi
+
+    if ! $STEP_OK; then
+        bad "$label" "failed after $(elapsed "$start")"
+        info "see $LOG_FILE"
+        fail_add "$label"
+    fi
+    return 0
+}
+
+step_ok() { $STEP_OK; }
+
+# do_step LABEL HINT CMD... -- act, or record the hint in --check mode.
+do_step() {
+    local label="$1" hint="$2"; shift 2
+    if acting; then run "$label" "$@"; else pending "$label" "$hint"; fi
+}
+
+# --- platform guard ----------------------------------------------------------
+
+if [ "$(uname -s)" != Darwin ]; then
+    printf '\n  %sError:%s this script only supports macOS. For Linux, follow DEV_SETUP.md.\n\n' \
+        "$RED" "$RESET" >&2
+    exit 1
+fi
+
+# Only a real run owns the log. --check must not truncate it, or inspecting an
+# environment destroys the evidence from the run you are trying to diagnose.
+acting && : >"$LOG_FILE"
+
+printf '\n  %sCommCare HQ dev setup%s  %s· macOS %s · %s%s\n' \
+    "$BOLD" "$RESET" "$DIM" "$(sw_vers -productVersion)" "$(uname -m)" "$RESET"
+$CHECK_ONLY && printf '  %schecking only, nothing will be changed%s\n' "$DIM" "$RESET"
+printf '  %slog: %s%s\n' "$DIM" "$LOG_FILE" "$RESET"
+
+# --- inspect: prerequisites --------------------------------------------------
+
+heading Prerequisites
+
+if have brew; then
+    ok homebrew "$(brew --version | head -1 | awk '{print $2}')"
+else
+    bad homebrew 'not found'
+    pending homebrew 'install from https://brew.sh, then re-run'
+fi
+
+# want LABEL FORMULA -- plan a Homebrew install, or explain why it cannot happen.
+want_brew() {
+    if have brew; then plan_add "$1" "brew install $2"
+    else pending "$1" "brew install $2"; fi
+}
+
+if have uv; then
+    ok uv "$(uv --version | awk '{print $2}')"
+else
+    bad uv 'not found'
+    want_brew uv uv
+fi
+
+if have node && have npm; then
+    node_v=$(node -v | sed 's/^v//' || true)
+    npm_v=$(npm -v)
+    if [ "$(printf '%s\n%s\n' "$NODE_MIN_MAJOR" "${node_v%%.*}" | sort -V | head -1)" = "$NODE_MIN_MAJOR" ] \
+       && [ "$(printf '%s\n%s\n' "$NPM_MIN_MAJOR" "${npm_v%%.*}" | sort -V | head -1)" = "$NPM_MIN_MAJOR" ]; then
+        ok 'node / npm' "v$node_v / $npm_v"
+    else
+        warn 'node / npm' "v$node_v / $npm_v (want node >= $NODE_MIN_MAJOR, npm >= $NPM_MIN_MAJOR)"
+        pending 'node / npm' 'brew upgrade node'
+    fi
+else
+    bad 'node / npm' 'not found'
+    want_brew 'node / npm' node
+fi
+
+# macOS ships a /usr/bin/java stub that exists but fails with no JDK installed,
+# so the version output has to be parsed rather than trusted.
+java_major_of() {
+    local out
+    out=$("$1" -version 2>&1 | head -1) || return 1
+    case "$out" in
+        *'version "'*) printf '%s' "$out" | sed -E 's/.*version "([0-9]+).*/\1/' ;;
+        *) return 1 ;;
+    esac
+}
+
+# Adds sdkman's JDK to PATH when that is where java lives. Called again after the
+# plan runs, since installing it is one of the things the plan can do.
+use_sdkman_java() {
+    local jm
+    [ -x "$SDKMAN_JAVA_BIN/java" ] || return 1
+    jm=$(java_major_of "$SDKMAN_JAVA_BIN/java") || return 1
+    [ "$jm" = "$JAVA_MAJOR" ] || return 1
+    case ":$PATH:" in *":$SDKMAN_JAVA_BIN:"*) ;; *) PATH="$SDKMAN_JAVA_BIN:$PATH"; export PATH ;; esac
+    return 0
+}
+
+report_java() {
+    local jm
+    if have java && jm=$(java_major_of java) && [ "$jm" = "$JAVA_MAJOR" ]; then
+        ok "java $JAVA_MAJOR" "$(java -version 2>&1 | head -1 | sed -E 's/.*version "([^"]+)".*/\1/')"
+        return 0
+    fi
+    if use_sdkman_java; then
+        warn "java $JAVA_MAJOR" 'installed via sdkman but not on PATH'
+        info "using $SDKMAN_JAVA_BIN for this run; source sdkman-init.sh in your profile to keep it"
+        return 0
+    fi
+    return 1
+}
+
+# sdkman is a prerequisite in its own right, so report it rather than leaving it
+# implicit. It is not installed automatically: its installer adds itself to your
+# shell profile, and this script does not edit shell profiles.
+if [ -s "$SDKMAN_INIT" ]; then
+    ok sdkman present
+else
+    bad sdkman 'not found'
+    info 'its installer adds sdkman to your shell profile, which this script will not do'
+    info 'run it yourself, then re-run this script to pick up the JDK'
+    pending sdkman "$SDKMAN_INSTALL"
+fi
+
+if report_java; then
+    : # report_java already printed the state
+elif [ -s "$SDKMAN_INIT" ]; then
+    bad "java $JAVA_MAJOR" 'not installed'
+    # sdkman is a set of shell functions, so it has to be sourced first.
+    plan_add "java $JAVA_MAJOR" ". \"$SDKMAN_INIT\"; sdk install java $JAVA_SDKMAN_CANDIDATE"
+else
+    bad "java $JAVA_MAJOR" 'needs sdkman first'
+    pending "java $JAVA_MAJOR" "install sdkman, then: sdk install java $JAVA_SDKMAN_CANDIDATE"
+fi
+
+if have sass; then
+    ok sass "$(sass --version 2>/dev/null | head -1 | awk '{print $1}')"
+else
+    bad sass 'not found'
+    plan_add sass 'npm install -g sass'
+fi
+
+if have yarn; then
+    ok yarn "$(yarn --version 2>/dev/null)"
+else
+    bad yarn 'not found'
+    want_brew yarn yarn
+fi
+
+# Homebrew's postgres formulae are keg-only, so they are frequently installed but
+# not on PATH. Re-checked after the plan runs, for the same reason as java.
+resolve_pg_keg() {
+    local formula p
+    have brew || return 1
+    for formula in libpq postgresql; do
+        if p=$(brew --prefix "$formula" 2>/dev/null) && [ -x "$p/bin/psql" ]; then
+            printf '%s' "$p/bin"; return 0
+        fi
+    done
+    return 1
+}
+# Must not be called from a command substitution: the PATH export would be lost
+# in the subshell, leaving psql "found" in the message but absent in practice.
+use_pg_keg() {
+    local keg
+    keg=$(resolve_pg_keg) || return 1
+    case ":$PATH:" in *":$keg:"*) ;; *) PATH="$keg:$PATH"; export PATH ;; esac
+    PG_KEG="$keg"
+    return 0
+}
+
+if have psql; then
+    ok 'postgres client' "$(psql --version | awk '{print $3}')"
+elif use_pg_keg; then
+    warn 'postgres client' 'installed but not on PATH (keg-only)'
+    info "using $PG_KEG for this run; add it to your shell profile to keep it"
+else
+    bad 'postgres client' 'not found'
+    want_brew 'postgres client' libpq
+fi
+
+# --- inspect: container engine -----------------------------------------------
+
+heading 'Container engine'
+
+# Rosetta matters here: two of HQ's images are published only for amd64.
+COLIMA_ARGS='--cpu 4 --memory 8 --disk 60'
+[ "$(uname -m)" = arm64 ] && COLIMA_ARGS="$COLIMA_ARGS --vm-type vz --vz-rosetta"
+
+if have docker; then
+    # `docker version` exits non-zero with no daemon even though it prints the
+    # client version, so take the output and ignore the status.
+    docker_v=$(docker version --format '{{.Client.Version}}' 2>/dev/null | head -1 || true)
+    ok 'docker cli' "${docker_v:-present}"
+else
+    bad 'docker cli' 'not found'
+    want_brew 'docker cli' docker
+fi
+
+# The docker CLI is only a client; something has to provide the daemon.
+if docker info >/dev/null 2>&1; then
+    ok 'docker daemon' reachable
+elif have colima; then
+    bad 'docker daemon' 'colima installed but not running'
+    plan_add 'docker daemon' "colima start $COLIMA_ARGS"
+elif have orb; then
+    bad 'docker daemon' 'OrbStack installed but not running'
+    plan_add 'docker daemon' 'orb start'
+elif [ -d /Applications/Docker.app ]; then
+    bad 'docker daemon' 'Docker Desktop installed but not running'
+    info 'it is a GUI app, so start it yourself rather than from this script'
+    pending 'docker daemon' 'open -a Docker'
+elif have brew; then
+    bad 'docker daemon' 'no container engine installed'
+    info 'colima is the lightest option and raises no licensing question'
+    info 'DEV_SETUP_MAC.md#container-engines covers Docker Desktop and OrbStack instead'
+    plan_add 'container engine' "brew install colima docker-compose && colima start $COLIMA_ARGS"
+else
+    bad 'docker daemon' 'no container engine installed'
+    pending 'docker daemon' 'see DEV_SETUP_MAC.md#container-engines'
+fi
+
+# Docker Desktop and OrbStack bundle compose; Homebrew's must be registered.
+if docker compose version >/dev/null 2>&1; then
+    compose_v=$(docker compose version --short 2>/dev/null | head -1 || true)
+    ok 'docker compose' "${compose_v:-present}"
+else
+    bad 'docker compose' 'not resolving'
+    plugin_dir=''
+    if have brew && p=$(brew --prefix 2>/dev/null) && [ -d "$p/lib/docker/cli-plugins" ]; then
+        plugin_dir="$p/lib/docker/cli-plugins"
+    fi
+    if [ -n "$plugin_dir" ]; then
+        info "plugin is at $plugin_dir but the docker cli is not looking there"
+        plan_add 'docker compose' "register_compose_plugin '$plugin_dir'"
+    else
+        info 'the compose plugin will be installed with the container engine'
+    fi
+fi
+
+# Merges into ~/.docker/config.json rather than overwriting: that file usually
+# holds other keys. Referenced by the plan entry above.
+register_compose_plugin() {
+    mkdir -p "$HOME/.docker"
+    /usr/bin/python3 - "$1" <<'PY'
+import json, os, sys
+path = os.path.expanduser('~/.docker/config.json')
+cfg = {}
+if os.path.exists(path):
+    with open(path) as f:
+        content = f.read().strip()
+    cfg = json.loads(content) if content else {}
+dirs = cfg.setdefault('cliPluginsExtraDirs', [])
+if sys.argv[1] not in dirs:
+    dirs.append(sys.argv[1])
+with open(path, 'w') as f:
+    json.dump(cfg, f, indent=2)
+    f.write('\n')
+PY
+}
+
+# --- inspect: formplayer files -----------------------------------------------
+
+heading Formplayer
+
+if [ -f formplayer.jar ]; then
+    skip formplayer.jar "$(du -h formplayer.jar | awk '{print $1}')"
+else
+    bad formplayer.jar 'missing (~136MB download)'
+    plan_add formplayer.jar "curl -sSL '$FORMPLAYER_JAR_URL' -o formplayer.jar"
+fi
+
+if [ -f application.properties ]; then
+    skip application.properties
+else
+    bad application.properties missing
+    plan_add application.properties "curl -sSL '$FORMPLAYER_PROPS_URL' -o application.properties"
+fi
+
+# --- the plan ----------------------------------------------------------------
+
+if [ "$(plan_count)" -gt 0 ]; then
+    heading 'Plan'
+    printf '%s' "$PLAN" | while IFS="$TAB" read -r label cmd; do
+        [ -n "$label" ] || continue
+        printf '    %-22s %s%s%s\n' "$label" "$DIM" "$cmd" "$RESET"
+    done
+
+    approved=false
+    if $CHECK_ONLY; then
+        printf '\n'
+        info 'checking only; nothing above will be run'
+    elif $ASSUME_YES; then
+        approved=true
+    elif [ ! -t 0 ]; then
+        printf '\n'
+        info 'no terminal for a prompt; re-run with --yes to approve'
+    else
+        printf '\n    %sInstall/run the %s item(s) above? [y/N]%s ' \
+            "$BOLD" "$(plan_count)" "$RESET"
+        read -r reply || reply=''
+        case "$reply" in [yY]*) approved=true ;; esac
+    fi
+
+    if $approved; then
+        printf '\n'
+        while IFS="$TAB" read -r label cmd; do
+            [ -n "$label" ] || continue
+            run "$label" bash -c "$(declare -f register_compose_plugin); set -e; $cmd"
+        done <<PLAN_EOF
+$PLAN
+PLAN_EOF
+        # java and psql can be installed without landing on PATH, so re-resolve.
+        # Both mutate PATH, so neither may be called in a command substitution.
+        use_sdkman_java || true
+        use_pg_keg || true
+
+        # Installing docker-compose does not register it with the docker CLI, and
+        # on a cold machine the plugin directory did not exist during inspection,
+        # so nothing could be planned then. Register it now that it is there,
+        # otherwise `docker compose` still fails and every service step below it
+        # collapses.
+        if ! docker compose version >/dev/null 2>&1; then
+            plugin_dir=''
+            if have brew && p=$(brew --prefix 2>/dev/null) && [ -d "$p/lib/docker/cli-plugins" ]; then
+                plugin_dir="$p/lib/docker/cli-plugins"
+            fi
+            if [ -n "$plugin_dir" ]; then
+                run 'docker compose' register_compose_plugin "$plugin_dir"
+                if docker compose version >/dev/null 2>&1; then
+                    ok 'docker compose' "$(docker compose version --short 2>/dev/null | head -1 || true)"
+                else
+                    bad 'docker compose' 'still not resolving after registering the plugin'
+                    pending 'docker compose' 'see DEV_SETUP_MAC.md#container-engines'
+                fi
+            fi
+        fi
+    else
+        while IFS="$TAB" read -r label cmd; do
+            [ -n "$label" ] || continue
+            pending "$label" "$cmd"
+        done <<PLAN_EOF
+$PLAN
+PLAN_EOF
+    fi
+fi
+
+# --- repository --------------------------------------------------------------
+
+heading Repository
+
+if git submodule status | grep -qE '^-'; then
+    bad submodules 'not initialized'
+    do_step submodules 'git submodule update --init --recursive' \
+        git submodule update --init --recursive
+else
+    skip submodules
+fi
+
+if [ -x git-hooks/install.sh ] && [ ! -e .git/hooks/pre-commit ]; then
+    bad 'git hooks' 'not installed'
+    do_step 'git hooks' 'git-hooks/install.sh' ./git-hooks/install.sh
+else
+    skip 'git hooks'
+fi
+
+if ! have uv; then
+    pending 'python deps' 'install uv, then uv sync --compile-bytecode'
+elif [ -x "$VENV_PY" ] && $CHECK_ONLY; then
+    # A run syncs anyway (cheap when current, and catches a stale venv after a
+    # pull), but an existing venv is not something --check should flag.
+    skip 'python deps' '.venv present'
+else
+    [ -x "$VENV_PY" ] || bad 'python deps' 'no .venv'
+    do_step 'python deps' 'uv sync --compile-bytecode' uv sync --compile-bytecode
+fi
+
+# These go through run() rather than being called directly so that a failure is
+# recorded and the run continues, instead of set -e ending it here.
+if [ -f localsettings.py ]; then
+    skip localsettings.py
+else
+    do_step localsettings.py 'cp localsettings.example.py localsettings.py' \
+        cp localsettings.example.py localsettings.py
+fi
+
+if [ -d sharedfiles ]; then
+    skip sharedfiles/
+else
+    do_step sharedfiles/ 'mkdir sharedfiles' mkdir -p sharedfiles
+fi
+
+manage() { "$VENV_PY" manage.py "$@"; }
+
+# --- services, databases, and the rest ---------------------------------------
+#
+# These need both the virtualenv and a reachable daemon. Rather than stopping,
+# note what is missing and let the summary report the rest.
+
+REST_OK=true
+if [ ! -x "$VENV_PY" ]; then
+    REST_OK=false
+    pending 'remaining steps' 'need a working virtualenv; fix the items above and re-run'
+fi
+if ! docker info >/dev/null 2>&1; then
+    REST_OK=false
+    pending 'remaining steps' 'need a running docker daemon; fix the items above and re-run'
+fi
+if ! docker compose version >/dev/null 2>&1; then
+    # Without this, ./scripts/docker starts nothing and every database and
+    # elasticsearch step below fails for a reason that looks unrelated.
+    REST_OK=false
+    pending 'remaining steps' 'need `docker compose` to resolve; see DEV_SETUP_MAC.md#container-engines'
+fi
+
+if $REST_OK; then
+    heading Services
+
+    expected_services=$(echo $SERVICES | wc -w | tr -d ' ')
+    count_services() {
+        docker ps ${1:+--filter health=$1} --format '{{.Names}}' 2>/dev/null | grep -c hqservice || true
+    }
+
+    if [ "$(count_services)" -ge "$expected_services" ]; then
+        skip containers "$(count_services) running"
+    elif acting; then
+        run containers ./scripts/docker up -d $SERVICES
+        # Verify state rather than trusting the exit code: check the containers
+        # exist before waiting on their health, or a compose failure turns into a
+        # five minute wait for containers that were never created.
+        if [ "$(count_services)" -eq 0 ]; then
+            bad containers 'no containers were created'
+            info 'docker compose started nothing; see the log for what it reported'
+            fail_add containers
+        else
+            start=$SECONDS
+            while [ "$(count_services healthy)" -lt "$expected_services" ] \
+                  && [ $((SECONDS - start)) -lt 300 ]; do
+                if [ -n "$CLEAR" ]; then
+                    printf '%s  %s·%s %-22s %s%s healthy, %s%s' "$CLEAR" "$CYAN" "$RESET" \
+                        'health' "$DIM" "$(count_services healthy)/$expected_services" \
+                        "$(elapsed "$start")" "$RESET"
+                fi
+                sleep 5
+            done
+            [ -n "$CLEAR" ] && printf '%s' "$CLEAR"
+            if [ "$(count_services healthy)" -ge "$expected_services" ]; then
+                ok containers "$(count_services healthy) healthy"
+            else
+                warn containers "$(count_services healthy) of $expected_services healthy after $(elapsed "$start")"
+                info 'kafka is often the holdout: ./scripts/docker restart kafka'
+            fi
+        fi
+    else
+        bad containers "$(count_services) of $expected_services running"
+        pending containers "./scripts/docker up -d $SERVICES"
+    fi
+
+    heading Databases
+
+    if ! have psql; then
+        pending 'formplayer db' 'needs the postgres client'
+    elif PGPASSWORD=commcarehq psql -h localhost -U commcarehq -lqt 2>/dev/null \
+            | cut -d'|' -f1 | grep -qw formplayer; then
+        skip 'formplayer db'
+    else
+        bad 'formplayer db' missing
+        do_step 'formplayer db' 'createdb formplayer -U commcarehq -h localhost' \
+            env PGPASSWORD=commcarehq createdb formplayer -U commcarehq -h localhost
+    fi
+
+    # Both are idempotent, so they run every time rather than being probed.
+    if acting; then
+        run 'couch views' manage sync_couch_views
+        run 'kafka topics' manage create_kafka_topics
+    else
+        info 'would run sync_couch_views and create_kafka_topics (both idempotent)'
+    fi
+
+    if manage migrate --check >/dev/null 2>&1; then
+        skip migrations 'up to date'
+    elif acting; then
+        bad migrations pending
+        # CCHQ_IS_FRESH_INSTALL skips migrations that only matter to existing
+        # data. It is only correct on a brand new database.
+        plan=$(manage showmigrations --plan 2>/dev/null || true)
+        if ! printf '%s' "$plan" | grep -q '^\[X\]'; then
+            info 'fresh database: using CCHQ_IS_FRESH_INSTALL=1'
+            run migrations env CCHQ_IS_FRESH_INSTALL=1 "$VENV_PY" manage.py migrate --noinput
+        else
+            run migrations manage migrate --noinput
+        fi
+    else
+        bad migrations pending
+        pending migrations 'CCHQ_IS_FRESH_INSTALL=1 ./manage.py migrate --noinput'
+    fi
+
+    heading Elasticsearch
+
+    es_indices() { curl -s -m 5 'localhost:9200/_cat/indices?h=index' 2>/dev/null | grep -c . || true; }
+
+    if [ "$(es_indices)" -gt 0 ]; then
+        skip indices "$(es_indices) present"
+    else
+        bad indices none
+        do_step indices './manage.py ptop_preindex' manage ptop_preindex
+    fi
+
+    heading 'Front end'
+
+    if [ -d node_modules ]; then
+        skip 'js deps'
+    elif ! have yarn; then
+        pending 'js deps' 'needs yarn'
+    else
+        bad 'js deps' 'not installed'
+        do_step 'js deps' 'yarn install --frozen-lockfile' yarn install --frozen-lockfile
+    fi
+
+    if acting; then
+        run 'js translations' manage compilejsi18n
+    else
+        info 'would run compilejsi18n'
+    fi
+
+    heading 'Application data'
+
+    # get_all_versions reports builds actually in the database, unlike
+    # get_default_build_spec, which reads a config document that can exist without them.
+    has_build=$(manage shell -c "
+from corehq.apps.builds.utils import get_all_versions
+try:
+    print('yes' if get_all_versions([]) else 'no')
+except Exception:
+    print('unknown')
+" 2>/dev/null | tail -1 || echo unknown)
+
+    case "$has_build" in
+        yes) skip 'commcare build' ;;
+        no)
+            bad 'commcare build' 'none installed'
+            do_step 'commcare build' './manage.py add_commcare_build --latest' \
+                manage add_commcare_build --latest
+            ;;
+        *)
+            warn 'commcare build' 'could not determine'
+            pending 'commcare build' './manage.py add_commcare_build --latest'
+            ;;
+    esac
+
+    has_superuser=$(manage shell -c "
+from django.contrib.auth.models import User
+print('yes' if User.objects.filter(is_superuser=True).exists() else 'no')
+" 2>/dev/null | tail -1 || echo unknown)
+
+    if [ "$has_superuser" = yes ]; then
+        skip superuser 'one already exists'
+    elif acting && [ -t 0 ]; then
+        # make_superuser prompts for a password itself, so it needs a terminal
+        # and must not have its output redirected.
+        printf '    %sSuperuser email (blank to skip):%s ' "$DIM" "$RESET"
+        read -r su_email || su_email=''
+        if [ -n "$su_email" ]; then
+            manage make_superuser "$su_email" || { bad superuser 'make_superuser failed'; fail_add superuser; }
+        else
+            skip superuser skipped
+        fi
+    else
+        bad superuser none
+        pending superuser './manage.py make_superuser <email>'
+    fi
+
+    heading 'Services check'
+    # check_services exits non-zero when any service is down, so capture its
+    # output first: piping it directly would trip pipefail.
+    services_out=$(manage check_services 2>/dev/null | strip_color | grep -E 'SUCCESS|FAILURE' || true)
+    if [ -n "$services_out" ]; then
+        printf '%s\n' "$services_out" | sed 's/^/  /'
+        if printf '%s' "$services_out" | grep -q FAILURE; then
+            info 'celery and formplayer report FAILURE until started, see Next steps'
+        fi
+    else
+        warn check_services 'could not run'
+    fi
+fi
+
+# --- summary -----------------------------------------------------------------
+
+if [ -n "$FAILED" ]; then
+    heading 'Failed'
+    printf '%s' "$FAILED"
+    info "full output: $LOG_FILE"
+fi
+
+if [ -n "$PENDING" ]; then
+    heading 'To do by hand'
+    printf '%s' "$HINTS"
+fi
+
+problems=$(( $(count_lines "$FAILED") + $(count_lines "$PENDING") ))
+
+if $CHECK_ONLY; then
+    printf '\n'
+    if [ "$problems" -gt 0 ]; then
+        printf '  %s%s item(s) need attention.%s\n\n' "$YELLOW" "$problems" "$RESET"
+        exit 1
+    fi
+    printf '  %sEnvironment looks complete.%s\n\n' "$GREEN" "$RESET"
+    exit 0
+fi
+
+heading 'Next steps'
+cat <<'EOF'
+  Two terminals. First, the support processes (webpack, celery, formplayer):
+
+    uvx honcho start -f Procfile.dev
+
+  Then Django on its own, so breakpoint()/pdb has a terminal to itself and you
+  can restart the app without cycling the rest:
+
+    uv run ./manage.py runserver localhost:8000
+
+  Then open http://localhost:8000
+
+  Re-run this script any time; it skips what is already done.
+  scripts/setup-dev.sh --check reports state without changing anything.
+EOF
+
+if [ "$problems" -gt 0 ]; then
+    printf '\n  %s%s item(s) need attention; the environment is incomplete.%s\n\n' \
+        "$YELLOW" "$problems" "$RESET"
+    exit 1
+fi
+printf '\n'

--- a/uv.lock
+++ b/uv.lock
@@ -1134,14 +1134,14 @@ wheels = [
 
 [[package]]
 name = "django-extensions"
-version = "3.1.3"
+version = "4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/40/22ff745aea0468dcefba8b165d010e5260d3058862ea280c2ce5212c8560/django-extensions-3.1.3.tar.gz", hash = "sha256:5f0fea7bf131ca303090352577a9e7f8bfbf5489bd9d9c8aea9401db28db34a0", size = 614094, upload-time = "2021-04-19T17:44:19.918Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/b3/ed0f54ed706ec0b54fd251cc0364a249c6cd6c6ec97f04dc34be5e929eac/django_extensions-4.1.tar.gz", hash = "sha256:7b70a4d28e9b840f44694e3f7feb54f55d495f8b3fa6c5c0e5e12bcb2aa3cdeb", size = 283078, upload-time = "2025-04-11T01:15:39.617Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/40/c94fde79735d0c3578ed7d595593bd52c5633d8a02e53a2ef9346f93e2db/django_extensions-3.1.3-py3-none-any.whl", hash = "sha256:50de8977794a66a91575dd40f87d5053608f679561731845edbd325ceeb387e3", size = 223440, upload-time = "2021-04-19T17:44:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/64/96/d967ca440d6a8e3861120f51985d8e5aec79b9a8bdda16041206adfe7adc/django_extensions-4.1-py3-none-any.whl", hash = "sha256:0699a7af28f2523bf8db309a80278519362cd4b6e1fd0a8cd4bf063e1e023336", size = 232980, upload-time = "2025-04-11T01:15:37.701Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Product Description

No end-user visible changes. This is developer environment tooling and
documentation: a setup script, a Procfile for the supporting dev processes,
corrections to `DEV_SETUP.md` / `DEV_SETUP_MAC.md`, and the fixes needed to make
the documented path actually work on a current Mac.

## Technical Summary

This started as a from-scratch install on a new machine following `DEV_SETUP.md`,
and grew into fixing what that install found. Three kinds of change:

**Things that were broken.**

- The `elasticsearch6` image would not start on Apple Silicon. ES 6.x spawns
  X-Pack ML's native controller at startup regardless of `xpack.ml.enabled`, and
  that binary ships linux-x86_64 only, so under emulation the node dies with
  `error=0, Failed to exec spawn helper`. `Dockerfile.es.6` now removes
  `modules/x-pack-ml/platform`; the spawner skips the module when no controller
  file is present. `xpack.ml.enabled: false` is set alongside it — it does not fix
  the spawn, but HQ uses no ML features and the config should say so.
  `DEV_SETUP_MAC.md` had told Mac developers to omit `elasticsearch6` from the
  docker up command and install ES by hand; that workaround is now demoted to a
  fallback.
- `scripts/docker` swallowed every `docker compose` failure. The trailing
  `if [ "$TEARDOWN" == "yes" ]` was the last command evaluated, so the script
  exited 0 whatever compose did. The status is now captured immediately and
  returned. This affects CI, which calls `scripts/docker test` and
  `scripts/docker down`.


**Things the docs got wrong.** Corrected against the actual install: 

- Homebrew's
`postgresql` is keg-only so `psql` never lands on `PATH`; `brew install sass/sass/sass` needs 
`brew trust` first and exits 0 having installed nothing without it;
- the `xmlsec` workaround is no longer needed now that a prebuilt wheel
is available; 
- the Formplayer section asked for three `localsettings.py` settings
that are all already defaults. 
- Docker Desktop is no longer presented as the only
Mac option — it needs a paid subscription for larger organizations — so
`DEV_SETUP_MAC.md` gains a Container engines section covering Colima and OrbStack
too, including the `cliPluginsExtraDirs` step Colima needs before `docker compose`
resolves.

**New tooling.**

- `scripts/setup-dev.sh` automates the macOS path through both guides. 

- `Procfile.dev` groups webpack, the celery worker and formplayer under
  `uvx honcho start -f Procfile.dev`. 

## Feature Flag

None.

## Safety Assurance

### Safety story

Almost all of this is inert with respect to the deployed application: two new
files that nothing in HQ reads, and documentation. Three changes touch shared
code paths, and each is bounded:



### Automated test coverage



### QA Plan

 On a Mac, run `scripts/setup-dev.sh --check` against your existing environment and confirm it
reports accurately, and ideally have someone set up a fresh machine with it.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
