### PR TITLE
Fix flaky test TestInvitationResource.test_create

### DIFF
--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -1413,7 +1413,7 @@ class TestInvitationResource(APIResourceTest):
         self.addCleanup(invitation.delete)
         self.assertEqual(invitation.get_role_name(), "App Editor")
         self.assertEqual(invitation.primary_location, self.loc1)
-        self.assertEqual(list(invitation.assigned_locations.all()), [self.loc1, self.loc2])
+        self.assertCountEqual(invitation.assigned_locations.all(), [self.loc1, self.loc2])
         self.assertEqual(invitation.profile, self.profile)
         self.assertEqual(invitation.custom_user_data["favorite_subject"], "math")
         self.assertEqual(invitation.tableau_role, "Viewer")


### PR DESCRIPTION
## Product Description


## Technical Summary

Comparing without regard to order is the fix; the ordering was never part of what the test means to assert.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Test-only, single assertion, no production code paths involved.

### Automated test coverage

The changed assertion is itself the coverage.
```
$ pytest corehq/apps/api/tests/test_user_resources.py::TestInvitationResource::test_create
1 failed
```

### QA Plan

None required.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
