### PR TITLE
Allow domain-scoping OAuth tokens

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -43,6 +43,7 @@ from corehq.apps.domain.auth import (
 )
 from corehq.apps.domain.models import Domain, DomainAuditRecordEntry
 from corehq.apps.domain.utils import normalize_domain_name
+from corehq.apps.hqwebapp.oauth_scopes import token_domains
 from corehq.apps.hqwebapp.signals import clear_login_attempts
 from corehq.apps.sso.utils.request_helpers import (
     is_request_blocked_from_viewing_domain_due_to_sso,
@@ -247,18 +248,40 @@ def _oauth2_check(scopes):
         if valid:
             request.user = r.user
             request._auth_method_restricts_superuser_access = True
+            # Read the raw scope string, not `access_token.scopes`, which intersects
+            # against an enumerated dict of static scopes and drops dynamic (domain) scopes.
+            access_token = getattr(r, 'access_token', None)
+            request.oauth_token_domains = token_domains(getattr(access_token, 'scope', None))
             return True
 
     def real_decorator(view):
         def wrapper(request, *args, **kwargs):
-            auth = auth_check(request)
-            if auth:
-                return view(request, *args, **kwargs)
-
-            response = HttpUnauthorized()
-            return response
+            if not auth_check(request):
+                return HttpUnauthorized()
+            if not _oauth_token_allows_request_domain(request):
+                return HttpResponseForbidden()
+            return view(request, *args, **kwargs)
         return wrapper
     return real_decorator
+
+
+def _oauth_token_allows_request_domain(request):
+    """
+    Check an OAuth2 token's project space scope against the requested project space.
+
+    Returns ``True`` when the token is not restricted to any project space.
+
+    A token restricted to one project space is still allowed on project-agnostic
+    endpoints. Those are how a client discovers which projects it may use, so
+    rejecting them would break integration setup.
+    """
+    allowed_domains = getattr(request, 'oauth_token_domains', None)
+    if not allowed_domains:
+        return True
+    domain = getattr(request, 'domain', '')
+    if not domain:
+        return True
+    return domain in allowed_domains
 
 
 def _login_or_challenge(challenge_fn, allow_cc_users=False, api_key=False,

--- a/corehq/apps/domain/tests/test_oauth_domain_scope.py
+++ b/corehq/apps/domain/tests/test_oauth_domain_scope.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock, patch
+
+from django.http.request import HttpRequest
+from django.http.response import HttpResponse
+from django.test import RequestFactory
+
+import pytest
+
+from corehq.apps.domain.decorators import (
+    _oauth2_check,
+    _oauth_token_allows_request_domain,
+)
+
+
+def _make_request(token_domains=None, domain=None):
+    request = HttpRequest()
+    if token_domains is not None:
+        request.oauth_token_domains = frozenset(token_domains)
+    if domain is not None:
+        request.domain = domain
+    return request
+
+
+class TestOauthTokenAllowsRequestDomain:
+
+    def test_token_without_a_project_space_is_unrestricted(self):
+        assert _oauth_token_allows_request_domain(_make_request(token_domains=[], domain='anything'))
+
+    def test_matching_project_space_is_allowed(self):
+        assert _oauth_token_allows_request_domain(
+            _make_request(token_domains=['my-project'], domain='my-project')
+        )
+
+    def test_other_project_space_is_rejected(self):
+        assert not _oauth_token_allows_request_domain(
+            _make_request(token_domains=['my-project'], domain='other-project')
+        )
+
+    def test_project_agnostic_endpoint_is_allowed(self):
+        """
+        These are how a client discovers which projects it may use, so a
+        restricted token must still reach them.
+        """
+        assert _oauth_token_allows_request_domain(_make_request(token_domains=['my-project']))
+
+    @pytest.mark.parametrize('domain, allowed', [
+        ('alpha', True),
+        ('beta', True),
+        ('gamma', False),
+    ])
+    def test_token_restricted_to_several_project_spaces(self, domain, allowed):
+        request = _make_request(token_domains=['alpha', 'beta'], domain=domain)
+        assert _oauth_token_allows_request_domain(request) is allowed
+
+
+def _run_oauth_view(token_scope, domain=None):
+    """Run a view behind ``_oauth2_check`` with a token carrying ``token_scope``."""
+    request_info = MagicMock()
+    request_info.access_token.scope = token_scope
+    request = RequestFactory().get('/')
+    if domain is not None:
+        request.domain = domain
+
+    oauthlib_core = MagicMock()
+    oauthlib_core.verify_request.return_value = (True, request_info)
+
+    with patch('corehq.apps.domain.decorators.get_oauthlib_core', return_value=oauthlib_core):
+        wrapped = _oauth2_check(['access_apis'])(lambda req, *args, **kwargs: HttpResponse())
+        return request, wrapped(request)
+
+
+class TestOauth2CheckEnforcesProjectSpace:
+
+    def test_restricted_token_reaches_its_own_project_space(self):
+        _, response = _run_oauth_view('access_apis domain:my-project', domain='my-project')
+        assert response.status_code == 200
+
+    def test_restricted_token_is_forbidden_on_another_project_space(self):
+        _, response = _run_oauth_view('access_apis domain:my-project', domain='other-project')
+        assert response.status_code == 403
+
+    def test_project_spaces_are_read_off_the_token(self):
+        request, _ = _run_oauth_view('access_apis domain:my-project', domain='my-project')
+        assert request.oauth_token_domains == frozenset({'my-project'})

--- a/corehq/apps/enterprise/models.py
+++ b/corehq/apps/enterprise/models.py
@@ -65,6 +65,17 @@ class EnterprisePermissions(models.Model):
         return list(set(config.domains) - {config.source_domain})
 
     @classmethod
+    def expand_domains(cls, domains):
+        """
+        Each of ``domains``, plus any domain it controls through enterprise
+        permissions.
+        """
+        expanded = set(domains)
+        for domain in domains:
+            expanded.update(cls.get_domains(domain))
+        return sorted(expanded)
+
+    @classmethod
     @quickcache(['domain'], timeout=7 * 24 * 60 * 60)
     def is_source_domain(cls, domain):
         """

--- a/corehq/apps/enterprise/tests/test_permissions.py
+++ b/corehq/apps/enterprise/tests/test_permissions.py
@@ -94,6 +94,12 @@ class EnterprisePermissionsTest(TestCase):
         self.assertListEqual(EnterprisePermissions.get_domains('county'), [])
         self.assertListEqual(EnterprisePermissions.get_domains('staging'), [])
 
+    def test_expand_domains(self):
+        self.assertListEqual(EnterprisePermissions.expand_domains(['state']), ['county', 'state'])
+        self.assertListEqual(EnterprisePermissions.expand_domains(['county']), ['county'])
+        self.assertListEqual(EnterprisePermissions.expand_domains(['staging']), ['staging'])
+        self.assertListEqual(EnterprisePermissions.expand_domains([]), [])
+
     def test_is_source_domain(self):
         self.assertTrue(EnterprisePermissions.is_source_domain('state'))
         self.assertFalse(EnterprisePermissions.is_source_domain('county'))

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -229,15 +229,16 @@ class HQAllowForm(AllowForm):
         label=_('On the project spaces:'),
         widget=forms.SelectMultiple(attrs={
             'class': 'form-select',
-            'x-select2': json.dumps({'allowClear': True}),
+            'x-select2': json.dumps({'selectionCssClass': 'form-select p-1 pb-2 pe-4'}),
             '@select2change': 'selectedDomains = $event.detail || []',
+            'x-ref': 'domains',
         }),
     )
 
     def __init__(self, *args, domain_choices=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['domains'].choices = list(domain_choices or [])
-        self.fields['domains'].widget.attrs['data-placeholder'] = _("Select project spaces")
+        self.fields['domains'].widget.attrs['data-placeholder'] = _("Choose project spaces")
 
     def clean(self):
         cleaned_data = super().clean()

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -1,3 +1,5 @@
+import json
+
 from django import forms
 from django.conf import settings
 from django.contrib.auth.forms import AuthenticationForm
@@ -10,9 +12,11 @@ from captcha.fields import ReCaptchaField
 from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import InlineField, StrictButton
 from crispy_forms.helper import FormHelper
+from oauth2_provider.forms import AllowForm
 from two_factor.forms import AuthenticationTokenForm, BackupTokenForm
 
 from corehq.apps.domain.forms import NoAutocompleteMixin
+from corehq.apps.hqwebapp.oauth_scopes import DOMAIN_SCOPE_PREFIX, domain_scope
 from corehq.apps.users.models import CouchUser
 from corehq.util.metrics import metrics_counter
 
@@ -213,3 +217,46 @@ class HQBackupTokenForm(BackupTokenForm):
             metrics_counter('commcare.auth.lockouts')
             raise ValidationError(LOCKOUT_MESSAGE)
         return cleaned_data
+
+
+class HQAllowForm(AllowForm):
+    """
+    The OAuth2 consent form, extended with a project space choice.
+    """
+
+    domains = forms.MultipleChoiceField(
+        required=False,
+        label=_('On the project spaces:'),
+        widget=forms.SelectMultiple(attrs={
+            'class': 'form-select',
+            'x-select2': json.dumps({'allowClear': True}),
+            '@select2change': 'selectedDomains = $event.detail || []',
+        }),
+    )
+
+    def __init__(self, *args, domain_choices=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['domains'].choices = list(domain_choices or [])
+        self.fields['domains'].widget.attrs['data-placeholder'] = _("Select project spaces")
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if cleaned_data.get('allow') and not cleaned_data.get('domains'):
+            self.add_error(
+                'domains', _("Choose which project spaces this application may access.")
+            )
+        cleaned_data['scope'] = self._scope_with_chosen_project_spaces(cleaned_data)
+        return cleaned_data
+
+    def _scope_with_chosen_project_spaces(self, cleaned_data):
+        """
+        Fold the chosen project spaces into the scope the grant will be made with.
+        """
+        scopes = [
+            scope for scope in (cleaned_data.get('scope') or '').split()
+            if not scope.startswith(DOMAIN_SCOPE_PREFIX)
+        ]
+        # Any project space the client asked for is dropped above: what the user
+        # picked here decides the grant, not what was requested.
+        scopes.extend(domain_scope(domain) for domain in cleaned_data.get('domains') or [])
+        return ' '.join(scopes)

--- a/corehq/apps/hqwebapp/oauth_scopes.py
+++ b/corehq/apps/hqwebapp/oauth_scopes.py
@@ -90,9 +90,8 @@ def token_domains(scope_string):
     >>> token_domains('access_apis')
     frozenset()
     """
-    if not isinstance(scope_string, str):
-        # `access_token` is not always a real token: callers may hold a stand-in
-        # without a usable scope. Treat that as unrestricted rather than failing.
+    if scope_string is None:
+        # No access token on the request, so nothing restricts it.
         return frozenset()
     return frozenset(
         scope.removeprefix(DOMAIN_SCOPE_PREFIX)

--- a/corehq/apps/hqwebapp/oauth_scopes.py
+++ b/corehq/apps/hqwebapp/oauth_scopes.py
@@ -1,0 +1,91 @@
+import re
+
+from django.utils.translation import gettext as _
+from oauth2_provider.scopes import SettingsScopes
+
+from corehq.apps.users.models import CouchUser
+
+DOMAIN_SCOPE_PREFIX = 'domain:'
+ALL_PROJECTS_SCOPE = ''
+
+class ScopeDescriptions(dict):
+    """
+    A scope description mapping that synthesizes an entry for any
+    ``domain:<name>`` key rather than raising ``KeyError``.
+
+    Only lookup is extended. Iteration and ``items()`` still yield the statically
+    configured scopes alone, so a domain scope is described on request but never
+    enumerated.
+    """
+
+    def __missing__(self, key):
+        if key.startswith(DOMAIN_SCOPE_PREFIX):
+            domain = key.removeprefix(DOMAIN_SCOPE_PREFIX)
+            return _('Access data in the "{}" project space only').format(domain)
+        raise KeyError(key)
+
+
+class HQScopes(SettingsScopes):
+    """
+    Adds the dynamic ``domain:<name>`` scope to the statically configured scopes.
+    Wired up via the ``SCOPES_BACKEND_CLASS`` setting.
+    """
+
+    def get_all_scopes(self):
+        return ScopeDescriptions(super().get_all_scopes())
+
+    def get_available_scopes(self, application=None, request=None, *args, **kwargs):
+        scopes = list(super().get_available_scopes(application, request, *args, **kwargs))
+        scopes.extend(self._grantable_domain_scopes(request))
+        return scopes
+
+    def _grantable_domain_scopes(self, request):
+        if request is None:
+            return []
+        requested = getattr(request, 'scopes', None) or []
+        domains = {
+            scope.removeprefix(DOMAIN_SCOPE_PREFIX)
+            for scope in requested
+            if isinstance(scope, str) and scope.startswith(DOMAIN_SCOPE_PREFIX)
+        }
+        user = getattr(request, 'user', None)
+        return [domain_scope(domain) for domain in domains if self._is_grantable(domain, user)]
+
+    def _is_grantable(self, domain, user):
+        from corehq.apps.domain.utils import legacy_domain_re
+
+        if not domain or not re.fullmatch(legacy_domain_re, domain):
+            return False
+        if user is None:
+            # The GET authorize step has no resource owner attached, so membership
+            # cannot be checked yet. The consent POST arrives with the real user
+            # and re-validates before any Grant row is written.
+            return True
+
+        couch_user = CouchUser.from_django_user(user)
+        return couch_user is not None and couch_user.is_member_of(domain, allow_enterprise=True)
+
+
+def token_domains(scope_string):
+    """
+    Parse the project spaces a token is restricted to out of its raw scope string.
+    An empty result means the token is not restricted to any project space.
+
+    >>> sorted(token_domains('access_apis domain:alpha domain:beta'))
+    ['alpha', 'beta']
+    >>> token_domains('access_apis')
+    frozenset()
+    """
+    if not isinstance(scope_string, str):
+        # `access_token` is not always a real token: callers may hold a stand-in
+        # without a usable scope. Treat that as unrestricted rather than failing.
+        return frozenset()
+    return frozenset(
+        scope.removeprefix(DOMAIN_SCOPE_PREFIX)
+        for scope in scope_string.split()
+        if scope.startswith(DOMAIN_SCOPE_PREFIX)
+    )
+
+
+def domain_scope(domain):
+    return f'{DOMAIN_SCOPE_PREFIX}{domain}'

--- a/corehq/apps/hqwebapp/oauth_scopes.py
+++ b/corehq/apps/hqwebapp/oauth_scopes.py
@@ -34,6 +34,20 @@ class HQScopes(SettingsScopes):
     def get_all_scopes(self):
         return ScopeDescriptions(super().get_all_scopes())
 
+    def describe_scopes(self, scopes):
+        """
+        Descriptions for ``scopes``, skipping any that have none. Each must be
+        looked up: checking membership first would report dynamic scopes as absent.
+        """
+        all_scopes = self.get_all_scopes()
+        descriptions = []
+        for scope in scopes:
+            try:
+                descriptions.append(all_scopes[scope])
+            except KeyError:
+                continue
+        return descriptions
+
     def get_available_scopes(self, application=None, request=None, *args, **kwargs):
         scopes = list(super().get_available_scopes(application, request, *args, **kwargs))
         scopes.extend(self._grantable_domain_scopes(request))

--- a/corehq/apps/hqwebapp/oauth_views.py
+++ b/corehq/apps/hqwebapp/oauth_views.py
@@ -1,13 +1,72 @@
 from django.utils.decorators import method_decorator
+
+from memoized import memoized
+from oauth2_provider.models import get_application_model
+from oauth2_provider.scopes import get_scopes_backend
 from oauth2_provider.views.base import AuthorizationView
 
+from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.hqwebapp.forms import HQAllowForm
+from corehq.apps.hqwebapp.oauth_scopes import DOMAIN_SCOPE_PREFIX
 
 
 @method_decorator(use_bootstrap5, name="dispatch")
 class HQAuthorizationView(AuthorizationView):
     """
-    The OAuth2 consent screen, extended with a custom HTML template.
+    The OAuth2 consent screen, extended to ask which project space is being shared.
     """
     urlname = 'oauth_authorize'
     template_name = 'hqwebapp/bootstrap5/oauth_authorize.html'
+    form_class = HQAllowForm
+
+    def get(self, request, *args, **kwargs):
+        # Disable approval_prompt=auto: it reuses an earlier approval and skips
+        # this screen, so a client could replay an authorize URL to get a token
+        # that names no project space. Clients should refresh instead.
+        request.GET = request.GET.copy()
+        request.GET.pop('approval_prompt', None)
+        return super().get(request, *args, **kwargs)
+
+    @property
+    @memoized
+    def domain_choices(self):
+        choices = [
+            (domain, self._domain_display_name(domain))
+            for domain in self.request.couch_user.get_domains()
+        ]
+        return sorted(choices, key=lambda choice: choice[1].lower())
+
+    @staticmethod
+    def _domain_display_name(domain):
+        domain_obj = Domain.get_by_name(domain)
+        return domain_obj.display_name() if domain_obj else domain
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['domain_choices'] = self.domain_choices
+        return kwargs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        scopes = [
+            scope for scope in context.get('scopes') or []
+            if not scope.startswith(DOMAIN_SCOPE_PREFIX)
+        ]
+        context['scopes'] = scopes
+        context['scopes_descriptions'] = get_scopes_backend().describe_scopes(scopes)
+        return context
+
+    def form_invalid(self, form):
+        # The context is built during GET and gone by the time a POST fails, so
+        # rebuild it from the hidden fields the form posted back.
+        client_id = form.data.get('client_id')
+        return self.render_to_response(self.get_context_data(
+            form=form,
+            application=get_application_model().objects.filter(client_id=client_id).first(),
+            client_id=client_id,
+            redirect_uri=form.data.get('redirect_uri'),
+            response_type=form.data.get('response_type'),
+            state=form.data.get('state'),
+            scopes=(form.data.get('scope') or '').split(),
+        ))

--- a/corehq/apps/hqwebapp/oauth_views.py
+++ b/corehq/apps/hqwebapp/oauth_views.py
@@ -33,7 +33,7 @@ class HQAuthorizationView(AuthorizationView):
     def domain_choices(self):
         choices = [
             (domain, self._domain_display_name(domain))
-            for domain in self.request.couch_user.get_domains()
+            for domain in self.request.couch_user.get_domains(allow_enterprise=True)
         ]
         return sorted(choices, key=lambda choice: choice[1].lower())
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/oauth_authorize.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/oauth_authorize.js
@@ -2,4 +2,26 @@ import "commcarehq";
 import Alpine from "alpinejs";
 import "hqwebapp/js/alpinejs/directives/select2";
 
+Alpine.data("consentForm", () => ({
+    selectedDomains: [],
+    domainCount: 0,
+
+    init() {
+        this.domainCount = this.$refs.domains.options.length;
+    },
+
+    setAllDomains(selected) {
+        Array.from(this.$refs.domains.options).forEach((option) => {
+            option.selected = selected;
+        });
+        // Emit this event so select2 knows a change has happened;
+        // programmatically setting selected is otherwise silent
+        this.$refs.domains.dispatchEvent(new Event("change"));
+    },
+
+    get allDomainsSelected() {
+        return this.domainCount > 0 && this.selectedDomains.length === this.domainCount;
+    },
+}));
+
 Alpine.start();

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/oauth_authorize.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/oauth_authorize.js
@@ -1,0 +1,5 @@
+import "commcarehq";
+import Alpine from "alpinejs";
+import "hqwebapp/js/alpinejs/directives/select2";
+
+Alpine.start();

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_select2.scss
@@ -73,6 +73,10 @@
   font-family: $font-family-base;
 }
 
+.select2-container .select2-search--inline .select2-search__field {
+  font-family: $font-family-base !important;
+}
+
 .select2-container.select2-container-active > .select2-choice {
   box-shadow: 0 0 10px $cc-brand-mid;
 }

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/oauth_authorize.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/oauth_authorize.html
@@ -62,7 +62,7 @@
           {% endblocktrans %}
         </h2>
 
-        <form method="post" action="" x-data="{ selectedDomains: [] }">
+        <form method="post" action="" x-data="consentForm">
           {% csrf_token %}
           {% for field in form %}
             {% if field.is_hidden %}{{ field }}{% endif %}
@@ -85,12 +85,37 @@
             <label class="form-label" for="{{ form.domains.id_for_label }}">
               {{ form.domains.label }}
             </label>
+            <div class="mb-2 float-end">
+              <button
+                type="button"
+                class="btn btn-sm btn-link p-0"
+                x-show="domainCount > 1"
+                @click="setAllDomains(true)"
+                :disabled="allDomainsSelected"
+              >
+                {% trans "Select all" %}
+              </button>
+              <button
+                type="button"
+                class="btn btn-sm btn-link p-0 ms-3"
+                @click="setAllDomains(false)"
+                :disabled="selectedDomains.length === 0"
+              >
+                {% trans "Clear" %}
+              </button>
+            </div>
             {{ form.domains }}
             {% for error in form.domains.errors %}
               <div class="text-danger small mt-1">{{ error }}</div>
             {% endfor %}
+            <div
+              class="alert alert-info mt-2 mb-0 py-2"
+              x-show="allDomainsSelected && domainCount > 1"
+            >
+              {% trans "This application will have access to data on all your project spaces." %}
+            </div>
           </div>
-          <div class="mt-3 text-center gap-3">
+          <div class="d-flex justify-content-center gap-2">
             <input
               type="submit"
               class="btn btn-outline-primary btn-lg"

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/oauth_authorize.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/oauth_authorize.html
@@ -3,6 +3,7 @@
 {% load compress %}
 {% load static %}
 {% load hq_shared_tags %}
+{% js_entry "hqwebapp/js/oauth_authorize" %}
 
 {% block stylesheets %}
   {% compress css %}
@@ -61,7 +62,7 @@
           {% endblocktrans %}
         </h2>
 
-        <form method="post" action="">
+        <form method="post" action="" x-data="{ selectedDomains: [] }">
           {% csrf_token %}
           {% for field in form %}
             {% if field.is_hidden %}{{ field }}{% endif %}
@@ -80,6 +81,15 @@
             <div class="alert alert-danger">{{ error }}</div>
           {% endfor %}
 
+          <div class="mb-3" x-cloak>
+            <label class="form-label" for="{{ form.domains.id_for_label }}">
+              {{ form.domains.label }}
+            </label>
+            {{ form.domains }}
+            {% for error in form.domains.errors %}
+              <div class="text-danger small mt-1">{{ error }}</div>
+            {% endfor %}
+          </div>
           <div class="mt-3 text-center gap-3">
             <input
               type="submit"
@@ -91,6 +101,8 @@
               class="btn btn-primary btn-lg"
               name="allow"
               value="{% trans 'Authorize' %}"
+              :disabled="selectedDomains.length === 0"
+              disabled
             />
           </div>
         </form>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/select2s._select2.style.diff.txt
@@ -8,7 +8,7 @@
      margin-left: 10px;
      margin-bottom: 3px;
    }
-@@ -14,74 +15,195 @@
+@@ -14,74 +15,199 @@
  }
  
  // Static width for select2 widgets, which otherwise grow too large on form view's case management tab
@@ -106,6 +106,10 @@
 +.select2-search__field::placeholder {
 +  font-size: $font-size-base;
 +  font-family: $font-family-base;
++}
++
++.select2-container .select2-search--inline .select2-search__field {
++  font-family: $font-family-base !important;
 +}
 +
 +.select2-container.select2-container-active > .select2-choice {

--- a/corehq/apps/hqwebapp/tests/test_oauth_authorize.py
+++ b/corehq/apps/hqwebapp/tests/test_oauth_authorize.py
@@ -1,0 +1,112 @@
+from urllib.parse import parse_qs, urlparse
+
+from django.test import TestCase
+from django.urls import reverse
+
+import pytest
+from oauth2_provider.models import (
+    AbstractApplication,
+    get_application_model,
+    get_grant_model,
+)
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.hqwebapp.forms import HQAllowForm
+from corehq.apps.users.models import WebUser
+
+
+class TestHQAllowForm:
+
+    def build_form(self, domain_choices=None, **data):
+        return HQAllowForm(
+            data={
+                'client_id': 'test-client-id',
+                'response_type': 'code',
+                'redirect_uri': 'https://example.com/callback',
+                'scope': 'access_apis',
+                **data,
+            },
+            domain_choices=domain_choices or [
+                ('alpha', 'Alpha Project'),
+                ('beta', 'Beta Project'),
+            ],
+        )
+
+    def test_domain_choices(self):
+        form = self.build_form(
+            domain_choices=[
+                ('gamma', 'Gamma Project'),
+                ('delta', 'Delta Project'),
+            ]
+        )
+        assert form.fields['domains'].choices == [
+            ('gamma', 'Gamma Project'),
+            ('delta', 'Delta Project'),
+        ]
+
+    @pytest.mark.parametrize('requested, chosen, granted', [
+        ('access_apis', ['alpha'], 'access_apis domain:alpha'),
+        ('access_apis', ['alpha', 'beta'], 'access_apis domain:alpha domain:beta'),
+        ('access_apis domain:beta', ['alpha'], 'access_apis domain:alpha'),
+    ])
+    def test_chosen_project_spaces_become_scopes(self, requested, chosen, granted):
+        form = self.build_form(scope=requested, allow='Authorize', domains=chosen)
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data['scope'] == granted
+
+    def test_authorizing_requires_a_project_space(self):
+        form = self.build_form(allow='Authorize')
+        assert not form.is_valid()
+        assert 'domains' in form.errors
+
+    def test_cancelling_does_not_require_a_project_space(self):
+        """
+        Cancel and Authorize submit the same form; Cancel just omits "allow".
+        """
+        form = self.build_form()
+        assert form.is_valid(), form.errors
+
+    def test_a_project_space_the_user_does_not_have_is_rejected(self):
+        form = self.build_form(allow='Authorize', domains=['not-mine'])
+        assert not form.is_valid()
+        assert 'domains' in form.errors
+
+
+class TestHQOAuthGrant(TestCase):
+    domain = 'consent-test'
+    username = 'consent@example.com'
+    password = '***'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = Domain.get_or_create_with_name(cls.domain, is_active=True)
+        cls.addClassCleanup(cls.domain_obj.delete)
+        cls.user = WebUser.create(cls.domain, cls.username, cls.password, None, None)
+        cls.addClassCleanup(cls.user.delete, cls.domain, deleted_by=None)
+        cls.application = get_application_model().objects.create(
+            name='Test Integration',
+            client_id='test-client-id',
+            client_type=AbstractApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=AbstractApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris='https://example.com/callback',
+            user=cls.user.get_django_user(),
+        )
+        cls.addClassCleanup(cls.application.delete)
+
+    def test_oauth_grant_includes_chosen_domain_scope(self):
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.post(reverse('oauth2_provider:authorize'), {
+            'client_id': self.application.client_id,
+            'response_type': 'code',
+            'redirect_uri': 'https://example.com/callback',
+            'scope': 'access_apis',
+            'allow': 'Authorize',
+            'domains': self.domain,
+        })
+
+        assert response.status_code == 302, response.status_code
+        code = parse_qs(urlparse(response['Location']).query)['code'][0]
+        assert get_grant_model().objects.get(code=code).scope == (
+            f'access_apis domain:{self.domain}'
+        )

--- a/corehq/apps/hqwebapp/tests/test_oauth_scopes.py
+++ b/corehq/apps/hqwebapp/tests/test_oauth_scopes.py
@@ -1,0 +1,133 @@
+import doctest
+from unittest.mock import patch
+
+import pytest
+
+from corehq.apps.hqwebapp import oauth_scopes
+from corehq.apps.hqwebapp.oauth_scopes import (
+    DOMAIN_SCOPE_PREFIX,
+    HQScopes,
+    ScopeDescriptions,
+    domain_scope,
+    token_domains,
+)
+from corehq.apps.users.models import CouchUser
+
+STATIC_SCOPES = {'access_apis', 'reports:view', 'mobile_access', 'sync'}
+
+
+class FakeOAuthRequest:
+    """Stands in for the oauthlib ``Request`` passed to ``get_available_scopes``."""
+
+    def __init__(self, scopes=None, user=None):
+        self.scopes = scopes
+        self.user = user
+
+
+class FakeCouchUser:
+    def __init__(self, domains):
+        self.domains = domains
+
+    def is_member_of(self, domain, allow_enterprise=False):
+        return domain in self.domains
+
+
+def _member_of(*domains):
+    """Stand the requesting user in for one belonging to ``domains``."""
+    return patch.object(CouchUser, 'from_django_user', return_value=FakeCouchUser(domains))
+
+
+def test_doctests():
+    results = doctest.testmod(oauth_scopes)
+    assert results.failed == 0
+
+
+def test_domain_scope():
+    assert domain_scope('my-project') == 'domain:my-project'
+
+
+@pytest.mark.parametrize('scope_string, expected', [
+    ('', frozenset()),
+    ('access_apis', frozenset()),
+    ('access_apis domain:alpha', frozenset({'alpha'})),
+    ('access_apis domain:alpha domain:beta', frozenset({'alpha', 'beta'})),
+    ('domain:alpha', frozenset({'alpha'})),
+    # Whitespace-separated, in any order, with duplicates collapsed.
+    ('  domain:alpha   access_apis  domain:alpha ', frozenset({'alpha'})),
+    # A scope that merely contains the prefix is not a domain scope.
+    ('access_apis notdomain:alpha', frozenset()),
+])
+def test_token_domains(scope_string, expected):
+    assert token_domains(scope_string) == expected
+
+
+@pytest.mark.parametrize('scope_string', [None, 42, object(), ['domain:alpha']])
+def test_token_domains_ignores_non_strings(scope_string):
+    assert token_domains(scope_string) == frozenset()
+
+
+def test_token_domains_fails_closed_on_empty_domain():
+    """
+    A bare ``domain:`` yields an unmatchable restriction rather than no restriction.
+
+    Such a scope is not grantable, so this only matters if one is written directly
+    to the database. Denying every project space is the safe reading.
+    """
+    assert token_domains('access_apis domain:') == frozenset({''})
+
+
+class TestScopeDescriptions:
+
+    def test_static_scopes_pass_through(self):
+        descriptions = ScopeDescriptions({'access_apis': 'Access CommCare API data'})
+        assert descriptions['access_apis'] == 'Access CommCare API data'
+
+    def test_domain_scope_is_synthesized(self):
+        descriptions = ScopeDescriptions()
+        assert 'my-project' in descriptions[f'{DOMAIN_SCOPE_PREFIX}my-project']
+
+    def test_unknown_scope_raises(self):
+        descriptions = ScopeDescriptions()
+        with pytest.raises(KeyError):
+            descriptions['bogus']
+
+
+class TestHQScopes:
+
+    def test_get_all_scopes_supports_domain_lookup(self):
+        all_scopes = HQScopes().get_all_scopes()
+        assert STATIC_SCOPES.issubset(all_scopes.keys())
+        assert 'my-project' in all_scopes[f'{DOMAIN_SCOPE_PREFIX}my-project']
+
+    def test_available_scopes_without_a_request(self):
+        """OIDC discovery calls this with no arguments; it must not raise."""
+        assert set(HQScopes().get_available_scopes()) == STATIC_SCOPES
+
+    def test_available_scopes_without_a_requested_domain(self):
+        request = FakeOAuthRequest(scopes=['access_apis'])
+        assert set(HQScopes().get_available_scopes(request=request)) == STATIC_SCOPES
+
+    def test_unauthenticated_authorize_step_permits_a_valid_project_space(self):
+        """
+        The GET authorize step has no resource owner, so the consent screen can
+        render for any syntactically valid project space.
+        """
+        request = FakeOAuthRequest(scopes=['access_apis', 'domain:my-project'], user=None)
+        assert 'domain:my-project' in HQScopes().get_available_scopes(request=request)
+
+    @pytest.mark.parametrize('domain', ['has space', 'has/slash', '', 'has?query'])
+    def test_syntactically_invalid_project_space_is_rejected(self, domain):
+        request = FakeOAuthRequest(scopes=[f'{DOMAIN_SCOPE_PREFIX}{domain}'], user=None)
+        available = HQScopes().get_available_scopes(request=request)
+        assert set(available) == STATIC_SCOPES
+
+    @pytest.mark.parametrize('requested, granted', [
+        (['domain:mine'], {'domain:mine'}),
+        (['domain:not-mine'], set()),
+        (['domain:mine', 'domain:not-mine'], {'domain:mine'}),
+    ])
+    def test_only_project_spaces_the_user_belongs_to_are_grantable(self, requested, granted):
+        request = FakeOAuthRequest(scopes=requested, user=object())
+        with _member_of('mine'):
+            available = HQScopes().get_available_scopes(request=request)
+        assert set(available) == STATIC_SCOPES | granted

--- a/corehq/apps/hqwebapp/tests/test_oauth_scopes.py
+++ b/corehq/apps/hqwebapp/tests/test_oauth_scopes.py
@@ -99,6 +99,20 @@ class TestHQScopes:
         assert STATIC_SCOPES.issubset(all_scopes.keys())
         assert 'my-project' in all_scopes[f'{DOMAIN_SCOPE_PREFIX}my-project']
 
+    def test_describe_scopes_covers_static_and_domain_scopes(self):
+        descriptions = HQScopes().describe_scopes(
+            ['access_apis', f'{DOMAIN_SCOPE_PREFIX}my-project']
+        )
+        assert len(descriptions) == 2
+        assert 'my-project' in descriptions[1]
+
+    def test_describe_scopes_skips_what_it_cannot_describe(self):
+        """
+        form_invalid feeds this the posted scope field, which is whatever came
+        back through the browser. Raising would turn a validation error into a 500.
+        """
+        assert HQScopes().describe_scopes(['bogus']) == []
+
     def test_available_scopes_without_a_request(self):
         """OIDC discovery calls this with no arguments; it must not raise."""
         assert set(HQScopes().get_available_scopes()) == STATIC_SCOPES

--- a/corehq/apps/hqwebapp/tests/test_oauth_scopes.py
+++ b/corehq/apps/hqwebapp/tests/test_oauth_scopes.py
@@ -47,6 +47,7 @@ def test_domain_scope():
 
 
 @pytest.mark.parametrize('scope_string, expected', [
+    (None, frozenset()),
     ('', frozenset()),
     ('access_apis', frozenset()),
     ('access_apis domain:alpha', frozenset({'alpha'})),
@@ -59,11 +60,6 @@ def test_domain_scope():
 ])
 def test_token_domains(scope_string, expected):
     assert token_domains(scope_string) == expected
-
-
-@pytest.mark.parametrize('scope_string', [None, 42, object(), ['domain:alpha']])
-def test_token_domains_ignores_non_strings(scope_string):
-    assert token_domains(scope_string) == frozenset()
 
 
 def test_token_domains_fails_closed_on_empty_domain():

--- a/corehq/apps/receiverwrapper/tests/test_auth.py
+++ b/corehq/apps/receiverwrapper/tests/test_auth.py
@@ -303,6 +303,46 @@ class _AuthTestsBothBackends(object):
             expected_status=401
         )
 
+    def test_oauth2_token_scoped_to_this_project_space(self):
+        client = Client(HTTP_AUTHORIZATION="bearer scopedtoken")
+        token_model = get_access_token_model()
+        one_hour = datetime.now() + timedelta(hours=1)
+        token_model.objects.create(
+            user=self.user.get_django_user(),
+            token='scopedtoken',
+            scope=f'sync domain:{self.domain}',
+            expires=one_hour
+        )
+        expected_auth_context = {
+            'doc_type': 'AuthContext',
+            'domain': self.domain,
+            'authenticated': True,
+            'user_id': self.user.get_id,
+        }
+        self._test_post(
+            file_path=self.bare_form,
+            client=client,
+            authtype='oauth2',
+            expected_auth_context=expected_auth_context
+        )
+
+    def test_oauth2_token_scoped_to_another_project_space(self):
+        client = Client(HTTP_AUTHORIZATION="bearer othertoken")
+        token_model = get_access_token_model()
+        one_hour = datetime.now() + timedelta(hours=1)
+        token_model.objects.create(
+            user=self.user.get_django_user(),
+            token='othertoken',
+            scope='sync domain:some-other-domain',
+            expires=one_hour
+        )
+        self._test_post(
+            file_path=self.bare_form,
+            client=client,
+            authtype='oauth2',
+            expected_status=403
+        )
+
 
 class AuthCouchOnlyTest(TestCase, AuthTestMixin, _AuthTestsCouchOnly):
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -664,12 +664,14 @@ class _AuthorizableMixin(IsMemberOfMixin):
             or self.has_permission(domain, 'edit_linked_configurations')
         )
 
-    def get_domains(self):
+    def get_domains(self, allow_enterprise=False):
         domains = [dm.domain for dm in self.domain_memberships]
-        if set(domains) == set(self.domains):
-            return domains
-        else:
+        if set(domains) != set(self.domains):
             raise self.Inconsistent("domains and domain_memberships out of sync")
+        if allow_enterprise:
+            from corehq.apps.enterprise.models import EnterprisePermissions
+            return EnterprisePermissions.expand_domains(domains)
+        return domains
 
     @memoized
     def has_permission(self, domain, permission, data=None):
@@ -2517,8 +2519,12 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     def get_language_code(self):
         return self.language
 
-    def get_domains(self):
-        return [dm.domain for dm in self.domain_memberships]
+    def get_domains(self, allow_enterprise=False):
+        domains = [dm.domain for dm in self.domain_memberships]
+        if allow_enterprise:
+            from corehq.apps.enterprise.models import EnterprisePermissions
+            return EnterprisePermissions.expand_domains(domains)
+        return domains
 
     @classmethod
     def get_admins_by_domain(cls, domain):

--- a/settings.py
+++ b/settings.py
@@ -891,9 +891,10 @@ OAUTH2_PROVIDER = {
     # https://django-oauth-toolkit.readthedocs.io/en/latest/settings.html#access-token-expire-seconds
     'ACCESS_TOKEN_EXPIRE_SECONDS': 15 * 60,
     'PKCE_REQUIRED': _pkce_required,
+    'SCOPES_BACKEND_CLASS': 'corehq.apps.hqwebapp.oauth_scopes.HQScopes',
     'SCOPES': {
-        'access_apis': 'Access API data on all your CommCare projects',
-        'reports:view': 'Allow users to view and download all report data',
+        'access_apis': 'Access CommCare API data',
+        'reports:view': 'View and download report data',
         'mobile_access': 'Allow access to mobile sync and submit endpoints',
         'sync': '(Deprecated, do not use) Allow access to mobile endpoints',
     },


### PR DESCRIPTION
## Product Description
Makes OAuth authorization requests ask for domain scope - allows selection of any number of project spaces but removes the implicit "all domains" access that this page used to apply.

https://github.com/user-attachments/assets/4e2cdcd1-e71e-4ac1-ada9-a9f92c5e5df7



## Technical Summary
Part of division dev week. Adds an optional domain scope `domain:{domain}` to OAuth token scopes by creating a custom scopes backend. This is enforced through changes to the existing oauth decorator, so it applies to all views/endpoints currently accessible to oauth. 

`_oauth2_check` is run inside the `login_or_oauth2_ex` decorator, which passes to the existing `_login_or_challenge` function to ensure the authenticated user has access to the resource. This modifies `_oauth2_check`: If the oauth token has a domain scope, we ensure that either the resource is domain-agnostic, or that the domain for this request is in the list of domain scopes on the token.

The old implicit "all domains" scope is still usable for backwards compatibility, but is no longer accessible to a user through UI: Select All explicitly selects all their projects rather than using the "all domains" scope.

## Safety Assurance

### Safety story
Tested locally and on staging. Changes are well-tested and follow convention for adding scopes to oauth tokens (space-separated, colon as modifier). The oauth decorator still runs existing auth checks - this adds another layer of security and does not remove any.

### Automated test coverage
Tests added for new domain scope, that scope is respected in the oauth decorator, that the form generates and saves domain scopes correctly, and that a list of enterprise-controlled domains can be returned correctly.

### QA Plan
Not planning formal QA.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
