### PR TITLE
Improve OAuth UI: match HQ styling

### DIFF
--- a/corehq/apps/hqwebapp/oauth_views.py
+++ b/corehq/apps/hqwebapp/oauth_views.py
@@ -1,0 +1,13 @@
+from django.utils.decorators import method_decorator
+from oauth2_provider.views.base import AuthorizationView
+
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
+
+
+@method_decorator(use_bootstrap5, name="dispatch")
+class HQAuthorizationView(AuthorizationView):
+    """
+    The OAuth2 consent screen, extended with a custom HTML template.
+    """
+    urlname = 'oauth_authorize'
+    template_name = 'hqwebapp/bootstrap5/oauth_authorize.html'

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/oauth_authorize.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/oauth_authorize.html
@@ -1,0 +1,100 @@
+{% extends "hqwebapp/bootstrap5/base_page.html" %}
+{% load i18n %}
+{% load compress %}
+{% load static %}
+{% load hq_shared_tags %}
+
+{% block stylesheets %}
+  {% compress css %}
+    <link
+      type="text/scss"
+      rel="stylesheet"
+      media="all"
+      href="{% static 'registration/scss/registration.scss' %}"
+    />
+  {% endcompress %}
+{% endblock stylesheets %}
+
+{% block background_content %}
+  <div class="bg-container">
+    <div class="bg-overlay"></div>
+  </div>
+{% endblock background_content %}
+
+{% block navigation %}
+  <nav
+    id="hq-navigation"
+    class="navbar navbar-expand-lg bg-light border-bottom-1 navbar-hq-main-menu"
+  >
+    <div class="container-fluid">
+      <div class="navbar-header hq-header">
+        <a
+          href="{% if request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}#{% else %}{% url "homepage" %}{% endif %}"
+          class="navbar-brand"
+        >
+          {% if CUSTOM_LOGO_URL %}
+            <img src="{{ CUSTOM_LOGO_URL }}" alt="CommCare HQ Logo" />
+          {% else %}
+            <!-- _navbar.scss supplies the default logo -->
+            <div></div>
+          {% endif %}
+        </a>
+      </div>
+    </div>
+  </nav>
+{% endblock navigation %}
+
+{% block title %}{% trans "Authorize Application" %}{% endblock title %}
+
+{% block content %}
+  <div class="reg-form-container">
+    {% if error %}
+      <div class="alert alert-danger">
+        <h2 class="h5">{% trans "Error" %}: {{ error.error }}</h2>
+        <p class="mb-0">{{ error.description }}</p>
+      </div>
+    {% else %}
+      <div class="form-bubble form-bubble-lg">
+        <h2 class="text-center mt-3">
+          {% blocktrans with application_name=application.name %}
+            Authorize {{ application_name }}?
+          {% endblocktrans %}
+        </h2>
+
+        <form method="post" action="">
+          {% csrf_token %}
+          {% for field in form %}
+            {% if field.is_hidden %}{{ field }}{% endif %}
+          {% endfor %}
+
+          <p class="mt-3">
+            {% trans "This application is requesting permission to:" %}
+          </p>
+          <ul>
+            {% for description in scopes_descriptions %}
+              <li>{{ description }}</li>
+            {% endfor %}
+          </ul>
+
+          {% for error in form.non_field_errors %}
+            <div class="alert alert-danger">{{ error }}</div>
+          {% endfor %}
+
+          <div class="mt-3 text-center gap-3">
+            <input
+              type="submit"
+              class="btn btn-outline-primary btn-lg"
+              value="{% trans 'Cancel' %}"
+            />
+            <input
+              type="submit"
+              class="btn btn-primary btn-lg"
+              name="allow"
+              value="{% trans 'Authorize' %}"
+            />
+          </div>
+        </form>
+      </div>
+    {% endif %}
+  </div>
+{% endblock content %}

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -10,6 +10,7 @@ from corehq.apps.domain.forms import ConfidentialDomainPasswordResetForm
 from corehq.apps.domain.views.settings import DomainPasswordResetView
 from corehq.apps.domain.views.sms import PublicSMSRatesView
 from corehq.apps.hqwebapp.decorators import waf_allow
+from corehq.apps.hqwebapp.oauth_views import HQAuthorizationView
 from corehq.apps.hqwebapp.session_details_endpoint.views import (
     SessionDetailsView,
 )
@@ -116,6 +117,7 @@ urlpatterns = [
         waf_allow('EC2MetaDataSSRF_BODY')(OauthApplicationRegistration.as_view()),
         name=OauthApplicationRegistration.urlname
     ),
+    url(r'^oauth/authorize/$', HQAuthorizationView.as_view(), name=HQAuthorizationView.urlname),
     url(r'^oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     url(r'^check_sso_login_status/', check_sso_login_status, name='check_sso_login_status'),
 ]


### PR DESCRIPTION
## Product Description
Replaces the generic OAuth request template with one styled for CommCare

Before:
<img width="1007" height="862" alt="image" src="https://github.com/user-attachments/assets/21462169-7692-481f-afd7-08a76afc3604" />


After:
<img width="1006" height="860" alt="image" src="https://github.com/user-attachments/assets/a5469179-0aa6-4cd1-a29d-92b2f9d9e0b9" />


## Technical Summary
Subclasses `AuthorizationView` from `oauth2_provider` to style the page according to the rest of HQ, and serves it at the same URL that the `oauth` url group would by default. Initial UI improvement to further work on OAuth workflow in HQ.

## Safety Assurance

### Safety story
Just affects UI; at this point it uses exactly the same form and underlying view functionality. Tested locally.

### Automated test coverage
Not here.

### QA Plan
Not for this change.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
