### PR TITLE
Do not create new resource on failed update due to missing object in APIs

### DIFF
--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -5,7 +5,12 @@ from django.http import HttpResponse
 from django.urls import NoReverseMatch, include, re_path
 
 from tastypie import http
-from tastypie.exceptions import BadRequest, ImmediateHttpResponse, InvalidSortError
+from tastypie.exceptions import (
+    BadRequest,
+    ImmediateHttpResponse,
+    InvalidSortError,
+    NotFound,
+)
 from tastypie.resources import Resource, convert_post_to_patch
 from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
@@ -168,6 +173,47 @@ class HqBaseResource(ApiVersioningMixin, CorsResourceMixin, JsonResourceMixin, R
 
     def get_required_privilege(self):
         return privileges.API_ACCESS
+
+    def put_detail(self, request, **kwargs):
+        """Update an existing object, or respond 404 if it does not exist.
+
+        Exactly copied from https://github.com/django-tastypie/django-tastypie/blob/v0.15.1/tastypie/resources.py#L1467
+        (BSD licensed) and modified to drop tastypie's fallback to
+        ``obj_create`` when ``obj_update`` raises ``NotFound``. That
+        fallback treats PUT as an upsert, but creates the object with a
+        server-generated id rather than the one provided in the URL, so a
+        caller that meant to update one record silently gets an unrelated
+        new one instead.
+
+        ``MultipleObjectsReturned`` is deliberately not caught: an
+        ambiguous id is a server-side data problem, not a reason to create
+        another object.
+        """
+        deserialized = self.deserialize(
+            request, request.body, format=request.META.get('CONTENT_TYPE', 'application/json'))
+        deserialized = self.alter_deserialized_detail_data(request, deserialized)
+        bundle = self.build_bundle(data=deserialized, request=request)
+
+        try:
+            updated_bundle = self.obj_update(bundle=bundle, **self.remove_api_resource_names(kwargs))
+        except NotFound:
+            # --- this part differs from the source ---
+            # tastypie's wrap_view() does not translate NotFound into a 404.
+            # The exception message is not echoed back: some of these carry
+            # internal detail, and tastypie's own get_detail() likewise
+            # answers a missing object with an empty 404 body.
+            return http.HttpNotFound()
+            # --- end of diff ---
+
+        if not self._meta.always_return_data:
+            return http.HttpNoContent()
+
+        # Invalidate prefetched_objects_cache for bundled object
+        # because we might have changed a prefetched field
+        updated_bundle.obj._prefetched_objects_cache = {}
+        updated_bundle = self.full_dehydrate(updated_bundle)
+        updated_bundle = self.alter_detail_data_to_serialize(request, updated_bundle)
+        return self.create_response(request, updated_bundle)
 
     def patch_list_replica(self, create_or_update_object, request=None, obj_limit=None, **kwargs):
         """

--- a/corehq/apps/api/tests/lookup_table_resources.py
+++ b/corehq/apps/api/tests/lookup_table_resources.py
@@ -253,6 +253,36 @@ class TestLookupTableResource(APIResourceTest):
         self.assertEqual(data_type.fields[0].properties, ['lang', 'name'])
         self.assertEqual(data_type.item_attributes, ['X'])
 
+    def test_cant_update_missing_lookup_table(self):
+        missing_id = uuid.uuid4()
+        # tag is required, but not checked when the id does not exist
+        lookup_table = {"tag": "brand_new_tag", "item_attributes": ["X"]}
+
+        response = self._assert_auth_post_resource(
+            self.single_endpoint(missing_id), json.dumps(lookup_table), method="PUT")
+
+        assert response.status_code == 404, response.content
+        assert not LookupTable.objects.filter(id=missing_id).exists()
+        assert LookupTable.objects.by_domain(self.domain.name).count() == 1
+
+    def test_cant_update_lookup_table_in_another_domain(self):
+        not_my_domain = 'not-my-project'
+        not_my_data_type = LookupTable(
+            domain=not_my_domain,
+            tag="their_table",
+            fields=[TypeField("fixture_property", ["lang", "name"])],
+            item_attributes=[]
+        )
+        not_my_data_type.save()
+        lookup_table = {"tag": "their_table", "item_attributes": ["X"]}
+
+        response = self._assert_auth_post_resource(
+            self.single_endpoint(not_my_data_type.id), json.dumps(lookup_table), method="PUT")
+
+        assert response.status_code == 404, response.content
+        assert LookupTable.objects.by_domain(self.domain.name).count() == 1
+        assert LookupTable.objects.get(id=not_my_data_type.id).item_attributes == []
+
     def test_update_field_name(self):
         lookup_table = {
             "fields": [{"name": "property", "properties": ["value"]}],
@@ -387,6 +417,50 @@ class TestLookupTableItemResourceV06(APIResourceTest):
         self.assertIn("[] is not of type 'object':", errors[0])
         data_item = LookupTableRow.objects.filter(domain=self.domain.name).first()
         self.assertIsNone(data_item)
+
+    def test_cant_update_missing_lookup_table_item(self):
+        missing_id = uuid.uuid4()
+        data_item_update = self._get_data_item_update()
+
+        response = self._assert_auth_post_resource(
+            self.single_endpoint(missing_id.hex),
+            json.dumps(data_item_update),
+            method="PUT",
+        )
+
+        assert response.status_code == 404, response.content
+        assert not LookupTableRow.objects.filter(id=missing_id).exists()
+        assert not LookupTableRow.objects.filter(domain=self.domain.name).exists()
+
+    def test_cant_update_lookup_table_item_in_another_domain(self):
+        not_my_domain = 'not-my-project'
+        not_my_data_type = LookupTable(
+            domain=not_my_domain,
+            tag="their_table",
+            fields=[TypeField("fixture_property", ["lang", "name"])],
+            item_attributes=[]
+        )
+        not_my_data_type.save()
+        not_my_data_item = LookupTableRow(
+            domain=not_my_domain,
+            table_id=not_my_data_type.id,
+            fields={"state_name": [Field(value="Tennessee", properties={"lang": "en"})]},
+            item_attributes={},
+            sort_key=1
+        )
+        not_my_data_item.save()
+        data_item_update = self._get_data_item_update()
+        data_item_update["data_type_id"] = not_my_data_type.id.hex
+
+        response = self._assert_auth_post_resource(
+            self.single_endpoint(not_my_data_item.id.hex),
+            json.dumps(data_item_update),
+            method="PUT",
+        )
+
+        assert response.status_code == 404, response.content
+        assert not LookupTableRow.objects.filter(domain=self.domain.name).exists()
+        assert LookupTableRow.objects.get(id=not_my_data_item.id).item_attributes == {}
 
     def test_update_field_value(self):
         data_item = self._create_data_item()

--- a/corehq/apps/api/tests/test_ucr_resources.py
+++ b/corehq/apps/api/tests/test_ucr_resources.py
@@ -163,6 +163,24 @@ class TestSimpleReportConfigurationResource(APIResourceTest):
         self.assertEqual(response.status_code, 403)  # 403 is "Forbidden"
 
 
+class TestDataSourceConfigurationResource(APIResourceTest):
+    resource = v0_5.DataSourceConfigurationResource
+    api_name = "v0.5"
+
+    @flag_enabled('USER_CONFIGURABLE_REPORTS')
+    def test_cant_update_missing_data_source(self):
+        response = self._assert_auth_post_resource(
+            self.single_endpoint(uuid.uuid4().hex),
+            json.dumps({"display_name": "renamed"}),
+            method="PUT",
+        )
+
+        assert response.status_code == 404, response.content
+        # put_detail must not echo the exception message: some carry internal
+        # detail, and get_document_or_404 even embeds a traceback
+        assert response.content == b""
+
+
 class TestConfigurableReportDataResource(APIResourceTest):
     resource = v0_5.ConfigurableReportDataResource
     api_name = "v0.5"

--- a/docs/api/fixture.rst
+++ b/docs/api/fixture.rst
@@ -307,6 +307,12 @@ Edit or Delete Lookup Table
         ]
     }
 
+**Response**
+
+PUT only updates an existing lookup table; it never creates one. If no lookup
+table with the given ID exists in the domain, the response is 404 Not Found.
+Use the Create Lookup Table endpoint to add a new lookup table.
+
 
 Lookup Table Rows API
 =====================
@@ -461,3 +467,9 @@ Edit or Delete Lookup Table Row
         }
       }
     }
+
+**Response**
+
+PUT only updates an existing lookup table row; it never creates one. If no row
+with the given ID exists in the domain, the response is 404 Not Found. Use the
+Create Lookup Table Row endpoint to add a new row.


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
API clients that `PUT` to an ID that does not exist now receive a 404. Previously they received a 201 for a brand new object they did not ask to create, at an ID they had no way to discover.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-20192

This is primarily an issue with the lookup table and lookup table row APIs. If executing a `PUT` against a specified ID, and that object does not exist in the db, tastypie routes the raised `NotFound` error to `obj_create`, resulting in a new object being created that doesn't even have the same ID as what the user requested.

We want our APIs to behave consistently, so the goal is always return a 404 when a user requests some action on an ID that does not exist.

The same path also swallowed cross-domain requests. A `PUT` to an ID belonging to another domain raises `NotFound` on the domain mismatch, so tastypie created a new object in the caller's domain rather than returning 404. For `lookup_table_item` that meant a new row in the caller's domain pointing at another domain's table.

`MultipleObjectsReturned` is intentionally no longer caught either. tastypie treated it as one more reason to create, but an ambiguous ID shouldn't be possible with our resources since these should be unique keys, so it now surfaces as a 500 rather than quietly creating an object.

### Follow-ups
These are left deliberately out of scope, to be stacked on top of this PR:

- `user` and `group` `PUT` still return 500 on both a missing ID and a cross-domain ID. They raise couch's `ResourceNotFound` and an `AssertionError` respectively, and will be handled separately.
- `user` `GET` returns a 400 with an internal serialization message, because `UserResource.obj_get` returns `None` instead of raising
- `location` `PUT` returns 400 rather than 404. Unlike the above, that one is deliberate and tested today, and changing it impacts the documented bulk `PATCH` behavior as well, so I'm saving that for a separate PR.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
**The change is narrower than the diff suggests.** It is a `put_detail` override on `HqBaseResource`, which nearly every API resource inherits, but **only three endpoints change behavior:** `lookup_table`, `lookup_table_item`, and `ucr_data_source`. The override only intercepts tastypie's `NotFound`, and no other resource that allows `PUT` raises it. `user` and `group` raise couch's `ResourceNotFound`, and `location` raises a `BadRequest` subclass. Those paths are untouched.

`ucr_data_source` changes here as a side effect of the override rather than by design: it already raised tastypie's `NotFound`, but defined no `obj_create`, so the upsert hit tastypie's base stub and a `PUT` to a missing ID returned 500. It now returns 404, and is covered by a test in this PR. The resource-level cleanup and its remaining coverage land in the stacked follow-up.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
New tests cover both `PUT` to a nonexistent ID and `PUT` to an ID owned by another domain, asserting the 404 and that no object was created:

- `lookup_table`
- `lookup_table_item`
- `ucr_data_source` (missing ID; this resource previously had no test coverage at all)

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


