### PR TITLE
Upgrade django-oauth-toolkit from 2.3.0 to 3.4.0

### DIFF
--- a/corehq/apps/dump_reload/tests/test_dump_models.py
+++ b/corehq/apps/dump_reload/tests/test_dump_models.py
@@ -136,6 +136,7 @@ UNKNOWN_MODELS = {
     "ivr.Call",
     "oauth2_provider.AccessToken",
     "oauth2_provider.Application",
+    "oauth2_provider.DeviceGrant",
     "oauth2_provider.Grant",
     "oauth2_provider.IDToken",
     "oauth2_provider.RefreshToken",

--- a/migrations.lock
+++ b/migrations.lock
@@ -825,6 +825,19 @@ oauth2_provider
  0005_auto_20211222_2352
  0006_alter_application_client_secret
  0007_application_post_logout_redirect_uris
+ 0008_alter_accesstoken_token
+ 0009_add_hash_client_secret
+ 0010_application_allowed_origins
+ 0011_refreshtoken_token_family
+ 0012_add_token_checksum
+ 0013_alter_application_authorization_grant_type_device
+ 0014_alter_help_text
+ 0015_refreshtoken_token_checksum
+ 0016_alter_devicegrant_scope
+ 0017_application_dcr_created
+ 0018_resource_indicators
+ 0019_application_registration_source
+ 0020_cimd_application_fields
 ota
  0001_initial
  0002_alter_db_index

--- a/urls.py
+++ b/urls.py
@@ -4,6 +4,10 @@ from django.contrib import admin
 from django.shortcuts import render
 from django.views.generic import RedirectView, TemplateView
 
+from oauth2_provider.urls import (
+    metadata_urlpatterns as oauth2_metadata_urlpatterns,
+)
+
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.extensions import extension_points
 from corehq.apps.enterprise.urls import \
@@ -103,6 +107,11 @@ for url_module in extension_points.domain_specific_urls():
 urlpatterns = [
     url(r'^favicon\.ico$', RedirectView.as_view(
         url=static('hqwebapp/images/favicon2.png'), permanent=True)),
+    # Strict RFC 8414 well-known URIs must live at the domain root. The distinct
+    # instance namespace keeps reverse("oauth2_provider:...") pointing at the
+    # /oauth/ mount in corehq.apps.hqwebapp.urls.
+    url(r'^', include((oauth2_metadata_urlpatterns, 'oauth2_provider'),
+                      namespace='oauth2_metadata')),
     url(r'^auditcare/', include('corehq.apps.auditcare.urls')),
     url(r'^admin/', admin.site.urls),
     url(r'^analytics/', include('corehq.apps.analytics.urls')),

--- a/uv.lock
+++ b/uv.lock
@@ -1167,17 +1167,18 @@ wheels = [
 
 [[package]]
 name = "django-oauth-toolkit"
-version = "2.3.0"
+version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
     { name = "jwcrypto" },
     { name = "oauthlib" },
     { name = "requests" },
+    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/2b/e0353101e242f1fb4e90a9bc5aa43894afd73e2e4650f40c6579e8f39389/django-oauth-toolkit-2.3.0.tar.gz", hash = "sha256:cf1cb1a5744672e6bd7d66b4a110a463bcef9cf5ed4f27e29682cc6a4d0df1ed", size = 89737, upload-time = "2023-05-31T21:04:46.768Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/a7/f185dc058f859b104c1fed06ab25eeebbb7e182c3e25c6f7e11e8df3f739/django_oauth_toolkit-3.4.0.tar.gz", hash = "sha256:e43bef1568d6322b44175e27eff82ed7d7cf210889a07d10b8a64e4190ff1351", size = 220227, upload-time = "2026-07-24T02:50:38.186Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/d7/0cbac32a14981d96e951c0fe76a113c4d415db2b093bdfdbbbbeea9df0e6/django_oauth_toolkit-2.3.0-py3-none-any.whl", hash = "sha256:47dfeab97ec21496f307c2cf3468e64ca08897fa499bf3104366d32005c9111d", size = 68890, upload-time = "2023-05-31T21:05:34.805Z" },
+    { url = "https://files.pythonhosted.org/packages/56/64/3cb3a71aaac17ebfc1db56522fdacddeb79dd041f1174584b210988df4c3/django_oauth_toolkit-3.4.0-py3-none-any.whl", hash = "sha256:c504457898a363d332fb98beed5eceeec9da4aa659055a50a93aa52e8ed55534", size = 145738, upload-time = "2026-07-24T02:50:36.852Z" },
 ]
 
 [[package]]
@@ -2106,11 +2107,11 @@ wheels = [
 
 [[package]]
 name = "oauthlib"
-version = "3.1.0"
+version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/c7/829c73c64d3749da7811c06319458e47f3461944da9d98bb4df1cb1598c2/oauthlib-3.1.0.tar.gz", hash = "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889", size = 155362, upload-time = "2019-08-06T14:50:42.995Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/57/ce2e7a8fa7c0afb54a0581b14a65b56e62b5759dbc98e80627142b8a3704/oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea", size = 147368, upload-time = "2019-08-06T14:50:40.718Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Product Description

No user-facing changes to existing OAuth flows. New: standards-based OAuth clients (including MCP clients) can now discover our authorization server via the RFC 8414 / RFC 9728 well-known endpoints at the domain root, e.g. `/.well-known/oauth-authorization-server/oauth`.

## Technical Summary

Upgrades `django-oauth-toolkit` from `2.3.0` to `3.4.0` and mounts the new server-metadata URLs at the domain root.


**Notable upstream changes**:
- Security fixes: unauthenticated open redirect from the authorization endpoint (`prompt=none`), client secrets no longer written to debug logs, cleartext tokens/codes no longer exposed or searchable in the Django admin, unguessable device-flow codes.
- `AccessToken`/`RefreshToken` lookups now go through a SHA-256 `token_checksum` field (tokens are still stored in cleartext; the checksum is computed automatically on save).
- Deprecations to track for 4.0: the implicit and password grants and plain PKCE emit `DeprecationWarning`s now and will be **rejected by default in 4.0** (RFC 9700 compliance gates). 
We audited production `Oauth application` rows for `authorization_grant_type` in (`password`, `implicit`) and found only Connect being the one using `password`. This has been communicated with Connect team but we can keep supporting them by setting `COMPLIANT_BCP_RFC9700_PASSWORD_GRANT` to `False`. 
- Admin behavior change: raw tokens are masked and can no longer be looked up via the DOT admin which should be fine. We don't want admins to look at raw tokens.

**Transitive bump**: `oauthlib` moves from 3.1.0 (2019) to 3.3.1, since 3.4.0 requires `>=3.3.0`.  This also affects the *outbound* OAuth client in `corehq.motech.auth` (requests-oauthlib). I have looked into it, the oauth clients that have no scopes defined would be affected by it. We have only 2 repeaters that fell into this criteria. One is from testing domain and another one from paused domain. 

**Root metadata mount** in https://github.com/dimagi/commcare-hq/pull/38046/commits/f0e5114844cf26d03328aae9b6caa4722d62c883 : RFC 8414 clients derive the metadata URL by inserting `/.well-known/oauth-authorization-server` between the host and the issuer's path, so for our issuer (`https://<host>/oauth`) the document must be served at the domain root. The `/oauth/` include only provides the OIDC-style fallback location. The mount follows the pattern from DOT's own docs; a distinct instance namespace keeps `reverse("oauth2_provider:...")` pointing at the `/oauth/` mount.

## Feature Flag

None.

## Safety Assurance

### Safety story

- All 13 new `oauth2_provider` migrations (0008–0020) applied cleanly against a local dev database and on staging, including both token-checksum backfills.
- Verified locally against a running server and on staging: login page renders, `/oauth/authorize/` behaves correctly, and all three discovery URLs return the correct metadata document (strict RFC 8414 root form with issuer path, bare root form, and the prefixed fallback).
- Access tokens expire in 15 minutes and `cleartokens` runs nightly, so the access-token backfill (0012) table is small; refresh tokens live 15 days, so 0015 is the larger backfill. 3.4 batches backfills via `bulk_update` (1000 rows/statement). Running `cleartokens` shortly before deploy minimizes migration time.
- This has been deployed on staging to test, deploy went smoothly. The migrations in the upgrade ran smoothly.
- The oauth flow has been tested on staging and it worked with clients.

### Automated test coverage

Existing OAuth auth coverage in `corehq/apps/receiverwrapper/tests/test_auth.py` exercises token validation through the upgraded toolkit.
### QA Plan

N/A

### Migrations

- [x] The migrations in this code can be safely applied first independently of the code. Pay particular attention to _backward incompatible_ operations like `RemoveField`, `RenameField`, `RemoveConstraint`, and [others described here](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md) that can cause errors when migrations are applied to a live database.

All operations are additive (new nullable-then-backfilled columns, field widening to `TextField`, new choices/defaults); 2.3.0 code runs fine against the 3.4 schema. The reverse is not true — 3.4 code requires the new columns — so migrations must land before or with the code, which is the standard deploy order.

### Rollback instructions

- [ ] This PR can be reverted after deploy with no further considerations

Reverting the code is safe: old code ignores the new columns and doesn't read `token_checksum`. Reversing the *migrations* is not recommended (the checksum columns would be dropped and would need re-backfilling on re-upgrade); leave the schema in place on rollback.

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

