### PR TITLE
Return 404 instead of 500 when updating a couch document that does not exist

### DIFF
--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -1,6 +1,6 @@
 import json
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.http import HttpResponse
 from django.urls import NoReverseMatch, include, re_path
 
@@ -16,7 +16,7 @@ from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_workflow_noop
 from corehq.apps.api.cors import add_cors_headers_to_response
-from corehq.apps.api.util import get_obj
+from corehq.apps.api.util import get_obj, get_object_or_not_exist
 from corehq.apps.users.util import is_dimagi_email
 
 
@@ -356,3 +356,12 @@ class CouchResourceMixin(object):
         return {
             'pk': get_obj(bundle_or_obj)._id
         }
+
+    def get_document_for_update(self, doc_id, domain):
+        """
+        Converts ``ObjectDoesNotExist`` into ``tastypie.NotFound``
+        """
+        try:
+            return get_object_or_not_exist(self._meta.object_class, doc_id, domain)
+        except ObjectDoesNotExist as err:
+            raise NotFound(str(err))

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -174,6 +174,24 @@ class HqBaseResource(ApiVersioningMixin, CorsResourceMixin, JsonResourceMixin, R
     def get_required_privilege(self):
         return privileges.API_ACCESS
 
+    def get_detail(self, request, **kwargs):
+        """Return a single object, or respond 404 if it does not exist.
+
+        Tastypie's ``get_detail`` only translates ``ObjectDoesNotExist``
+        into a 404, so an ``obj_get`` that signals a missing object with
+        ``NotFound`` -- the natural reading of that name, and what
+        ``obj_update`` requires -- escapes to ``_handle_500`` instead.
+        Accepting both here means either exception works from either hook.
+
+        Unlike ``put_detail``, this only has to wrap the parent: tastypie
+        lets ``NotFound`` propagate out of ``get_detail`` rather than
+        acting on it.
+        """
+        try:
+            return super().get_detail(request, **kwargs)
+        except NotFound:
+            return http.HttpNotFound()
+
     def put_detail(self, request, **kwargs):
         """Update an existing object, or respond 404 if it does not exist.
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -14,7 +14,6 @@ from django.core.exceptions import ValidationError
 from django.db.models import Max, Min, Q
 from django.db.models.functions import TruncDate
 from django.http import (
-    Http404,
     HttpResponse,
     HttpResponseForbidden,
     HttpResponseNotFound,
@@ -976,13 +975,7 @@ class SimpleReportConfigurationResource(CouchResourceMixin, HqBaseResource, Doma
         } for c in obj_columns]
 
     def obj_get(self, bundle, **kwargs):
-        domain = kwargs['domain']
-        pk = kwargs['pk']
-        try:
-            report_configuration = get_document_or_404(ReportConfiguration, domain, pk)
-        except Http404 as e:
-            raise NotFound(str(e))
-        return report_configuration
+        return get_object_or_not_exist(ReportConfiguration, kwargs['pk'], kwargs['domain'])
 
     def obj_get_list(self, bundle, **kwargs):
         domain = kwargs['domain']

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -349,8 +349,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             raise BadRequest(_("You must require account confirmation to send a confirmation email."))
 
     def obj_update(self, bundle, **kwargs):
-        bundle.obj = CommCareUser.get(kwargs['pk'])
-        assert bundle.obj.domain == kwargs['domain']
+        bundle.obj = self.get_document_for_update(kwargs['pk'], kwargs['domain'])
         send_confirmation_email = string_to_boolean(bundle.data.pop('send_confirmation_email_now', False))
         user_change_logger = self._get_user_change_logger(bundle)
         errors = self._update(bundle, user_change_logger)
@@ -760,8 +759,7 @@ class GroupResource(v0_4.GroupResource):
         return bundle
 
     def obj_update(self, bundle, **kwargs):
-        bundle.obj = Group.get(kwargs['pk'])
-        assert bundle.obj.domain == kwargs['domain']
+        bundle.obj = self.get_document_for_update(kwargs['pk'], kwargs['domain'])
         if self._update(bundle):
             assert bundle.obj.domain == kwargs['domain']
             bundle.obj.save()

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -67,6 +67,7 @@ from corehq.apps.api.resources.serializers import ListToSingleObjectSerializer
 from corehq.apps.api.util import (
     django_date_filter,
     get_obj,
+    get_object_or_not_exist,
     make_date_filter,
     parse_str_to_date,
     cursor_based_query_for_datasource
@@ -1022,13 +1023,7 @@ class DataSourceConfigurationResource(CouchResourceMixin, HqBaseResource, Domain
 
     def obj_get(self, bundle, **kwargs):
         self._ensure_toggle_enabled(bundle.request)
-        domain = kwargs['domain']
-        pk = kwargs['pk']
-        try:
-            data_source = get_document_or_404(DataSourceConfiguration, domain, pk)
-        except Http404 as e:
-            raise NotFound(str(e))
-        return data_source
+        return get_object_or_not_exist(DataSourceConfiguration, kwargs['pk'], kwargs['domain'])
 
     def obj_get_list(self, bundle, **kwargs):
         self._ensure_toggle_enabled(bundle.request)
@@ -1037,12 +1032,7 @@ class DataSourceConfigurationResource(CouchResourceMixin, HqBaseResource, Domain
 
     def obj_update(self, bundle, **kwargs):
         self._ensure_toggle_enabled(bundle.request)
-        domain = kwargs['domain']
-        pk = kwargs['pk']
-        try:
-            data_source = get_document_or_404(DataSourceConfiguration, domain, pk)
-        except Http404 as e:
-            raise NotFound(str(e))
+        data_source = self.get_document_for_update(kwargs['pk'], kwargs['domain'])
         allowed_update_fields = [
             'display_name',
             'configured_filter',
@@ -1075,6 +1065,7 @@ class DataSourceConfigurationResource(CouchResourceMixin, HqBaseResource, Domain
 
     class Meta(CustomResourceMeta):
         resource_name = 'ucr_data_source'
+        object_class = DataSourceConfiguration
         list_allowed_methods = ['get']
         detail_allowed_methods = ['get', 'put']
         always_return_data = True

--- a/corehq/apps/api/tests/group_resources.py
+++ b/corehq/apps/api/tests/group_resources.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 
 from corehq.apps.api.resources import v0_5
 from corehq.apps.es.groups import group_adapter
@@ -139,6 +140,25 @@ class TestGroupResource(APIResourceTest):
         self.assertTrue(modified.reporting)
         self.assertTrue(modified.case_sharing)
         self.assertEqual(modified.metadata["localization"], "Ghana")
+
+    def test_cant_update_missing_group(self):
+        response = self._assert_auth_post_resource(self.single_endpoint(uuid.uuid4().hex),
+                                                   json.dumps({"name": "test group"}),
+                                                   content_type='application/json',
+                                                   method='PUT')
+
+        assert response.status_code == 404, response.content
+
+    def test_cant_update_group_in_another_domain(self):
+        not_my_group = self._add_group(Group({"name": "theirs", "domain": "not-my-project"}))
+
+        response = self._assert_auth_post_resource(self.single_endpoint(not_my_group._id),
+                                                   json.dumps({"name": "mine now"}),
+                                                   content_type='application/json',
+                                                   method='PUT')
+
+        assert response.status_code == 404, response.content
+        assert Group.get(not_my_group._id).name == "theirs"
 
     def test_delete_group(self):
 

--- a/corehq/apps/api/tests/test_ucr_resources.py
+++ b/corehq/apps/api/tests/test_ucr_resources.py
@@ -168,6 +168,12 @@ class TestDataSourceConfigurationResource(APIResourceTest):
     api_name = "v0.5"
 
     @flag_enabled('USER_CONFIGURABLE_REPORTS')
+    def test_cant_get_missing_data_source(self):
+        response = self._assert_auth_get_resource(self.single_endpoint(uuid.uuid4().hex))
+
+        assert response.status_code == 404, response.content
+
+    @flag_enabled('USER_CONFIGURABLE_REPORTS')
     def test_cant_update_missing_data_source(self):
         response = self._assert_auth_post_resource(
             self.single_endpoint(uuid.uuid4().hex),
@@ -179,6 +185,26 @@ class TestDataSourceConfigurationResource(APIResourceTest):
         # put_detail must not echo the exception message: some carry internal
         # detail, and get_document_or_404 even embeds a traceback
         assert response.content == b""
+
+    @flag_enabled('USER_CONFIGURABLE_REPORTS')
+    def test_cant_update_data_source_in_another_domain(self):
+        not_my_data_source = DataSourceConfiguration(
+            domain='not-my-project',
+            referenced_doc_type="XFormInstance",
+            table_id=uuid.uuid4().hex,
+            display_name="theirs",
+        )
+        not_my_data_source.save()
+        self.addCleanup(not_my_data_source.delete)
+
+        response = self._assert_auth_post_resource(
+            self.single_endpoint(not_my_data_source._id),
+            json.dumps({"display_name": "mine now"}),
+            method="PUT",
+        )
+
+        assert response.status_code == 404, response.content
+        assert DataSourceConfiguration.get(not_my_data_source._id).display_name == "theirs"
 
 
 class TestConfigurableReportDataResource(APIResourceTest):

--- a/corehq/apps/api/tests/test_ucr_resources.py
+++ b/corehq/apps/api/tests/test_ucr_resources.py
@@ -143,6 +143,25 @@ class TestSimpleReportConfigurationResource(APIResourceTest):
         self.assertEqual(response_dict['meta']['total_count'], 2)
         self.assertEqual(len(response_dict['objects']), 2)
 
+    def test_cant_get_missing_report_configuration(self):
+        response = self._assert_auth_get_resource(self.single_endpoint(uuid.uuid4().hex))
+
+        assert response.status_code == 404, response.content
+
+    def test_cant_get_report_configuration_in_another_domain(self):
+        not_mine = ReportConfiguration(
+            domain='not-my-project',
+            config_id=self.data_source._id,
+            columns=[],
+            filters=[],
+        )
+        not_mine.save()
+        self.addCleanup(not_mine.delete)
+
+        response = self._assert_auth_get_resource(self.single_endpoint(not_mine._id))
+
+        assert response.status_code == 404, response.content
+
     def test_disallowed_methods(self):
         response = self._assert_auth_post_resource(
             self.single_endpoint(self.report_configuration._id),

--- a/corehq/apps/api/tests/test_ucr_resources.py
+++ b/corehq/apps/api/tests/test_ucr_resources.py
@@ -341,6 +341,11 @@ class TestConfigurableReportDataResource(APIResourceTest):
         cls.report_configuration.save()
         cls.addClassCleanup(cls.report_configuration.delete)
 
+    def test_cant_fetch_data_for_missing_report(self):
+        response = self.client.get(self.single_endpoint(uuid.uuid4().hex))
+
+        assert response.status_code == 404, response.content
+
     def test_fetching_data(self):
         response = self.client.get(
             self.single_endpoint(self.report_configuration._id))

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from unittest.mock import Mock, patch, call
 
 from django.test import TestCase
@@ -457,6 +458,28 @@ class TestCommCareUserResource(APIResourceTest):
         )
         self.assertEqual(user_history.change_messages['password'], UserChangeMessage.password_reset()['password'])
         self.assertEqual(user_history.changed_via, USER_CHANGE_VIA_API)
+
+    def test_cant_update_missing_user(self):
+        response = self._assert_auth_post_resource(self.single_endpoint(uuid.uuid4().hex),
+                                                   json.dumps({"first_name": "test"}),
+                                                   content_type='application/json',
+                                                   method='PUT')
+
+        assert response.status_code == 404, response.content
+
+    def test_cant_update_user_in_another_domain(self):
+        not_my_user = CommCareUser.create(domain='not-my-project', username="theirs",
+                                          password="qwer1234", created_by=None, created_via=None)
+        self.addCleanup(not_my_user.delete, 'not-my-project', deleted_by=None)
+        first_name_before = not_my_user.first_name
+
+        response = self._assert_auth_post_resource(self.single_endpoint(not_my_user._id),
+                                                   json.dumps({"first_name": "mine now"}),
+                                                   content_type='application/json',
+                                                   method='PUT')
+
+        assert response.status_code == 404, response.content
+        assert CommCareUser.get(not_my_user._id).first_name == first_name_before
 
     def test_update_fails(self):
         user = CommCareUser.create(domain=self.domain.name, username="test", password="qwer1234",

--- a/docs/api/mobile-worker.rst
+++ b/docs/api/mobile-worker.rst
@@ -248,6 +248,11 @@ Request & Response Details
        }
     }
 
+**Response**
+
+PUT only updates an existing mobile worker, it never creates one. If no mobile
+worker with the given ID exists in the domain, the response is 404 Not Found.
+
 User Delete (Mobile Worker)
 ===========================
 

--- a/docs/api/user-group.rst
+++ b/docs/api/user-group.rst
@@ -231,3 +231,8 @@ Request & Response Details
         "8a642f722c9e617eeed29290e409fcd5"
       ]
     }
+
+**Response**
+
+PUT only updates an existing group, it never creates one. If no group with the
+given ID exists in the domain, the response is 404 Not Found.


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
`PUT` to a mobile worker or group ID that does not exist now returns 404 instead of 500. `GET` for an unknown UCR data source likewise returns 404 instead of 500. (UCR's `PUT` was already fixed by #38045, this PR fixes its `GET`.)

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
https://dimagi.atlassian.net/browse/SAAS-20201

#38045 is what stops tastypie creating a new object when `obj_update` raises `NotFound`. `CommCareUserResource` and `GroupResource` both define `obj_create`, so if this PR landed on its own, a `PUT` to a missing ID would silently create a new mobile worker or group instead of returning 500.

`CouchResourceMixin.get_document_for_update` now does the lookup and converts `ObjectDoesNotExist` into `NotFound`, reading the document class off `_meta.object_class` so callers pass only ID and domain. 

The downside of this change is that it still relies on those creating APIs on couch resources to use this helper in the `obj_update` method, but ideally we aren't adding new APIs backed by couch models.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
N/A — the UCR data source endpoints sit behind the pre-existing `USER_CONFIGURABLE_REPORTS` flag.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Every affected request previously returned a 500. 

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

Full `corehq/apps/api/tests/` suite passes.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA needed.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
