### PR TITLE
fix double offset in bulk user resource and add regression test

### DIFF
--- a/corehq/apps/api/resources/pagination.py
+++ b/corehq/apps/api/resources/pagination.py
@@ -39,6 +39,21 @@ class NoCountingPaginator(Paginator):
         return None
 
 
+class PreSlicedPaginator(Paginator):
+    """
+    Paginator for resources whose ``obj_get_list`` has already applied
+    ``limit`` and ``offset`` to the underlying query, so that the objects
+    handed to the paginator *are* the requested page.
+
+    The default paginator would slice that page a second time, dropping
+    ``offset`` records that the query had already skipped, which makes any
+    request with ``offset >= limit`` come back empty.
+    """
+
+    def get_slice(self, limit, offset):
+        return self.objects
+
+
 class DoesNothingPaginator(Paginator):
     def page(self):
         return {

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -151,7 +151,12 @@ from . import (
     v0_1,
     v0_4,
 )
-from .pagination import DoesNothingPaginator, NoCountingPaginator, response_for_cursor_based_pagination
+from .pagination import (
+    DoesNothingPaginator,
+    NoCountingPaginator,
+    PreSlicedPaginator,
+    response_for_cursor_based_pagination,
+)
 
 MOCK_BULK_USER_ES = None
 EXPORT_DATASOURCE_DEFAULT_PAGINATION_LIMIT = 1000
@@ -197,6 +202,7 @@ class BulkUserResource(HqBaseResource, DomainSpecificResourceMixin):
         detail_allowed_methods = ['get']
         object_class = object
         resource_name = 'bulk-user'
+        paginator_class = PreSlicedPaginator
 
     def dehydrate(self, bundle):
         fields = bundle.request.GET.getlist('fields')
@@ -222,13 +228,19 @@ class BulkUserResource(HqBaseResource, DomainSpecificResourceMixin):
         fields = list(self.fields)
         fields.remove('id')
         fields.append('_id')
+        # The paginator resolves (and validates) 'limit' and 'offset' the same
+        # way it will when building the response meta, so the page reported
+        # there always matches the page fetched from Elasticsearch.
+        paginator = self._meta.paginator_class(
+            params, [], limit=self._meta.limit, max_limit=self._meta.max_limit,
+        )
         fn = MOCK_BULK_USER_ES or user_es_call
         users = fn(
             domain=kwargs['domain'],
             q=param('q'),
             fields=fields,
-            size=param('limit'),
-            start_at=param('offset'),
+            size=paginator.get_limit(),
+            start_at=paginator.get_offset(),
         )
         return list(map(self.to_obj, users))
 

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -1084,12 +1084,20 @@ class TestBulkUserAPI(APIResourceTest):
         result = self.query(limit=limit)
         self.assertEqual(result.status_code, 200)
         users = json.loads(result.content)['objects']
-        self.assertEqual(len(users), limit)
+        self.assertEqual(
+            [user['username'] for user in users],
+            ['robb_stark', 'jon_snow', 'brandon_stark'],
+        )
 
-        result = self.query(start_at=limit, limit=limit)
+        # 'offset' is applied by the Elasticsearch query, so the paginator must
+        # not slice the results a second time and skip the whole page.
+        result = self.query(offset=limit, limit=limit)
         self.assertEqual(result.status_code, 200)
         users = json.loads(result.content)['objects']
-        self.assertEqual(len(users), limit)
+        self.assertEqual(
+            [user['username'] for user in users],
+            ['eddard_stark', 'catelyn_stark', 'tyrion_lannister'],
+        )
 
     def test_basic(self):
         response = self.query()


### PR DESCRIPTION
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
The bulk user api was applying offsets twice, once in the view itself and once in the native tastypie paginator, causing paged data after page 1 to return zero results. This creates a custom paginator class that respects the pagination already done in `obj_get_list`.

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
new regression test to ensure correct behavior, and existing tests

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
bulk user resource has existing tests to make sure the core functionality is correct

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
