### PR TITLE
Add ProjectDB Query Tester

### DIFF
--- a/corehq/apps/project_db/describe.py
+++ b/corehq/apps/project_db/describe.py
@@ -1,0 +1,30 @@
+import sqlalchemy
+from sqlalchemy.schema import CreateIndex, CreateTable
+
+from corehq.apps.project_db.table_ddl import (
+    DomainSchema,
+    get_project_db_engine,
+)
+
+
+def describe_project_db(domain):
+    """Return the DDL of a domain's ProjectDB tables, annotated with row counts"""
+    engine = get_project_db_engine()
+    metadata = sqlalchemy.MetaData()
+    metadata.reflect(bind=engine, schema=DomainSchema(domain).name)
+
+    lines = [f"-- Project DB schema for domain: {domain}"]
+    if not metadata.tables:
+        lines.append(f"-- ERROR: No project DB tables found for domain '{domain}'")
+    with engine.connect() as conn:
+        for table in sorted(metadata.tables.values(), key=lambda t: t.name):
+            row_count = conn.execute(
+                sqlalchemy.select([sqlalchemy.func.count()]).select_from(table)
+            ).scalar()
+            ddl = str(CreateTable(table).compile(dialect=engine.dialect)).strip()
+            lines.append(f"\n-- {row_count} rows")
+            lines.append(f"{ddl};")
+            for index in table.indexes:
+                idx_ddl = str(CreateIndex(index).compile(dialect=engine.dialect)).strip()
+                lines.append(f"{idx_ddl};")
+    return '\n'.join(lines)

--- a/corehq/apps/project_db/describe.py
+++ b/corehq/apps/project_db/describe.py
@@ -1,3 +1,5 @@
+from django.template import Context, Template
+
 import sqlalchemy
 from sqlalchemy.schema import CreateIndex, CreateTable
 
@@ -6,25 +8,54 @@ from corehq.apps.project_db.table_ddl import (
     get_project_db_engine,
 )
 
+DESCRIPTION_TEMPLATE = """\
+This project has the following tables:
+{% for summary in table_summaries %}\
+ * {{ summary }}
+{% endfor %}\
+
+Here is a SQL description of the tables:
+
+{% for statement in table_definitions %}\
+{{ statement }};
+{% endfor %}\
+"""
+
 
 def describe_project_db(domain):
     """Return the DDL of a domain's ProjectDB tables, annotated with row counts"""
     engine = get_project_db_engine()
     metadata = sqlalchemy.MetaData()
     metadata.reflect(bind=engine, schema=DomainSchema(domain).name)
+    tables = sorted(metadata.tables.values(), key=lambda t: t.name)
+    if not tables:
+        return f"ERROR: No project DB tables found for domain '{domain}'"
 
-    lines = [f"-- Project DB schema for domain: {domain}"]
-    if not metadata.tables:
-        lines.append(f"-- ERROR: No project DB tables found for domain '{domain}'")
     with engine.connect() as conn:
-        for table in sorted(metadata.tables.values(), key=lambda t: t.name):
-            row_count = conn.execute(
-                sqlalchemy.select([sqlalchemy.func.count()]).select_from(table)
-            ).scalar()
-            ddl = str(CreateTable(table).compile(dialect=engine.dialect)).strip()
-            lines.append(f"\n-- {row_count} rows")
-            lines.append(f"{ddl};")
-            for index in table.indexes:
-                idx_ddl = str(CreateIndex(index).compile(dialect=engine.dialect)).strip()
-                lines.append(f"{idx_ddl};")
-    return '\n'.join(lines)
+        context = {
+            'table_summaries': list(_table_summaries(tables, conn)),
+            'table_definitions': list(_table_definitions(tables, engine)),
+        }
+    return Template(DESCRIPTION_TEMPLATE).render(Context(context, autoescape=False))
+
+
+def _table_summaries(tables, conn):
+    for table in tables:
+        row_count = conn.execute(
+            sqlalchemy.select([sqlalchemy.func.count()]).select_from(table)
+        ).scalar()
+        yield f"{table.name} - {row_count} rows"
+
+
+def _table_definitions(tables, engine):
+    # Copying to a schema-less MetaData drops the schema qualifier from the DDL
+    unqualified = sqlalchemy.MetaData()
+    for table in tables:
+        table = table.tometadata(unqualified, schema=None)
+        yield _compile_ddl(CreateTable(table), engine)
+        for index in table.indexes:
+            yield _compile_ddl(CreateIndex(index), engine)
+
+
+def _compile_ddl(statement, engine):
+    return str(statement.compile(dialect=engine.dialect)).strip()

--- a/corehq/apps/project_db/describe.py
+++ b/corehq/apps/project_db/describe.py
@@ -9,6 +9,36 @@ from corehq.apps.project_db.table_ddl import (
 )
 
 DESCRIPTION_TEMPLATE = """\
+This is the ProjectDB for {{ domain }}: relational, schema'd tables of the
+project's case data, generated automatically from the data dictionary.
+
+The SQL you pass in will be parsed and rebuilt, with only a limited subset of
+functionality available.
+
+Schema:
+ * Every table has the same case metadata columns.
+ * Each case property has a prop__<name> text column holding its raw value.
+ * Properties with a declared type also have a parallel typed column
+   (date_prop__, number_prop__, select_prop__, gps_prop__) holding the coerced
+   value, or NULL where the raw text could not be coerced.
+ * select_prop columns use an empty array instead of NULL.
+ * prop__ columns are not nullable; unset properties are stored as the empty string.
+ * Cases link to each other through parent_id and host_id, which hold the
+   case_id of a case in another table.
+
+Supported SQL:
+ * SELECT of a column list or *, with optional AS aliases.
+ * A single table in the FROM clause.
+ * JOIN and LEFT JOIN, with an ON condition.
+ * WHERE, combining conditions with AND, OR and NOT, and comparing columns and
+   literals with =, <>, <, <=, >, >=, IS NULL/TRUE/FALSE and IN.
+ * UNION and UNION ALL of the above.
+
+Not supported:
+ * Aggregates, function calls and arithmetic.
+ * GROUP BY, ORDER BY, LIMIT, DISTINCT and LIKE.
+ * Subqueries, CTEs and table aliases.
+
 This project has the following tables:
 {% for summary in table_summaries %}\
  * {{ summary }}
@@ -33,6 +63,7 @@ def describe_project_db(domain):
 
     with engine.connect() as conn:
         context = {
+            'domain': domain,
             'table_summaries': list(_table_summaries(tables, conn)),
             'table_definitions': list(_table_definitions(tables, engine)),
         }

--- a/corehq/apps/project_db/management/commands/manage_project_db.py
+++ b/corehq/apps/project_db/management/commands/manage_project_db.py
@@ -3,9 +3,9 @@ from django.core.management.base import BaseCommand, CommandError
 
 import dateutil.parser
 import sqlalchemy
-from sqlalchemy.schema import CreateIndex, CreateTable
 
 from corehq.apps.data_dictionary.models import CaseType
+from corehq.apps.project_db.describe import describe_project_db
 from corehq.apps.project_db.populate import send_to_project_db
 from corehq.apps.project_db.table_ddl import (
     DomainSchema,
@@ -72,7 +72,7 @@ class Command(BaseCommand):
         if drop:
             _drop(domain, self.stdout)
         if describe:
-            _describe(domain)
+            self.stdout.write(describe_project_db(domain))
 
 
 def _drop(domain, stdout):
@@ -110,24 +110,3 @@ def _populate_case_type(domain, case_type, start_date, prefix):
     cases = with_progress_bar(iter_all_rows(accessor), length=total,
                               oneline='concise', prefix=f"{prefix}: {case_type}")
     send_to_project_db(domain, case_type, cases)
-
-
-def _describe(domain):
-    engine = get_project_db_engine()
-    metadata = sqlalchemy.MetaData()
-    metadata.reflect(bind=engine, schema=DomainSchema(domain).name)
-    if not metadata.tables:
-        raise CommandError(f"No project DB tables found for domain '{domain}'")
-
-    print(f"-- Project DB schema for domain: {domain}")
-    with engine.connect() as conn:
-        for table in sorted(metadata.tables.values(), key=lambda t: t.name):
-            row_count = conn.execute(
-                sqlalchemy.select([sqlalchemy.func.count()]).select_from(table)
-            ).scalar()
-            ddl = str(CreateTable(table).compile(dialect=engine.dialect)).strip()
-            print(f"\n-- {row_count} rows")
-            print(f"{ddl};")
-            for index in table.indexes:
-                idx_ddl = str(CreateIndex(index).compile(dialect=engine.dialect)).strip()
-                print(f"{idx_ddl};")

--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -217,6 +217,13 @@ def create_or_update_project_db(domain):
             update_table(conn, table)
 
 
+def get_domain_tables(domain):
+    engine = get_project_db_engine()
+    metadata = sqlalchemy.MetaData()
+    metadata.reflect(bind=engine, schema=DomainSchema(domain).name)
+    return {t.comment: t for t in metadata.tables.values()}
+
+
 def preview_drop(domain):
     """Return the PostgreSQL CASCADE notices for dropping a domain's schema"""
     schema = DomainSchema(domain)

--- a/corehq/apps/project_db/templates/project_db/partials/query_results.html
+++ b/corehq/apps/project_db/templates/project_db/partials/query_results.html
@@ -14,6 +14,9 @@
       </dl>
     {% endif %}
   </details>
+  <p class="text-body-secondary">
+    {% blocktrans with duration=result.duration|floatformat:3 %}Evaluated in {{ duration }} seconds{% endblocktrans %}
+  </p>
   {% if result.rows %}
     {% if result.rows|length == max_rows %}
       <div class="alert alert-info">

--- a/corehq/apps/project_db/templates/project_db/partials/query_results.html
+++ b/corehq/apps/project_db/templates/project_db/partials/query_results.html
@@ -1,0 +1,32 @@
+{% load i18n %}
+{% if error %}
+  <div class="alert alert-danger">{{ error }}</div>
+{% else %}
+  {% if rows %}
+    {% if rows|length == max_rows %}
+      <div class="alert alert-info">
+        {% blocktrans %}Showing the first {{ max_rows }} rows.{% endblocktrans %}
+      </div>
+    {% endif %}
+    <div class="table-responsive">
+      <table class="table table-striped table-sm">
+        <thead>
+          <tr>
+            {% for column in columns %}
+            <th>{{ column }}</th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in rows %}
+            <tr>
+              {% for value in row %}<td>{{ value }}</td>{% endfor %}
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <p class="text-body-secondary">{% trans "No results" %}</p>
+  {% endif %}
+{% endif %}

--- a/corehq/apps/project_db/templates/project_db/partials/query_results.html
+++ b/corehq/apps/project_db/templates/project_db/partials/query_results.html
@@ -2,8 +2,20 @@
 {% if error %}
   <div class="alert alert-danger">{{ error }}</div>
 {% else %}
-  {% if rows %}
-    {% if rows|length == max_rows %}
+  <details open>
+    <summary class="h6">{% trans "Translated SQL" %}</summary>
+    <pre class="p-3 mb-3 bg-body-tertiary border rounded">{{ result.query.sql }}</pre>
+    {% if result.query.params %}
+      <dl class="row font-monospace mb-4">
+        {% for name, value in result.query.params.items %}
+          <dt class="col-sm-2 fw-normal text-body-secondary">:{{ name }}</dt>
+          <dd class="col-sm-10">{{ value }}</dd>
+        {% endfor %}
+      </dl>
+    {% endif %}
+  </details>
+  {% if result.rows %}
+    {% if result.rows|length == max_rows %}
       <div class="alert alert-info">
         {% blocktrans %}Showing the first {{ max_rows }} rows.{% endblocktrans %}
       </div>
@@ -12,13 +24,13 @@
       <table class="table table-striped table-sm">
         <thead>
           <tr>
-            {% for column in columns %}
+            {% for column in result.columns %}
             <th>{{ column }}</th>
             {% endfor %}
           </tr>
         </thead>
         <tbody>
-          {% for row in rows %}
+          {% for row in result.rows %}
             <tr>
               {% for value in row %}<td>{{ value }}</td>{% endfor %}
             </tr>

--- a/corehq/apps/project_db/templates/project_db/query_project_db.html
+++ b/corehq/apps/project_db/templates/project_db/query_project_db.html
@@ -5,6 +5,22 @@
 
 {% block page_content %}
   <h2 class="h4 mb-3">{% trans "Query ProjectDB" %}</h2>
+  <details class="mb-4" open>
+    <summary class="h6">{% trans "Tables" %}</summary>
+    {% if table_names %}
+      <ul class="list-inline font-monospace mb-0">
+        {% for table_name in table_names %}
+          <li class="list-inline-item badge bg-light text-dark border">
+            {{ table_name }}
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="text-body-secondary mb-0">
+        {% trans "This project has no ProjectDB tables yet." %}
+      </p>
+    {% endif %}
+  </details>
   <form
     hx-post="{{ request.path_info }}"
     hq-hx-action="run_query"

--- a/corehq/apps/project_db/templates/project_db/query_project_db.html
+++ b/corehq/apps/project_db/templates/project_db/query_project_db.html
@@ -1,7 +1,31 @@
 {% extends 'hqwebapp/bootstrap5/base_section.html' %}
 {% load i18n %}
 {% load hq_shared_tags %}
+{% js_entry 'hqwebapp/js/htmx_and_alpine' %}
 
 {% block page_content %}
-  <h3>{% trans "Query ProjectDB" %}</h3>
+  <h2 class="h4 mb-3">{% trans "Query ProjectDB" %}</h2>
+  <form
+    hx-post="{{ request.path_info }}"
+    hq-hx-action="run_query"
+    hx-target="#query-results"
+    hx-disabled-elt="find button[type=submit]"
+  >
+    <div class="mb-3">
+      <textarea
+        class="form-control font-monospace"
+        name="sql"
+        rows="8"
+        spellcheck="false"
+        placeholder="SELECT * FROM my_case_type"
+      ></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">{% trans "Run" %}</button>
+  </form>
+  <div id="query-results" class="mt-4"></div>
 {% endblock %}
+
+{% block modals %}
+  {% include "hqwebapp/htmx/error_modal.html" %}
+  {{ block.super }}
+{% endblock modals %}

--- a/corehq/apps/project_db/templates/project_db/query_project_db.html
+++ b/corehq/apps/project_db/templates/project_db/query_project_db.html
@@ -37,6 +37,18 @@
       ></textarea>
     </div>
     <button type="submit" class="btn btn-primary">{% trans "Run" %}</button>
+    <button
+      type="button"
+      class="btn btn-outline-primary"
+      hx-post="{{ request.path_info }}"
+      hq-hx-action="copy_db_context"
+      hx-swap="none"
+      hx-disabled-elt="this"
+      x-data
+      @htmx:after-request="navigator.clipboard.writeText($event.detail.xhr.responseText)"
+    >
+      <i class="fa fa-clipboard"></i> {% trans "Copy DB Context" %}
+    </button>
   </form>
   <div id="query-results" class="mt-4"></div>
 {% endblock %}

--- a/corehq/apps/project_db/templates/project_db/query_project_db.html
+++ b/corehq/apps/project_db/templates/project_db/query_project_db.html
@@ -1,0 +1,7 @@
+{% extends 'hqwebapp/bootstrap5/base_section.html' %}
+{% load i18n %}
+{% load hq_shared_tags %}
+
+{% block page_content %}
+  <h3>{% trans "Query ProjectDB" %}</h3>
+{% endblock %}

--- a/corehq/apps/project_db/urls.py
+++ b/corehq/apps/project_db/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from corehq.apps.project_db.views import QueryProjectDBView
+
+urlpatterns = [
+    path('query/', QueryProjectDBView.as_view(), name=QueryProjectDBView.urlname),
+]

--- a/corehq/apps/project_db/views.py
+++ b/corehq/apps/project_db/views.py
@@ -1,0 +1,23 @@
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.utils.translation import gettext_lazy
+
+from corehq import toggles
+from corehq.apps.domain.decorators import domain_admin_required
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.settings.views import BaseProjectDataView
+
+
+@method_decorator([
+    use_bootstrap5,
+    toggles.PROJECT_DB.required_decorator(),
+    domain_admin_required,
+], name='dispatch')
+class QueryProjectDBView(BaseProjectDataView):
+    urlname = 'query_project_db'
+    page_title = gettext_lazy("Query ProjectDB")
+    template_name = 'project_db/query_project_db.html'
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, args=[self.domain])

--- a/corehq/apps/project_db/views.py
+++ b/corehq/apps/project_db/views.py
@@ -2,6 +2,9 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
 
+import sqlglot
+from sqlalchemy.dialects import postgresql
+
 from corehq import toggles
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
@@ -14,14 +17,6 @@ from corehq.apps.settings.views import BaseProjectDataView
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
 MAX_ROWS = 100
-
-
-def run_user_sql(domain, sql):
-    """Run user-supplied SQL against ``domain``'s tables, returning columns and rows"""
-    query = translate(sql, get_domain_tables(domain))
-    with get_project_db_engine().connect() as conn:
-        result = conn.execute(query)
-        return list(result.keys()), result.fetchmany(MAX_ROWS)
 
 
 @method_decorator([
@@ -46,10 +41,34 @@ class QueryProjectDBView(HqHtmxActionMixin, BaseProjectDataView):
     def run_query(self, request, *args, **kwargs):
         context = {'sql': request.POST.get('sql', '')}
         try:
-            columns, rows = run_user_sql(self.domain, context['sql'])
+            query_result = run_user_sql(self.domain, context['sql'])
         except UnsupportedSQL as error:
             context['error'] = str(error)
         else:
-            context.update({'columns': columns, 'rows': rows, 'max_rows': MAX_ROWS})
+            context.update({
+                'result': query_result,
+                'max_rows': MAX_ROWS,
+            })
         return self.render_htmx_partial_response(
             request, 'project_db/partials/query_results.html', context)
+
+
+def run_user_sql(domain, user_sql):
+    query = translate(user_sql, get_domain_tables(domain))
+    with get_project_db_engine().connect() as conn:
+        result = conn.execute(query)
+        return {
+            'query': compile_query(query),
+            'columns': list(result.keys()),
+            'rows': result.fetchmany(MAX_ROWS),
+        }
+
+
+def compile_query(query):
+    """Render a SQLAlchemy selectable as pretty-printed PostgreSQL and its bound params"""
+    compiled = query.compile(dialect=postgresql.dialect(paramstyle='named'))
+    sql = sqlglot.transpile(str(compiled), read='postgres', write='postgres', pretty=True)[0]
+    return {
+        'sql': sql,
+        'params': compiled.params
+    }

--- a/corehq/apps/project_db/views.py
+++ b/corehq/apps/project_db/views.py
@@ -1,3 +1,5 @@
+import time
+
 from django.http import HttpResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -62,11 +64,15 @@ class QueryProjectDBView(HqHtmxActionMixin, BaseProjectDataView):
 def run_user_sql(domain, user_sql):
     query = translate(user_sql, get_domain_tables(domain))
     with get_project_db_engine().connect() as conn:
+        start = time.perf_counter()
         result = conn.execute(query)
+        rows = result.fetchmany(MAX_ROWS)
+        duration = time.perf_counter() - start
         return {
             'query': compile_query(query),
             'columns': list(result.keys()),
-            'rows': result.fetchmany(MAX_ROWS),
+            'rows': rows,
+            'duration': duration,
         }
 
 

--- a/corehq/apps/project_db/views.py
+++ b/corehq/apps/project_db/views.py
@@ -5,7 +5,23 @@ from django.utils.translation import gettext_lazy
 from corehq import toggles
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.project_db.table_ddl import (
+    get_domain_tables,
+    get_project_db_engine,
+)
+from corehq.apps.project_db.user_sql import UnsupportedSQL, translate
 from corehq.apps.settings.views import BaseProjectDataView
+from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
+
+MAX_ROWS = 100
+
+
+def run_user_sql(domain, sql):
+    """Run user-supplied SQL against ``domain``'s tables, returning columns and rows"""
+    query = translate(sql, get_domain_tables(domain))
+    with get_project_db_engine().connect() as conn:
+        result = conn.execute(query)
+        return list(result.keys()), result.fetchmany(MAX_ROWS)
 
 
 @method_decorator([
@@ -13,7 +29,7 @@ from corehq.apps.settings.views import BaseProjectDataView
     toggles.PROJECT_DB.required_decorator(),
     domain_admin_required,
 ], name='dispatch')
-class QueryProjectDBView(BaseProjectDataView):
+class QueryProjectDBView(HqHtmxActionMixin, BaseProjectDataView):
     urlname = 'query_project_db'
     page_title = gettext_lazy("Query ProjectDB")
     template_name = 'project_db/query_project_db.html'
@@ -21,3 +37,15 @@ class QueryProjectDBView(BaseProjectDataView):
     @property
     def page_url(self):
         return reverse(self.urlname, args=[self.domain])
+
+    @hq_hx_action('post')
+    def run_query(self, request, *args, **kwargs):
+        context = {'sql': request.POST.get('sql', '')}
+        try:
+            columns, rows = run_user_sql(self.domain, context['sql'])
+        except UnsupportedSQL as error:
+            context['error'] = str(error)
+        else:
+            context.update({'columns': columns, 'rows': rows, 'max_rows': MAX_ROWS})
+        return self.render_htmx_partial_response(
+            request, 'project_db/partials/query_results.html', context)

--- a/corehq/apps/project_db/views.py
+++ b/corehq/apps/project_db/views.py
@@ -38,6 +38,10 @@ class QueryProjectDBView(HqHtmxActionMixin, BaseProjectDataView):
     def page_url(self):
         return reverse(self.urlname, args=[self.domain])
 
+    @property
+    def page_context(self):
+        return {'table_names': sorted(get_domain_tables(self.domain))}
+
     @hq_hx_action('post')
     def run_query(self, request, *args, **kwargs):
         context = {'sql': request.POST.get('sql', '')}

--- a/corehq/apps/project_db/views.py
+++ b/corehq/apps/project_db/views.py
@@ -1,3 +1,4 @@
+from django.http import HttpResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
@@ -8,6 +9,7 @@ from sqlalchemy.dialects import postgresql
 from corehq import toggles
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
+from corehq.apps.project_db.describe import describe_project_db
 from corehq.apps.project_db.table_ddl import (
     get_domain_tables,
     get_project_db_engine,
@@ -51,6 +53,10 @@ class QueryProjectDBView(HqHtmxActionMixin, BaseProjectDataView):
             })
         return self.render_htmx_partial_response(
             request, 'project_db/partials/query_results.html', context)
+
+    @hq_hx_action('post')
+    def copy_db_context(self, request, *args, **kwargs):
+        return HttpResponse(describe_project_db(self.domain))
 
 
 def run_user_sql(domain, user_sql):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -468,6 +468,7 @@ class ProjectDataTab(UITab):
         '/a/{domain}/importer/',
         '/a/{domain}/case/',
         '/a/{domain}/clean/',
+        '/a/{domain}/project_db/',
         '/a/{domain}/microplanning/',
         '/a/{domain}/kyc/',
         '/a/{domain}/payments/'
@@ -1024,6 +1025,15 @@ class ProjectDataTab(UITab):
                     'show_in_dropdown': False,
                     'subpages': [],
                 }])
+            if toggles.PROJECT_DB.enabled(self.domain):
+                from corehq.apps.project_db.views import QueryProjectDBView
+                explore_data_views.append({
+                    'title': _(QueryProjectDBView.page_title),
+                    'url': reverse(QueryProjectDBView.urlname, args=(self.domain,)),
+                    'icon': 'fa fa-database',
+                    'show_in_dropdown': False,
+                    'subpages': [],
+                })
         return explore_data_views
 
     def _get_geospatial_views(self):

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1025,6 +1025,14 @@ CASE_SEARCH_ENDPOINTS = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
+PROJECT_DB = StaticToggle(
+    'project_db',
+    'ProjectDB: Auto-managed SQL database of project case data',
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN],
+    description="Note that this is in testing and will not work without a dev helping.",
+)
+
 GEOCODER_MY_LOCATION_BUTTON = StaticToggle(
     "geocoder_my_location_button",
     "USH: Add button to geocoder to populate search with the user's current location",

--- a/urls.py
+++ b/urls.py
@@ -72,6 +72,7 @@ domain_specific = [
     url(r'^case/', include('corehq.apps.hqcase.urls')),
     url(r'^case/', include('corehq.apps.case_search.urls')),
     url(r'^clean/', include('corehq.apps.data_cleaning.urls')),
+    url(r'^project_db/', include('corehq.apps.project_db.urls')),
     url(r'^cloudcare/', include('corehq.apps.cloudcare.urls')),
     url(r'^campaign/', include('corehq.apps.campaign.urls')),
     url(r'^microplanning/', include('corehq.apps.geospatial.urls')),


### PR DESCRIPTION
## Product Description
Admin-only page that allows for testing user-constructed SQL against a ProjectDB database

<img width="3717" height="2012" alt="image" src="https://github.com/user-attachments/assets/d80ccbcf-044d-4869-82fd-033ac8b9c418" />

This is now available on staging if you'd like to play around with it:
https://staging.commcarehq.org/a/co-carecoordination-test/project_db/query/

## Technical Summary
The feature should be pretty self-explanatory  - the commits are logical, I'd review that way.  It's a straightforward HTMX and Alpine page with a textarea input and a table output.

I'm interested in developing this further as needs arise.  I'll for sure add an "EXPLAIN ANALYZE" button at some point, for example.  Will also have to look into bringing the query builder in here so we can try out parameterized filtering on top of this base SELECT statement.

## Feature Flag
Introduces a new "ProjectDB" feature flag, gating access to this.

## Safety Assurance


### Safety story
Still pre-release.  Notably though, this is the thing that allows for users to write "SQL" queries, so this is a good place to air any remaining concerns about that, though https://github.com/dimagi/commcare-hq/pull/37976 is the PR that introduces the mechanism by which that is done safely.

### Automated test coverage
Omitted - the underlying logic is heavily tested, but I didn't write tests for the view layer.

### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
