### PR TITLE
Domain-scoped OAuth followups

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1126,9 +1126,16 @@ class UserDomainsResource(ApiVersioningMixin, CorsResourceMixin, Resource):
 
         api_key = getattr(request, 'api_key', None)  # HQApiKey set by HQApiKeyAuthentication
         api_key_domain = getattr(api_key, 'domain', '')
+        oauth_domains = getattr(request, 'oauth_token_domains', None)
 
         results = []
-        domains = [api_key_domain] if api_key_domain else couch_user.get_domains()
+        if api_key_domain:
+            domains = [api_key_domain]
+        elif oauth_domains:
+            domains = [domain for domain in couch_user.get_domains() if domain in oauth_domains]
+        else:
+            domains = couch_user.get_domains()
+
         for domain in domains:
             domain_object = Domain.get_by_name(domain)
             if feature_flag and feature_flag not in toggles.toggles_dict(username=username, domain=domain):

--- a/corehq/apps/api/tests/test_user_resources.py
+++ b/corehq/apps/api/tests/test_user_resources.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import Mock, patch, call
 
+from django.http import HttpRequest
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.http import urlencode
@@ -1189,7 +1190,7 @@ class TestUserDomainsResource(TestCase):
     def test_domain_returned_when_no_filter(self, _):
         bundle = Bundle()
         bundle.obj = self.user
-        bundle.request = Mock()
+        bundle.request = Mock(spec=HttpRequest)
         bundle.request.GET = {}
         bundle.request.user = self.user
         bundle.request.api_key = None
@@ -1200,7 +1201,7 @@ class TestUserDomainsResource(TestCase):
     def test_exception_when_invalid_filter_sent(self, _):
         bundle = Bundle()
         bundle.obj = self.user
-        bundle.request = Mock()
+        bundle.request = Mock(spec=HttpRequest)
         bundle.request.GET = {"feature_flag": "its_a_feature_not_bug"}
         bundle.request.user = self.user
         bundle.request.api_key = None
@@ -1212,7 +1213,7 @@ class TestUserDomainsResource(TestCase):
     def test_domain_returned_when_valid_flag_sent(self, *args):
         bundle = Bundle()
         bundle.obj = self.user
-        bundle.request = Mock()
+        bundle.request = Mock(spec=HttpRequest)
         bundle.request.GET = {"feature_flag": "superset-analytics"}
         bundle.request.user = self.user
         bundle.request.api_key = None
@@ -1223,7 +1224,7 @@ class TestUserDomainsResource(TestCase):
     def test_domain_not_returned_when_flag_not_enabled(self, *args):
         bundle = Bundle()
         bundle.obj = self.user
-        bundle.request = Mock()
+        bundle.request = Mock(spec=HttpRequest)
         bundle.request.GET = {"feature_flag": "superset-analytics"}
         bundle.request.user = self.user
         bundle.request.api_key = None
@@ -1250,7 +1251,7 @@ class TestUserDomainsResourcePagination(TestCase):
         assert len(data['objects']) == 25
 
 
-class TestUserDomainsResourceApiKeyFiltering(TestCase):
+class TestUserDomainsResourceCredentialScopeFiltering(TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -1266,12 +1267,13 @@ class TestUserDomainsResourceApiKeyFiltering(TestCase):
         cls.user.save()
         cls.addClassCleanup(cls.user.delete, cls.domain, deleted_by=None)
 
-    def _make_bundle(self, api_key=None):
+    def _make_bundle(self, api_key=None, oauth_token_domains=None):
         bundle = Bundle()
-        bundle.request = Mock()
+        bundle.request = Mock(spec=HttpRequest)
         bundle.request.GET = {}
         bundle.request.user = self.user.get_django_user()
         bundle.request.api_key = api_key
+        bundle.request.oauth_token_domains = oauth_token_domains
         return bundle
 
     @patch('corehq.apps.api.resources.v0_5.domain_has_privilege', return_value=True)
@@ -1301,6 +1303,26 @@ class TestUserDomainsResourceApiKeyFiltering(TestCase):
         api_key = Mock()
         api_key.domain = self.domain2
         resp = UserDomainsResource().obj_get_list(self._make_bundle(api_key=api_key))
+        domain_names = [d.domain_name for d in resp]
+        assert domain_names == [self.domain2]
+
+    @patch('corehq.apps.api.resources.v0_5.domain_has_privilege', return_value=True)
+    def test_all_domains_returned_with_unrestricted_oauth_token(self, _):
+        resp = UserDomainsResource().obj_get_list(
+            self._make_bundle(oauth_token_domains=frozenset())
+        )
+        domain_names = [d.domain_name for d in resp]
+        assert set(domain_names) == {self.domain, self.domain2}
+
+    @patch('corehq.apps.api.resources.v0_5.domain_has_privilege', return_value=True)
+    def test_only_token_domains_returned_with_domain_scoped_oauth_token(self, _):
+        """
+        A scoped token is let through to this endpoint so a client can find out
+        which project spaces it may use, so it must not see the others.
+        """
+        resp = UserDomainsResource().obj_get_list(
+            self._make_bundle(oauth_token_domains=frozenset({self.domain2}))
+        )
         domain_names = [d.domain_name for d in resp]
         assert domain_names == [self.domain2]
 

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -7,6 +7,7 @@ from django.contrib.auth.signals import user_login_failed
 from django.core.exceptions import ValidationError
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext_lazy
 
 from captcha.fields import ReCaptchaField
 from crispy_forms import layout as crispy
@@ -226,7 +227,6 @@ class HQAllowForm(AllowForm):
 
     domains = forms.MultipleChoiceField(
         required=False,
-        label=_('On the project spaces:'),
         widget=forms.SelectMultiple(attrs={
             'class': 'form-select',
             'x-select2': json.dumps({'selectionCssClass': 'form-select p-1 pb-2 pe-4'}),
@@ -237,14 +237,27 @@ class HQAllowForm(AllowForm):
 
     def __init__(self, *args, domain_choices=None, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields['domains'].choices = list(domain_choices or [])
-        self.fields['domains'].widget.attrs['data-placeholder'] = _("Choose project spaces")
+        domain_field = self.fields['domains']
+        domain_field.choices = list(domain_choices or [])
+        self.choice_count = len(domain_field.choices)
+        domain_field.label = ngettext_lazy(
+            "On the project space:",
+            "On the project spaces:",
+            self.choice_count,
+        )
+        domain_field.widget.attrs['data-placeholder'] = ngettext_lazy(
+            "Choose project space",
+            "Choose project spaces",
+            self.choice_count,
+        )
+        if self.choice_count == 1:
+            domain_field.initial = [domain_field.choices[0][0]]
 
     def clean(self):
         cleaned_data = super().clean()
         if cleaned_data.get('allow') and not cleaned_data.get('domains'):
             self.add_error(
-                'domains', _("Choose which project spaces this application may access.")
+                'domains', _("Choose at least one project space."),
             )
         cleaned_data['scope'] = self._scope_with_chosen_project_spaces(cleaned_data)
         return cleaned_data

--- a/corehq/apps/hqwebapp/oauth_scopes.py
+++ b/corehq/apps/hqwebapp/oauth_scopes.py
@@ -1,12 +1,19 @@
 import re
 
-from django.utils.translation import gettext as _
-from oauth2_provider.scopes import SettingsScopes
+from django.utils.translation import gettext_lazy as _
+from oauth2_provider.scopes import BaseScopes
 
 from corehq.apps.users.models import CouchUser
 
 DOMAIN_SCOPE_PREFIX = 'domain:'
 ALL_PROJECTS_SCOPE = ''
+
+STATIC_SCOPES = {
+    'access_apis': _("Access CommCare API data"),
+    'reports:view': _("View and download report data"),
+    'mobile_access': _("Allow access to mobile sync and submit endpoints"),
+    'sync': _("(Deprecated, do not use) Allow access to mobile endpoints"),
+}
 
 class ScopeDescriptions(dict):
     """
@@ -25,14 +32,17 @@ class ScopeDescriptions(dict):
         raise KeyError(key)
 
 
-class HQScopes(SettingsScopes):
+class HQScopes(BaseScopes):
     """
-    Adds the dynamic ``domain:<name>`` scope to the statically configured scopes.
+    Adds the dynamic ``domain:<name>`` scope to STATIC_SCOPES.
     Wired up via the ``SCOPES_BACKEND_CLASS`` setting.
     """
 
     def get_all_scopes(self):
-        return ScopeDescriptions(super().get_all_scopes())
+        return ScopeDescriptions(STATIC_SCOPES)
+
+    def get_default_scopes(self, application=None, request=None, *args, **kwargs):
+        return list(STATIC_SCOPES)
 
     def describe_scopes(self, scopes):
         """
@@ -49,9 +59,7 @@ class HQScopes(SettingsScopes):
         return descriptions
 
     def get_available_scopes(self, application=None, request=None, *args, **kwargs):
-        scopes = list(super().get_available_scopes(application, request, *args, **kwargs))
-        scopes.extend(self._grantable_domain_scopes(request))
-        return scopes
+        return list(STATIC_SCOPES) + self._grantable_domain_scopes(request)
 
     def _grantable_domain_scopes(self, request):
         if request is None:

--- a/corehq/apps/hqwebapp/oauth_views.py
+++ b/corehq/apps/hqwebapp/oauth_views.py
@@ -1,14 +1,82 @@
+from django.forms import modelform_factory
+from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
-
 from memoized import memoized
 from oauth2_provider.models import get_application_model
 from oauth2_provider.scopes import get_scopes_backend
 from oauth2_provider.views.base import AuthorizationView
 
+from corehq.apps.domain.decorators import (
+    require_superuser,
+)
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
-from corehq.apps.hqwebapp.forms import HQAllowForm
+from corehq.apps.hqwebapp.forms import (
+    HQAllowForm,
+)
+from corehq.apps.hqwebapp.models import HQOauthApplication
 from corehq.apps.hqwebapp.oauth_scopes import DOMAIN_SCOPE_PREFIX
+from corehq.apps.hqwebapp.views import BasePageView
+from corehq.util.view_utils import reverse
+
+
+@method_decorator(require_superuser, name="dispatch")
+class OauthApplicationRegistration(BasePageView):
+    urlname = 'oauth_application_registration'
+    page_title = "Oauth Application Registration"
+    template_name = "hqwebapp/bootstrap3/oauth_application_registration_form.html"
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname)
+
+    @property
+    def base_application_form(self):
+        return modelform_factory(
+            get_application_model(),
+            fields=(
+                "name",
+                "client_id",
+                "client_secret",
+                "client_type",
+                "authorization_grant_type",
+                "redirect_uris",
+            ),
+        )
+
+    @property
+    def hq_application_form(self):
+        return modelform_factory(
+            HQOauthApplication,
+            fields=(
+                "pkce_required",
+            ),
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        if 'forms' not in kwargs:
+            context['forms'] = [self.base_application_form(), self.hq_application_form()]
+        return context
+
+    def post(self, request, *args, **kwargs):
+
+        base_application_form = self.base_application_form(data=self.request.POST)
+        hq_application_form = self.hq_application_form(data=self.request.POST)
+
+        if base_application_form.is_valid() and hq_application_form.is_valid():
+            base_application_form.instance.user = self.request.user
+            base_application = base_application_form.save()
+            HQOauthApplication.objects.create(
+                application=base_application,
+                **hq_application_form.cleaned_data,
+            )
+        else:
+            return self.render_to_response(self.get_context_data(
+                forms=[base_application_form, hq_application_form]
+            ))
+
+        return HttpResponseRedirect(reverse('oauth2_provider:detail', args=[str(base_application.id)]))
 
 
 @method_decorator(use_bootstrap5, name="dispatch")

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/oauth_authorize.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/oauth_authorize.js
@@ -8,6 +8,9 @@ Alpine.data("consentForm", () => ({
 
     init() {
         this.domainCount = this.$refs.domains.options.length;
+        this.selectedDomains = Array.from(
+            this.$refs.domains.selectedOptions, (option) => option.value,
+        );
     },
 
     setAllDomains(selected) {

--- a/corehq/apps/hqwebapp/tests/test_oauth_authorize.py
+++ b/corehq/apps/hqwebapp/tests/test_oauth_authorize.py
@@ -44,6 +44,14 @@ class TestHQAllowForm:
             ('delta', 'Delta Project'),
         ]
 
+    @pytest.mark.parametrize('choices, initial', [
+        ([('alpha', 'Alpha Project')], ['alpha']),
+        ([('alpha', 'Alpha Project'), ('beta', 'Beta Project')], None),
+    ])
+    def test_a_lone_project_space_is_preselected(self, choices, initial):
+        form = self.build_form(domain_choices=choices)
+        assert form.fields['domains'].initial == initial
+
     @pytest.mark.parametrize('requested, chosen, granted', [
         ('access_apis', ['alpha'], 'access_apis domain:alpha'),
         ('access_apis', ['alpha', 'beta'], 'access_apis domain:alpha domain:beta'),

--- a/corehq/apps/hqwebapp/tests/test_oauth_scopes.py
+++ b/corehq/apps/hqwebapp/tests/test_oauth_scopes.py
@@ -6,14 +6,13 @@ import pytest
 from corehq.apps.hqwebapp import oauth_scopes
 from corehq.apps.hqwebapp.oauth_scopes import (
     DOMAIN_SCOPE_PREFIX,
+    STATIC_SCOPES,
     HQScopes,
     ScopeDescriptions,
     domain_scope,
     token_domains,
 )
 from corehq.apps.users.models import CouchUser
-
-STATIC_SCOPES = {'access_apis', 'reports:view', 'mobile_access', 'sync'}
 
 
 class FakeOAuthRequest:
@@ -96,8 +95,11 @@ class TestHQScopes:
 
     def test_get_all_scopes_supports_domain_lookup(self):
         all_scopes = HQScopes().get_all_scopes()
-        assert STATIC_SCOPES.issubset(all_scopes.keys())
+        assert set(STATIC_SCOPES).issubset(all_scopes.keys())
         assert 'my-project' in all_scopes[f'{DOMAIN_SCOPE_PREFIX}my-project']
+
+    def test_default_scopes(self):
+        assert HQScopes().get_default_scopes() == list(STATIC_SCOPES)
 
     def test_describe_scopes_covers_static_and_domain_scopes(self):
         descriptions = HQScopes().describe_scopes(
@@ -115,11 +117,11 @@ class TestHQScopes:
 
     def test_available_scopes_without_a_request(self):
         """OIDC discovery calls this with no arguments; it must not raise."""
-        assert set(HQScopes().get_available_scopes()) == STATIC_SCOPES
+        assert HQScopes().get_available_scopes() == list(STATIC_SCOPES)
 
     def test_available_scopes_without_a_requested_domain(self):
         request = FakeOAuthRequest(scopes=['access_apis'])
-        assert set(HQScopes().get_available_scopes(request=request)) == STATIC_SCOPES
+        assert HQScopes().get_available_scopes(request=request) == list(STATIC_SCOPES)
 
     def test_unauthenticated_authorize_step_permits_a_valid_project_space(self):
         """
@@ -133,7 +135,7 @@ class TestHQScopes:
     def test_syntactically_invalid_project_space_is_rejected(self, domain):
         request = FakeOAuthRequest(scopes=[f'{DOMAIN_SCOPE_PREFIX}{domain}'], user=None)
         available = HQScopes().get_available_scopes(request=request)
-        assert set(available) == STATIC_SCOPES
+        assert available == list(STATIC_SCOPES)
 
     @pytest.mark.parametrize('requested, granted', [
         (['domain:mine'], {'domain:mine'}),
@@ -144,4 +146,4 @@ class TestHQScopes:
         request = FakeOAuthRequest(scopes=requested, user=object())
         with _member_of('mine'):
             available = HQScopes().get_available_scopes(request=request)
-        assert set(available) == STATIC_SCOPES | granted
+        assert set(available) == set(STATIC_SCOPES) | granted

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -10,14 +10,16 @@ from corehq.apps.domain.forms import ConfidentialDomainPasswordResetForm
 from corehq.apps.domain.views.settings import DomainPasswordResetView
 from corehq.apps.domain.views.sms import PublicSMSRatesView
 from corehq.apps.hqwebapp.decorators import waf_allow
-from corehq.apps.hqwebapp.oauth_views import HQAuthorizationView
+from corehq.apps.hqwebapp.oauth_views import (
+    HQAuthorizationView,
+    OauthApplicationRegistration,
+)
 from corehq.apps.hqwebapp.session_details_endpoint.views import (
     SessionDetailsView,
 )
 from corehq.apps.hqwebapp.views import (
     BugReportView,
     MaintenanceAlertsView,
-    OauthApplicationRegistration,
     SolutionsFeatureRequestView,
     check_sso_login_status,
     create_alert,

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -16,7 +16,6 @@ from django.contrib.auth.models import User
 from django.contrib.auth.views import LogoutView
 from django.core import cache
 from django.core.mail.message import EmailMessage
-from django.forms import modelform_factory
 from django.http import (
     Http404,
     HttpResponse,
@@ -48,7 +47,6 @@ from django.views.generic.base import View
 import httpagentparser
 import pytz
 from memoized import memoized
-from oauth2_provider.models import get_application_model
 from sentry_sdk import last_event_id
 from two_factor.utils import default_device
 from two_factor.views import LoginView
@@ -99,7 +97,7 @@ from corehq.apps.hqwebapp.forms import (
     HQBackupTokenForm,
 )
 from corehq.apps.hqwebapp.login_utils import get_custom_login_page
-from corehq.apps.hqwebapp.models import HQOauthApplication, ServerLocation
+from corehq.apps.hqwebapp.models import ServerLocation
 from corehq.apps.hqwebapp.utils import get_environment_friendly_name
 from corehq.apps.hqwebapp.utils.bootstrap import (
     get_bootstrap_version,
@@ -1487,65 +1485,6 @@ def log_email_event(request, secret, domain=None):
     handle_email_sns_event(message)
 
     return HttpResponse()
-
-
-@method_decorator(require_superuser, name="dispatch")
-class OauthApplicationRegistration(BasePageView):
-    urlname = 'oauth_application_registration'
-    page_title = "Oauth Application Registration"
-    template_name = "hqwebapp/bootstrap3/oauth_application_registration_form.html"
-
-    @property
-    def page_url(self):
-        return reverse(self.urlname)
-
-    @property
-    def base_application_form(self):
-        return modelform_factory(
-            get_application_model(),
-            fields=(
-                "name",
-                "client_id",
-                "client_secret",
-                "client_type",
-                "authorization_grant_type",
-                "redirect_uris",
-            ),
-        )
-
-    @property
-    def hq_application_form(self):
-        return modelform_factory(
-            HQOauthApplication,
-            fields=(
-                "pkce_required",
-            ),
-        )
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        if 'forms' not in kwargs:
-            context['forms'] = [self.base_application_form(), self.hq_application_form()]
-        return context
-
-    def post(self, request, *args, **kwargs):
-
-        base_application_form = self.base_application_form(data=self.request.POST)
-        hq_application_form = self.hq_application_form(data=self.request.POST)
-
-        if base_application_form.is_valid() and hq_application_form.is_valid():
-            base_application_form.instance.user = self.request.user
-            base_application = base_application_form.save()
-            HQOauthApplication.objects.create(
-                application=base_application,
-                **hq_application_form.cleaned_data,
-            )
-        else:
-            return self.render_to_response(self.get_context_data(
-                forms=[base_application_form, hq_application_form]
-            ))
-
-        return HttpResponseRedirect(reverse('oauth2_provider:detail', args=[str(base_application.id)]))
 
 
 @csrf_exempt

--- a/settings.py
+++ b/settings.py
@@ -892,12 +892,6 @@ OAUTH2_PROVIDER = {
     'ACCESS_TOKEN_EXPIRE_SECONDS': 15 * 60,
     'PKCE_REQUIRED': _pkce_required,
     'SCOPES_BACKEND_CLASS': 'corehq.apps.hqwebapp.oauth_scopes.HQScopes',
-    'SCOPES': {
-        'access_apis': 'Access CommCare API data',
-        'reports:view': 'View and download report data',
-        'mobile_access': 'Allow access to mobile sync and submit endpoints',
-        'sync': '(Deprecated, do not use) Allow access to mobile endpoints',
-    },
     'REFRESH_TOKEN_EXPIRE_SECONDS': 60 * 60 * 24 * 15,  # 15 days
 }
 


### PR DESCRIPTION
## Product Description
- Using a domain-scoped OAuth token to access the `list_domains` endpoint now returns only the domains that token can access, in line with how we handle domain-scoped API keys.
- OAuth scope descriptions will now be correctly translated on the user-facing OAuth screen
- Users with only a single project space reaching the OAuth screen will have the option pre-selected, and see singularized text:
<img width="490" height="355" alt="image" src="https://github.com/user-attachments/assets/5caea747-151f-4a7e-983f-5ff61100d493" />


## Technical Summary
Follow-ups to #38040 as described above. In addition, this moves the existing `OauthApplicationRegistration` view to the newer `oauth_views.py`, as it is related functionality (though admin- rather than user- facing).


## Safety Assurance

### Safety story
Returning a scoped list of domains for `list_domains` arguably improves security. Moving our scope definitions to a `BaseScopes` subclass is a supported way of dealing with scopes provided by the `oauth2_provider` library we use. Moving the Oauth Application Registration view is purely mechanical and handling the case of a single project space is a minor UI change. Tested UI changes locally.

### Automated test coverage
Yes, there are tests added for getting OAuth scopes and listing only scoped domains.

### QA Plan
No formal QA planned.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
