### PR TITLE
Do not display low credits modal for enterprise customer

### DIFF
--- a/corehq/apps/accounting/mixins.py
+++ b/corehq/apps/accounting/mixins.py
@@ -2,7 +2,7 @@ import itertools
 from datetime import date, timedelta
 
 from corehq.apps.accounting.const import DAYS_PAST_DUE_TO_TRIGGER_DOWNGRADE
-from corehq.apps.accounting.models import CreditLine, Subscription
+from corehq.apps.accounting.models import CreditLine, SoftwarePlanEdition, Subscription
 from corehq.apps.accounting.utils import get_first_day_x_months_later
 from corehq.apps.accounting.utils.unpaid_invoice import Downgrade
 from corehq.apps.accounting.utils.invoicing import (
@@ -82,7 +82,11 @@ class BillingModalsMixin(object):
     def _low_credits_context(self):
         context = {}
         current_subscription = Subscription.get_active_subscription_by_domain(self.domain)
-        if current_subscription:
+        not_enterprise_subscription = (
+            current_subscription
+            and current_subscription.plan_version.plan.edition != SoftwarePlanEdition.ENTERPRISE
+        )
+        if current_subscription and not_enterprise_subscription:
             monthly_fee = current_subscription.plan_version.product_rate.monthly_fee
             if monthly_fee:
                 prepaid_credits = get_total_credits_available_for_product(current_subscription)

--- a/corehq/apps/accounting/mixins.py
+++ b/corehq/apps/accounting/mixins.py
@@ -82,11 +82,11 @@ class BillingModalsMixin(object):
     def _low_credits_context(self):
         context = {}
         current_subscription = Subscription.get_active_subscription_by_domain(self.domain)
-        not_enterprise_subscription = (
+        enterprise_subscription = (
             current_subscription
-            and current_subscription.plan_version.plan.edition != SoftwarePlanEdition.ENTERPRISE
+            and current_subscription.plan_version.plan.edition == SoftwarePlanEdition.ENTERPRISE
         )
-        if current_subscription and not_enterprise_subscription:
+        if current_subscription and not enterprise_subscription:
             monthly_fee = current_subscription.plan_version.product_rate.monthly_fee
             if monthly_fee:
                 prepaid_credits = get_total_credits_available_for_product(current_subscription)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Enterprise customer shouldn't see this low credits alert because their renewals are handled differently, and at an HQ level.
<img width="370" height="108" alt="Screenshot 2026-08-21 at 3 50 14 PM" src="https://github.com/user-attachments/assets/00f544e8-a8be-4f17-8fb7-102fd3820265" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-20203

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Straightforward change to exclude enterprise subscription.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
