### PR TITLE
Do not sync usercase with migration in progress

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -75,6 +75,7 @@ from corehq.apps.domain.utils import (
     domain_restricts_superusers,
     guess_domain_language,
 )
+from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.mobile_auth.utils import generate_aes_key
 from corehq.apps.reports.const import TABLEAU_ROLES
@@ -1639,7 +1640,8 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
                     domains_to_sync_usercase = getattr(self, 'domains', [])
                 # We need to sync to domains the user is leaving so that usercase is closed
                 for domain in domains_to_sync_usercase + getattr(self, '_leaving_domains', []):
-                    sync_usercases_if_applicable(domain, self, spawn_task)
+                    if not any_migrations_in_progress(domain):
+                        sync_usercases_if_applicable(domain, self, spawn_task)
         self._leaving_domains = []
 
     def fire_signals(self):

--- a/corehq/apps/users/tests/test_signals.py
+++ b/corehq/apps/users/tests/test_signals.py
@@ -27,6 +27,7 @@ from ..signals import update_user_in_es
 @patch('corehq.apps.sms.tasks.sync_user_phone_numbers', new=MagicMock())
 @patch('corehq.apps.users.models.CouchUser.sync_to_django_user', new=MagicMock())
 @patch('corehq.apps.users.models.CommCareUser.project', new=MagicMock())
+@patch('corehq.apps.users.models.any_migrations_in_progress', lambda *a: False)
 @patch('corehq.apps.callcenter.tasks.Domain.get_by_name', new=lambda _: MagicMock())
 @patch('corehq.apps.analytics.signals.get_subscription_properties_by_user', new=MagicMock(return_value={}))
 @patch('corehq.apps.analytics.signals.get_domain_membership_properties', new=MagicMock(return_value={}))
@@ -62,6 +63,7 @@ class TestUserSignals(SimpleTestCase):
 
 @mock_out_couch()
 @patch('corehq.apps.users.models.CouchUser.sync_to_django_user', new=MagicMock)
+@patch('corehq.apps.users.models.any_migrations_in_progress', lambda *a: False)
 @patch_user_data_db_layer
 @patch('corehq.apps.analytics.signals.update_hubspot_properties')
 @patch('corehq.apps.callcenter.tasks.sync_usercases')


### PR DESCRIPTION
Fixes an error affecting users who belong to a domain that has an in-progress data migration. Previously, actions that saved a user record — including resetting a password — could fail with a server error if any domain the user belongs to was mid-migration, because the save attempted to sync that domain's usercase and the migrating domain rejects form submissions. Saving a user (e.g. a password reset) now simply skips usercase sync for domains that are currently migrating, instead of failing.

This will leave a usercase in an open state if a user leaves the associated domain while a migration is in progress. Doesn't seem great to leave the case in an inconsistent state like that, but I can't think of a better alternative; blocking the user save seems worse.

https://dimagi.atlassian.net/browse/SAAS-20215

Claude thinks this was introduced by #36934. I'm not so sure, but including for posterity:

> The PR body explicitly states the mechanism: "As part of previous changes, all domains that have `USERCASE` privileges will already have usercases created and synced... those checks are replaced with `privileges.USERCASE` checks" — which broadened `sync_usercases_if_applicable` from `checking domain_obj.usercase_enabled` (a narrow, explicitly-set flag) to `domain_has_privilege(domain, privileges.USERCASE)` (true for essentially any paid-plan domain).
>
> Before PR #36934, this failure mode existed too (the 503-on-migration check dates to 2015-2017), but it only fired for domains with the explicit `usercase_enabled` flag set — a much smaller population. This PR widened that population to essentially all paid domains, making the interaction with in-progress migrations much more likely to be hit — matching what Sentry is showing starting around that deploy window.

## Safety Assurance

### Safety story

This only skips a sync call for domains currently mid-migration; it does not change behavior for any domain that isn't migrating. Usercase data is not lost — it will sync on the next save once the migration finishes unless the user is leaving the domain.

### Automated test coverage

Updated `corehq/apps/users/tests/test_signals.py` to mock `any_migrations_in_progress` so existing usercase-sync tests continue to reflect the non-migrating case.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations
