### PR TITLE
ProjectDB: advanced query support and query parameters

### DIFF
--- a/corehq/apps/project_db/describe.py
+++ b/corehq/apps/project_db/describe.py
@@ -28,16 +28,24 @@ Schema:
 
 Supported SQL:
  * SELECT of a column list or *, with optional AS aliases.
- * A single table in the FROM clause.
- * JOIN and LEFT JOIN, with an ON condition.
+ * DISTINCT, and DISTINCT ON (columns).
+ * A single table in the FROM clause, with an optional alias.
+ * JOIN and LEFT JOIN, with an ON condition. A table can be joined to itself if
+   each side is given a different alias.
  * WHERE, combining conditions with AND, OR and NOT, and comparing columns and
    literals with =, <>, <, <=, >, >=, IS NULL/TRUE/FALSE and IN.
+ * Array containment against an ARRAY['a', 'b'] literal, for select_prop__
+   columns: @> holds all of these, <@ holds only these, && holds any of these.
+ * ORDER BY a column, with ASC/DESC and NULLS FIRST/LAST.
  * UNION and UNION ALL of the above.
+ * Named :parameters wherever a literal is allowed
 
 Not supported:
- * Aggregates, function calls and arithmetic.
- * GROUP BY, ORDER BY, LIMIT, DISTINCT and LIKE.
- * Subqueries, CTEs and table aliases.
+ * Aggregates, function calls, arithmetic and casts (::type).
+ * GROUP BY, LIMIT, LIKE and BETWEEN.
+ * Negative numbers.
+ * Subqueries and CTEs.
+ * INTERSECT and EXCEPT.
 
 This project has the following tables:
 {% for summary in table_summaries %}\

--- a/corehq/apps/project_db/populate.py
+++ b/corehq/apps/project_db/populate.py
@@ -106,8 +106,6 @@ def coerce_to_select(value):
     return [x for x in str(value).split(' ') if x]
 
 
-
-
 def coerce_to_gps(value):
     """Parse a GPS case property into an earthdistance ``earth`` cube literal."""
     try:

--- a/corehq/apps/project_db/templates/project_db/partials/query_results.html
+++ b/corehq/apps/project_db/templates/project_db/partials/query_results.html
@@ -4,10 +4,10 @@
 {% else %}
   <details open>
     <summary class="h6">{% trans "Translated SQL" %}</summary>
-    <pre class="p-3 mb-3 bg-body-tertiary border rounded">{{ query.sql }}</pre>
-    {% if query.params %}
+    <pre class="p-3 mb-3 bg-body-tertiary border rounded">{{ query.translated_sql }}</pre>
+    {% if query.bound_literals %}
       <dl class="row font-monospace mb-4">
-        {% for name, value in query.params.items %}
+        {% for name, value in query.bound_literals.items %}
           <dt class="col-sm-2 fw-normal text-body-secondary">:{{ name }}</dt>
           <dd class="col-sm-10">{{ value }}</dd>
         {% endfor %}

--- a/corehq/apps/project_db/templates/project_db/partials/query_results.html
+++ b/corehq/apps/project_db/templates/project_db/partials/query_results.html
@@ -4,44 +4,83 @@
 {% else %}
   <details open>
     <summary class="h6">{% trans "Translated SQL" %}</summary>
-    <pre class="p-3 mb-3 bg-body-tertiary border rounded">{{ result.query.sql }}</pre>
-    {% if result.query.params %}
+    <pre class="p-3 mb-3 bg-body-tertiary border rounded">{{ query.sql }}</pre>
+    {% if query.params %}
       <dl class="row font-monospace mb-4">
-        {% for name, value in result.query.params.items %}
+        {% for name, value in query.params.items %}
           <dt class="col-sm-2 fw-normal text-body-secondary">:{{ name }}</dt>
           <dd class="col-sm-10">{{ value }}</dd>
         {% endfor %}
       </dl>
     {% endif %}
   </details>
-  <p class="text-body-secondary">
-    {% blocktrans with duration=result.duration|floatformat:3 %}Evaluated in {{ duration }} seconds{% endblocktrans %}
-  </p>
-  {% if result.rows %}
-    {% if result.rows|length == max_rows %}
-      <div class="alert alert-info">
-        {% blocktrans %}Showing the first {{ max_rows }} rows.{% endblocktrans %}
-      </div>
-    {% endif %}
-    <div class="table-responsive">
-      <table class="table table-striped table-sm">
-        <thead>
+
+  {% if parameters %}
+    <h3 class="h6">{% trans "Try it out" %}</h3>
+    <table class="table table-sm align-middle mb-3">
+      <tbody>
+        {% for parameter in parameters %}
           <tr>
-            {% for column in result.columns %}
-            <th>{{ column }}</th>
-            {% endfor %}
+            <th scope="row" class="fw-normal font-monospace text-nowrap w-25">
+              <label for="param-{{ parameter.name }}">:{{ parameter.name }}</label>
+            </th>
+            <td>
+              <input
+                type="text"
+                class="form-control form-control-sm"
+                id="param-{{ parameter.name }}"
+                name="param:{{ parameter.name }}"
+                value="{{ parameter.value }}"
+                spellcheck="false"
+              >
+            </td>
           </tr>
-        </thead>
-        <tbody>
-          {% for row in result.rows %}
+        {% endfor %}
+      </tbody>
+    </table>
+    <button
+      type="button"
+      class="btn btn-primary mb-4"
+      hq-hx-action="run_query_with_parameters"
+      hx-post="{{ request.path_info }}"
+      hx-target="#query-results"
+      hx-include="#query-form, #query-results"
+      hx-disabled-elt="this"
+    >
+      {% trans "Run" %}
+    </button>
+  {% endif %}
+
+  {% if result %}
+    <p class="text-body-secondary">
+      {% blocktrans with duration=result.duration|floatformat:3 %}Evaluated in {{ duration }} seconds{% endblocktrans %}
+    </p>
+    {% if result.rows %}
+      {% if result.rows|length == max_rows %}
+        <div class="alert alert-info">
+          {% blocktrans %}Showing the first {{ max_rows }} rows.{% endblocktrans %}
+        </div>
+      {% endif %}
+      <div class="table-responsive">
+        <table class="table table-striped table-sm">
+          <thead>
             <tr>
-              {% for value in row %}<td>{{ value }}</td>{% endfor %}
+              {% for column in result.columns %}
+              <th>{{ column }}</th>
+              {% endfor %}
             </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% else %}
-    <p class="text-body-secondary">{% trans "No results" %}</p>
+          </thead>
+          <tbody>
+            {% for row in result.rows %}
+              <tr>
+                {% for value in row %}<td>{{ value }}</td>{% endfor %}
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      <p class="text-body-secondary">{% trans "No results" %}</p>
+    {% endif %}
   {% endif %}
 {% endif %}

--- a/corehq/apps/project_db/templates/project_db/query_project_db.html
+++ b/corehq/apps/project_db/templates/project_db/query_project_db.html
@@ -22,9 +22,11 @@
     {% endif %}
   </details>
   <form
+    id="query-form"
     hx-post="{{ request.path_info }}"
-    hq-hx-action="run_query"
+    hq-hx-action="process_query"
     hx-target="#query-results"
+    hx-include="#query-results"
     hx-disabled-elt="find button[type=submit]"
   >
     <div class="mb-3">
@@ -36,7 +38,7 @@
         placeholder="SELECT * FROM my_case_type"
       ></textarea>
     </div>
-    <button type="submit" class="btn btn-primary">{% trans "Run" %}</button>
+    <button type="submit" class="btn btn-primary">{% trans "Process" %}</button>
     <button
       type="button"
       class="btn btn-outline-primary"

--- a/corehq/apps/project_db/tests/test_user_sql.py
+++ b/corehq/apps/project_db/tests/test_user_sql.py
@@ -16,7 +16,14 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects import postgresql
 
-from corehq.apps.project_db.user_sql import UnsupportedSQL, _bind, translate
+from corehq.apps.project_db.user_sql import (
+    BadParameters,
+    UnsupportedSQL,
+    _bind,
+    clean_parameters,
+    get_parameters,
+    translate,
+)
 
 CLIENT = table('client', column('case_id'), column('name'))
 VISIT = table('visit', column('visit_id'), column('parent_id'), column('name'))
@@ -293,8 +300,39 @@ def test_query_parameters_are_left_unbound():
     assert str(compiled) == ('SELECT client.name \nFROM client \n'
                              'WHERE client.name = %(who)s '
                              'AND client.case_id = %(hq_param_1)s')
-    assert [name for name, bind in compiled.binds.items() if bind.required] == ['who']
     assert compiled.params == {'hq_param_1': 'c1', 'who': None}
+
+
+@pytest.mark.parametrize('sql, expected', [
+    ('SELECT * FROM client', []),
+    # Parameters come back in the order they appear
+    ('SELECT * FROM client WHERE name IN :names AND case_id = :cid',
+     ['names', 'cid']),
+    # Literals are already bound, and a parameter used twice is listed once
+    ("SELECT * FROM client WHERE name = :who AND case_id = 'c1' OR name = :who",
+     ['who']),
+])
+def test_get_parameters(sql, expected):
+    assert get_parameters(translate(sql, TABLES)) == expected
+
+
+@pytest.mark.parametrize('sql, raw, expected', [
+    ('SELECT * FROM client', {}, {}),
+    ('SELECT * FROM client WHERE name = :who', {'who': 'ann'}, {'who': 'ann'}),
+    # A falsy value is passed through as-is
+    ('SELECT * FROM client WHERE name = :who', {'who': ''}, {'who': ''}),
+])
+def test_clean_parameters(sql, raw, expected):
+    assert clean_parameters(translate(sql, TABLES), raw) == expected
+
+
+@pytest.mark.parametrize('sql, raw', [
+    ('SELECT * FROM client WHERE name = :who', {}),
+    ('SELECT * FROM client', {'stale': 'x'}),
+])
+def test_clean_parameters_rejects_a_mismatched_set(sql, raw):
+    with pytest.raises(BadParameters):
+        clean_parameters(translate(sql, TABLES), raw)
 
 
 def test_handle_quoted_tables():

--- a/corehq/apps/project_db/tests/test_user_sql.py
+++ b/corehq/apps/project_db/tests/test_user_sql.py
@@ -28,6 +28,10 @@ ON = CLIENT.c.case_id == VISIT.c.parent_id
 CLIENT_VISIT = CLIENT.join(VISIT, ON)
 JOIN_SQL = 'FROM client JOIN visit ON client.case_id = visit.parent_id'
 
+# An alias is what makes joining a table to itself possible
+VISIT_V, VISIT_P = VISIT.alias('v'), VISIT.alias('p')
+SELF_JOIN = VISIT_V.join(VISIT_P, VISIT_V.c.parent_id == VISIT_P.c.visit_id)
+
 
 @pytest.mark.parametrize('sql, expected', [
     ('SELECT * FROM client', select([CLIENT])),
@@ -74,6 +78,11 @@ JOIN_SQL = 'FROM client JOIN visit ON client.case_id = visit.parent_id'
      select([CLIENT.join(VISIT, and_(ON, VISIT.c.name == literal('x')))])),
     ('SELECT * FROM client LEFT JOIN visit ON client.case_id = visit.parent_id',
      select([CLIENT.join(VISIT, ON, isouter=True)])),
+
+    # Table aliases
+    ('SELECT v.visit_id, p.visit_id '
+     'FROM visit AS v JOIN visit AS p ON v.parent_id = p.visit_id',
+     select([VISIT_V.c.visit_id, VISIT_P.c.visit_id]).select_from(SELF_JOIN)),
 
     # DISTINCT
     ('SELECT DISTINCT name FROM client', select([CLIENT.c.name]).distinct()),
@@ -221,8 +230,9 @@ def _compiled(query):
     'SELECT * FROM client JOIN visit USING (case_id)',  # USING instead of ON
     'SELECT * FROM client JOIN visit',                  # no ON clause
     'SELECT * FROM client, visit',                      # comma join has no ON
-    'SELECT * FROM client AS c JOIN visit ON c.case_id = visit.parent_id',  # alias
     'SELECT * FROM client JOIN client ON client.case_id = client.case_id',  # self join
+    'SELECT * FROM client AS c(a, b)',    # column aliases on a table
+    "SELECT * FROM client AS c WHERE client.name = 'x'",  # table must be referenced by alias
     f'SELECT name {JOIN_SQL}',              # ambiguous, both tables have `name`
     f'SELECT client.visit_id {JOIN_SQL}',   # column belongs to the other table
 ])
@@ -234,8 +244,7 @@ def test_rejects_unsupported(sql):
 @pytest.mark.parametrize('alias, expected', [
     ('id', 'id'),
     ('"My Id"', '"My Id"'),
-    # A column alias is the only user-supplied identifier that reaches the
-    # generated SQL, so it must always come back out quoted and escaped.
+    # Ensure user-supplied identifiers come out quoted and escaped
     ('"a""b"', '"a""b"'),
     ('"a\'b"', '"a\'b"'),
     ('"); DROP TABLE client; --"', '"); DROP TABLE client; --"'),
@@ -245,6 +254,11 @@ def test_escapes_alias_identifiers(alias, expected):
     query = translate(f'SELECT case_id AS {alias} FROM client', TABLES)
     sql, params = _compiled(query)
     assert sql == f'SELECT client.case_id AS {expected} \nFROM client'
+    assert params == {}
+
+    query = translate(f'SELECT case_id FROM client AS {alias}', TABLES)
+    sql, params = _compiled(query)
+    assert sql == f'SELECT {expected}.case_id \nFROM client AS {expected}'
     assert params == {}
 
 

--- a/corehq/apps/project_db/tests/test_user_sql.py
+++ b/corehq/apps/project_db/tests/test_user_sql.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 import pytest
 from sqlalchemy import (
     and_,
+    bindparam,
     column,
     not_,
     nullsfirst,
@@ -157,6 +158,13 @@ SELF_JOIN = VISIT_V.join(VISIT_P, VISIT_V.c.parent_id == VISIT_P.c.visit_id)
     ('SELECT * FROM client WHERE name IS NOT TRUE',
      select([CLIENT]).where(not_(CLIENT.c.name.is_(True)))),
 
+    # Query parameters are left for the caller to bind after translation
+    ('SELECT * FROM client WHERE name = :who',
+     select([CLIENT]).where(CLIENT.c.name == bindparam('who'))),
+    # One parameter can hold a whole list of values
+    ('SELECT * FROM client WHERE name IN :names',
+     select([CLIENT]).where(CLIENT.c.name.in_(bindparam('names', expanding=True)))),
+
     # Array operators
     ("SELECT * FROM survey WHERE symptoms @> ARRAY['fever', 'cough']",
      select([SURVEY]).where(SURVEY.c.symptoms.bool_op('@>')(_bind(['fever', 'cough'])))),
@@ -213,6 +221,16 @@ def _compiled(query):
     'SELECT * FROM client WHERE case_id = -1',    # negative number
     "SELECT * FROM client WHERE name LIKE 'x%'",  # LIKE
     'SELECT * FROM client WHERE name IN ()',      # IN with no values
+
+    # Query parameters must be named, and the name must be a plain identifier
+    # because it is interpolated into the compiled SQL
+    'SELECT * FROM client WHERE name = %s',           # unnamed
+    'SELECT * FROM client WHERE name = ?',            # unnamed
+    'SELECT * FROM client WHERE name = $1',           # positional
+    'SELECT * FROM client WHERE name = %(who)s',      # not the supported spelling
+    'SELECT * FROM client WHERE name = :hq_param_1',  # reserved prefix
+    'SELECT * FROM client WHERE name IN tbl',         # IN takes a list or parameter
+    'SELECT * FROM client WHERE name = :"a)s; DROP TABLE client; --"',
     'SELECT * FROM survey WHERE symptoms @> ARRAY[symptoms]', # Array literals only
     'SELECT * FROM client WHERE name IN (SELECT name FROM client)',  # IN a subquery
     'SELECT * FROM client WHERE name',            # not a comparison
@@ -267,6 +285,16 @@ def test_literals_bind_under_our_own_prefix():
                    'WHERE client.name = %(hq_param_1)s '
                    'AND client.case_id = %(hq_param_2)s')
     assert params == {'hq_param_1': (str, 'x'), 'hq_param_2': (int, 5)}
+
+
+def test_query_parameters_are_left_unbound():
+    query = translate("SELECT name FROM client WHERE name = :who AND case_id = 'c1'", TABLES)
+    compiled = query.compile(dialect=postgresql.dialect())
+    assert str(compiled) == ('SELECT client.name \nFROM client \n'
+                             'WHERE client.name = %(who)s '
+                             'AND client.case_id = %(hq_param_1)s')
+    assert [name for name, bind in compiled.binds.items() if bind.required] == ['who']
+    assert compiled.params == {'hq_param_1': 'c1', 'who': None}
 
 
 def test_handle_quoted_tables():

--- a/corehq/apps/project_db/tests/test_user_sql.py
+++ b/corehq/apps/project_db/tests/test_user_sql.py
@@ -21,7 +21,8 @@ from corehq.apps.project_db.user_sql import UnsupportedSQL, translate
 CLIENT = table('client', column('case_id'), column('name'))
 VISIT = table('visit', column('visit_id'), column('parent_id'), column('name'))
 FORM = table('form', column('form_id'), column('visit_id'))
-TABLES = {'client': CLIENT, 'visit': VISIT, 'form': FORM}
+SURVEY = table('survey', column('symptoms'))
+TABLES = {'client': CLIENT, 'visit': VISIT, 'form': FORM, 'survey': SURVEY}
 
 ON = CLIENT.c.case_id == VISIT.c.parent_id
 CLIENT_VISIT = CLIENT.join(VISIT, ON)
@@ -147,6 +148,16 @@ JOIN_SQL = 'FROM client JOIN visit ON client.case_id = visit.parent_id'
      select([CLIENT]).where(CLIENT.c.name.is_(False))),
     ('SELECT * FROM client WHERE name IS NOT TRUE',
      select([CLIENT]).where(not_(CLIENT.c.name.is_(True)))),
+
+    # Array operators
+    ("SELECT * FROM survey WHERE symptoms @> ARRAY['fever', 'cough']",
+     select([SURVEY]).where(SURVEY.c.symptoms.bool_op('@>')(literal(['fever', 'cough'])))),
+    ("SELECT * FROM survey WHERE symptoms <@ ARRAY['fever']",
+     select([SURVEY]).where(SURVEY.c.symptoms.bool_op('<@')(literal(['fever'])))),
+    ("SELECT * FROM survey WHERE symptoms && ARRAY['fever']",
+     select([SURVEY]).where(SURVEY.c.symptoms.bool_op('&&')(literal(['fever'])))),
+    ("SELECT * FROM survey WHERE symptoms @> '{fever,cough}'",
+     select([SURVEY]).where(SURVEY.c.symptoms.bool_op('@>')(literal('{fever,cough}')))),
 ])
 def test_valid_queries(sql, expected):
     assert _compiled(translate(sql, TABLES)) == _compiled(expected)
@@ -194,6 +205,7 @@ def _compiled(query):
     'SELECT * FROM client WHERE case_id = -1',    # negative number
     "SELECT * FROM client WHERE name LIKE 'x%'",  # LIKE
     'SELECT * FROM client WHERE name IN ()',      # IN with no values
+    'SELECT * FROM survey WHERE symptoms @> ARRAY[symptoms]', # Array literals only
     'SELECT * FROM client WHERE name IN (SELECT name FROM client)',  # IN a subquery
     'SELECT * FROM client WHERE name',            # not a comparison
     "SELECT * FROM client WHERE LOWER(name) = 'x'",  # function call

--- a/corehq/apps/project_db/tests/test_user_sql.py
+++ b/corehq/apps/project_db/tests/test_user_sql.py
@@ -4,7 +4,6 @@ import pytest
 from sqlalchemy import (
     and_,
     column,
-    literal,
     not_,
     nullsfirst,
     nullslast,
@@ -16,7 +15,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects import postgresql
 
-from corehq.apps.project_db.user_sql import UnsupportedSQL, translate
+from corehq.apps.project_db.user_sql import UnsupportedSQL, _bind, translate
 
 CLIENT = table('client', column('case_id'), column('name'))
 VISIT = table('visit', column('visit_id'), column('parent_id'), column('name'))
@@ -44,21 +43,21 @@ SELF_JOIN = VISIT_V.join(VISIT_P, VISIT_V.c.parent_id == VISIT_P.c.visit_id)
      select([CLIENT.c.case_id.label('My Id')])),
 
     ("SELECT * FROM client WHERE name = 'x'",
-     select([CLIENT]).where(CLIENT.c.name == literal('x'))),
+     select([CLIENT]).where(CLIENT.c.name == _bind('x'))),
     ("SELECT * FROM client WHERE name <> 'x'",
-     select([CLIENT]).where(CLIENT.c.name != literal('x'))),
+     select([CLIENT]).where(CLIENT.c.name != _bind('x'))),
     ('SELECT * FROM client WHERE case_id > 5',
-     select([CLIENT]).where(CLIENT.c.case_id > literal(5))),
+     select([CLIENT]).where(CLIENT.c.case_id > _bind(5))),
     ('SELECT * FROM client WHERE case_id <= 5.5',
-     select([CLIENT]).where(CLIENT.c.case_id <= literal(Decimal('5.5')))),
+     select([CLIENT]).where(CLIENT.c.case_id <= _bind(Decimal('5.5')))),
     # Operands may appear in either order
     ("SELECT * FROM client WHERE 'x' = name",
-     select([CLIENT]).where(literal('x') == CLIENT.c.name)),
+     select([CLIENT]).where(_bind('x') == CLIENT.c.name)),
 
     # Columns may be qualified by their table
     ('SELECT client.name FROM client', select([CLIENT.c.name])),
     ("SELECT * FROM client WHERE client.name = 'x'",
-     select([CLIENT]).where(CLIENT.c.name == literal('x'))),
+     select([CLIENT]).where(CLIENT.c.name == _bind('x'))),
 
     # Joins
     (f'SELECT * {JOIN_SQL}', select([CLIENT_VISIT])),
@@ -68,14 +67,14 @@ SELF_JOIN = VISIT_V.join(VISIT_P, VISIT_V.c.parent_id == VISIT_P.c.visit_id)
     (f'SELECT parent_id {JOIN_SQL}',
      select([VISIT.c.parent_id]).select_from(CLIENT_VISIT)),
     (f"SELECT * {JOIN_SQL} WHERE visit.name = 'x'",
-     select([CLIENT_VISIT]).where(VISIT.c.name == literal('x'))),
+     select([CLIENT_VISIT]).where(VISIT.c.name == _bind('x'))),
     (f'SELECT client.name, form.form_id {JOIN_SQL} '
      'JOIN form ON visit.visit_id = form.visit_id',
      select([CLIENT.c.name, FORM.c.form_id]).select_from(
          CLIENT_VISIT.join(FORM, VISIT.c.visit_id == FORM.c.visit_id))),
     ("SELECT * FROM client JOIN visit "
      "ON client.case_id = visit.parent_id AND visit.name = 'x'",
-     select([CLIENT.join(VISIT, and_(ON, VISIT.c.name == literal('x')))])),
+     select([CLIENT.join(VISIT, and_(ON, VISIT.c.name == _bind('x')))])),
     ('SELECT * FROM client LEFT JOIN visit ON client.case_id = visit.parent_id',
      select([CLIENT.join(VISIT, ON, isouter=True)])),
 
@@ -113,38 +112,38 @@ SELF_JOIN = VISIT_V.join(VISIT_P, VISIT_V.c.parent_id == VISIT_P.c.visit_id)
      union(union(select([CLIENT.c.case_id]), select([VISIT.c.visit_id])),
            select([FORM.c.form_id]))),
     ("SELECT case_id FROM client WHERE name = 'x' UNION SELECT visit_id FROM visit",
-     union(select([CLIENT.c.case_id]).where(CLIENT.c.name == literal('x')),
+     union(select([CLIENT.c.case_id]).where(CLIENT.c.name == _bind('x')),
            select([VISIT.c.visit_id]))),
 
     # WHERE clauses
     ("SELECT * FROM client WHERE name = 'x' AND case_id = 'c1'",
-     select([CLIENT]).where(and_(CLIENT.c.name == literal('x'),
-                                 CLIENT.c.case_id == literal('c1')))),
+     select([CLIENT]).where(and_(CLIENT.c.name == _bind('x'),
+                                 CLIENT.c.case_id == _bind('c1')))),
     ("SELECT * FROM client WHERE name = 'x' OR case_id = 'c1'",
-     select([CLIENT]).where(or_(CLIENT.c.name == literal('x'),
-                                CLIENT.c.case_id == literal('c1')))),
+     select([CLIENT]).where(or_(CLIENT.c.name == _bind('x'),
+                                CLIENT.c.case_id == _bind('c1')))),
     ("SELECT * FROM client WHERE NOT name = 'x'",
-     select([CLIENT]).where(not_(CLIENT.c.name == literal('x')))),
+     select([CLIENT]).where(not_(CLIENT.c.name == _bind('x')))),
     ("SELECT * FROM client WHERE (name = 'x')",
-     select([CLIENT]).where(CLIENT.c.name == literal('x'))),
+     select([CLIENT]).where(CLIENT.c.name == _bind('x'))),
     # Parentheses override the usual AND-before-OR precedence
     ("SELECT * FROM client WHERE (name = 'x' OR name = 'y') AND case_id = 'c1'",
-     select([CLIENT]).where(and_(or_(CLIENT.c.name == literal('x'),
-                                     CLIENT.c.name == literal('y')),
-                                 CLIENT.c.case_id == literal('c1')))),
+     select([CLIENT]).where(and_(or_(CLIENT.c.name == _bind('x'),
+                                     CLIENT.c.name == _bind('y')),
+                                 CLIENT.c.case_id == _bind('c1')))),
     ("SELECT * FROM client WHERE name = 'x' AND case_id = 'c1' AND name = 'y'",
-     select([CLIENT]).where(and_(and_(CLIENT.c.name == literal('x'),
-                                      CLIENT.c.case_id == literal('c1')),
-                                 CLIENT.c.name == literal('y')))),
+     select([CLIENT]).where(and_(and_(CLIENT.c.name == _bind('x'),
+                                      CLIENT.c.case_id == _bind('c1')),
+                                 CLIENT.c.name == _bind('y')))),
     ("SELECT * FROM client WHERE name IN ('x', 'y')",
-     select([CLIENT]).where(CLIENT.c.name.in_([literal('x'), literal('y')]))),
+     select([CLIENT]).where(CLIENT.c.name.in_([_bind('x'), _bind('y')]))),
     # The values may be any supported value expression, not just literals
     ('SELECT * FROM client WHERE name IN (case_id)',
      select([CLIENT]).where(CLIENT.c.name.in_([CLIENT.c.case_id]))),
     ("SELECT * FROM client WHERE name NOT IN ('x')",
-     select([CLIENT]).where(not_(CLIENT.c.name.in_([literal('x')])))),
+     select([CLIENT]).where(not_(CLIENT.c.name.in_([_bind('x')])))),
     ('SELECT * FROM client WHERE name = TRUE',
-     select([CLIENT]).where(CLIENT.c.name == literal(True))),
+     select([CLIENT]).where(CLIENT.c.name == _bind(True))),
     ('SELECT * FROM client WHERE name IS NULL',
      select([CLIENT]).where(CLIENT.c.name.is_(None))),
     ('SELECT * FROM client WHERE name IS NOT NULL',
@@ -160,13 +159,13 @@ SELF_JOIN = VISIT_V.join(VISIT_P, VISIT_V.c.parent_id == VISIT_P.c.visit_id)
 
     # Array operators
     ("SELECT * FROM survey WHERE symptoms @> ARRAY['fever', 'cough']",
-     select([SURVEY]).where(SURVEY.c.symptoms.bool_op('@>')(literal(['fever', 'cough'])))),
+     select([SURVEY]).where(SURVEY.c.symptoms.bool_op('@>')(_bind(['fever', 'cough'])))),
     ("SELECT * FROM survey WHERE symptoms <@ ARRAY['fever']",
-     select([SURVEY]).where(SURVEY.c.symptoms.bool_op('<@')(literal(['fever'])))),
+     select([SURVEY]).where(SURVEY.c.symptoms.bool_op('<@')(_bind(['fever'])))),
     ("SELECT * FROM survey WHERE symptoms && ARRAY['fever']",
-     select([SURVEY]).where(SURVEY.c.symptoms.bool_op('&&')(literal(['fever'])))),
+     select([SURVEY]).where(SURVEY.c.symptoms.bool_op('&&')(_bind(['fever'])))),
     ("SELECT * FROM survey WHERE symptoms @> '{fever,cough}'",
-     select([SURVEY]).where(SURVEY.c.symptoms.bool_op('@>')(literal('{fever,cough}')))),
+     select([SURVEY]).where(SURVEY.c.symptoms.bool_op('@>')(_bind('{fever,cough}')))),
 ])
 def test_valid_queries(sql, expected):
     assert _compiled(translate(sql, TABLES)) == _compiled(expected)
@@ -260,6 +259,14 @@ def test_escapes_alias_identifiers(alias, expected):
     sql, params = _compiled(query)
     assert sql == f'SELECT {expected}.case_id \nFROM client AS {expected}'
     assert params == {}
+
+
+def test_literals_bind_under_our_own_prefix():
+    sql, params = _compiled(translate("SELECT name FROM client WHERE name = 'x' AND case_id = 5", TABLES))
+    assert sql == ('SELECT client.name \nFROM client \n'
+                   'WHERE client.name = %(hq_param_1)s '
+                   'AND client.case_id = %(hq_param_2)s')
+    assert params == {'hq_param_1': (str, 'x'), 'hq_param_2': (int, 5)}
 
 
 def test_handle_quoted_tables():

--- a/corehq/apps/project_db/tests/test_user_sql.py
+++ b/corehq/apps/project_db/tests/test_user_sql.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import (
@@ -19,9 +20,8 @@ from sqlalchemy.dialects import postgresql
 from corehq.apps.project_db.user_sql import (
     BadParameters,
     UnsupportedSQL,
+    UserSQL,
     _bind,
-    clean_parameters,
-    get_parameters,
     translate,
 )
 
@@ -303,6 +303,14 @@ def test_query_parameters_are_left_unbound():
     assert compiled.params == {'hq_param_1': 'c1', 'who': None}
 
 
+def _user_sql(sql):
+    """A ``UserSQL`` over the test tables, with the domain lookup already done"""
+    user_sql = UserSQL('test-domain', sql)
+    with patch('corehq.apps.project_db.user_sql.get_domain_tables', return_value=TABLES):
+        user_sql.query  # a cached_property, so the tables are resolved just once
+    return user_sql
+
+
 @pytest.mark.parametrize('sql, expected', [
     ('SELECT * FROM client', []),
     # Parameters come back in the order they appear
@@ -312,8 +320,19 @@ def test_query_parameters_are_left_unbound():
     ("SELECT * FROM client WHERE name = :who AND case_id = 'c1' OR name = :who",
      ['who']),
 ])
-def test_get_parameters(sql, expected):
-    assert get_parameters(translate(sql, TABLES)) == expected
+def test_parameters(sql, expected):
+    assert _user_sql(sql).parameters == expected
+
+
+def test_get_info_separates_literals_from_parameters():
+    """These are the three things the results page renders"""
+    info = _user_sql(
+        "SELECT name FROM client WHERE name = :who AND case_id = 'c1'").get_info()
+    assert info.parameters == ['who']
+    assert info.bound_literals == {'hq_param_1': 'c1'}
+    # sqlglot rewrites the placeholders to pyformat when it pretty-prints
+    assert '%(who)s' in info.translated_sql
+    assert '%(hq_param_1)s' in info.translated_sql
 
 
 @pytest.mark.parametrize('sql, raw, expected', [
@@ -323,7 +342,7 @@ def test_get_parameters(sql, expected):
     ('SELECT * FROM client WHERE name = :who', {'who': ''}, {'who': ''}),
 ])
 def test_clean_parameters(sql, raw, expected):
-    assert clean_parameters(translate(sql, TABLES), raw) == expected
+    assert _user_sql(sql)._clean_parameters(raw) == expected
 
 
 @pytest.mark.parametrize('sql, raw', [
@@ -332,7 +351,7 @@ def test_clean_parameters(sql, raw, expected):
 ])
 def test_clean_parameters_rejects_a_mismatched_set(sql, raw):
     with pytest.raises(BadParameters):
-        clean_parameters(translate(sql, TABLES), raw)
+        _user_sql(sql)._clean_parameters(raw)
 
 
 def test_handle_quoted_tables():

--- a/corehq/apps/project_db/tests/test_user_sql.py
+++ b/corehq/apps/project_db/tests/test_user_sql.py
@@ -6,6 +6,8 @@ from sqlalchemy import (
     column,
     literal,
     not_,
+    nullsfirst,
+    nullslast,
     or_,
     select,
     table,
@@ -79,6 +81,14 @@ JOIN_SQL = 'FROM client JOIN visit ON client.case_id = visit.parent_id'
      select([CLIENT.c.name]).distinct(CLIENT.c.case_id)),
     ('SELECT DISTINCT ON (case_id, name) name FROM client',
      select([CLIENT.c.name]).distinct(CLIENT.c.case_id, CLIENT.c.name)),
+
+    # ORDER BY - each key gets its own direction and default NULLS placement
+    ('SELECT * FROM client ORDER BY name, case_id DESC',
+     select([CLIENT]).order_by(nullslast(CLIENT.c.name.asc()),
+                               nullsfirst(CLIENT.c.case_id.desc()))),
+    # An explicit NULLS placement overrides the direction's default
+    ('SELECT name FROM client ORDER BY name DESC NULLS LAST',
+     select([CLIENT.c.name]).order_by(nullslast(CLIENT.c.name.desc()))),
 
     # Unions
     ('SELECT case_id FROM client UNION SELECT visit_id FROM visit',
@@ -179,6 +189,8 @@ def _compiled(query):
     "SELECT * FROM client WHERE name IS 'x'",       # IS with an unsupported operand
     'SELECT * FROM client WHERE name IS DISTINCT FROM NULL',  # IS DISTINCT FROM
     'SELECT DISTINCT ON () name FROM client',        # DISTINCT ON with no columns
+    'SELECT name FROM client ORDER BY 1',           # ORDER BY an ordinal
+    'SELECT name AS n FROM client ORDER BY n',      # ORDER BY a column alias
     'SELECT * FROM client WHERE case_id = -1',    # negative number
     "SELECT * FROM client WHERE name LIKE 'x%'",  # LIKE
     'SELECT * FROM client WHERE name IN ()',      # IN with no values

--- a/corehq/apps/project_db/tests/test_user_sql.py
+++ b/corehq/apps/project_db/tests/test_user_sql.py
@@ -72,6 +72,14 @@ JOIN_SQL = 'FROM client JOIN visit ON client.case_id = visit.parent_id'
     ('SELECT * FROM client LEFT JOIN visit ON client.case_id = visit.parent_id',
      select([CLIENT.join(VISIT, ON, isouter=True)])),
 
+    # DISTINCT
+    ('SELECT DISTINCT name FROM client', select([CLIENT.c.name]).distinct()),
+    # DISTINCT ON columns need not appear in the projection
+    ('SELECT DISTINCT ON (case_id) name FROM client',
+     select([CLIENT.c.name]).distinct(CLIENT.c.case_id)),
+    ('SELECT DISTINCT ON (case_id, name) name FROM client',
+     select([CLIENT.c.name]).distinct(CLIENT.c.case_id, CLIENT.c.name)),
+
     # Unions
     ('SELECT case_id FROM client UNION SELECT visit_id FROM visit',
      union(select([CLIENT.c.case_id]), select([VISIT.c.visit_id]))),
@@ -170,6 +178,7 @@ def _compiled(query):
     'SELECT visit.name FROM client',      # qualified by a table not in the FROM
     "SELECT * FROM client WHERE name IS 'x'",       # IS with an unsupported operand
     'SELECT * FROM client WHERE name IS DISTINCT FROM NULL',  # IS DISTINCT FROM
+    'SELECT DISTINCT ON () name FROM client',        # DISTINCT ON with no columns
     'SELECT * FROM client WHERE case_id = -1',    # negative number
     "SELECT * FROM client WHERE name LIKE 'x%'",  # LIKE
     'SELECT * FROM client WHERE name IN ()',      # IN with no values

--- a/corehq/apps/project_db/user_sql.py
+++ b/corehq/apps/project_db/user_sql.py
@@ -8,7 +8,17 @@ import sqlglot
 from sqlglot import exp
 from sqlglot.errors import SqlglotError
 
-from sqlalchemy import and_, literal, not_, or_, select, union, union_all
+from sqlalchemy import (
+    and_,
+    literal,
+    not_,
+    nullsfirst,
+    nullslast,
+    or_,
+    select,
+    union,
+    union_all,
+)
 
 
 class UnsupportedSQL(Exception):
@@ -57,8 +67,8 @@ def _unpack(node, *args):
 
 
 def _convert_select(node, tables):
-    expressions, from_, joins, where, distinct = _unpack(
-        node, 'expressions', 'from_', 'joins', 'where', 'distinct')
+    expressions, from_, joins, where, distinct, order = _unpack(
+        node, 'expressions', 'from_', 'joins', 'where', 'distinct', 'order')
     if from_ is None:
         raise UnsupportedSQL("a FROM clause is required")
     selectable = _convert_table_ref(from_.this, tables)
@@ -70,6 +80,8 @@ def _convert_select(node, tables):
     if where is not None:
         predicate, = _unpack(where, 'this')
         query = query.where(_convert_predicate(predicate, selectable.c))
+    if order is not None:
+        query = query.order_by(*_convert_order(order, selectable.c))
     return query
 
 
@@ -82,6 +94,19 @@ def _convert_distinct_on(node, columns):
     if not on_expressions:
         raise UnsupportedSQL("DISTINCT ON requires at least one column")
     return [_convert_column(e, columns) for e in on_expressions]
+
+
+def _convert_order(node, columns):
+    """Convert an ORDER BY clause to a list of sort keys"""
+    order_expressions, = _unpack(node, 'expressions')
+    return [_convert_sort_key(e, columns) for e in order_expressions]
+
+
+def _convert_sort_key(node, columns):
+    expression, desc, nulls_first = _unpack(node, 'this', 'desc', 'nulls_first')
+    col = _convert_column(expression, columns)
+    sort_key = col.desc() if desc else col.asc()
+    return nullsfirst(sort_key) if nulls_first else nullslast(sort_key)
 
 
 def _convert_join(node, selectable, tables):

--- a/corehq/apps/project_db/user_sql.py
+++ b/corehq/apps/project_db/user_sql.py
@@ -114,7 +114,7 @@ def _convert_join(node, selectable, tables):
     table_ref, on, side = _unpack(node, 'this', 'on', 'side')
     table = _convert_table_ref(table_ref, tables)
     if table.name in {col.table.name for col in selectable.c}:
-        raise UnsupportedSQL(f"table joined more than once: {table.name}")
+        raise UnsupportedSQL(f"table name used more than once: {table.name}")
     predicate = _convert_predicate(on, list(selectable.c) + list(table.c))
 
     if not side:
@@ -241,8 +241,12 @@ def _convert_table_ref(node, tables):
     """Return the table a SQL table reference refers to"""
     if not (isinstance(node, exp.Table) and isinstance(node.this, exp.Identifier)):
         raise UnsupportedSQL(f"expected table, got {str(node)}")
-    identifier, = _unpack(node, 'this')
+    identifier, alias = _unpack(node, 'this', 'alias')
     try:
-        return tables[identifier.name]
+        selectable = tables[identifier.name]
     except KeyError:
         raise UnsupportedSQL(f"unknown table: {identifier.name}")
+    if alias is not None:
+        alias_identifier, = _unpack(alias, 'this')
+        return selectable.alias(alias_identifier.name)
+    return selectable

--- a/corehq/apps/project_db/user_sql.py
+++ b/corehq/apps/project_db/user_sql.py
@@ -170,6 +170,12 @@ COMPARISONS = {
     exp.LTE: operator.le,
 }
 
+ARRAY_OPS = {
+    exp.ArrayContainsAll: '@>',
+    exp.ArrayContainedBy: '<@',
+    exp.ArrayOverlaps: '&&',
+}
+
 
 def _convert_predicate(node, columns):
     """Convert a boolean-valued SQL expression to a ``ColumnElement``"""
@@ -196,6 +202,10 @@ def _convert_predicate(node, columns):
         left, right = _unpack(node, 'this', 'expression')
         return combine(_convert_predicate(left, columns),
                        _convert_predicate(right, columns))
+    if array_op := ARRAY_OPS.get(type(node)):
+        left, right = _unpack(node, 'this', 'expression')
+        contains = _convert_value(left, columns).bool_op(array_op)
+        return contains(_convert_value(right, columns))
     if compare := COMPARISONS.get(type(node)):
         left, right = _unpack(node, 'this', 'expression')
         return compare(_convert_value(left, columns),
@@ -212,7 +222,19 @@ def _convert_value(node, columns):
     if isinstance(node, exp.Boolean):
         value, = _unpack(node, 'this')
         return literal(bool(value))
+    if isinstance(node, exp.Array):
+        return _convert_array(node)
     return _convert_column(node, columns)
+
+
+def _convert_array(node):
+    """Convert an ``ARRAY[...]`` literal into a single bound parameter"""
+    elements, = _unpack(node, 'expressions')
+    for element in elements:
+        if not isinstance(element, exp.Literal):
+            raise UnsupportedSQL(f"array elements must be literals: {str(element)}")
+        _unpack(element, 'this', 'is_string')
+    return literal([element.to_py() for element in elements])
 
 
 def _convert_table_ref(node, tables):

--- a/corehq/apps/project_db/user_sql.py
+++ b/corehq/apps/project_db/user_sql.py
@@ -6,9 +6,6 @@ import operator
 import re
 
 import sqlglot
-from sqlglot import exp
-from sqlglot.errors import SqlglotError
-
 from sqlalchemy import (
     and_,
     bindparam,
@@ -20,10 +17,21 @@ from sqlalchemy import (
     union,
     union_all,
 )
+from sqlglot import exp
+from sqlglot.errors import SqlglotError
 
 
-class UnsupportedSQL(Exception):
+class _UserFacingError(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+
+class UnsupportedSQL(_UserFacingError):
     """Raised when the input uses SQL that the translator does not support."""
+
+
+class BadParameters(_UserFacingError):
+    """The parameters don't match the query"""
 
 
 LITERAL_PARAM_PREFIX = 'hq_param'  # Our reserved namespace for parameters
@@ -36,6 +44,22 @@ PARAM_NAME = re.compile(r'[A-Za-z_][A-Za-z0-9_]*\Z')
 def _bind(value):
     """Bind a value as a uniquely named parameter"""
     return bindparam(LITERAL_PARAM_PREFIX, value, unique=True)
+
+
+def get_parameters(query):
+    """Return the parameters a translated query leaves for the caller to supply"""
+    return [name for name, bind in query.compile().binds.items() if bind.required]
+
+
+def clean_parameters(query, raw_parameters):
+    """Validate input parameters against query"""
+    binds = {
+        name: bind for name, bind in query.compile().binds.items()
+        if bind.required
+    }
+    if set(raw_parameters) != set(binds):
+        raise BadParameters(f"Expected params {set(binds)}, got {set(raw_parameters)}")
+    return {name: raw_parameters[name] for name, bind in binds.items()}
 
 
 def translate(sql, tables):

--- a/corehq/apps/project_db/user_sql.py
+++ b/corehq/apps/project_db/user_sql.py
@@ -4,6 +4,9 @@ Only a strict subset of SQL is supported; anything outside it errors
 """
 import operator
 import re
+import time
+from collections import namedtuple
+from functools import cached_property
 
 import sqlglot
 from sqlalchemy import (
@@ -17,20 +20,26 @@ from sqlalchemy import (
     union,
     union_all,
 )
+from sqlalchemy.dialects import postgresql
 from sqlglot import exp
 from sqlglot.errors import SqlglotError
 
+from corehq.apps.project_db.table_ddl import (
+    get_domain_tables,
+    get_project_db_engine,
+)
 
-class _UserFacingError(Exception):
+
+class UserSQLValidationError(Exception):
     def __init__(self, msg):
         self.msg = msg
 
 
-class UnsupportedSQL(_UserFacingError):
+class UnsupportedSQL(UserSQLValidationError):
     """Raised when the input uses SQL that the translator does not support."""
 
 
-class BadParameters(_UserFacingError):
+class BadParameters(UserSQLValidationError):
     """The parameters don't match the query"""
 
 
@@ -46,20 +55,56 @@ def _bind(value):
     return bindparam(LITERAL_PARAM_PREFIX, value, unique=True)
 
 
-def get_parameters(query):
-    """Return the parameters a translated query leaves for the caller to supply"""
-    return [name for name, bind in query.compile().binds.items() if bind.required]
+QueryInfo = namedtuple('QueryInfo', 'translated_sql bound_literals parameters')
+QueryResult = namedtuple('QueryResult', 'columns rows duration')
 
 
-def clean_parameters(query, raw_parameters):
-    """Validate input parameters against query"""
-    binds = {
-        name: bind for name, bind in query.compile().binds.items()
-        if bind.required
-    }
-    if set(raw_parameters) != set(binds):
-        raise BadParameters(f"Expected params {set(binds)}, got {set(raw_parameters)}")
-    return {name: raw_parameters[name] for name, bind in binds.items()}
+class UserSQL:
+    def __init__(self, domain, raw_sql):
+        self.domain = domain
+        self.raw_sql = raw_sql
+
+    @cached_property
+    def query(self):
+        return translate(self.raw_sql, get_domain_tables(self.domain))
+
+    @cached_property
+    def _compiled(self):
+        return self.query.compile(dialect=postgresql.dialect(paramstyle='named'))
+
+    def get_info(self):
+        return QueryInfo(
+            translated_sql=sqlglot.transpile(
+                str(self._compiled), read='postgres', write='postgres', pretty=True
+            )[0],
+            bound_literals={
+                name: value for name, value in self._compiled.params.items()
+                if name not in self.parameters
+            },
+            parameters=self.parameters,
+        )
+
+    @property
+    def parameters(self):
+        """Return the parameters a translated query leaves for the caller to supply"""
+        return [name for name, bind in self._compiled.binds.items() if bind.required]
+
+    def run(self, parameter_values, max_rows):
+        params = self._clean_parameters(parameter_values)
+        with get_project_db_engine().connect() as conn:
+            start = time.perf_counter()
+            result = conn.execute(self.query, params)
+            rows = result.fetchmany(max_rows)
+            return QueryResult(
+                columns=list(result.keys()),
+                rows=rows,
+                duration=time.perf_counter() - start,
+            )
+
+    def _clean_parameters(self, raw_parameters):
+        if set(raw_parameters) != set(self.parameters):
+            raise BadParameters(f"Expected params {set(self.parameters)}, got {set(raw_parameters)}")
+        return {name: raw_parameters[name] for name in self.parameters}
 
 
 def translate(sql, tables):

--- a/corehq/apps/project_db/user_sql.py
+++ b/corehq/apps/project_db/user_sql.py
@@ -3,6 +3,7 @@
 Only a strict subset of SQL is supported; anything outside it errors
 """
 import operator
+import re
 
 import sqlglot
 from sqlglot import exp
@@ -26,6 +27,10 @@ class UnsupportedSQL(Exception):
 
 
 LITERAL_PARAM_PREFIX = 'hq_param'  # Our reserved namespace for parameters
+
+# A query parameter's name is interpolated into the compiled SQL, so it is
+# restricted to characters that cannot close the placeholder and inject SQL.
+PARAM_NAME = re.compile(r'[A-Za-z_][A-Za-z0-9_]*\Z')
 
 
 def _bind(value):
@@ -201,11 +206,15 @@ def _convert_predicate(node, columns):
         value = _convert_value(expression, columns)
         return value.isnot(target) if negate else value.is_(target)
     if isinstance(node, exp.In):
-        value, values = _unpack(node, 'this', 'expressions')
+        value, values, field = _unpack(node, 'this', 'expressions', 'field')
+        operand = _convert_value(value, columns)
+        if field is not None:
+            if not isinstance(field, exp.Placeholder):
+                raise UnsupportedSQL(f"unsupported IN expression: {str(field)}")
+            return operand.in_(_convert_placeholder(field, expanding=True))
         if not values:
             raise UnsupportedSQL("IN requires at least one value")
-        return _convert_value(value, columns).in_(
-            [_convert_value(v, columns) for v in values])
+        return operand.in_([_convert_value(v, columns) for v in values])
     if combine := BOOLEAN_OPS.get(type(node)):
         left, right = _unpack(node, 'this', 'expression')
         return combine(_convert_predicate(left, columns),
@@ -232,7 +241,19 @@ def _convert_value(node, columns):
         return _bind(bool(value))
     if isinstance(node, exp.Array):
         return _convert_array(node)
+    if isinstance(node, exp.Placeholder):
+        return _convert_placeholder(node)
     return _convert_column(node, columns)
+
+
+def _convert_placeholder(node, expanding=False):
+    """Convert a ``:name`` placeholder to a parameter for the caller to bind"""
+    name, = _unpack(node, 'this')
+    if not isinstance(name, str) or not PARAM_NAME.match(name):
+        raise UnsupportedSQL("query parameters must be written as `:name`")
+    if name.startswith(LITERAL_PARAM_PREFIX):
+        raise UnsupportedSQL(f"query parameter names may not begin with '{LITERAL_PARAM_PREFIX}'")
+    return bindparam(name, expanding=expanding)
 
 
 def _convert_array(node):

--- a/corehq/apps/project_db/user_sql.py
+++ b/corehq/apps/project_db/user_sql.py
@@ -57,17 +57,31 @@ def _unpack(node, *args):
 
 
 def _convert_select(node, tables):
-    expressions, from_, joins, where = _unpack(node, 'expressions', 'from_', 'joins', 'where')
+    expressions, from_, joins, where, distinct = _unpack(
+        node, 'expressions', 'from_', 'joins', 'where', 'distinct')
     if from_ is None:
         raise UnsupportedSQL("a FROM clause is required")
     selectable = _convert_table_ref(from_.this, tables)
     for join in joins or []:
         selectable = _convert_join(join, selectable, tables)
     query = select(_convert_projection(expressions, selectable.c)).select_from(selectable)
+    if distinct is not None:
+        query = query.distinct(*_convert_distinct_on(distinct, selectable.c))
     if where is not None:
         predicate, = _unpack(where, 'this')
         query = query.where(_convert_predicate(predicate, selectable.c))
     return query
+
+
+def _convert_distinct_on(node, columns):
+    """Resolve the columns of a ``DISTINCT ON``, or none for a plain ``DISTINCT``"""
+    on, = _unpack(node, 'on')
+    if on is None:
+        return []
+    on_expressions, = _unpack(on, 'expressions')
+    if not on_expressions:
+        raise UnsupportedSQL("DISTINCT ON requires at least one column")
+    return [_convert_column(e, columns) for e in on_expressions]
 
 
 def _convert_join(node, selectable, tables):

--- a/corehq/apps/project_db/user_sql.py
+++ b/corehq/apps/project_db/user_sql.py
@@ -10,7 +10,7 @@ from sqlglot.errors import SqlglotError
 
 from sqlalchemy import (
     and_,
-    literal,
+    bindparam,
     not_,
     nullsfirst,
     nullslast,
@@ -23,6 +23,14 @@ from sqlalchemy import (
 
 class UnsupportedSQL(Exception):
     """Raised when the input uses SQL that the translator does not support."""
+
+
+LITERAL_PARAM_PREFIX = 'hq_param'  # Our reserved namespace for parameters
+
+
+def _bind(value):
+    """Bind a value as a uniquely named parameter"""
+    return bindparam(LITERAL_PARAM_PREFIX, value, unique=True)
 
 
 def translate(sql, tables):
@@ -218,10 +226,10 @@ def _convert_value(node, columns):
     """Convert a SQL value expression to a ``ColumnElement``"""
     if isinstance(node, exp.Literal):
         _unpack(node, 'this', 'is_string')
-        return literal(node.to_py())  # Use `literal` to make this a bound parameter
+        return _bind(node.to_py())  # Bind it so the value never reaches the SQL
     if isinstance(node, exp.Boolean):
         value, = _unpack(node, 'this')
-        return literal(bool(value))
+        return _bind(bool(value))
     if isinstance(node, exp.Array):
         return _convert_array(node)
     return _convert_column(node, columns)
@@ -234,7 +242,7 @@ def _convert_array(node):
         if not isinstance(element, exp.Literal):
             raise UnsupportedSQL(f"array elements must be literals: {str(element)}")
         _unpack(element, 'this', 'is_string')
-    return literal([element.to_py() for element in elements])
+    return _bind([element.to_py() for element in elements])
 
 
 def _convert_table_ref(node, tables):

--- a/corehq/apps/project_db/views.py
+++ b/corehq/apps/project_db/views.py
@@ -16,7 +16,13 @@ from corehq.apps.project_db.table_ddl import (
     get_domain_tables,
     get_project_db_engine,
 )
-from corehq.apps.project_db.user_sql import UnsupportedSQL, translate
+from corehq.apps.project_db.user_sql import (
+    BadParameters,
+    UnsupportedSQL,
+    clean_parameters,
+    get_parameters,
+    translate,
+)
 from corehq.apps.settings.views import BaseProjectDataView
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
@@ -42,17 +48,39 @@ class QueryProjectDBView(HqHtmxActionMixin, BaseProjectDataView):
         return {'table_names': sorted(get_domain_tables(self.domain))}
 
     @hq_hx_action('post')
-    def run_query(self, request, *args, **kwargs):
-        context = {'sql': request.POST.get('sql', '')}
+    def process_query(self, request, *args, **kwargs):
+        """Translate the query, running it if it takes no parameters"""
+        return self._query_response(request, always_run=False)
+
+    @hq_hx_action('post')
+    def run_query_with_parameters(self, request, *args, **kwargs):
+        """Run the query with the parameter values given on the page"""
+        return self._query_response(request, always_run=True)
+
+    def _query_response(self, request, always_run):
+        submitted_params = {
+            name.removeprefix('param:'): value
+            for name, value in request.POST.items()
+            if name.startswith('param:')
+        }
+        context = {'sql': request.POST.get('sql', ''),
+                   'max_rows': MAX_ROWS}
         try:
-            query_result = run_user_sql(self.domain, context['sql'])
+            query = translate(context['sql'], get_domain_tables(self.domain))
         except UnsupportedSQL as error:
-            context['error'] = str(error)
+            context['error'] = error.msg
         else:
-            context.update({
-                'result': query_result,
-                'max_rows': MAX_ROWS,
-            })
+            query_params = get_parameters(query)
+            context['query'] = compile_query(query)
+            context['parameters'] = [{
+                'name': parameter,
+                'value': submitted_params.get(parameter, ''),
+            } for parameter in query_params]
+            if always_run or not query_params:
+                try:
+                    context['result'] = execute_query(query, submitted_params)
+                except BadParameters as error:
+                    context['error'] = error.msg
         return self.render_htmx_partial_response(
             request, 'project_db/partials/query_results.html', context)
 
@@ -61,26 +89,25 @@ class QueryProjectDBView(HqHtmxActionMixin, BaseProjectDataView):
         return HttpResponse(describe_project_db(self.domain))
 
 
-def run_user_sql(domain, user_sql):
-    query = translate(user_sql, get_domain_tables(domain))
+def execute_query(query, submitted_params):
+    params = clean_parameters(query, submitted_params)
     with get_project_db_engine().connect() as conn:
         start = time.perf_counter()
-        result = conn.execute(query)
+        result = conn.execute(query, params)
         rows = result.fetchmany(MAX_ROWS)
-        duration = time.perf_counter() - start
         return {
-            'query': compile_query(query),
             'columns': list(result.keys()),
             'rows': rows,
-            'duration': duration,
+            'duration': time.perf_counter() - start,
         }
 
 
 def compile_query(query):
-    """Render a SQLAlchemy selectable as pretty-printed PostgreSQL and its bound params"""
+    """Render a SQLAlchemy selectable as pretty-printed PostgreSQL and its bound values"""
     compiled = query.compile(dialect=postgresql.dialect(paramstyle='named'))
-    sql = sqlglot.transpile(str(compiled), read='postgres', write='postgres', pretty=True)[0]
+    unbound = get_parameters(query)
     return {
-        'sql': sql,
-        'params': compiled.params
+        'sql': sqlglot.transpile(str(compiled), read='postgres', write='postgres', pretty=True)[0],
+        'params': {name: value for name, value in compiled.params.items()
+                   if name not in unbound},
     }

--- a/corehq/apps/project_db/views.py
+++ b/corehq/apps/project_db/views.py
@@ -1,28 +1,14 @@
-import time
-
 from django.http import HttpResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
 
-import sqlglot
-from sqlalchemy.dialects import postgresql
-
 from corehq import toggles
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.project_db.describe import describe_project_db
-from corehq.apps.project_db.table_ddl import (
-    get_domain_tables,
-    get_project_db_engine,
-)
-from corehq.apps.project_db.user_sql import (
-    BadParameters,
-    UnsupportedSQL,
-    clean_parameters,
-    get_parameters,
-    translate,
-)
+from corehq.apps.project_db.table_ddl import get_domain_tables
+from corehq.apps.project_db.user_sql import UserSQL, UserSQLValidationError
 from corehq.apps.settings.views import BaseProjectDataView
 from corehq.util.htmx_action import HqHtmxActionMixin, hq_hx_action
 
@@ -63,51 +49,23 @@ class QueryProjectDBView(HqHtmxActionMixin, BaseProjectDataView):
             for name, value in request.POST.items()
             if name.startswith('param:')
         }
-        context = {'sql': request.POST.get('sql', ''),
-                   'max_rows': MAX_ROWS}
+        context = {'max_rows': MAX_ROWS}
+        user_sql = UserSQL(self.domain, request.POST.get('sql', ''))
         try:
-            query = translate(context['sql'], get_domain_tables(self.domain))
-        except UnsupportedSQL as error:
+            context['query'] = user_sql.get_info()
+            if always_run or not user_sql.parameters:
+                context['result'] = user_sql.run(submitted_params, MAX_ROWS)
+        except UserSQLValidationError as error:
             context['error'] = error.msg
         else:
-            query_params = get_parameters(query)
-            context['query'] = compile_query(query)
-            context['parameters'] = [{
-                'name': parameter,
-                'value': submitted_params.get(parameter, ''),
-            } for parameter in query_params]
-            if always_run or not query_params:
-                try:
-                    context['result'] = execute_query(query, submitted_params)
-                except BadParameters as error:
-                    context['error'] = error.msg
+            # Re-render parameters with values previously submitted for them
+            context['parameters'] = [
+                {'name': name, 'value': submitted_params.get(name, '')}
+                for name in user_sql.parameters
+            ]
         return self.render_htmx_partial_response(
             request, 'project_db/partials/query_results.html', context)
 
     @hq_hx_action('post')
     def copy_db_context(self, request, *args, **kwargs):
         return HttpResponse(describe_project_db(self.domain))
-
-
-def execute_query(query, submitted_params):
-    params = clean_parameters(query, submitted_params)
-    with get_project_db_engine().connect() as conn:
-        start = time.perf_counter()
-        result = conn.execute(query, params)
-        rows = result.fetchmany(MAX_ROWS)
-        return {
-            'columns': list(result.keys()),
-            'rows': rows,
-            'duration': time.perf_counter() - start,
-        }
-
-
-def compile_query(query):
-    """Render a SQLAlchemy selectable as pretty-printed PostgreSQL and its bound values"""
-    compiled = query.compile(dialect=postgresql.dialect(paramstyle='named'))
-    unbound = get_parameters(query)
-    return {
-        'sql': sqlglot.transpile(str(compiled), read='postgres', write='postgres', pretty=True)[0],
-        'params': {name: value for name, value in compiled.params.items()
-                   if name not in unbound},
-    }


### PR DESCRIPTION
## Product Description
The ProjectDB user SQL parser now supports:
* Named `:parameters`
* `DISTINCT` / `DISTINCT ON`
* `ORDER BY`
* Array containment operators (`@>`, `<@`, `&&`) for querying multi-select properties
* Table aliases (which is what makes self-joins possible)

Parameters can also now be provided in the query tester:
<img width="2501" height="1673" alt="image" src="https://github.com/user-attachments/assets/a1f054ea-b743-40e1-9e89-bf959035fbf5" />

No type coercion is supported yet, so they are all passed through as strings

## Technical Summary

I recommend reviewing by commit.

## Feature Flag
`PROJECT_DB`

## Safety Assurance

### Safety story
Pre-release, admin-only behind the feature flag.

### Automated test coverage

`user_sql.py` is covered thoroughly.  View-layer tests are omitted.

### QA Plan

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
