### PR TITLE
Restrict case search endpoint views to domain admins

### DIFF
--- a/corehq/apps/case_search/CASE_SEARCH_ENDPOINTS.rst
+++ b/corehq/apps/case_search/CASE_SEARCH_ENDPOINTS.rst
@@ -100,8 +100,4 @@ TODOs
 -----
 
 - [ ] Sort configuration
-- [ ] Guard with role permission (right now everybody on domain can see the views)
-- [ ] Allow usage of today's date, user id, etc.
-  - Either an option in the endpoint config
-  - Or via separately configured parameters on the case list page
 - [ ] Paginate endpoint list view (currently unbounded query)

--- a/corehq/apps/case_search/endpoint_views.py
+++ b/corehq/apps/case_search/endpoint_views.py
@@ -23,6 +23,7 @@ from corehq.apps.case_search.models import (
     criteria_dict_to_criteria_list,
 )
 from corehq.apps.case_search.utils import QueryHelper, get_primary_case_search_endpoint_results
+from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import not_found
@@ -30,9 +31,10 @@ from corehq.apps.settings.views import BaseProjectDataView
 
 from dimagi.utils.logging import notify_exception
 
-_ENDPOINT_DECORATORS = [
+_ADMIN_ENDPOINT_DECORATORS = [
     use_bootstrap5,
     toggles.CASE_SEARCH_ENDPOINTS.required_decorator(),
+    domain_admin_required,
 ]
 
 def empty_query():
@@ -129,7 +131,7 @@ class CaseSearchEndpointForm(forms.Form):
         return cleaned
 
 
-@method_decorator(_ENDPOINT_DECORATORS, name='dispatch')
+@method_decorator(_ADMIN_ENDPOINT_DECORATORS, name='dispatch')
 class CaseSearchEndpointsView(BaseProjectDataView):
     urlname = 'case_search_endpoints'
     page_title = gettext_lazy('Case Search Endpoints')
@@ -190,7 +192,7 @@ class CaseSearchEndpointEditBaseView(BaseProjectDataView):
         return self.render_to_response(self.get_context_data())
 
 
-@method_decorator(_ENDPOINT_DECORATORS, name='dispatch')
+@method_decorator(_ADMIN_ENDPOINT_DECORATORS, name='dispatch')
 class CaseSearchEndpointNewView(CaseSearchEndpointEditBaseView):
     urlname = 'case_search_endpoint_new'
     page_title = gettext_lazy('New Case Search Endpoint')
@@ -239,7 +241,7 @@ class CaseSearchEndpointNewView(CaseSearchEndpointEditBaseView):
         )
 
 
-@method_decorator(_ENDPOINT_DECORATORS, name='dispatch')
+@method_decorator(_ADMIN_ENDPOINT_DECORATORS, name='dispatch')
 class CaseSearchEndpointEditView(CaseSearchEndpointEditBaseView):
     urlname = 'case_search_endpoint_edit'
     page_title = gettext_lazy('Edit Case Search Endpoint')
@@ -300,7 +302,7 @@ class CaseSearchEndpointEditView(CaseSearchEndpointEditBaseView):
         )
 
 
-@method_decorator(_ENDPOINT_DECORATORS, name='dispatch')
+@method_decorator(_ADMIN_ENDPOINT_DECORATORS, name='dispatch')
 class CaseSearchEndpointDeactivateView(BaseDomainView):
     urlname = 'case_search_endpoint_deactivate'
     http_method_names = ['post']
@@ -328,7 +330,7 @@ class CaseSearchEndpointDeactivateView(BaseDomainView):
         )
 
 
-@method_decorator(_ENDPOINT_DECORATORS, name='dispatch')
+@method_decorator(_ADMIN_ENDPOINT_DECORATORS, name='dispatch')
 class CaseSearchEndpointTestView(BaseDomainView):
     """Runs a query builder spec against the project's cases and returns an
     HTMX partial with the matching results (or validation errors).

--- a/corehq/apps/case_search/tests/test_endpoint_views.py
+++ b/corehq/apps/case_search/tests/test_endpoint_views.py
@@ -92,6 +92,41 @@ class EndpointViewTestCase(TestCase):
         return data
 
 
+class TestEndpointViewAccess(EndpointViewTestCase):
+    nonadmin_username = 'nonadmin@example.com'
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.nonadmin = WebUser.create(
+            cls.domain, cls.nonadmin_username, 'password', None, None
+        )
+        cls.addClassCleanup(cls.nonadmin.delete, cls.domain, None)
+
+    def setUp(self):
+        super().setUp()
+        self.client.login(username=self.nonadmin_username, password='password')
+
+    def test_nonadmin_member_is_denied(self):
+        ep = self._make_endpoint()
+        cases = [
+            ('get', self._list_url()),
+            ('get', self._new_url()),
+            ('get', self._edit_url(ep.id)),
+            ('post', self._deactivate_url(ep.id)),
+            ('post', self._test_url()),
+        ]
+        for method, url in cases:
+            with self.subTest(method=method, url=url):
+                response = getattr(self.client, method)(url)
+                # domain_admin_required redirects rather than returning 403.
+                self.assertRedirects(
+                    response, reverse('homepage'), fetch_redirect_response=False
+                )
+        ep.refresh_from_db()
+        assert ep.is_active
+
+
 class TestCaseSearchEndpointsListView(EndpointViewTestCase):
     def test_empty_list(self):
         response = self.client.get(self._list_url())

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -634,7 +634,8 @@ class ProjectDataTab(UITab):
                 'url': reverse(CSQLFixtureExpressionView.urlname, args=[self.domain]),
             }]])
 
-        if toggles.CASE_SEARCH_ENDPOINTS.enabled(self.domain):
+        if (toggles.CASE_SEARCH_ENDPOINTS.enabled(self.domain)
+                and self.couch_user.is_domain_admin(self.domain)):
             items.append([_('Case Search Endpoints'), [{
                 'title': _(CaseSearchEndpointsView.page_title),
                 'url': reverse(CaseSearchEndpointsView.urlname, args=[self.domain]),


### PR DESCRIPTION
## Product Description

Restrict case search endpoint views to domain admins.
Only show menu for navigation to domain admins

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6629

## Feature Flag

CASE_SEARCH_ENDPOINTS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

Added tests to validate access

### QA Plan

Will get tested when feature is complete

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
