### PR TITLE
Pick case search endpoint type before on creation

### DIFF
--- a/corehq/apps/case_search/endpoint_views.py
+++ b/corehq/apps/case_search/endpoint_views.py
@@ -2,6 +2,7 @@ import json
 
 from django import forms
 from django.db import transaction
+from django.http import Http404
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -74,16 +75,14 @@ def _add_endpoint_version(endpoint, *, action, created_by, case_type=None, query
 
 class CaseSearchEndpointForm(forms.Form):
     name = forms.CharField()
-    target_type = forms.ChoiceField(
-        choices=CaseSearchEndpoint.TargetType.choices
-    )
     case_type = forms.CharField(required=False)
     query = forms.JSONField(required=False)
     parameters = forms.JSONField(required=False)
 
-    def __init__(self, *args, domain, exclude_pk=None, capability=None, **kwargs):
+    def __init__(self, *args, domain, target_type, exclude_pk=None, capability=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.domain = domain
+        self.target_type = target_type
         self.exclude_pk = exclude_pk
         self.capability = capability
 
@@ -116,6 +115,9 @@ class CaseSearchEndpointForm(forms.Form):
 
     def clean(self):
         cleaned = super().clean()
+        if self.target_type != CaseSearchEndpoint.TargetType.ELASTICSEARCH:
+            # Project DB endpoints have no query spec to validate yet.
+            return cleaned
         query = cleaned.get('query')
         parameters = cleaned.get('parameters')
         # Only run semantic validation when both fields parsed cleanly.
@@ -150,6 +152,10 @@ class CaseSearchEndpointsView(BaseProjectDataView):
             )
             .select_related('current_version')
             .order_by('name'),
+            'target_types': [
+                CaseSearchEndpoint.TargetType.ELASTICSEARCH,
+                CaseSearchEndpoint.TargetType.PROJECT_DB,
+            ],
         }
 
 
@@ -158,6 +164,7 @@ class CaseSearchEndpointEditBaseView(BaseProjectDataView):
 
     template_name = 'case_search/endpoint_edit.html'
     mode = None
+    target_type = None
 
     @property
     def parent_pages(self):
@@ -182,6 +189,8 @@ class CaseSearchEndpointEditBaseView(BaseProjectDataView):
         return {
             'capability': self.capability,
             'endpoint_mode': self.mode,
+            'target_type': self.target_type,
+            'target_type_display': CaseSearchEndpoint.TargetType(self.target_type).label,
             'max_group_depth': MAX_QUERY_DEPTH - 1,
             'post_url': self.page_url,
             'form': self._form,
@@ -198,17 +207,24 @@ class CaseSearchEndpointNewView(CaseSearchEndpointEditBaseView):
     page_title = gettext_lazy('New Case Search Endpoint')
     mode = 'new'
 
+    @cached_property
+    def target_type(self):
+        value = self.request.GET.get('target_type')
+        if value not in CaseSearchEndpoint.TargetType.values:
+            raise Http404(f"Unknown target_type: {value!r}")
+        return value
+
     @property
     def page_url(self):
-        return reverse(self.urlname, args=[self.domain])
+        return reverse(self.urlname, args=[self.domain], query={'target_type': self.target_type})
 
     def _make_form(self, data=None):
         return CaseSearchEndpointForm(
             data,
             domain=self.domain,
+            target_type=self.target_type,
             capability=self.capability,
             initial={
-                'target_type': CaseSearchEndpoint.TargetType.PROJECT_DB,
                 'query': empty_query,
                 'parameters': list,
             },
@@ -223,7 +239,7 @@ class CaseSearchEndpointNewView(CaseSearchEndpointEditBaseView):
             endpoint = CaseSearchEndpoint.objects.create(
                 domain=self.domain,
                 name=cd['name'],
-                target_type=cd['target_type'],
+                target_type=self.target_type,
             )
             _add_endpoint_version(
                 endpoint,
@@ -254,6 +270,10 @@ class CaseSearchEndpointEditView(CaseSearchEndpointEditBaseView):
         return super().dispatch(request, *args, **kwargs)
 
     @property
+    def target_type(self):
+        return self._endpoint.target_type
+
+    @property
     def page_url(self):
         return reverse(self.urlname, args=[self.domain, self._endpoint.id])
 
@@ -262,11 +282,11 @@ class CaseSearchEndpointEditView(CaseSearchEndpointEditBaseView):
         return CaseSearchEndpointForm(
             data,
             domain=self.domain,
+            target_type=self.target_type,
             exclude_pk=self._endpoint.pk,
             capability=self.capability,
             initial={
                 'name': self._endpoint.name,
-                'target_type': self._endpoint.target_type,
                 'case_type': current.case_type if current else None,
                 'query': current.query if current else empty_query,
                 'parameters': current.parameters if current else list,
@@ -287,7 +307,6 @@ class CaseSearchEndpointEditView(CaseSearchEndpointEditBaseView):
         endpoint = self._endpoint
         with transaction.atomic():
             endpoint.name = cd['name']
-            endpoint.target_type = cd['target_type']
             _add_endpoint_version(
                 endpoint,
                 action=CaseSearchEndpointVersion.Action.UPDATE,
@@ -295,7 +314,7 @@ class CaseSearchEndpointEditView(CaseSearchEndpointEditBaseView):
                 case_type=cd['case_type'],
                 query=cd['query'],
                 parameters=cd['parameters'],
-                extra_update_fields=['name', 'target_type'],
+                extra_update_fields=['name'],
             )
         return redirect(
             reverse(CaseSearchEndpointsView.urlname, args=[self.domain])

--- a/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
+++ b/corehq/apps/case_search/static/case_search/js/endpoint_edit.js
@@ -23,7 +23,6 @@ const SLOT_TYPE_MATCH_FIELD = "match_field";
 Alpine.data("endpointForm", () => {
     return {
         name: initialPageData.get("initial_name"),
-        targetType: initialPageData.get("initial_target_type"),
         targetCasetype: initialPageData.get("initial_case_type"),
         parameters: initialPageData.get("initial_parameters") || [],
         testParamValues: {},

--- a/corehq/apps/case_search/templates/case_search/endpoint_edit.html
+++ b/corehq/apps/case_search/templates/case_search/endpoint_edit.html
@@ -157,39 +157,57 @@
       </div>
     </div>
 
-    {# ── Query card ── #}
-    <div class="card mb-3">
-      <div class="card-header">
-        <i class="fa-solid fa-filter me-1"></i>{% trans "Query" %}
-      </div>
-      <div class="card-body">
-        {# Case Type #}
-        <div class="row g-3 mb-3 align-items-center">
-          <label for="case-type" class="col-md-2 col-form-label fw-semibold"
-            >{% trans "Case Type" %}</label
-          >
-          <div class="col-md-4">
-            <select
-              id="case-type"
-              name="case_type"
-              class="form-select{% if form.case_type.errors %}is-invalid{% endif %}"
-              x-model="targetCasetype"
-              @change="onCasetypeChange()"
-            >
-              <option value="">{% trans "-- Select a case type --" %}</option>
-              {% for ct_name in capability.case_types %}
-                <option value="{{ ct_name }}">{{ ct_name }}</option>
-              {% endfor %}
-            </select>
-            {% for error in form.case_type.errors %}
-              <div class="invalid-feedback">{{ error }}</div>
-            {% endfor %}
-          </div>
+    {% if target_type == 'project_db' %}
+      {# ── SQL card ── #}
+      <div class="card mb-3">
+        <div class="card-header">
+          <i class="fa-solid fa-database me-1"></i>{% trans "SQL" %}
         </div>
-
-        {% include "case_search/partials/query_builder.html" %}
+        <div class="card-body">
+          {# No name attribute: nothing is posted or stored yet. #}
+          <textarea
+            id="endpoint-sql"
+            class="form-control font-monospace"
+            rows="12"
+            aria-label="{% trans "SQL" %}"
+          ></textarea>
+        </div>
       </div>
-    </div>
+    {% else %}
+      {# ── Query card ── #}
+      <div class="card mb-3">
+        <div class="card-header">
+          <i class="fa-solid fa-filter me-1"></i>{% trans "Query" %}
+        </div>
+        <div class="card-body">
+          {# Case Type #}
+          <div class="row g-3 mb-3 align-items-center">
+            <label for="case-type" class="col-md-2 col-form-label fw-semibold"
+              >{% trans "Case Type" %}</label
+            >
+            <div class="col-md-4">
+              <select
+                id="case-type"
+                name="case_type"
+                class="form-select{% if form.case_type.errors %}is-invalid{% endif %}"
+                x-model="targetCasetype"
+                @change="onCasetypeChange()"
+              >
+                <option value="">{% trans "-- Select a case type --" %}</option>
+                {% for ct_name in capability.case_types %}
+                  <option value="{{ ct_name }}">{{ ct_name }}</option>
+                {% endfor %}
+              </select>
+              {% for error in form.case_type.errors %}
+                <div class="invalid-feedback">{{ error }}</div>
+              {% endfor %}
+            </div>
+          </div>
+
+          {% include "case_search/partials/query_builder.html" %}
+        </div>
+      </div>
+    {% endif %}
 
     {# ── Tester card ── #}
     <div class="card mb-3">

--- a/corehq/apps/case_search/templates/case_search/endpoint_edit.html
+++ b/corehq/apps/case_search/templates/case_search/endpoint_edit.html
@@ -17,7 +17,6 @@
 {% block page_content %}
   {% initial_page_data "endpoint_mode" endpoint_mode %}
   {% initial_page_data "initial_name" form.name.value %}
-  {% initial_page_data "initial_target_type" form.target_type.value %}
   {% initial_page_data "initial_case_type" form.case_type.value %}
   {% initial_page_data "initial_parameters" form.parameters.value %}
   {% initial_page_data "initial_query" form.query.value %}
@@ -63,24 +62,17 @@
             {% endfor %}
           </div>
 
-          {# Target Type #}
+          {# Endpoint Type — fixed when the endpoint is created #}
           <div class="col-md-3">
-            <label for="target-type" class="form-label fw-semibold"
-              >{% trans "Target Type" %}</label
+            <label class="form-label fw-semibold"
+              >{% trans "Endpoint Type" %}</label
             >
-            <select
-              id="target-type"
-              name="target_type"
-              class="form-select{% if form.target_type.errors %}is-invalid{% endif %}"
-              x-model="targetType"
-            >
-              {% for value, label in form.target_type.field.choices %}
-                <option value="{{ value }}">{{ label }}</option>
-              {% endfor %}
-            </select>
-            {% for error in form.target_type.errors %}
-              <div class="invalid-feedback">{{ error }}</div>
-            {% endfor %}
+            <input
+              type="text"
+              class="form-control-plaintext"
+              value="{{ target_type_display }}"
+              readonly
+            />
           </div>
 
           {% if endpoint and endpoint.current_version %}

--- a/corehq/apps/case_search/templates/case_search/endpoint_edit.html
+++ b/corehq/apps/case_search/templates/case_search/endpoint_edit.html
@@ -83,28 +83,6 @@
             {% endfor %}
           </div>
 
-          {# Case Type #}
-          <div class="col-md-3">
-            <label for="case-type" class="form-label fw-semibold"
-              >{% trans "Case Type" %}</label
-            >
-            <select
-              id="case-type"
-              name="case_type"
-              class="form-select{% if form.case_type.errors %}is-invalid{% endif %}"
-              x-model="targetCasetype"
-              @change="onCasetypeChange()"
-            >
-              <option value="">{% trans "-- Select a case type --" %}</option>
-              {% for ct_name in capability.case_types %}
-                <option value="{{ ct_name }}">{{ ct_name }}</option>
-              {% endfor %}
-            </select>
-            {% for error in form.case_type.errors %}
-              <div class="invalid-feedback">{{ error }}</div>
-            {% endfor %}
-          </div>
-
           {% if endpoint and endpoint.current_version %}
             <div class="col-md-3">
               <label class="form-label fw-semibold"
@@ -193,6 +171,30 @@
         <i class="fa-solid fa-filter me-1"></i>{% trans "Query" %}
       </div>
       <div class="card-body">
+        {# Case Type #}
+        <div class="row g-3 mb-3 align-items-center">
+          <label for="case-type" class="col-md-2 col-form-label fw-semibold"
+            >{% trans "Case Type" %}</label
+          >
+          <div class="col-md-4">
+            <select
+              id="case-type"
+              name="case_type"
+              class="form-select{% if form.case_type.errors %}is-invalid{% endif %}"
+              x-model="targetCasetype"
+              @change="onCasetypeChange()"
+            >
+              <option value="">{% trans "-- Select a case type --" %}</option>
+              {% for ct_name in capability.case_types %}
+                <option value="{{ ct_name }}">{{ ct_name }}</option>
+              {% endfor %}
+            </select>
+            {% for error in form.case_type.errors %}
+              <div class="invalid-feedback">{{ error }}</div>
+            {% endfor %}
+          </div>
+        </div>
+
         {% include "case_search/partials/query_builder.html" %}
       </div>
     </div>

--- a/corehq/apps/case_search/templates/case_search/endpoint_list.html
+++ b/corehq/apps/case_search/templates/case_search/endpoint_list.html
@@ -6,12 +6,40 @@
 {% block page_content %}
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h2 class="h4 mb-0">{% trans "Case Search Endpoints" %}</h2>
-    <a
-      href="{% url 'case_search_endpoint_new' domain %}"
-      class="btn btn-primary"
-    >
-      {% trans "New Endpoint" %}
-    </a>
+    <div class="btn-group">
+      {% with primary=target_types.0 %}
+        <a
+          href="{% url 'case_search_endpoint_new' domain %}?target_type={{ primary.value }}"
+          class="btn btn-primary"
+        >
+          {% blocktrans trimmed with label=primary.label %}
+            New Endpoint ({{ label }})
+          {% endblocktrans %}
+        </a>
+      {% endwith %}
+      <button
+        type="button"
+        class="btn btn-primary dropdown-toggle dropdown-toggle-split"
+        data-bs-toggle="dropdown"
+        aria-expanded="false"
+      >
+        <span class="visually-hidden">{% trans "Toggle Dropdown" %}</span>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-end">
+        {% for target_type in target_types|slice:"1:" %}
+          <li>
+            <a
+              class="dropdown-item"
+              href="{% url 'case_search_endpoint_new' domain %}?target_type={{ target_type.value }}"
+            >
+              {% blocktrans trimmed with label=target_type.label %}
+                New Endpoint ({{ label }})
+              {% endblocktrans %}
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
   </div>
 
   {% if endpoints %}
@@ -19,7 +47,7 @@
       <thead>
         <tr>
           <th>{% trans "Name" %}</th>
-          <th>{% trans "Target Type" %}</th>
+          <th>{% trans "Endpoint Type" %}</th>
           <th>{% trans "Case Type" %}</th>
           <th>{% trans "Version" %}</th>
           <th>{% trans "Updated On" %}</th>

--- a/corehq/apps/case_search/tests/test_endpoint_views.py
+++ b/corehq/apps/case_search/tests/test_endpoint_views.py
@@ -43,10 +43,12 @@ class EndpointViewTestCase(TestCase):
         flag.__enter__()
         self.addCleanup(flag.__exit__, None, None, None)
 
-    def _make_endpoint(self, name='my-endpoint', case_type='case_type_a'):
+    def _make_endpoint(self, name='my-endpoint', case_type='case_type_a',
+                       target_type=CaseSearchEndpoint.TargetType.ELASTICSEARCH):
         endpoint = CaseSearchEndpoint.objects.create(
             domain=self.domain,
             name=name,
+            target_type=target_type,
         )
         version = CaseSearchEndpointVersion.objects.create(
             endpoint=endpoint,
@@ -63,8 +65,9 @@ class EndpointViewTestCase(TestCase):
     def _list_url(self):
         return reverse(CaseSearchEndpointsView.urlname, args=[self.domain])
 
-    def _new_url(self):
-        return reverse(CaseSearchEndpointNewView.urlname, args=[self.domain])
+    def _new_url(self, target_type=CaseSearchEndpoint.TargetType.ELASTICSEARCH):
+        url = reverse(CaseSearchEndpointNewView.urlname, args=[self.domain])
+        return f'{url}?target_type={target_type}' if target_type else url
 
     def _edit_url(self, endpoint_id):
         return reverse(
@@ -83,7 +86,6 @@ class EndpointViewTestCase(TestCase):
     def _post_data(self, **overrides):
         data = {
             'name': 'an-endpoint',
-            'target_type': CaseSearchEndpoint.TargetType.PROJECT_DB,
             'case_type': 'my_case_type',
             'query': json.dumps(EMPTY_QUERY),
             'parameters': '[]',
@@ -139,6 +141,13 @@ class TestCaseSearchEndpointsListView(EndpointViewTestCase):
         assert response.status_code == 200
         assert ep in response.context['endpoints']
 
+    def test_new_endpoint_button_per_target_type(self):
+        response = self.client.get(self._list_url())
+        content = response.content.decode()
+        for target_type in CaseSearchEndpoint.TargetType:
+            assert f'?target_type={target_type.value}' in content
+            assert f'New Endpoint ({target_type.label})' in content
+
     def test_inactive_endpoints_not_shown(self):
         ep = self._make_endpoint()
         ep.is_active = False
@@ -155,10 +164,41 @@ class TestCaseSearchEndpointNewView(EndpointViewTestCase):
         assert 'capability' in response.context
         # Defaults are seeded on the form (read via form.<field>.value).
         form = response.context['form']
-        assert form['target_type'].value() == (
-            CaseSearchEndpoint.TargetType.PROJECT_DB
-        )
         assert json.loads(form['query'].value()) == EMPTY_QUERY
+
+    def test_target_type_comes_from_querystring(self):
+        cases = [
+            ('project_db', CaseSearchEndpoint.TargetType.PROJECT_DB),
+            ('es', CaseSearchEndpoint.TargetType.ELASTICSEARCH),
+        ]
+        for param, expected in cases:
+            with self.subTest(param=param):
+                response = self.client.get(self._new_url(target_type=param))
+                assert response.status_code == 200
+                assert response.context['target_type'] == expected
+
+    def test_invalid_target_type_404s(self):
+        for param in ['bogus', None]:
+            with self.subTest(param=param):
+                response = self.client.get(self._new_url(target_type=param))
+                assert response.status_code == 404
+
+    def test_create_project_db_endpoint(self):
+        response = self.client.post(
+            self._new_url(target_type='project_db'),
+            self._post_data(
+                name='sql-endpoint',
+                case_type='',
+                # Project DB endpoints skip query validation entirely, so a
+                # spec that Elasticsearch would reject still saves.
+                query=json.dumps({'type': 'bogus'}),
+            ),
+        )
+        assert response.status_code == 302
+        endpoint = CaseSearchEndpoint.objects.get(
+            domain=self.domain, name='sql-endpoint'
+        )
+        assert endpoint.target_type == CaseSearchEndpoint.TargetType.PROJECT_DB
 
     def test_create_endpoint(self):
         response = self.client.post(
@@ -172,6 +212,7 @@ class TestCaseSearchEndpointNewView(EndpointViewTestCase):
         endpoint = CaseSearchEndpoint.objects.get(
             domain=self.domain, name='new-endpoint'
         )
+        assert endpoint.target_type == CaseSearchEndpoint.TargetType.ELASTICSEARCH
         assert endpoint.current_version.case_type == 'my_case_type'
         assert endpoint.current_version is not None
         assert endpoint.current_version.version_number == 1
@@ -306,13 +347,11 @@ class TestCaseSearchEndpointEditView(EndpointViewTestCase):
             self._edit_url(ep.id),
             self._post_data(
                 name='renamed',
-                target_type=CaseSearchEndpoint.TargetType.ELASTICSEARCH,
                 case_type='new_target',
             ),
         )
         ep.refresh_from_db()
         assert ep.name == 'renamed'
-        assert ep.target_type == CaseSearchEndpoint.TargetType.ELASTICSEARCH
         assert ep.current_version.case_type == 'new_target'
 
     def test_duplicate_name_error(self):


### PR DESCRIPTION
## Product Description

With adding the project DB SQL bases case search endpoints, the configuration of the endpoints will look quite different based on the type and it does not make sense anymore to allow switching the type after creation.

* Move the selection of the endpoint type (aka target type) to a btn-group.
* Move the case type field to the query card since it only makes sense for ElasticSearch based endpoints
* Add a new "SQL" card for project DB SQL endpoint

**Before**:

You could change the endpoint type (aka target type) on the create/edit endpoint view.

<img width="960" height="156" alt="image" src="https://github.com/user-attachments/assets/c1acdda9-f37f-42af-96fb-bc0f1775a5b0" />

**After:**

You pick the endpoint type using the "New Endpoint" Button.

<img width="352" height="154" alt="image" src="https://github.com/user-attachments/assets/71ef09f3-4eab-478e-81b2-2839a3563b19" />


## Technical Summary

https://dimagi.atlassian.net/browse/USH-6629

## Feature Flag

CASE_SEARCH_ENDPOINTS

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

Updated test

### QA Plan

This will be tested as complete feature once done.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
