### PR TITLE
Project DB fixes

### DIFF
--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -220,7 +220,7 @@ def create_or_update_project_db(domain):
 def get_domain_tables(domain):
     engine = get_project_db_engine()
     metadata = sqlalchemy.MetaData()
-    metadata.reflect(bind=engine, schema=DomainSchema(domain).name)
+    metadata.reflect(bind=engine, schema=DomainSchema(domain).name, resolve_fks=False)
     return {t.comment: t for t in metadata.tables.values()}
 
 

--- a/corehq/apps/project_db/tests/test_user_sql.py
+++ b/corehq/apps/project_db/tests/test_user_sql.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects import postgresql
 
 from corehq.apps.project_db.user_sql import (
+    MAX_PAREN_DEPTH,
     BadParameters,
     UnsupportedSQL,
     UserSQL,
@@ -359,3 +360,18 @@ def test_handle_quoted_tables():
     tables = {'hyphenated-table': hyphenated_table}
     result = translate('SELECT * FROM "hyphenated-table"', tables)
     assert str(result) == str(select([hyphenated_table]))
+
+
+def test_rejects_deeply_nested_parentheses():
+    sql = 'SELECT * FROM client WHERE ' + '(' * 100 + 'name = 1' + ')' * 100
+    with pytest.raises(UnsupportedSQL, match='nested too deeply'):
+        translate(sql, TABLES)
+
+
+def test_allows_parentheses_nested_up_to_the_limit():
+    # The deepest nesting the limit allows must still parse, so that raising
+    # the limit past what the stack allows fails here rather than crashing
+    # the interpreter.
+    depth = MAX_PAREN_DEPTH
+    sql = 'SELECT * FROM client WHERE ' + '(' * depth + 'name = 1' + ')' * depth
+    assert translate(sql, TABLES) is not None

--- a/corehq/apps/project_db/tests/test_user_sql.py
+++ b/corehq/apps/project_db/tests/test_user_sql.py
@@ -19,6 +19,7 @@ from sqlalchemy.dialects import postgresql
 
 from corehq.apps.project_db.user_sql import (
     MAX_PAREN_DEPTH,
+    MAX_TREE_DEPTH,
     BadParameters,
     UnsupportedSQL,
     UserSQL,
@@ -362,16 +363,25 @@ def test_handle_quoted_tables():
     assert str(result) == str(select([hyphenated_table]))
 
 
-def test_rejects_deeply_nested_parentheses():
-    sql = 'SELECT * FROM client WHERE ' + '(' * 100 + 'name = 1' + ')' * 100
+@pytest.mark.parametrize('sql', [
+    # Nesting deep enough to exhaust the parser's stack
+    'SELECT * FROM client WHERE ' + '(' * 100 + 'name = 1' + ')' * 100,
+    # Nesting deep enough to exhaust the conversion's stack: this parses fine
+    'SELECT * FROM client WHERE ' + ' AND '.join(['name = 1'] * 1000),
+])
+def test_rejects_deeply_nested(sql):
     with pytest.raises(UnsupportedSQL, match='nested too deeply'):
         translate(sql, TABLES)
 
 
-def test_allows_parentheses_nested_up_to_the_limit():
-    # The deepest nesting the limit allows must still parse, so that raising
-    # the limit past what the stack allows fails here rather than crashing
-    # the interpreter.
-    depth = MAX_PAREN_DEPTH
-    sql = 'SELECT * FROM client WHERE ' + '(' * depth + 'name = 1' + ')' * depth
+@pytest.mark.parametrize('sql', [
+    # The deepest nesting each limit allows must still be translatable, so
+    # that raising a limit past what the stack allows fails here rather than
+    # crashing the interpreter.
+    'SELECT * FROM client WHERE ' + '(' * MAX_PAREN_DEPTH + 'name = 1'
+    + ')' * MAX_PAREN_DEPTH,
+    'SELECT * FROM client WHERE '
+    + ' AND '.join(['name = 1'] * (MAX_TREE_DEPTH - 5)),
+])
+def test_allows_nesting_up_to_the_limit(sql):
     assert translate(sql, TABLES) is not None

--- a/corehq/apps/project_db/tests/test_user_sql.py
+++ b/corehq/apps/project_db/tests/test_user_sql.py
@@ -1,3 +1,4 @@
+import sys
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -16,9 +17,9 @@ from sqlalchemy import (
     union_all,
 )
 from sqlalchemy.dialects import postgresql
+from unmagic import fixture, use
 
 from corehq.apps.project_db.user_sql import (
-    MAX_PAREN_DEPTH,
     MAX_TREE_DEPTH,
     BadParameters,
     UnsupportedSQL,
@@ -363,25 +364,40 @@ def test_handle_quoted_tables():
     assert str(result) == str(select([hyphenated_table]))
 
 
-@pytest.mark.parametrize('sql', [
-    # Nesting deep enough to exhaust the parser's stack
-    'SELECT * FROM client WHERE ' + '(' * 100 + 'name = 1' + ')' * 100,
-    # Nesting deep enough to exhaust the conversion's stack: this parses fine
-    'SELECT * FROM client WHERE ' + ' AND '.join(['name = 1'] * 1000),
-])
-def test_rejects_deeply_nested(sql):
+@fixture
+def restore_trace_function():
+    """Put back a trace function that exhausting the stack has dropped
+
+    CPython disables tracing when the stack overflows while calling the trace
+    function, which makes coverage warn that its data is unreliable, failing
+    the whole test run at interpreter shutdown.
+    """
+    trace = sys.gettrace()
+    try:
+        yield
+    finally:
+        if sys.gettrace() is not trace:
+            sys.settrace(trace)
+
+
+@use(restore_trace_function)
+def test_rejects_nesting_that_exhausts_the_parser():
+    sql = 'SELECT * FROM client WHERE ' + '(' * 100 + 'name = 1' + ')' * 100
     with pytest.raises(UnsupportedSQL, match='nested too deeply'):
         translate(sql, TABLES)
 
 
-@pytest.mark.parametrize('sql', [
-    # The deepest nesting each limit allows must still be translatable, so
-    # that raising a limit past what the stack allows fails here rather than
+def test_rejects_a_parse_tree_too_deep_to_convert():
+    # This parses fine: the nesting is in the tree, not in parentheses
+    sql = 'SELECT * FROM client WHERE ' + ' AND '.join(['name = 1'] * 1000)
+    with pytest.raises(UnsupportedSQL, match='nested too deeply'):
+        translate(sql, TABLES)
+
+
+def test_allows_nesting_up_to_the_limit():
+    # The deepest tree the limit allows must still be translatable, so that
+    # raising the limit past what the stack allows fails here rather than
     # crashing the interpreter.
-    'SELECT * FROM client WHERE ' + '(' * MAX_PAREN_DEPTH + 'name = 1'
-    + ')' * MAX_PAREN_DEPTH,
-    'SELECT * FROM client WHERE '
-    + ' AND '.join(['name = 1'] * (MAX_TREE_DEPTH - 5)),
-])
-def test_allows_nesting_up_to_the_limit(sql):
+    sql = ('SELECT * FROM client WHERE '
+           + ' AND '.join(['name = 1'] * (MAX_TREE_DEPTH - 5)))
     assert translate(sql, TABLES) is not None

--- a/corehq/apps/project_db/user_sql.py
+++ b/corehq/apps/project_db/user_sql.py
@@ -50,7 +50,7 @@ LITERAL_PARAM_PREFIX = 'hq_param'  # Our reserved namespace for parameters
 PARAM_NAME = re.compile(r'[A-Za-z_][A-Za-z0-9_]*\Z')
 
 MAX_PAREN_DEPTH = 20
-
+MAX_TREE_DEPTH = 100
 NESTED_TOO_DEEPLY = "SQL is nested too deeply"
 
 
@@ -126,6 +126,8 @@ def translate(sql, tables):
         raise UnsupportedSQL("could not parse SQL")
     if len(statements) != 1:
         raise UnsupportedSQL("this only supports a single statement")
+    # Reject a parse tree deeper than the conversion can handle
+    _check_tree_depth(statements[0])
 
     return _convert_query(statements[0], tables)
 
@@ -140,6 +142,20 @@ def _check_paren_depth(sql):
                 raise UnsupportedSQL(NESTED_TOO_DEEPLY)
         elif char == ')':
             depth -= 1
+
+
+def _check_tree_depth(node):
+    """Reject deep parse trees
+
+    Long chains of operators such as ``a = 1 AND b = 2 AND ...`` parse into a
+    deep tree without any nested parentheses.
+    """
+    nodes = [(node, 1)]
+    while nodes:
+        node, depth = nodes.pop()
+        if depth > MAX_TREE_DEPTH:
+            raise UnsupportedSQL(NESTED_TOO_DEEPLY)
+        nodes.extend((child, depth + 1) for child in node.iter_expressions())
 
 
 def _convert_query(node, tables):

--- a/corehq/apps/project_db/user_sql.py
+++ b/corehq/apps/project_db/user_sql.py
@@ -49,7 +49,6 @@ LITERAL_PARAM_PREFIX = 'hq_param'  # Our reserved namespace for parameters
 # restricted to characters that cannot close the placeholder and inject SQL.
 PARAM_NAME = re.compile(r'[A-Za-z_][A-Za-z0-9_]*\Z')
 
-MAX_PAREN_DEPTH = 20
 MAX_TREE_DEPTH = 100
 NESTED_TOO_DEEPLY = "SQL is nested too deeply"
 
@@ -117,31 +116,20 @@ def translate(sql, tables):
     :param sql: the user-supplied SQL statement
     :param tables: mapping of table name to SQLAlchemy ``Table``
     """
-    # sqlglot's parser recurses about 20 stack frames per level of parentheses,
-    # so deeply nested input exhausts the stack
-    _check_paren_depth(sql)
     try:
         statements = sqlglot.parse(sql, read='postgres')
     except SqlglotError:
         raise UnsupportedSQL("could not parse SQL")
+    except RecursionError:
+        # The parser recurses about 20 stack frames per level of parentheses,
+        # so nesting them exhausts the stack before it can report anything.
+        raise UnsupportedSQL(NESTED_TOO_DEEPLY) from None
     if len(statements) != 1:
         raise UnsupportedSQL("this only supports a single statement")
     # Reject a parse tree deeper than the conversion can handle
     _check_tree_depth(statements[0])
 
     return _convert_query(statements[0], tables)
-
-
-def _check_paren_depth(sql):
-    """Reject SQL whose parentheses nest deeper than the parser can handle"""
-    depth = 0
-    for char in sql:
-        if char == '(':
-            depth += 1
-            if depth > MAX_PAREN_DEPTH:
-                raise UnsupportedSQL(NESTED_TOO_DEEPLY)
-        elif char == ')':
-            depth -= 1
 
 
 def _check_tree_depth(node):

--- a/corehq/apps/project_db/user_sql.py
+++ b/corehq/apps/project_db/user_sql.py
@@ -49,6 +49,10 @@ LITERAL_PARAM_PREFIX = 'hq_param'  # Our reserved namespace for parameters
 # restricted to characters that cannot close the placeholder and inject SQL.
 PARAM_NAME = re.compile(r'[A-Za-z_][A-Za-z0-9_]*\Z')
 
+MAX_PAREN_DEPTH = 20
+
+NESTED_TOO_DEEPLY = "SQL is nested too deeply"
+
 
 def _bind(value):
     """Bind a value as a uniquely named parameter"""
@@ -113,6 +117,9 @@ def translate(sql, tables):
     :param sql: the user-supplied SQL statement
     :param tables: mapping of table name to SQLAlchemy ``Table``
     """
+    # sqlglot's parser recurses about 20 stack frames per level of parentheses,
+    # so deeply nested input exhausts the stack
+    _check_paren_depth(sql)
     try:
         statements = sqlglot.parse(sql, read='postgres')
     except SqlglotError:
@@ -121,6 +128,18 @@ def translate(sql, tables):
         raise UnsupportedSQL("this only supports a single statement")
 
     return _convert_query(statements[0], tables)
+
+
+def _check_paren_depth(sql):
+    """Reject SQL whose parentheses nest deeper than the parser can handle"""
+    depth = 0
+    for char in sql:
+        if char == '(':
+            depth += 1
+            if depth > MAX_PAREN_DEPTH:
+                raise UnsupportedSQL(NESTED_TOO_DEEPLY)
+        elif char == ')':
+            depth -= 1
 
 
 def _convert_query(node, tables):


### PR DESCRIPTION
## Product Description

Fix two issues found in the project DB code:

* Deep recursions in the SQL caused a 500. Now it results in UnsupportedSQL.
* get_domain_tables should not follow foreign keys. There should not be any breaking out of the schema. But better save than sorry.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6593

## Feature Flag

PROJECT_DB

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

Added test for recursion error.

### QA Plan

None

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
