### PR TITLE
PR 4 Couch to sql migration for CommCareBuild

### DIFF
--- a/corehq/apps/builds/migrations/0004_remove_couch_id_from_database.py
+++ b/corehq/apps/builds/migrations/0004_remove_couch_id_from_database.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+
+INDEX_NAME = 'builds_comm_couch_i_3b9fc6_idx'
+DROP_INDEX_SQL = f'DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}'
+CREATE_INDEX_SQL = (
+    f'CREATE INDEX CONCURRENTLY IF NOT EXISTS {INDEX_NAME} '
+    f'ON builds_commcaremobilebuild (couch_id)'
+)
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ('builds', '0003_remove_commcaremobilebuild_couch_id'),
+    ]
+    operations = [
+        migrations.RunSQL(
+            sql=DROP_INDEX_SQL,
+            reverse_sql=CREATE_INDEX_SQL,
+            state_operations=[
+                migrations.RemoveIndex(
+                    model_name='commcaremobilebuild',
+                    name=INDEX_NAME,
+                ),
+            ],
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE builds_commcaremobilebuild DROP COLUMN couch_id;",
+            reverse_sql="ALTER TABLE builds_commcaremobilebuild ADD COLUMN couch_id VARCHAR(126);"
+        )
+
+    ]

--- a/migrations.lock
+++ b/migrations.lock
@@ -228,6 +228,7 @@ builds
  0001_initial
  0002_populate_commcaremobilebuild
  0003_remove_commcaremobilebuild_couch_id
+ 0004_remove_couch_id_from_database
 campaign
  0001_initial
  0002_dashboardmap_dashboardreport


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
PR 1: https://github.com/dimagi/commcare-hq/pull/37954
PR 2: https://github.com/dimagi/commcare-hq/pull/37955
PR 3: https://github.com/dimagi/commcare-hq/pull/37956

The last PR of couch to sql migration for CommCareBuild. PR 3 only dropped the `couch_id` column from Django model, and this PR is to remove it from the sql database.
This PR should not be merged until PR 3 is merged for 6 weeks.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. Straightforward migration.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Migrations
<!-- Delete this section if the PR does not contain any migrations -->
<!-- https://commcare-hq.readthedocs.io/migrations_in_practice.html -->
- [x] The migrations in this code can be safely applied first independently of the code. Pay particular attention to _backward incompatible_ operations like `RemoveField`, `RenameField`, `RemoveConstraint`, and [others described here](https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/incompatibilities.md) that can cause errors when migrations are applied to a live database.

<!-- Please link to any past code changes that are coordinated with this migration -->
https://github.com/dimagi/commcare-hq/pull/37956

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
