### PR TITLE
Move Case Search Endpoints under Explore Data

### DIFF
--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -635,13 +635,6 @@ class ProjectDataTab(UITab):
                 'url': reverse(CSQLFixtureExpressionView.urlname, args=[self.domain]),
             }]])
 
-        if (toggles.CASE_SEARCH_ENDPOINTS.enabled(self.domain)
-                and self.couch_user.is_domain_admin(self.domain)):
-            items.append([_('Case Search Endpoints'), [{
-                'title': _(CaseSearchEndpointsView.page_title),
-                'url': reverse(CaseSearchEndpointsView.urlname, args=[self.domain]),
-            }]])
-
         if self._can_view_data_dictionary:
             items.append([DataDictionaryView.page_title, [{
                 'title': DataDictionaryView.page_title,
@@ -1035,6 +1028,15 @@ class ProjectDataTab(UITab):
                     'show_in_dropdown': False,
                     'subpages': [],
                 })
+        if (toggles.CASE_SEARCH_ENDPOINTS.enabled(self.domain)
+                and self.couch_user.is_domain_admin(self.domain)):
+            explore_data_views.append({
+                'title': _(CaseSearchEndpointsView.page_title),
+                'url': reverse(CaseSearchEndpointsView.urlname, args=(self.domain,)),
+                'icon': 'fa fa-search',
+                'show_in_dropdown': False,
+                'subpages': [],
+            })
         return explore_data_views
 
     def _get_geospatial_views(self):


### PR DESCRIPTION
## Product Description

Move "Case Search Endpoints" under "Explore Data" in the menu.

<img width="207" height="141" alt="image" src="https://github.com/user-attachments/assets/b2589791-5143-4c01-b6bc-e4c1ba90a6aa" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag

CASE_SEARCH_ENDPOINTS

## Safety Assurance

### Safety story

Just reordering a menu behind a FF. Very low risk

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
