### PR TITLE
Public Webforms: One-time Link Request Workflow

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
@@ -40,33 +40,7 @@
       {% if not request.user.is_authenticated %}
         <nav class="navbar-menus navbar-signin" role="navigation">
           <div class="nav-settings-bar pull-right">
-            <div class="navbar-btn dropdown" style="display: inline-block;">
-              <button
-                class="dropdown-toggle btn btn-default"
-                data-toggle="dropdown"
-                aria-haspopup="true"
-                aria-expanded="false"
-              >
-                {{ LANGUAGE_CODE|language_name_local }}
-                <span class="caret"></span>
-              </button>
-              <ul class="dropdown-menu">
-                {% for lang_code, name in LANGUAGES %}
-                  <li>
-                    <form action="{% url 'set_language' %}" method="post">
-                      {% csrf_token %}
-                      <button
-                        type="submit"
-                        name="language"
-                        value="{{ lang_code }}"
-                      >
-                        {{ lang_code|language_name_local }}
-                      </button>
-                    </form>
-                  </li>
-                {% endfor %}
-              </ul>
-            </div>
+            {% include "hqwebapp/partials/bootstrap3/language_dropdown.html" %}
             <a href="{% url "login" %}" class="btn btn-primary navbar-btn"
               >{% trans 'Sign In' %}</a
             >

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
@@ -65,33 +65,7 @@
       {% if not request.user.is_authenticated %}
         <nav class="navbar-signin ms-2" role="navigation">
           <div class="nav-settings-bar">
-            <div class="me-2 dropdown d-inline-block">
-              <button
-                class="dropdown-toggle btn btn-outline-primary"
-                data-bs-toggle="dropdown"
-                aria-haspopup="true"
-                aria-expanded="false"
-              >
-                {{ LANGUAGE_CODE|language_name_local }}
-              </button>
-              <ul class="dropdown-menu">
-                {% for lang_code, name in LANGUAGES %}
-                  <li>
-                    <form action="{% url 'set_language' %}" method="post">
-                      {% csrf_token %}
-                      <button
-                        class="dropdown-item"
-                        type="submit"
-                        name="language"
-                        value="{{ lang_code }}"
-                      >
-                        {{ lang_code|language_name_local }}
-                      </button>
-                    </form>
-                  </li>
-                {% endfor %}
-              </ul>
-            </div>
+            {% include "hqwebapp/partials/bootstrap5/language_dropdown.html" %}
             <a href="{% url "login" %}" class="btn btn-primary me-2"
               >{% trans 'Sign In' %}</a
             >

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/language_dropdown.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/language_dropdown.html
@@ -1,0 +1,25 @@
+{% load hq_shared_tags %}
+
+<div class="navbar-btn dropdown" style="display: inline-block;">
+  <button
+    class="dropdown-toggle btn btn-default"
+    data-toggle="dropdown"
+    aria-haspopup="true"
+    aria-expanded="false"
+  >
+    {{ LANGUAGE_CODE|language_name_local }}
+    <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu">
+    {% for lang_code, name in LANGUAGES %}
+      <li>
+        <form action="{% url 'set_language' %}" method="post">
+          {% csrf_token %}
+          <button type="submit" name="language" value="{{ lang_code }}">
+            {{ lang_code|language_name_local }}
+          </button>
+        </form>
+      </li>
+    {% endfor %}
+  </ul>
+</div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/language_dropdown.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap3/language_dropdown.html
@@ -10,7 +10,7 @@
     {{ LANGUAGE_CODE|language_name_local }}
     <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu">
+  <ul class="dropdown-menu dropdown-menu-right">
     {% for lang_code, name in LANGUAGES %}
       <li>
         <form action="{% url 'set_language' %}" method="post">

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/language_dropdown.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/language_dropdown.html
@@ -9,7 +9,7 @@
   >
     {{ LANGUAGE_CODE|language_name_local }}
   </button>
-  <ul class="dropdown-menu">
+  <ul class="dropdown-menu dropdown-menu-end">
     {% for lang_code, name in LANGUAGES %}
       <li>
         <form action="{% url 'set_language' %}" method="post">

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/language_dropdown.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bootstrap5/language_dropdown.html
@@ -1,0 +1,29 @@
+{% load hq_shared_tags %}
+
+<div class="me-2 dropdown d-inline-block">
+  <button
+    class="dropdown-toggle btn btn-outline-primary"
+    data-bs-toggle="dropdown"
+    aria-haspopup="true"
+    aria-expanded="false"
+  >
+    {{ LANGUAGE_CODE|language_name_local }}
+  </button>
+  <ul class="dropdown-menu">
+    {% for lang_code, name in LANGUAGES %}
+      <li>
+        <form action="{% url 'set_language' %}" method="post">
+          {% csrf_token %}
+          <button
+            class="dropdown-item"
+            type="submit"
+            name="language"
+            value="{{ lang_code }}"
+          >
+            {{ lang_code|language_name_local }}
+          </button>
+        </form>
+      </li>
+    {% endfor %}
+  </ul>
+</div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
@@ -9,7 +9,7 @@
    {% if show_trial_banner %}
      {% include "hqwebapp/partials/trial_banner.html" %}
    {% endif %}
-@@ -17,38 +17,62 @@
+@@ -17,47 +17,11 @@
  {% endblock pre_navigation_content %}
  
  {% block navigation %}
@@ -20,24 +20,60 @@
 +    class="navbar navbar-expand-lg bg-light border-bottom-1 navbar-hq-main-menu"
    >
      <div class="container-fluid">
-+      <div class="navbar-header hq-header">
-+        <a
-+          href="{% if request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}#{% else %}{% url "homepage" %}{% endif %}"
-+          class="navbar-brand"
-+        >
-+          {% if CUSTOM_LOGO_URL %}
-+            <img src="{{ CUSTOM_LOGO_URL }}" alt="CommCare HQ Logo" />
-+          {% else %}
-+            <!-- _navbar.scss supplies the default logo -->
-+            <div></div>
-+          {% endif %}
-+        </a>
-+      </div>
-+
-       {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated %}
+-      {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated %}
 -        <ul
 -          class="nav navbar-nav collapse-fullmenu-toggle"
 -          id="hq-fullmenu-responsive"
+-          role="menu"
+-        >
+-          <li>
+-            <a href="#hq-full-menu" data-toggle="collapse">
+-              <i class="fa fa-bars"></i>
+-              {% trans "Menu" %}
+-            </a>
+-          </li>
+-        </ul>
+-      {% endif %}
+-
+-      {% if not request.user.is_authenticated %}
+-        <nav class="navbar-menus navbar-signin" role="navigation">
+-          <div class="nav-settings-bar pull-right">
+-            {% include "hqwebapp/partials/bootstrap3/language_dropdown.html" %}
+-            <a href="{% url "login" %}" class="btn btn-primary navbar-btn"
+-              >{% trans 'Sign In' %}</a
+-            >
+-            {% if ANALYTICS_IDS.HUBSPOT_API_ID %}
+-              <a
+-                href="#cta-form-get-demo"
+-                data-toggle="modal"
+-                id="cta-form-get-demo-button-header"
+-                class="btn btn-purple navbar-btn"
+-              >
+-                {% trans 'Schedule a Demo' %}
+-              </a>
+-            {% endif %}
+-          </div>
+-        </nav>
+-      {% endif %}
+-
+       <div class="navbar-header hq-header">
+         <a
+           href="{% if request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}#{% else %}{% url "homepage" %}{% endif %}"
+@@ -66,50 +30,69 @@
+           {% if CUSTOM_LOGO_URL %}
+             <img src="{{ CUSTOM_LOGO_URL }}" alt="CommCare HQ Logo" />
+           {% else %}
+-            <!-- navbar.less supplies the default logo -->
++            <!-- _navbar.scss supplies the default logo -->
+             <div></div>
+           {% endif %}
+         </a>
+       </div>
+ 
+       {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated %}
+-        <ul
+-          class="nav navbar-nav collapse-mainmenu-toggle"
+-          id="hq-mainmenu-responsive"
 -          role="menu"
 +        <button
 +          class="navbar-toggler"
@@ -49,7 +85,7 @@
 +          aria-label="toggle menu"
          >
 -          <li>
--            <a href="#hq-full-menu" data-toggle="collapse">
+-            <a href="#hq-main-tabs" data-toggle="collapse">
 -              <i class="fa fa-bars"></i>
 -              {% trans "Menu" %}
 -            </a>
@@ -59,98 +95,7 @@
 +          {% trans "Menu" %}
 +        </button>
 +      {% endif %}
-+
-+      {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated %}
-+        <div class="collapse navbar-collapse ms-2" id="hq-full-menu">
-+          <div class="nav-settings-bar pe-2">
-+            {% include 'hqwebapp/includes/bootstrap5/global_navigation_bar.html' %}
-+          </div>
-+          {% block tabs %}
-+            {% format_main_menu %}
-+          {% endblock %}
-+        </div>
-       {% endif %}
  
-       {% if not request.user.is_authenticated %}
--        <nav class="navbar-menus navbar-signin" role="navigation">
--          <div class="nav-settings-bar pull-right">
--            <div class="navbar-btn dropdown" style="display: inline-block;">
-+        <nav class="navbar-signin ms-2" role="navigation">
-+          <div class="nav-settings-bar">
-+            <div class="me-2 dropdown d-inline-block">
-               <button
--                class="dropdown-toggle btn btn-default"
--                data-toggle="dropdown"
-+                class="dropdown-toggle btn btn-outline-primary"
-+                data-bs-toggle="dropdown"
-                 aria-haspopup="true"
-                 aria-expanded="false"
-               >
-                 {{ LANGUAGE_CODE|language_name_local }}
--                <span class="caret"></span>
-               </button>
-               <ul class="dropdown-menu">
-                 {% for lang_code, name in LANGUAGES %}
-@@ -56,6 +80,7 @@
-                     <form action="{% url 'set_language' %}" method="post">
-                       {% csrf_token %}
-                       <button
-+                        class="dropdown-item"
-                         type="submit"
-                         name="language"
-                         value="{{ lang_code }}"
-@@ -67,15 +92,15 @@
-                 {% endfor %}
-               </ul>
-             </div>
--            <a href="{% url "login" %}" class="btn btn-primary navbar-btn"
-+            <a href="{% url "login" %}" class="btn btn-primary me-2"
-               >{% trans 'Sign In' %}</a
-             >
-             {% if ANALYTICS_IDS.HUBSPOT_API_ID %}
-               <a
-                 href="#cta-form-get-demo"
--                data-toggle="modal"
-+                data-bs-toggle="modal"
-                 id="cta-form-get-demo-button-header"
--                class="btn btn-purple navbar-btn"
-+                class="btn btn-purple me-2"
-               >
-                 {% trans 'Schedule a Demo' %}
-               </a>
-@@ -83,59 +108,17 @@
-           </div>
-         </nav>
-       {% endif %}
--
--      <div class="navbar-header hq-header">
--        <a
--          href="{% if request|toggle_enabled:"USER_TESTING_SIMPLIFY" %}#{% else %}{% url "homepage" %}{% endif %}"
--          class="navbar-brand"
--        >
--          {% if CUSTOM_LOGO_URL %}
--            <img src="{{ CUSTOM_LOGO_URL }}" alt="CommCare HQ Logo" />
--          {% else %}
--            <!-- navbar.less supplies the default logo -->
--            <div></div>
--          {% endif %}
--        </a>
--      </div>
--
--      {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated %}
--        <ul
--          class="nav navbar-nav collapse-mainmenu-toggle"
--          id="hq-mainmenu-responsive"
--          role="menu"
--        >
--          <li>
--            <a href="#hq-main-tabs" data-toggle="collapse">
--              <i class="fa fa-bars"></i>
--              {% trans "Menu" %}
--            </a>
--          </li>
--        </ul>
--
 -        <nav
 -          class="navbar-menus fullmenu collapse"
 -          id="hq-full-menu"
@@ -158,12 +103,37 @@
 -        >
 -          <div class="nav-settings-bar pull-right">
 -            {% include 'hqwebapp/includes/bootstrap3/global_navigation_bar.html' %}
--          </div>
--          {% block tabs %}
--            {% format_main_menu %}
--          {% endblock %}
--        </nav>
--      {% endif %}
++      {% if not request|toggle_enabled:"USER_TESTING_SIMPLIFY" and request.user.is_authenticated %}
++        <div class="collapse navbar-collapse ms-2" id="hq-full-menu">
++          <div class="nav-settings-bar pe-2">
++            {% include 'hqwebapp/includes/bootstrap5/global_navigation_bar.html' %}
+           </div>
+           {% block tabs %}
+             {% format_main_menu %}
+           {% endblock %}
++        </div>
++      {% endif %}
++
++      {% if not request.user.is_authenticated %}
++        <nav class="navbar-signin ms-2" role="navigation">
++          <div class="nav-settings-bar">
++            {% include "hqwebapp/partials/bootstrap5/language_dropdown.html" %}
++            <a href="{% url "login" %}" class="btn btn-primary me-2"
++              >{% trans 'Sign In' %}</a
++            >
++            {% if ANALYTICS_IDS.HUBSPOT_API_ID %}
++              <a
++                href="#cta-form-get-demo"
++                data-bs-toggle="modal"
++                id="cta-form-get-demo-button-header"
++                class="btn btn-purple me-2"
++              >
++                {% trans 'Schedule a Demo' %}
++              </a>
++            {% endif %}
++          </div>
+         </nav>
+       {% endif %}
      </div>
 -  </div>
 +  </nav>
@@ -181,7 +151,7 @@
  {% endblock post_navigation_content %}
  
  {% block messages %}
-@@ -145,10 +128,15 @@
+@@ -119,10 +102,15 @@
          {% if messages %}
            {% for message in messages %}
              <div
@@ -199,7 +169,7 @@
              </div>
            {% endfor %}
          {% endif %}
-@@ -157,9 +145,17 @@
+@@ -131,9 +119,17 @@
            class="ko-template"
            data-bind="foreach: {data: alerts, beforeRemove: fadeOut}"
          >
@@ -219,7 +189,7 @@
            </div>
          </div>
        </div>
-@@ -169,16 +165,16 @@
+@@ -143,16 +139,16 @@
  
  {% block footer %}
    {% if not enterprise_mode %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/language_dropdown.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/partials/language_dropdown.html.diff.txt
@@ -1,0 +1,34 @@
+--- 
++++ 
+@@ -1,21 +1,25 @@
+ {% load hq_shared_tags %}
+ 
+-<div class="navbar-btn dropdown" style="display: inline-block;">
++<div class="me-2 dropdown d-inline-block">
+   <button
+-    class="dropdown-toggle btn btn-default"
+-    data-toggle="dropdown"
++    class="dropdown-toggle btn btn-outline-primary"
++    data-bs-toggle="dropdown"
+     aria-haspopup="true"
+     aria-expanded="false"
+   >
+     {{ LANGUAGE_CODE|language_name_local }}
+-    <span class="caret"></span>
+   </button>
+-  <ul class="dropdown-menu dropdown-menu-right">
++  <ul class="dropdown-menu dropdown-menu-end">
+     {% for lang_code, name in LANGUAGES %}
+       <li>
+         <form action="{% url 'set_language' %}" method="post">
+           {% csrf_token %}
+-          <button type="submit" name="language" value="{{ lang_code }}">
++          <button
++            class="dropdown-item"
++            type="submit"
++            name="language"
++            value="{{ lang_code }}"
++          >
+             {{ lang_code|language_name_local }}
+           </button>
+         </form>

--- a/corehq/apps/public_webforms/messaging.py
+++ b/corehq/apps/public_webforms/messaging.py
@@ -1,0 +1,45 @@
+from django.template.loader import render_to_string
+from django.utils.timesince import timeuntil
+from django.utils.translation import gettext as _
+
+from dimagi.utils.web import get_static_url_prefix
+
+from corehq.apps.hqwebapp.tasks import send_html_email_async
+from corehq.apps.sms.api import send_sms
+
+
+def send_one_time_link(session, form_name):
+    if session.email:
+        _email_one_time_link(session, form_name)
+    else:
+        _text_one_time_link(session, form_name)
+
+
+def _email_one_time_link(session, form_name):
+    domain = session.public_webform.domain
+    context = {
+        'form_name': form_name,
+        'url': session.one_time_link,
+        'expires_in': timeuntil(session.expires_at),
+        'url_prefix': get_static_url_prefix(),
+    }
+    send_html_email_async.delay(
+        _("Your one-time link for {form_name}").format(form_name=form_name),
+        session.email,
+        render_to_string('public_webforms/email/one_time_link.html', context),
+        text_content=render_to_string(
+            'public_webforms/email/one_time_link.txt', context
+        ),
+        domain=domain,
+        use_domain_gateway=True,
+    )
+
+
+def _text_one_time_link(session, form_name):
+    send_sms(
+        session.public_webform.domain,
+        None,  # the respondent is not a contact this project knows
+        session.phone_number,
+        _("Your one-time link for {form_name} is: {url}").format(
+            form_name=form_name, url=session.one_time_link),
+    )

--- a/corehq/apps/public_webforms/models.py
+++ b/corehq/apps/public_webforms/models.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from uuid import UUID, uuid4
 
 from django.db import models
@@ -92,6 +93,8 @@ class PublicWebform(models.Model):
 
 
 class PublicFormSession(models.Model):
+
+    DEFAULT_LIFESPAN = timedelta(hours=1)
 
     id = models.UUIDField(primary_key=True, default=uuid4)
     session_key = models.UUIDField(default=uuid4, unique=True, db_index=True)

--- a/corehq/apps/public_webforms/models.py
+++ b/corehq/apps/public_webforms/models.py
@@ -86,6 +86,10 @@ class PublicWebform(models.Model):
     def is_expired(self):
         return self.expires_at < timezone.now()
 
+    @property
+    def is_open(self):
+        return not self.is_disabled and not self.is_expired
+
 
 class PublicFormSession(models.Model):
 

--- a/corehq/apps/public_webforms/models.py
+++ b/corehq/apps/public_webforms/models.py
@@ -125,6 +125,17 @@ class PublicFormSession(models.Model):
             expires_at__gt=timezone.now(),
         ).first()
 
+    @classmethod
+    def get_active_session_for_contact(cls, public_webform, email=None, phone_number=None):
+        assert bool(email) != bool(phone_number)
+        contact = {'email': email} if email else {'phone_number': phone_number}
+        return cls.objects.filter(
+            public_webform=public_webform,
+            submitted_at__isnull=True,
+            expires_at__gt=timezone.now(),
+            **contact,
+        ).order_by('-created_at').first()
+
     @property
     def session_username(self):
         return f"{PUBLIC_USER_ID}{self.id.hex}@{self.public_webform.domain}.commcarehq.org"

--- a/corehq/apps/public_webforms/models.py
+++ b/corehq/apps/public_webforms/models.py
@@ -137,6 +137,12 @@ class PublicFormSession(models.Model):
         ).order_by('-created_at').first()
 
     @property
+    def one_time_link(self):
+        """The absolute link sent to the respondent who asked for it."""
+        # TODO: implement real public link handling, at this url or otherwise
+        return f'{self.public_webform.public_url}{self.id.hex}/'
+
+    @property
     def session_username(self):
         return f"{PUBLIC_USER_ID}{self.id.hex}@{self.public_webform.domain}.commcarehq.org"
 

--- a/corehq/apps/public_webforms/models.py
+++ b/corehq/apps/public_webforms/models.py
@@ -80,8 +80,7 @@ class PublicWebform(models.Model):
     @property
     def public_url(self):
         """The absolute link a respondent opens to request a one-time link."""
-        # TODO: point at the real public route once it exists
-        return f'{get_url_base()}/placeholder/url/{self.public_id.hex}'
+        return f'{get_url_base()}/webforms/{self.public_id.hex}/'
 
     @property
     def is_expired(self):

--- a/corehq/apps/public_webforms/public/forms.py
+++ b/corehq/apps/public_webforms/public/forms.py
@@ -1,5 +1,4 @@
 import re
-from datetime import timedelta
 
 from django import forms
 from django.utils import timezone
@@ -85,5 +84,5 @@ class PublicWebformLinkRequestForm(forms.Form):
             public_webform=self.webform,
             email=self.cleaned_data['email'],
             phone_number=self.cleaned_data['phone_number'],
-            expires_at=timezone.now() + timedelta(hours=1),
+            expires_at=timezone.now() + PublicFormSession.DEFAULT_LIFESPAN,
         )

--- a/corehq/apps/public_webforms/public/forms.py
+++ b/corehq/apps/public_webforms/public/forms.py
@@ -1,0 +1,46 @@
+from django import forms
+from django.utils.translation import gettext_lazy as _
+
+
+class PublicWebformLinkRequestForm(forms.Form):
+
+    delivery = forms.ChoiceField(
+        label=_("How would you like to receive your link?"),
+        choices=[],
+        widget=forms.RadioSelect,
+    )
+    email = forms.EmailField(
+        label=_("Email Address"),
+        required=False,
+        widget=forms.EmailInput(attrs={
+            'class': 'form-control form-control-lg',
+            'placeholder': "you@example.com",
+            'autocomplete': 'email',
+        }),
+    )
+    phone_number = forms.CharField(
+        label=_("Phone Number"),
+        required=False,
+        max_length=50,
+        widget=forms.TextInput(attrs={
+            'class': 'form-control form-control-lg',
+            'type': 'tel',
+            'autocomplete': 'tel',
+        }),
+    )
+
+    def __init__(self, webform, *args, **kwargs):
+        self.webform = webform
+        super().__init__(*args, **kwargs)
+        delivery_choices = []
+        if webform.allow_email:
+            delivery_choices.append(('email', _("Email")))
+        if webform.allow_sms:
+            delivery_choices.append(('sms', _("Text Message")))
+
+        self.fields['delivery'].choices = delivery_choices
+        self.fields['delivery'].initial = delivery_choices[0][0] if delivery_choices else None
+
+    @property
+    def can_choose_delivery(self):
+        return len(self.fields['delivery'].choices) > 1

--- a/corehq/apps/public_webforms/public/forms.py
+++ b/corehq/apps/public_webforms/public/forms.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 from corehq.apps.hqwebapp.fields import TurnstileField
 from corehq.apps.public_webforms.models import PublicFormSession
+from corehq.apps.public_webforms.rate_limiter import rate_limit_link_request
 
 
 class PublicWebformLinkRequestForm(forms.Form):
@@ -67,6 +68,10 @@ class PublicWebformLinkRequestForm(forms.Form):
             cleaned_data['email'] = ''
             cleaned_data['phone_number'] = self._clean_phone_number(
                 cleaned_data.get('phone_number'))
+
+        contact = cleaned_data.get('email') or cleaned_data.get('phone_number')
+        if contact and rate_limit_link_request(contact):
+            self.add_error(None, _("Please wait a moment before trying again."))
         return cleaned_data
 
     def _clean_phone_number(self, phone_number):

--- a/corehq/apps/public_webforms/public/forms.py
+++ b/corehq/apps/public_webforms/public/forms.py
@@ -16,6 +16,7 @@ class PublicWebformLinkRequestForm(forms.Form):
             'class': 'form-control form-control-lg',
             'placeholder': "you@example.com",
             'autocomplete': 'email',
+            'x-model': 'email',
         }),
     )
     phone_number = forms.CharField(
@@ -26,6 +27,7 @@ class PublicWebformLinkRequestForm(forms.Form):
             'class': 'form-control form-control-lg',
             'type': 'tel',
             'autocomplete': 'tel',
+            'x-model': 'phoneNumber',
         }),
     )
 

--- a/corehq/apps/public_webforms/public/forms.py
+++ b/corehq/apps/public_webforms/public/forms.py
@@ -79,10 +79,14 @@ class PublicWebformLinkRequestForm(forms.Form):
             self.add_error('phone_number', _("Enter a valid phone number."))
         return digits
 
-    def create_session(self):
-        return PublicFormSession.objects.create(
+    def get_or_create_session(self):
+        email = self.cleaned_data['email']
+        phone_number = self.cleaned_data['phone_number']
+        contact = {'email': email} if email else {'phone_number': phone_number}
+        session = PublicFormSession.get_active_session_for_contact(
+            self.webform, **contact)
+        return session or PublicFormSession.objects.create(
             public_webform=self.webform,
-            email=self.cleaned_data['email'],
-            phone_number=self.cleaned_data['phone_number'],
             expires_at=timezone.now() + PublicFormSession.DEFAULT_LIFESPAN,
+            **contact,
         )

--- a/corehq/apps/public_webforms/public/forms.py
+++ b/corehq/apps/public_webforms/public/forms.py
@@ -1,5 +1,11 @@
+import re
+from datetime import timedelta
+
 from django import forms
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+
+from corehq.apps.public_webforms.models import PublicFormSession
 
 
 class PublicWebformLinkRequestForm(forms.Form):
@@ -46,3 +52,36 @@ class PublicWebformLinkRequestForm(forms.Form):
     @property
     def can_choose_delivery(self):
         return len(self.fields['delivery'].choices) > 1
+
+    def clean(self):
+        cleaned_data = super().clean()
+        delivery = cleaned_data.get('delivery')
+        # the field for the option not chosen is submitted but ignored, so
+        # switching between them can't leave a stale value behind
+        if delivery == 'email':
+            cleaned_data['phone_number'] = ''
+            if not cleaned_data.get('email'):
+                self.add_error('email', _("Enter the email address to send your link to."))
+        elif delivery == 'sms':
+            cleaned_data['email'] = ''
+            cleaned_data['phone_number'] = self._clean_phone_number(
+                cleaned_data.get('phone_number'))
+        return cleaned_data
+
+    def _clean_phone_number(self, phone_number):
+        # the widget submits a full international number, punctuation and all
+        digits = re.sub(r'[\s+\-().]', '', phone_number or '')
+        if not digits:
+            self.add_error(
+                'phone_number', _("Enter the phone number to send your link to."))
+        elif not digits.isdigit():
+            self.add_error('phone_number', _("Enter a valid phone number."))
+        return digits
+
+    def create_session(self):
+        return PublicFormSession.objects.create(
+            public_webform=self.webform,
+            email=self.cleaned_data['email'],
+            phone_number=self.cleaned_data['phone_number'],
+            expires_at=timezone.now() + timedelta(hours=1),
+        )

--- a/corehq/apps/public_webforms/public/forms.py
+++ b/corehq/apps/public_webforms/public/forms.py
@@ -5,6 +5,7 @@ from django import forms
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from corehq.apps.hqwebapp.fields import TurnstileField
 from corehq.apps.public_webforms.models import PublicFormSession
 
 
@@ -36,6 +37,7 @@ class PublicWebformLinkRequestForm(forms.Form):
             'x-model': 'phoneNumber',
         }),
     )
+    turnstile = TurnstileField()
 
     def __init__(self, webform, *args, **kwargs):
         self.webform = webform

--- a/corehq/apps/public_webforms/public/forms.py
+++ b/corehq/apps/public_webforms/public/forms.py
@@ -70,7 +70,7 @@ class PublicWebformLinkRequestForm(forms.Form):
                 cleaned_data.get('phone_number'))
 
         contact = cleaned_data.get('email') or cleaned_data.get('phone_number')
-        if contact and rate_limit_link_request(contact):
+        if contact and rate_limit_link_request(self.webform.domain, contact):
             self.add_error(None, _("Please wait a moment before trying again."))
         return cleaned_data
 

--- a/corehq/apps/public_webforms/public/urls.py
+++ b/corehq/apps/public_webforms/public/urls.py
@@ -1,0 +1,13 @@
+from django.urls import re_path as url
+
+from corehq.apps.public_webforms.public.views import (
+    PublicWebformRequestView,
+)
+
+urlpatterns = [
+    url(
+        r'^(?P<public_id>[a-f0-9]{32})/$',
+        PublicWebformRequestView.as_view(),
+        name=PublicWebformRequestView.urlname,
+    )
+]

--- a/corehq/apps/public_webforms/public/urls.py
+++ b/corehq/apps/public_webforms/public/urls.py
@@ -1,6 +1,7 @@
 from django.urls import re_path as url
 
 from corehq.apps.public_webforms.public.views import (
+    PublicWebformLinkSentView,
     PublicWebformRequestView,
 )
 
@@ -9,5 +10,10 @@ urlpatterns = [
         r'^(?P<public_id>[a-f0-9]{32})/$',
         PublicWebformRequestView.as_view(),
         name=PublicWebformRequestView.urlname,
-    )
+    ),
+    url(
+        r'^(?P<public_id>[a-f0-9]{32})/sent/$',
+        PublicWebformLinkSentView.as_view(),
+        name=PublicWebformLinkSentView.urlname,
+    ),
 ]

--- a/corehq/apps/public_webforms/public/views.py
+++ b/corehq/apps/public_webforms/public/views.py
@@ -64,7 +64,7 @@ class PublicWebformRequestView(BasePublicWebformView):
     def post(self, request, *args, **kwargs):
         if not self.form.is_valid():
             return self.get(request, *args, **kwargs)
-        self.form.create_session()
+        self.form.get_or_create_session()
         return HttpResponseRedirect(reverse(
             PublicWebformLinkSentView.urlname,
             kwargs={'public_id': self.webform.public_id.hex},

--- a/corehq/apps/public_webforms/public/views.py
+++ b/corehq/apps/public_webforms/public/views.py
@@ -3,8 +3,10 @@ from memoized import memoized
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import get_language, gettext_lazy as _
 
+from corehq.apps.app_manager.dbaccessors import get_app
+from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.public_webforms.models import PublicWebform
@@ -31,4 +33,15 @@ class BasePublicWebformView(BasePageView):
 @method_decorator(use_bootstrap5, name='dispatch')
 class PublicWebformRequestView(BasePublicWebformView):
     urlname = 'public_webform_request'
-    template_name = 'public_webforms/public/base.html'
+    template_name = 'public_webforms/public/webform_request.html'
+
+    @property
+    @memoized
+    def form_name(self):
+        app = get_app(self.webform.domain, self.webform.app_build_id)
+        form = app.get_form(self.webform.form_unique_id) if app else None
+        return clean_trans(form.name, [get_language()] + app.langs) if form else None
+
+    @property
+    def page_title(self):
+        return self.form_name

--- a/corehq/apps/public_webforms/public/views.py
+++ b/corehq/apps/public_webforms/public/views.py
@@ -2,7 +2,7 @@ from memoized import memoized
 
 from django.contrib import messages
 from django.http import HttpResponseRedirect
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import get_language, gettext_lazy as _
@@ -18,6 +18,15 @@ from corehq.apps.public_webforms.public.forms import (
 
 
 class BasePublicWebformView(BasePageView):
+
+    def dispatch(self, request, *args, **kwargs):
+        if not self.webform.is_open:
+            return render(
+                request,
+                'public_webforms/public/webform_closed.html',
+                status=404,
+            )
+        return super().dispatch(request, *args, **kwargs)
 
     @property
     @memoized

--- a/corehq/apps/public_webforms/public/views.py
+++ b/corehq/apps/public_webforms/public/views.py
@@ -2,8 +2,10 @@ from memoized import memoized
 
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 
+from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.public_webforms.models import PublicWebform
 
@@ -24,3 +26,9 @@ class BasePublicWebformView(BasePageView):
         context = super().main_context
         context['section'] = {'page_name': _("One-Time Link Request")}
         return context
+
+
+@method_decorator(use_bootstrap5, name='dispatch')
+class PublicWebformRequestView(BasePublicWebformView):
+    urlname = 'public_webform_request'
+    template_name = 'public_webforms/public/base.html'

--- a/corehq/apps/public_webforms/public/views.py
+++ b/corehq/apps/public_webforms/public/views.py
@@ -12,6 +12,7 @@ from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import BasePageView
+from corehq.apps.public_webforms.messaging import send_one_time_link
 from corehq.apps.public_webforms.models import PublicFormSession, PublicWebform
 from corehq.apps.public_webforms.public.forms import (
     PublicWebformLinkRequestForm,
@@ -64,7 +65,7 @@ class PublicWebformRequestView(BasePublicWebformView):
     def post(self, request, *args, **kwargs):
         if not self.form.is_valid():
             return self.get(request, *args, **kwargs)
-        self.form.get_or_create_session()
+        send_one_time_link(self.form.get_or_create_session(), self.form_name)
         return HttpResponseRedirect(reverse(
             PublicWebformLinkSentView.urlname,
             kwargs={'public_id': self.webform.public_id.hex},

--- a/corehq/apps/public_webforms/public/views.py
+++ b/corehq/apps/public_webforms/public/views.py
@@ -1,6 +1,6 @@
 from memoized import memoized
 
-from django.http import HttpResponseRedirect
+from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
@@ -8,6 +8,8 @@ from django.utils.decorators import method_decorator
 from django.utils.timesince import timeuntil
 from django.utils.translation import get_language, gettext_lazy as _
 
+from corehq import privileges, toggles
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
@@ -19,12 +21,23 @@ from corehq.apps.public_webforms.public.forms import (
 )
 
 
+def public_webforms_enabled(domain):
+    return (
+        domain_has_privilege(domain, privileges.PUBLIC_WEBFORMS)
+        and toggles.PUBLIC_WEBFORMS.enabled(domain, namespace=toggles.NAMESPACE_DOMAIN)
+    )
+
+
 class BasePublicWebformView(BasePageView):
 
     @property
     @memoized
     def webform(self):
-        return get_object_or_404(PublicWebform, public_id=self.kwargs.get('public_id'))
+        webform = get_object_or_404(
+            PublicWebform, public_id=self.kwargs.get('public_id'))
+        if not public_webforms_enabled(webform.domain):
+            raise Http404
+        return webform
 
     @property
     def page_url(self):

--- a/corehq/apps/public_webforms/public/views.py
+++ b/corehq/apps/public_webforms/public/views.py
@@ -10,6 +10,9 @@ from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.public_webforms.models import PublicWebform
+from corehq.apps.public_webforms.public.forms import (
+    PublicWebformLinkRequestForm,
+)
 
 
 class BasePublicWebformView(BasePageView):
@@ -45,3 +48,9 @@ class PublicWebformRequestView(BasePublicWebformView):
     @property
     def page_title(self):
         return self.form_name
+
+    @property
+    def page_context(self):
+        context = super().page_context
+        context['form'] = PublicWebformLinkRequestForm(self.webform)
+        return context

--- a/corehq/apps/public_webforms/public/views.py
+++ b/corehq/apps/public_webforms/public/views.py
@@ -1,5 +1,7 @@
 from memoized import memoized
 
+from django.contrib import messages
+from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -49,8 +51,21 @@ class PublicWebformRequestView(BasePublicWebformView):
     def page_title(self):
         return self.form_name
 
+    def post(self, request, *args, **kwargs):
+        if not self.form.is_valid():
+            return self.get(request, *args, **kwargs)
+        self.form.create_session()
+        messages.success(request, _("Your one-time link is on its way."))
+        return HttpResponseRedirect(self.page_url)
+
     @property
     def page_context(self):
         context = super().page_context
-        context['form'] = PublicWebformLinkRequestForm(self.webform)
+        context['form'] = self.form
         return context
+
+    @property
+    @memoized
+    def form(self):
+        data = [self.request.POST] if self.request.method == 'POST' else []
+        return PublicWebformLinkRequestForm(self.webform, *data)

--- a/corehq/apps/public_webforms/public/views.py
+++ b/corehq/apps/public_webforms/public/views.py
@@ -1,0 +1,26 @@
+from memoized import memoized
+
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from corehq.apps.hqwebapp.views import BasePageView
+from corehq.apps.public_webforms.models import PublicWebform
+
+
+class BasePublicWebformView(BasePageView):
+
+    @property
+    @memoized
+    def webform(self):
+        return get_object_or_404(PublicWebform, public_id=self.kwargs.get('public_id'))
+
+    @property
+    def page_url(self):
+        return reverse(self.urlname, kwargs={'public_id': self.webform.public_id.hex})
+
+    @property
+    def main_context(self):
+        context = super().main_context
+        context['section'] = {'page_name': _("One-Time Link Request")}
+        return context

--- a/corehq/apps/public_webforms/public/views.py
+++ b/corehq/apps/public_webforms/public/views.py
@@ -1,32 +1,24 @@
 from memoized import memoized
 
-from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.decorators import method_decorator
+from django.utils.timesince import timeuntil
 from django.utils.translation import get_language, gettext_lazy as _
 
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans
 from corehq.apps.hqwebapp.decorators import use_bootstrap5
 from corehq.apps.hqwebapp.views import BasePageView
-from corehq.apps.public_webforms.models import PublicWebform
+from corehq.apps.public_webforms.models import PublicFormSession, PublicWebform
 from corehq.apps.public_webforms.public.forms import (
     PublicWebformLinkRequestForm,
 )
 
 
 class BasePublicWebformView(BasePageView):
-
-    def dispatch(self, request, *args, **kwargs):
-        if not self.webform.is_open:
-            return render(
-                request,
-                'public_webforms/public/webform_closed.html',
-                status=404,
-            )
-        return super().dispatch(request, *args, **kwargs)
 
     @property
     @memoized
@@ -49,6 +41,15 @@ class PublicWebformRequestView(BasePublicWebformView):
     urlname = 'public_webform_request'
     template_name = 'public_webforms/public/webform_request.html'
 
+    def dispatch(self, request, *args, **kwargs):
+        if not self.webform.is_open:
+            return render(
+                request,
+                'public_webforms/public/webform_closed.html',
+                status=404,
+            )
+        return super().dispatch(request, *args, **kwargs)
+
     @property
     @memoized
     def form_name(self):
@@ -64,8 +65,10 @@ class PublicWebformRequestView(BasePublicWebformView):
         if not self.form.is_valid():
             return self.get(request, *args, **kwargs)
         self.form.create_session()
-        messages.success(request, _("Your one-time link is on its way."))
-        return HttpResponseRedirect(self.page_url)
+        return HttpResponseRedirect(reverse(
+            PublicWebformLinkSentView.urlname,
+            kwargs={'public_id': self.webform.public_id.hex},
+        ))
 
     @property
     def page_context(self):
@@ -78,3 +81,26 @@ class PublicWebformRequestView(BasePublicWebformView):
     def form(self):
         data = [self.request.POST] if self.request.method == 'POST' else []
         return PublicWebformLinkRequestForm(self.webform, *data)
+
+
+@method_decorator(use_bootstrap5, name='dispatch')
+class PublicWebformLinkSentView(BasePublicWebformView):
+
+    urlname = 'public_webform_link_sent'
+    template_name = 'public_webforms/public/webform_link_sent.html'
+
+    @property
+    def page_context(self):
+        context = super().page_context
+        now = timezone.now()
+        context.update({
+            # the session is not carried across the redirect, so this is how
+            # long any link lasts, not how long this respondent's link has left
+            'link_lifespan': timeuntil(
+                now + PublicFormSession.DEFAULT_LIFESPAN, now),
+            'request_url': reverse(
+                PublicWebformRequestView.urlname,
+                kwargs={'public_id': self.webform.public_id.hex},
+            ) if self.webform.is_open else None,
+        })
+        return context

--- a/corehq/apps/public_webforms/rate_limiter.py
+++ b/corehq/apps/public_webforms/rate_limiter.py
@@ -1,0 +1,45 @@
+from django.conf import settings
+
+from corehq.project_limits.rate_limiter import (
+    RateDefinition,
+    RateLimiter,
+    get_dynamic_rate_definition,
+)
+from corehq.util.decorators import run_only_when, silence_and_report_error
+from corehq.util.metrics import metrics_counter
+
+STATUS_CONTACT_RATE_LIMITED = 'contact_rate_limited'
+STATUS_ACCEPTED = 'accepted'
+
+SHOULD_RATE_LIMIT_LINK_REQUESTS = not settings.UNIT_TESTING
+
+
+@run_only_when(lambda: SHOULD_RATE_LIMIT_LINK_REQUESTS)
+@silence_and_report_error(
+    "Exception raised in the public webform link request rate limiter",
+    'commcare.public_webforms.link_request_rate_limiter_errors')
+def rate_limit_link_request(contact):
+    scope = 'contact:{}'.format(contact)
+    window = link_requests_per_contact.get_window_of_first_exceeded_limit(scope)
+    status = STATUS_CONTACT_RATE_LIMITED if window else STATUS_ACCEPTED
+    if status == STATUS_ACCEPTED:
+        link_requests_per_contact.report_usage(scope)
+
+    metrics_counter('commcare.public_webforms.link_requests', 1, tags={
+        'status': status,
+        'window': window or 'none',
+    })
+    return status != STATUS_ACCEPTED
+
+
+link_requests_per_contact = RateLimiter(
+    feature_key='public_webform_link_requests_per_contact',
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
+        'public_webform_link_requests_per_contact',
+        default=RateDefinition(
+            per_week=30,
+            per_day=15,
+            per_hour=5,
+        )
+    ).get_rate_limits(scope),
+)

--- a/corehq/apps/public_webforms/rate_limiter.py
+++ b/corehq/apps/public_webforms/rate_limiter.py
@@ -5,9 +5,14 @@ from corehq.project_limits.rate_limiter import (
     RateLimiter,
     get_dynamic_rate_definition,
 )
+from dimagi.utils.web import get_ip
+
 from corehq.util.decorators import run_only_when, silence_and_report_error
+from corehq.util.global_request import get_request
 from corehq.util.metrics import metrics_counter
 
+STATUS_GLOBAL_RATE_LIMITED = 'global_rate_limited'
+STATUS_IP_RATE_LIMITED = 'ip_rate_limited'
 STATUS_CONTACT_RATE_LIMITED = 'contact_rate_limited'
 STATUS_ACCEPTED = 'accepted'
 
@@ -19,17 +24,48 @@ SHOULD_RATE_LIMIT_LINK_REQUESTS = not settings.UNIT_TESTING
     "Exception raised in the public webform link request rate limiter",
     'commcare.public_webforms.link_request_rate_limiter_errors')
 def rate_limit_link_request(contact):
-    scope = 'contact:{}'.format(contact)
-    window = link_requests_per_contact.get_window_of_first_exceeded_limit(scope)
-    status = STATUS_CONTACT_RATE_LIMITED if window else STATUS_ACCEPTED
+    ip_address = _get_ip_address()
+    status, window = _check_for_exceeded_rate_limits(contact, ip_address)
     if status == STATUS_ACCEPTED:
-        link_requests_per_contact.report_usage(scope)
+        _report_usage(contact, ip_address)
 
     metrics_counter('commcare.public_webforms.link_requests', 1, tags={
         'status': status,
         'window': window or 'none',
     })
     return status != STATUS_ACCEPTED
+
+
+def _get_ip_address():
+    request = get_request()
+    return get_ip(request) if request else None
+
+
+def _check_for_exceeded_rate_limits(contact, ip_address):
+    # widest scope first, so that the metric names the broadest limit reached
+    window = link_requests_global.get_window_of_first_exceeded_limit()
+    if window:
+        return STATUS_GLOBAL_RATE_LIMITED, window
+
+    if ip_address:
+        window = link_requests_per_ip.get_window_of_first_exceeded_limit(
+            'ip:{}'.format(ip_address))
+        if window:
+            return STATUS_IP_RATE_LIMITED, window
+
+    window = link_requests_per_contact.get_window_of_first_exceeded_limit(
+        'contact:{}'.format(contact))
+    if window:
+        return STATUS_CONTACT_RATE_LIMITED, window
+
+    return STATUS_ACCEPTED, None
+
+
+def _report_usage(contact, ip_address):
+    link_requests_global.report_usage()
+    if ip_address:
+        link_requests_per_ip.report_usage('ip:{}'.format(ip_address))
+    link_requests_per_contact.report_usage('contact:{}'.format(contact))
 
 
 link_requests_per_contact = RateLimiter(
@@ -40,6 +76,32 @@ link_requests_per_contact = RateLimiter(
             per_week=30,
             per_day=15,
             per_hour=5,
+        )
+    ).get_rate_limits(scope),
+)
+
+
+link_requests_per_ip = RateLimiter(
+    feature_key='public_webform_link_requests_per_ip',
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
+        'public_webform_link_requests_per_ip',
+        # generous, because a clinic full of respondents may share one address
+        default=RateDefinition(
+            per_week=2000,
+            per_day=500,
+            per_hour=100,
+        )
+    ).get_rate_limits(scope),
+)
+
+link_requests_global = RateLimiter(
+    feature_key='public_webform_link_requests_global',
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
+        'public_webform_link_requests_global',
+        # a ceiling on what the feature can cost HQ, not a per-project limit
+        default=RateDefinition(
+            per_day=50000,
+            per_hour=5000,
         )
     ).get_rate_limits(scope),
 )

--- a/corehq/apps/public_webforms/rate_limiter.py
+++ b/corehq/apps/public_webforms/rate_limiter.py
@@ -12,6 +12,7 @@ from corehq.util.global_request import get_request
 from corehq.util.metrics import metrics_counter
 
 STATUS_GLOBAL_RATE_LIMITED = 'global_rate_limited'
+STATUS_DOMAIN_RATE_LIMITED = 'domain_rate_limited'
 STATUS_IP_RATE_LIMITED = 'ip_rate_limited'
 STATUS_CONTACT_RATE_LIMITED = 'contact_rate_limited'
 STATUS_ACCEPTED = 'accepted'
@@ -23,11 +24,13 @@ SHOULD_RATE_LIMIT_LINK_REQUESTS = not settings.UNIT_TESTING
 @silence_and_report_error(
     "Exception raised in the public webform link request rate limiter",
     'commcare.public_webforms.link_request_rate_limiter_errors')
-def rate_limit_link_request(contact):
+def rate_limit_link_request(domain, contact):
     ip_address = _get_ip_address()
-    status, window = _check_for_exceeded_rate_limits(contact, ip_address)
+    status, window = _check_for_exceeded_rate_limits(
+        domain, contact, ip_address
+    )
     if status == STATUS_ACCEPTED:
-        _report_usage(contact, ip_address)
+        _report_usage(domain, contact, ip_address)
 
     metrics_counter('commcare.public_webforms.link_requests', 1, tags={
         'status': status,
@@ -41,11 +44,16 @@ def _get_ip_address():
     return get_ip(request) if request else None
 
 
-def _check_for_exceeded_rate_limits(contact, ip_address):
+def _check_for_exceeded_rate_limits(domain, contact, ip_address):
     # widest scope first, so that the metric names the broadest limit reached
     window = link_requests_global.get_window_of_first_exceeded_limit()
     if window:
         return STATUS_GLOBAL_RATE_LIMITED, window
+
+    window = link_requests_per_domain.get_window_of_first_exceeded_limit(
+        'domain:{}'.format(domain))
+    if window:
+        return STATUS_DOMAIN_RATE_LIMITED, window
 
     if ip_address:
         window = link_requests_per_ip.get_window_of_first_exceeded_limit(
@@ -61,8 +69,9 @@ def _check_for_exceeded_rate_limits(contact, ip_address):
     return STATUS_ACCEPTED, None
 
 
-def _report_usage(contact, ip_address):
+def _report_usage(domain, contact, ip_address):
     link_requests_global.report_usage()
+    link_requests_per_domain.report_usage('domain:{}'.format(domain))
     if ip_address:
         link_requests_per_ip.report_usage('ip:{}'.format(ip_address))
     link_requests_per_contact.report_usage('contact:{}'.format(contact))
@@ -94,14 +103,26 @@ link_requests_per_ip = RateLimiter(
     ).get_rate_limits(scope),
 )
 
+link_requests_per_domain = RateLimiter(
+    feature_key='public_webform_link_requests_per_domain',
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
+        'public_webform_link_requests_per_domain',
+        default=RateDefinition(
+            per_week=60000,
+            per_day=20000,
+            per_hour=3000,
+        )
+    ).get_rate_limits(scope),
+)
+
 link_requests_global = RateLimiter(
     feature_key='public_webform_link_requests_global',
     get_rate_limits=lambda scope: get_dynamic_rate_definition(
         'public_webform_link_requests_global',
-        # a ceiling on what the feature can cost HQ, not a per-project limit
+        # a ceiling on what the feature can cost HQ as a whole
         default=RateDefinition(
-            per_day=50000,
-            per_hour=5000,
+            per_day=500000,
+            per_hour=50000,
         )
     ).get_rate_limits(scope),
 )

--- a/corehq/apps/public_webforms/static/public_webforms/js/request.js
+++ b/corehq/apps/public_webforms/static/public_webforms/js/request.js
@@ -1,0 +1,35 @@
+import 'commcarehq';
+
+import $ from 'jquery';
+import Alpine from 'alpinejs';
+import intlTelInput from 'intl-tel-input/build/js/intlTelInput.min';
+
+Alpine.start();
+
+document.addEventListener('DOMContentLoaded', () => {
+    const phoneNumber = document.getElementById('id_phone_number');
+    if (!phoneNumber) {
+        return;
+    }
+
+    const widget = intlTelInput(phoneNumber, {
+        containerClass: 'w-100',
+        separateDialCode: true,
+        loadUtils: () => import('intl-tel-input/utils'),
+    });
+
+    phoneNumber.addEventListener('focus', () => {
+        // wait until a user interacts with the widget to guess their country code
+        $.get('https://ipinfo.io', function () {}, 'jsonp').always(function (resp) {
+            if (resp && resp.country && !phoneNumber.value) {
+                widget.setCountry(resp.country);
+            }
+        });
+    }, {once: true});
+
+    // the dial code sits outside the input, so submit the full number
+    phoneNumber.form.addEventListener('submit', () => {
+        phoneNumber.value = widget.getNumber();
+    });
+
+});

--- a/corehq/apps/public_webforms/templates/public_webforms/email/one_time_link.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/email/one_time_link.html
@@ -1,0 +1,59 @@
+{% extends "registration/email/base_templates/_base.html" %}
+{% load i18n %}
+
+{% block preview_text %}
+  {% blocktrans %}
+    Your one-time link for {{ form_name }}
+  {% endblocktrans %}
+{% endblock %}
+
+{% block cta_headline %}
+  {% blocktrans %}
+    Your link is ready
+  {% endblocktrans %}
+{% endblock %}
+
+{% block cta_url %}{{ url }}{% endblock %}
+
+{% block cta_text %}
+  {% blocktrans %}
+    Open the form
+  {% endblocktrans %}
+{% endblock %}
+
+{% block lead_text %}
+  {% blocktrans %}
+    You asked for a link to complete {{ form_name }}.
+  {% endblocktrans %}
+{% endblock %}
+
+{% block secondary_text %}
+  <p>
+    {% blocktrans %}
+      Click the button or copy and paste the link below.
+    {% endblocktrans %}
+  </p>
+  <div
+    style="
+      background-color: #ffffff;
+      border: 1px solid #f2f2f1;
+      border-radius: 0.5em;
+      padding: 0.5em;
+      word-break: break-all;
+    "
+  >
+    <code> {{ url }} </code>
+  </div>
+  <p>
+    {% blocktrans %}
+      This link expires in {{ expires_in }} and can only be used once. If you
+      didn't request this, you can ignore this email.
+    {% endblocktrans %}
+  </p>
+{% endblock %}
+
+{% block reason_for_email %}
+  {% blocktrans %}
+    You received this message because a one-time link was requested
+  {% endblocktrans %}
+{% endblock %}

--- a/corehq/apps/public_webforms/templates/public_webforms/email/one_time_link.txt
+++ b/corehq/apps/public_webforms/templates/public_webforms/email/one_time_link.txt
@@ -1,0 +1,7 @@
+{% load i18n %}{% blocktrans %}You asked for a link to complete {{ form_name }}.{% endblocktrans %}
+
+{% blocktrans %}Copy and paste the link below.{% endblocktrans %}
+
+{{ url }}
+
+{% blocktrans %}This link expires in {{ expires_in }} and can only be used once. If you received this by mistake, you can ignore this email.{% endblocktrans %}

--- a/corehq/apps/public_webforms/templates/public_webforms/public/base.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/public/base.html
@@ -1,0 +1,33 @@
+{% extends "hqwebapp/bootstrap5/base_page.html" %}
+
+{% block content %}
+  <div class="col-sm-9 col-md-8 col-lg-7 col-xl-6 col-xxl-5 m-auto">
+    {{ block.super }}
+  </div>
+{% endblock content %}
+
+{% block navigation %}
+  <nav
+    id="hq-navigation"
+    class="navbar navbar-expand-lg bg-light border-bottom-1 navbar-hq-main-menu"
+  >
+    <div class="container-fluid">
+      <div class="navbar-header hq-header">
+        <a href="{% url "homepage" %}" class="navbar-brand">
+          {% if CUSTOM_LOGO_URL %}
+            <img src="{{ CUSTOM_LOGO_URL }}" alt="CommCare HQ Logo" />
+          {% else %}
+            <div></div>
+          {% endif %}
+        </a>
+      </div>
+      {% if not request.couch_user %}
+        <nav class="navbar-signin ms-2" role="navigation">
+          <div class="nav-settings-bar">
+            {% include "hqwebapp/partials/bootstrap5/language_dropdown.html" %}
+          </div>
+        </nav>
+      {% endif %}
+    </div>
+  </nav>
+{% endblock navigation %}

--- a/corehq/apps/public_webforms/templates/public_webforms/public/base.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/public/base.html
@@ -1,4 +1,5 @@
 {% extends "hqwebapp/bootstrap5/base_page.html" %}
+{% load hq_shared_tags %}
 
 {% block content %}
   <div class="col-sm-9 col-md-8 col-lg-7 col-xl-6 col-xxl-5 m-auto">
@@ -15,7 +16,10 @@
       <div class="navbar-header hq-header">
         <a href="{% url "homepage" %}" class="navbar-brand">
           {% if CUSTOM_LOGO_URL %}
-            <img src="{{ CUSTOM_LOGO_URL }}" alt="CommCare HQ Logo" />
+            <img
+              src="{{ CUSTOM_LOGO_URL }}"
+              alt="{% trans_html_attr 'CommCare HQ Logo' %}"
+            />
           {% else %}
             <div></div>
           {% endif %}

--- a/corehq/apps/public_webforms/templates/public_webforms/public/partials/link_request_form.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/public/partials/link_request_form.html
@@ -90,6 +90,13 @@
       >{% trans "Message and data rates may apply." %}</span
     >
   </div>
+  
+  <div class="mb-3">
+    {{ form.turnstile }}
+    {% if form.turnstile.errors %}
+      <div class="help-block text-danger">{{ form.turnstile.errors }}</div>
+    {% endif %}
+  </div>
 
   <button
     type="submit"

--- a/corehq/apps/public_webforms/templates/public_webforms/public/partials/link_request_form.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/public/partials/link_request_form.html
@@ -1,7 +1,14 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-<form method="post" x-data="{ delivery: '{{ form.delivery.value|escapejs }}' }">
+<form
+  method="post"
+  x-data="{
+    delivery: '{{ form.delivery.value|escapejs }}',
+    email: '{{ form.email.value|default_if_none:''|escapejs }}',
+    phoneNumber: '{{ form.phone_number.value|default_if_none:''|escapejs }}',
+  }"
+>
   {% csrf_token %}
 
   {% if form.can_choose_delivery %}
@@ -87,6 +94,8 @@
   <button
     type="submit"
     class="btn btn-primary btn-lg icon-link disable-on-submit"
+    :disabled="delivery === 'email' ? !email.trim() : !phoneNumber.trim()"
+    disabled
   >
     {% trans "Send my link" %}
     <i class="fa fa-arrow-right"></i>

--- a/corehq/apps/public_webforms/templates/public_webforms/public/partials/link_request_form.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/public/partials/link_request_form.html
@@ -1,0 +1,94 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+
+<form method="post" x-data="{ delivery: '{{ form.delivery.value|escapejs }}' }">
+  {% csrf_token %}
+
+  {% if form.can_choose_delivery %}
+    <fieldset class="mb-4">
+      <legend class="form-label fs-6 border-0">
+        {{ form.delivery.label }}
+      </legend>
+      <div class="btn-group w-100" role="group">
+        {% for option in form.delivery %}
+          <input
+            type="radio"
+            class="btn-check"
+            name="{{ form.delivery.html_name }}"
+            id="{{ option.id_for_label }}"
+            value="{{ option.data.value }}"
+            x-model="delivery"
+          />
+          <label
+            class="btn btn-lg btn-outline-primary"
+            for="{{ option.id_for_label }}"
+          >
+            {% if option.data.value == 'email' %}
+              <i class="fa-regular fa-envelope pe-2"></i>
+            {% else %}
+              <i class="fa-regular fa-comment pe-2"></i>
+            {% endif %}
+            {{ option.data.label }}
+          </label>
+        {% endfor %}
+      </div>
+    </fieldset>
+  {% else %}
+    <input
+      type="hidden"
+      name="{{ form.delivery.html_name }}"
+      value="{{ form.delivery.initial }}"
+    />
+  {% endif %}
+
+  <div class="mb-4" x-show="delivery === 'email'" x-cloak>
+    <label class="form-label" for="{{ form.email.id_for_label }}">
+      {{ form.email.label }}
+    </label>
+    <div class="input-group input-group-lg">
+      <span class="input-group-text">
+        <i class="fa-regular fa-envelope"></i>
+      </span>
+      {{ form.email }}
+    </div>
+    {% if form.email.errors %}
+      <div class="help-block text-danger">{{ form.email.errors }}</div>
+    {% endif %}
+  </div>
+
+  <div class="mb-4" x-show="delivery === 'sms'" x-cloak>
+    <label class="form-label" for="{{ form.phone_number.id_for_label }}">
+      {{ form.phone_number.label }}
+    </label>
+    {{ form.phone_number }}
+    {% if form.phone_number.errors %}
+      <div class="help-block text-danger">{{ form.phone_number.errors }}</div>
+    {% endif %}
+  </div>
+
+  <div class="alert alert-light mb-4">
+    {% blocktrans %}
+      Information you submit will be used in accordance with Dimagi's
+      <a href="http://www.dimagi.com/terms/latest/privacy/" target="_blank"
+        >Privacy Policy</a
+      >,
+      <a href="http://www.dimagi.com/terms/latest/tos/" target="_blank"
+        >Terms of Service</a
+      >, and
+      <a href="http://www.dimagi.com/terms/latest/ba/" target="_blank"
+        >Business Agreement</a
+      >.
+    {% endblocktrans %}
+    <span x-show="delivery === 'sms'"
+      >{% trans "Message and data rates may apply." %}</span
+    >
+  </div>
+
+  <button
+    type="submit"
+    class="btn btn-primary btn-lg icon-link disable-on-submit"
+  >
+    {% trans "Send my link" %}
+    <i class="fa fa-arrow-right"></i>
+  </button>
+</form>

--- a/corehq/apps/public_webforms/templates/public_webforms/public/partials/link_request_form.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/public/partials/link_request_form.html
@@ -11,6 +11,10 @@
 >
   {% csrf_token %}
 
+  {% for error in form.non_field_errors %}
+    <div class="alert alert-warning">{{ error }}</div>
+  {% endfor %}
+
   {% if form.can_choose_delivery %}
     <fieldset class="mb-4">
       <legend class="form-label fs-6 border-0">

--- a/corehq/apps/public_webforms/templates/public_webforms/public/partials/link_request_form.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/public/partials/link_request_form.html
@@ -80,13 +80,13 @@
   <div class="alert alert-light mb-4">
     {% blocktrans %}
       Information you submit will be used in accordance with Dimagi's
-      <a href="http://www.dimagi.com/terms/latest/privacy/" target="_blank"
+      <a href="https://www.dimagi.com/terms/latest/privacy/" target="_blank"
         >Privacy Policy</a
       >,
-      <a href="http://www.dimagi.com/terms/latest/tos/" target="_blank"
+      <a href="https://www.dimagi.com/terms/latest/tos/" target="_blank"
         >Terms of Service</a
       >, and
-      <a href="http://www.dimagi.com/terms/latest/ba/" target="_blank"
+      <a href="https://www.dimagi.com/terms/latest/ba/" target="_blank"
         >Business Agreement</a
       >.
     {% endblocktrans %}
@@ -94,7 +94,7 @@
       >{% trans "Message and data rates may apply." %}</span
     >
   </div>
-  
+
   <div class="mb-3">
     {{ form.turnstile }}
     {% if form.turnstile.errors %}

--- a/corehq/apps/public_webforms/templates/public_webforms/public/webform_closed.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/public/webform_closed.html
@@ -1,0 +1,14 @@
+{% extends "public_webforms/public/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "One-Time Link Request" %}{% endblock title %}
+
+{% block page_name %}{% trans "Requests Closed" %}{% endblock page_name %}
+
+{% block page_content %}
+  <div class="lead">
+    {% blocktrans %}
+      This form is not currently accepting submissions.
+    {% endblocktrans %}
+  </div>
+{% endblock page_content %}

--- a/corehq/apps/public_webforms/templates/public_webforms/public/webform_link_sent.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/public/webform_link_sent.html
@@ -1,0 +1,24 @@
+{% extends "public_webforms/public/base.html" %}
+{% load i18n %}
+
+{% block page_name %}{% trans "Check Your Messages" %}{% endblock page_name %}
+
+{% block page_content %}
+  <div class="lead">
+    {% blocktrans %}
+      We sent a link using the contact information you provided.
+    {% endblocktrans %}
+  </div>
+  <p class="mt-4">
+    {% blocktrans %}
+      The link expires in {{ link_lifespan }} and only works once.
+    {% endblocktrans %}
+  </p>
+  {% if request_url %}
+    <div class="mt-4">
+      <a class="btn btn-lg btn-outline-primary" href="{{ request_url }}"
+        >{% trans "Request another link" %}</a
+      >
+    </div>
+  {% endif %}
+{% endblock page_content %}

--- a/corehq/apps/public_webforms/templates/public_webforms/public/webform_request.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/public/webform_request.html
@@ -1,1 +1,26 @@
 {% extends "public_webforms/public/base.html" %}
+{% load i18n %}
+{% load hq_shared_tags %}
+{% js_entry "public_webforms/js/request" %}
+
+{% block stylesheets %}
+  {{ block.super }}
+  <link
+    rel="stylesheet"
+    href="{% static 'intl-tel-input/build/css/intlTelInput.css' %}"
+  />
+{% endblock stylesheets %}
+
+{% block page_content %}
+    {{ block.super }}
+    <div class="lead mb-4">
+      {% blocktrans %}
+        We'll send a private, single-use link to complete the form using the
+        contact information you provide below.
+      {% endblocktrans %}
+    </div>
+
+    <div class="row">
+      {% include "public_webforms/public/partials/link_request_form.html" %}
+    </div>
+{% endblock page_content %}

--- a/corehq/apps/public_webforms/templates/public_webforms/public/webform_request.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/public/webform_request.html
@@ -1,0 +1,1 @@
+{% extends "public_webforms/public/base.html" %}

--- a/corehq/apps/public_webforms/templates/public_webforms/public/webform_request.html
+++ b/corehq/apps/public_webforms/templates/public_webforms/public/webform_request.html
@@ -3,6 +3,15 @@
 {% load hq_shared_tags %}
 {% js_entry "public_webforms/js/request" %}
 
+{% block js %}
+  {{ block.super }}
+  <script
+    src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+    async
+    defer
+  ></script>
+{% endblock js %}
+
 {% block stylesheets %}
   {{ block.super }}
   <link

--- a/corehq/apps/public_webforms/tests/test_messaging.py
+++ b/corehq/apps/public_webforms/tests/test_messaging.py
@@ -1,0 +1,51 @@
+from unittest import mock
+
+from unmagic import fixture, use
+
+from corehq.apps.public_webforms.messaging import send_one_time_link
+from corehq.apps.public_webforms.tests.utils import (
+    create_session,
+    create_webform,
+    webform_domain,
+)
+
+
+@fixture
+def outbound():
+    with (
+        mock.patch(
+            'corehq.apps.public_webforms.messaging.send_html_email_async.delay'
+        ) as email,
+        mock.patch('corehq.apps.public_webforms.messaging.send_sms') as sms,
+    ):
+        yield mock.Mock(email=email, sms=sms)
+
+
+@use(webform_domain, outbound)
+class TestSendOneTimeLink:
+
+    def test_an_email_respondent_is_emailed(self):
+        session = create_session(
+            create_webform(), email='respondent@example.com')
+
+        send_one_time_link(session, "Test Form Name")
+
+        # send_html_email_async.delay(subject, recipient, html_content)
+        email = outbound().email.call_args.args
+        assert "Test Form Name" in email[0]
+        assert email[1] == 'respondent@example.com'
+        assert session.one_time_link in email[2]
+        assert session.one_time_link in (
+            outbound().email.call_args.kwargs['text_content'])
+
+    def test_an_sms_respondent_is_texted(self):
+        session = create_session(create_webform(), phone_number='15551234567')
+
+        send_one_time_link(session, "Test Form Name")
+
+        # send_sms(domain, contact, phone_number, text)
+        sms = outbound().sms.call_args.args
+        assert sms[1] is None  # the respondent is nobody this project knows
+        assert sms[2] == '15551234567'
+        assert "Test Form Name" in sms[3]
+        assert session.one_time_link in sms[3]

--- a/corehq/apps/public_webforms/tests/test_models.py
+++ b/corehq/apps/public_webforms/tests/test_models.py
@@ -42,6 +42,19 @@ def test_is_expired(offset, expected):
     assert PublicWebform(expires_at=timezone.now() + offset).is_expired is expected
 
 
+@pytest.mark.parametrize('offset, is_disabled, expected', [
+    (datetime.timedelta(minutes=1), False, True),
+    (datetime.timedelta(minutes=1), True, False),
+    (datetime.timedelta(minutes=-1), False, False),
+    (datetime.timedelta(minutes=-1), True, False),
+], ids=['open', 'closed', 'expired', 'expired-and-closed'])
+def test_is_open(offset, is_disabled, expected):
+    webform = PublicWebform(
+        expires_at=timezone.now() + offset, is_disabled=is_disabled)
+
+    assert webform.is_open is expected
+
+
 @use('db')
 @pytest.mark.parametrize('expires_in, is_disabled, expected', [
     (datetime.timedelta(days=1), False, PublicWebformStatus.OPEN),

--- a/corehq/apps/public_webforms/tests/test_models.py
+++ b/corehq/apps/public_webforms/tests/test_models.py
@@ -23,7 +23,7 @@ from corehq.apps.public_webforms.models import (
     PublicWebform,
     PublicWebformStatus,
 )
-from corehq.apps.public_webforms.tests.utils import create_webform
+from corehq.apps.public_webforms.tests.utils import create_session, create_webform
 from corehq.apps.users.util import PUBLIC_USER_ID
 
 
@@ -80,11 +80,7 @@ def test_with_status_derives_status_from_expiry_and_the_open_setting(
 ], ids=['no-submissions', 'one-submission'])
 def test_with_submissions_count(submitted_at, expected_submissions):
     webform = create_webform()
-    PublicFormSession.objects.create(
-        public_webform=webform,
-        expires_at=timezone.now() + datetime.timedelta(days=1),
-        submitted_at=submitted_at,
-    )
+    create_session(webform, submitted_at=submitted_at)
 
     annotated = PublicWebform.objects.with_submissions_count().get(pk=webform.pk)
     assert annotated.submissions == expected_submissions
@@ -222,10 +218,7 @@ class AllowPublicFormSessionTests(TestCase):
             allow_email=True,
             expires_at=future_expiration,
         )
-        self.session = PublicFormSession.objects.create(
-            public_webform=self.webform,
-            expires_at=future_expiration,
-        )
+        self.session = create_session(self.webform, expires_at=future_expiration)
         self.factory = RequestFactory()
 
     def _request(self, with_header=True, cookie_value=None):

--- a/corehq/apps/public_webforms/tests/test_models.py
+++ b/corehq/apps/public_webforms/tests/test_models.py
@@ -86,6 +86,49 @@ def test_with_submissions_count(submitted_at, expected_submissions):
     assert annotated.submissions == expected_submissions
 
 
+@use('db')
+def test_get_active_session_for_contact():
+    webform = create_webform()
+    session = create_session(webform, email='respondent@example.com')
+
+    found = PublicFormSession.get_active_session_for_contact(
+        webform, email='respondent@example.com', phone_number='')
+
+    assert found == session
+
+
+@use('db')
+def test_get_active_session_for_contact_ignores_another_contact():
+    webform = create_webform()
+    create_session(webform, email='someone-else@example.com')
+
+    assert PublicFormSession.get_active_session_for_contact(
+        webform, email='respondent@example.com', phone_number='') is None
+
+
+@use('db')
+@pytest.mark.parametrize('session_kwargs', [
+    {'expires_at': timezone.now() - datetime.timedelta(minutes=1)},
+    {'submitted_at': timezone.now()},
+], ids=['expired', 'already-submitted'])
+def test_get_active_session_for_contact_ignores_inactive_session(session_kwargs):
+    webform = create_webform()
+    create_session(webform, email='respondent@example.com', **session_kwargs)
+
+    assert PublicFormSession.get_active_session_for_contact(
+        webform, email='respondent@example.com', phone_number='') is None
+
+
+@pytest.mark.parametrize('email, phone_number', [
+    ('respondent@example.com', '15551234567'),
+    ('', ''),
+], ids=['both', 'neither'])
+def test_get_active_session_for_contact_requires_exactly_one_channel(email, phone_number):
+    with pytest.raises(AssertionError):
+        PublicFormSession.get_active_session_for_contact(
+            PublicWebform(), email=email, phone_number=phone_number)
+
+
 def test_public_form_session_username():
     webform = PublicWebform(domain='public-forms-domain')
     session = PublicFormSession(public_webform=webform)

--- a/corehq/apps/public_webforms/tests/test_models.py
+++ b/corehq/apps/public_webforms/tests/test_models.py
@@ -137,6 +137,14 @@ def test_public_form_session_username():
     )
 
 
+def test_public_form_session_one_time_link():
+    webform = PublicWebform(domain='public-forms-domain')
+    session = PublicFormSession(public_webform=webform)
+    # absolute because it is shared over email and SMS
+    assert session.one_time_link.startswith(get_url_base())
+    assert session.id.hex in session.one_time_link
+
+
 class PublicFormUserTests(SimpleTestCase):
 
     def setUp(self):

--- a/corehq/apps/public_webforms/tests/test_public_forms.py
+++ b/corehq/apps/public_webforms/tests/test_public_forms.py
@@ -1,9 +1,11 @@
 import pytest
+from unmagic import use
 
 from corehq.apps.public_webforms.models import PublicWebform
 from corehq.apps.public_webforms.public.forms import (
     PublicWebformLinkRequestForm,
 )
+from corehq.apps.public_webforms.tests.utils import create_webform
 
 
 def _form(allow_email=True, allow_sms=True, data=None):
@@ -52,3 +54,77 @@ def test_a_channel_the_webform_disallows_is_rejected(
 
     assert not form.is_valid()
     assert 'delivery' in form.errors
+
+
+@pytest.mark.parametrize('delivery, missing', [
+    ('email', 'email'),
+    ('sms', 'phone_number'),
+], ids=['email', 'sms'])
+def test_the_chosen_channel_needs_contact_information(delivery, missing):
+    form = _form(data={'delivery': delivery})
+
+    assert not form.is_valid()
+    assert missing in form.errors
+
+
+@pytest.mark.parametrize('data, expected_discarded', [
+    (
+        {'delivery': 'email', 'email': 'respondent@example.com', 'phone_number': '+15551234567'},
+        'phone_number'
+    ),
+    (
+        {'delivery': 'sms', 'phone_number': '+15551234567', 'email': 'respondent@example.com'},
+        'email'
+    ),
+], ids=['email-chosen', 'sms-chosen'])
+def test_the_channel_not_chosen_is_discarded(data, expected_discarded):
+    # both inputs are submitted whichever one is on screen, so switching
+    # between them must not leave the other one's value behind
+    form = _form(data=data)
+
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data[expected_discarded] == ''
+
+
+@pytest.mark.parametrize('entered, expected', [
+    ('+254712345678', '254712345678'),
+    ('+1 (555) 123-4567', '15551234567'),
+    ('  15551234567  ', '15551234567'),
+], ids=['international', 'punctuation', 'whitespace'])
+def test_phone_number_is_reduced_to_its_digits(entered, expected):
+    form = _form(data={'delivery': 'sms', 'phone_number': entered})
+
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data['phone_number'] == expected
+
+
+@pytest.mark.parametrize('entered', [
+    '  ',
+    '555-CALL-NOW',
+], ids=['only-punctuation', 'letters'])
+def test_phone_number_rejects_non_digits(entered):
+    form = _form(data={'delivery': 'sms', 'phone_number': entered})
+
+    assert not form.is_valid()
+    assert 'phone_number' in form.errors
+
+
+@use('db')
+@pytest.mark.parametrize('data, email, phone_number', [
+    ({'delivery': 'email', 'email': 'respondent@example.com'},
+     'respondent@example.com', ''),
+    ({'delivery': 'sms', 'phone_number': '+15551234567'},
+     '', '15551234567'),
+], ids=['email', 'sms'])
+def test_create_session_records_contact_info(
+    data, email, phone_number
+):
+    webform = create_webform(allow_sms=True)
+    form = PublicWebformLinkRequestForm(webform, data)
+    assert form.is_valid(), form.errors
+
+    session = form.create_session()
+
+    assert session.public_webform == webform
+    assert session.email == email
+    assert session.phone_number == phone_number

--- a/corehq/apps/public_webforms/tests/test_public_forms.py
+++ b/corehq/apps/public_webforms/tests/test_public_forms.py
@@ -5,7 +5,10 @@ from corehq.apps.public_webforms.models import PublicWebform
 from corehq.apps.public_webforms.public.forms import (
     PublicWebformLinkRequestForm,
 )
-from corehq.apps.public_webforms.tests.utils import create_webform
+from corehq.apps.public_webforms.tests.utils import (
+    create_webform,
+    skip_turnstile,
+)
 
 
 def _form(allow_email=True, allow_sms=True, data=None):
@@ -40,6 +43,7 @@ def test_a_choice_is_offered_only_when_both_channels_are_allowed(
     assert form.can_choose_delivery is expected
 
 
+@use(skip_turnstile)
 @pytest.mark.parametrize('allow_email, allow_sms, delivery', [
     (True, False, 'sms'),
     (False, True, 'email'),
@@ -56,6 +60,7 @@ def test_a_channel_the_webform_disallows_is_rejected(
     assert 'delivery' in form.errors
 
 
+@use(skip_turnstile)
 @pytest.mark.parametrize('delivery, missing', [
     ('email', 'email'),
     ('sms', 'phone_number'),
@@ -67,6 +72,7 @@ def test_the_chosen_channel_needs_contact_information(delivery, missing):
     assert missing in form.errors
 
 
+@use(skip_turnstile)
 @pytest.mark.parametrize('data, expected_discarded', [
     (
         {'delivery': 'email', 'email': 'respondent@example.com', 'phone_number': '+15551234567'},
@@ -86,6 +92,7 @@ def test_the_channel_not_chosen_is_discarded(data, expected_discarded):
     assert form.cleaned_data[expected_discarded] == ''
 
 
+@use(skip_turnstile)
 @pytest.mark.parametrize('entered, expected', [
     ('+254712345678', '254712345678'),
     ('+1 (555) 123-4567', '15551234567'),
@@ -98,6 +105,7 @@ def test_phone_number_is_reduced_to_its_digits(entered, expected):
     assert form.cleaned_data['phone_number'] == expected
 
 
+@use(skip_turnstile)
 @pytest.mark.parametrize('entered', [
     '  ',
     '555-CALL-NOW',
@@ -109,7 +117,7 @@ def test_phone_number_rejects_non_digits(entered):
     assert 'phone_number' in form.errors
 
 
-@use('db')
+@use('db', skip_turnstile)
 @pytest.mark.parametrize('data, email, phone_number', [
     ({'delivery': 'email', 'email': 'respondent@example.com'},
      'respondent@example.com', ''),

--- a/corehq/apps/public_webforms/tests/test_public_forms.py
+++ b/corehq/apps/public_webforms/tests/test_public_forms.py
@@ -120,19 +120,33 @@ def test_phone_number_rejects_non_digits(entered):
 @use('db', skip_turnstile)
 @pytest.mark.parametrize('data, email, phone_number', [
     ({'delivery': 'email', 'email': 'respondent@example.com'},
-     'respondent@example.com', ''),
+     'respondent@example.com', None),
     ({'delivery': 'sms', 'phone_number': '+15551234567'},
-     '', '15551234567'),
+     None, '15551234567'),
 ], ids=['email', 'sms'])
-def test_create_session_records_contact_info(
+def test_a_session_records_contact_info(
     data, email, phone_number
 ):
     webform = create_webform(allow_sms=True)
     form = PublicWebformLinkRequestForm(webform, data)
     assert form.is_valid(), form.errors
 
-    session = form.create_session()
+    session = form.get_or_create_session()
 
     assert session.public_webform == webform
     assert session.email == email
     assert session.phone_number == phone_number
+
+
+@use('db', skip_turnstile)
+def test_asking_twice_returns_the_link_already_sent():
+    webform = create_webform()
+    form = PublicWebformLinkRequestForm(
+        webform, {'delivery': 'email', 'email': 'respondent@example.com'}
+    )
+    assert form.is_valid(), form.errors
+
+    first = form.get_or_create_session()
+    second = form.get_or_create_session()
+
+    assert second == first

--- a/corehq/apps/public_webforms/tests/test_public_forms.py
+++ b/corehq/apps/public_webforms/tests/test_public_forms.py
@@ -1,0 +1,54 @@
+import pytest
+
+from corehq.apps.public_webforms.models import PublicWebform
+from corehq.apps.public_webforms.public.forms import (
+    PublicWebformLinkRequestForm,
+)
+
+
+def _form(allow_email=True, allow_sms=True, data=None):
+    webform = PublicWebform(allow_email=allow_email, allow_sms=allow_sms)
+    return PublicWebformLinkRequestForm(webform, data)
+
+
+@pytest.mark.parametrize('allow_email, allow_sms, expected', [
+    (True, False, ['email']),
+    (False, True, ['sms']),
+    (True, True, ['email', 'sms']),
+], ids=['email-only', 'sms-only', 'both'])
+def test_delivery_offers_only_the_channels_the_webform_allows(
+    allow_email, allow_sms, expected
+):
+    form = _form(allow_email=allow_email, allow_sms=allow_sms)
+
+    choices = form.fields['delivery'].choices
+    assert [choice[0] for choice in choices] == expected
+
+
+@pytest.mark.parametrize('allow_email, allow_sms, expected', [
+    (True, True, True),
+    (True, False, False),
+    (False, True, False),
+], ids=['both', 'email-only', 'sms-only'])
+def test_a_choice_is_offered_only_when_both_channels_are_allowed(
+    allow_email, allow_sms, expected
+):
+    form = _form(allow_email=allow_email, allow_sms=allow_sms)
+
+    assert form.can_choose_delivery is expected
+
+
+@pytest.mark.parametrize('allow_email, allow_sms, delivery', [
+    (True, False, 'sms'),
+    (False, True, 'email'),
+], ids=['sms-not-allowed', 'email-not-allowed'])
+def test_a_channel_the_webform_disallows_is_rejected(
+    allow_email, allow_sms, delivery
+):
+    form = _form(
+        allow_email=allow_email, allow_sms=allow_sms,
+        data={'delivery': delivery},
+    )
+
+    assert not form.is_valid()
+    assert 'delivery' in form.errors

--- a/corehq/apps/public_webforms/tests/test_public_views.py
+++ b/corehq/apps/public_webforms/tests/test_public_views.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest import mock
 from uuid import uuid4
 
 from django.test import Client
@@ -73,9 +74,23 @@ def test_a_request_to_a_webform_not_accepting_requests_creates_no_session():
 @use('db', skip_turnstile)
 def test_a_requested_link_redirects_to_a_page_saying_it_was_sent():
     webform = create_webform(is_disabled=False)
-
-    response = _request_a_link(webform.public_id)
+    with mock.patch('corehq.apps.public_webforms.public.views.get_app', return_value=None):
+        response = _request_a_link(webform.public_id)
 
     assert response.status_code == 302
     assert response.url == _url(
         PublicWebformLinkSentView.urlname, webform.public_id)
+
+
+@use('db', skip_turnstile)
+def test_a_requested_link_is_sent():
+    webform = create_webform(is_disabled=False)
+
+    with (
+        mock.patch('corehq.apps.public_webforms.public.views.get_app', return_value=None),
+        mock.patch('corehq.apps.public_webforms.public.views.send_one_time_link') as send
+    ):
+        _request_a_link(webform.public_id, email='someone@example.com')
+
+    session = PublicFormSession.objects.get(public_webform=webform)
+    assert send.call_args.args[0] == session

--- a/corehq/apps/public_webforms/tests/test_public_views.py
+++ b/corehq/apps/public_webforms/tests/test_public_views.py
@@ -9,24 +9,26 @@ import pytest
 from unmagic import use
 
 from corehq.apps.public_webforms.models import PublicFormSession
-from corehq.apps.public_webforms.public.views import PublicWebformRequestView
+from corehq.apps.public_webforms.public.views import (
+    PublicWebformLinkSentView,
+    PublicWebformRequestView,
+)
 from corehq.apps.public_webforms.tests.utils import (
     create_webform,
     skip_turnstile,
 )
 
 
-def _url(public_id):
-    return reverse(
-        PublicWebformRequestView.urlname, kwargs={'public_id': public_id.hex})
+def _url(urlname, public_id):
+    return reverse(urlname, kwargs={'public_id': public_id.hex})
 
 
 def _get(public_id):
-    return Client().get(_url(public_id))
+    return Client().get(_url(PublicWebformRequestView.urlname, public_id))
 
 
 def _request_a_link(public_id, **fields):
-    return Client().post(_url(public_id), {
+    return Client().post(_url(PublicWebformRequestView.urlname, public_id), {
         'delivery': 'email',
         'email': 'respondent@example.com',
         **fields,
@@ -66,3 +68,14 @@ def test_a_request_to_a_webform_not_accepting_requests_creates_no_session():
 
     assert b'Requests Closed' in response.content
     assert not PublicFormSession.objects.filter(public_webform=webform).exists()
+
+
+@use('db', skip_turnstile)
+def test_a_requested_link_redirects_to_a_page_saying_it_was_sent():
+    webform = create_webform(is_disabled=False)
+
+    response = _request_a_link(webform.public_id)
+
+    assert response.status_code == 302
+    assert response.url == _url(
+        PublicWebformLinkSentView.urlname, webform.public_id)

--- a/corehq/apps/public_webforms/tests/test_public_views.py
+++ b/corehq/apps/public_webforms/tests/test_public_views.py
@@ -16,6 +16,7 @@ from corehq.apps.public_webforms.public.views import (
 )
 from corehq.apps.public_webforms.tests.utils import (
     create_webform,
+    public_webforms_available,
     skip_turnstile,
 )
 
@@ -36,7 +37,7 @@ def _request_a_link(public_id, **fields):
     })
 
 
-@use('db')
+@use('db', public_webforms_available)
 @pytest.mark.parametrize('expires_in, is_disabled', [
     (datetime.timedelta(days=1), True),
     (datetime.timedelta(days=-1), False),
@@ -53,7 +54,7 @@ def test_a_webform_not_accepting_requests_says_so(expires_in, is_disabled):
     assert b'Requests Closed' in response.content
 
 
-@use('db')
+@use('db', public_webforms_available)
 def test_an_unknown_link_is_not_found():
     response = _get(uuid4())
 
@@ -61,7 +62,7 @@ def test_an_unknown_link_is_not_found():
     assert b'Requests Closed' not in response.content
 
 
-@use('db', skip_turnstile)
+@use('db', public_webforms_available, skip_turnstile)
 def test_a_request_to_a_webform_not_accepting_requests_creates_no_session():
     webform = create_webform(is_disabled=True)
 
@@ -71,7 +72,7 @@ def test_a_request_to_a_webform_not_accepting_requests_creates_no_session():
     assert not PublicFormSession.objects.filter(public_webform=webform).exists()
 
 
-@use('db', skip_turnstile)
+@use('db', public_webforms_available, skip_turnstile)
 def test_a_requested_link_redirects_to_a_page_saying_it_was_sent():
     webform = create_webform(is_disabled=False)
     with mock.patch('corehq.apps.public_webforms.public.views.get_app', return_value=None):
@@ -82,7 +83,7 @@ def test_a_requested_link_redirects_to_a_page_saying_it_was_sent():
         PublicWebformLinkSentView.urlname, webform.public_id)
 
 
-@use('db', skip_turnstile)
+@use('db', public_webforms_available, skip_turnstile)
 def test_a_requested_link_is_sent():
     webform = create_webform(is_disabled=False)
 

--- a/corehq/apps/public_webforms/tests/test_public_views.py
+++ b/corehq/apps/public_webforms/tests/test_public_views.py
@@ -1,0 +1,68 @@
+import datetime
+from uuid import uuid4
+
+from django.test import Client
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+from unmagic import use
+
+from corehq.apps.public_webforms.models import PublicFormSession
+from corehq.apps.public_webforms.public.views import PublicWebformRequestView
+from corehq.apps.public_webforms.tests.utils import (
+    create_webform,
+    skip_turnstile,
+)
+
+
+def _url(public_id):
+    return reverse(
+        PublicWebformRequestView.urlname, kwargs={'public_id': public_id.hex})
+
+
+def _get(public_id):
+    return Client().get(_url(public_id))
+
+
+def _request_a_link(public_id, **fields):
+    return Client().post(_url(public_id), {
+        'delivery': 'email',
+        'email': 'respondent@example.com',
+        **fields,
+    })
+
+
+@use('db')
+@pytest.mark.parametrize('expires_in, is_disabled', [
+    (datetime.timedelta(days=1), True),
+    (datetime.timedelta(days=-1), False),
+    (datetime.timedelta(days=-1), True),
+], ids=['closed', 'expired', 'expired-and-closed'])
+def test_a_webform_not_accepting_requests_says_so(expires_in, is_disabled):
+    webform = create_webform(
+        expires_at=timezone.now() + expires_in, is_disabled=is_disabled)
+
+    response = _get(webform.public_id)
+
+    assert response.status_code == 404
+    # the respondent is told the link is dead, not left with a bare 404
+    assert b'Requests Closed' in response.content
+
+
+@use('db')
+def test_an_unknown_link_is_not_found():
+    response = _get(uuid4())
+
+    assert response.status_code == 404
+    assert b'Requests Closed' not in response.content
+
+
+@use('db', skip_turnstile)
+def test_a_request_to_a_webform_not_accepting_requests_creates_no_session():
+    webform = create_webform(is_disabled=True)
+
+    response = _request_a_link(webform.public_id)
+
+    assert b'Requests Closed' in response.content
+    assert not PublicFormSession.objects.filter(public_webform=webform).exists()

--- a/corehq/apps/public_webforms/tests/test_rate_limiter.py
+++ b/corehq/apps/public_webforms/tests/test_rate_limiter.py
@@ -1,21 +1,31 @@
 from unittest import mock
 from uuid import uuid4
 
+from django.test import RequestFactory
+
 from unmagic import fixture, use
 
 from corehq.apps.public_webforms.rate_limiter import (
+    link_requests_global,
     link_requests_per_contact,
+    link_requests_per_ip,
     rate_limit_link_request,
 )
+from corehq.util.global_request.api import set_request
 
 
 @fixture
 def limiter_on():
-    with mock.patch(
-        'corehq.apps.public_webforms.rate_limiter'
-        '.SHOULD_RATE_LIMIT_LINK_REQUESTS', True
-    ):
-        yield
+    """The limiter is off under test, so a test that wants it says so."""
+    set_request(RequestFactory().post('/', REMOTE_ADDR='203.0.113.7'))
+    try:
+        with mock.patch(
+            'corehq.apps.public_webforms.rate_limiter'
+            '.SHOULD_RATE_LIMIT_LINK_REQUESTS', True
+        ):
+            yield
+    finally:
+        set_request(None)
 
 
 def _a_contact():
@@ -31,7 +41,17 @@ def _requests_allowed_per_hour():
     )
 
 
-@use(limiter_on)
+def _exhausted(limiter):
+    """Stand in for a limiter whose hourly window is already spent.
+
+    The IP and global limits are too large to reach by making real requests,
+    so what is checked is that they are consulted at all.
+    """
+    return mock.patch.object(
+        limiter, 'get_window_of_first_exceeded_limit', return_value='hour')
+
+
+@use('db', limiter_on)
 def test_contact_rate_limiter_allows_multiple_requests():
     # a respondent who did not receive the first message asks a second time
     contact = _a_contact()
@@ -40,7 +60,7 @@ def test_contact_rate_limiter_allows_multiple_requests():
     assert rate_limit_link_request(contact) is False
 
 
-@use(limiter_on)
+@use('db', limiter_on)
 def test_contact_rate_limiter_blocks_too_many_requests():
     contact = _a_contact()
 
@@ -48,3 +68,45 @@ def test_contact_rate_limiter_blocks_too_many_requests():
         assert rate_limit_link_request(contact) is False
 
     assert rate_limit_link_request(contact) is True
+
+
+@use('db', limiter_on)
+def test_exhausted_ip_limit_blocks_requests_based_on_ip():
+    with _exhausted(link_requests_per_ip) as exceeded:
+        assert rate_limit_link_request(_a_contact()) is True
+
+    # the address the request came from, not the contact it named
+    assert exceeded.call_args.args == ('ip:203.0.113.7',)
+
+
+@use('db', limiter_on)
+def test_exhausted_global_limit_blocks_everything():
+    with _exhausted(link_requests_global):
+        assert rate_limit_link_request(_a_contact()) is True
+
+
+@use('db', limiter_on)
+def test_accepted_request_counts_toward_all_limits():
+    contact = _a_contact()
+
+    with (
+        mock.patch.object(link_requests_global, 'report_usage') as globally,
+        mock.patch.object(link_requests_per_ip, 'report_usage') as per_ip,
+        mock.patch.object(link_requests_per_contact, 'report_usage') as per_contact,
+    ):
+        rate_limit_link_request(contact)
+
+    assert globally.called
+    assert per_ip.call_args.args == ('ip:203.0.113.7',)
+    assert per_contact.call_args.args == (f'contact:{contact}',)
+
+
+@use('db', limiter_on)
+def test_refused_request_does_not_count_toward_limits():
+    with _exhausted(link_requests_global):
+        with mock.patch.object(
+            link_requests_per_contact, 'report_usage'
+        ) as per_contact:
+            rate_limit_link_request(_a_contact())
+
+    assert not per_contact.called

--- a/corehq/apps/public_webforms/tests/test_rate_limiter.py
+++ b/corehq/apps/public_webforms/tests/test_rate_limiter.py
@@ -1,0 +1,50 @@
+from unittest import mock
+from uuid import uuid4
+
+from unmagic import fixture, use
+
+from corehq.apps.public_webforms.rate_limiter import (
+    link_requests_per_contact,
+    rate_limit_link_request,
+)
+
+
+@fixture
+def limiter_on():
+    with mock.patch(
+        'corehq.apps.public_webforms.rate_limiter'
+        '.SHOULD_RATE_LIMIT_LINK_REQUESTS', True
+    ):
+        yield
+
+
+def _a_contact():
+    return f'{uuid4().hex}@example.com'
+
+
+def _requests_allowed_per_hour():
+    return next(
+        limit
+        for __, limits in link_requests_per_contact.get_rate_limits('')
+        for counter, limit in limits
+        if counter.key == 'hour'
+    )
+
+
+@use(limiter_on)
+def test_contact_rate_limiter_allows_multiple_requests():
+    # a respondent who did not receive the first message asks a second time
+    contact = _a_contact()
+
+    assert rate_limit_link_request(contact) is False
+    assert rate_limit_link_request(contact) is False
+
+
+@use(limiter_on)
+def test_contact_rate_limiter_blocks_too_many_requests():
+    contact = _a_contact()
+
+    for __ in range(_requests_allowed_per_hour()):
+        assert rate_limit_link_request(contact) is False
+
+    assert rate_limit_link_request(contact) is True

--- a/corehq/apps/public_webforms/tests/test_rate_limiter.py
+++ b/corehq/apps/public_webforms/tests/test_rate_limiter.py
@@ -8,6 +8,7 @@ from unmagic import fixture, use
 from corehq.apps.public_webforms.rate_limiter import (
     link_requests_global,
     link_requests_per_contact,
+    link_requests_per_domain,
     link_requests_per_ip,
     rate_limit_link_request,
 )
@@ -30,6 +31,10 @@ def limiter_on():
 
 def _a_contact():
     return f'{uuid4().hex}@example.com'
+
+
+def _a_domain():
+    return f'project-{uuid4().hex}'
 
 
 def _requests_allowed_per_hour():
@@ -55,25 +60,37 @@ def _exhausted(limiter):
 def test_contact_rate_limiter_allows_multiple_requests():
     # a respondent who did not receive the first message asks a second time
     contact = _a_contact()
+    domain = _a_domain()
 
-    assert rate_limit_link_request(contact) is False
-    assert rate_limit_link_request(contact) is False
+    assert rate_limit_link_request(domain, contact) is False
+    assert rate_limit_link_request(domain, contact) is False
 
 
 @use('db', limiter_on)
 def test_contact_rate_limiter_blocks_too_many_requests():
     contact = _a_contact()
+    domain = _a_domain()
 
     for __ in range(_requests_allowed_per_hour()):
-        assert rate_limit_link_request(contact) is False
+        assert rate_limit_link_request(domain, contact) is False
 
-    assert rate_limit_link_request(contact) is True
+    assert rate_limit_link_request(domain, contact) is True
+
+
+@use('db', limiter_on)
+def test_exhausted_domain_limit_blocks_requests_based_on_domain():
+    domain = _a_domain()
+
+    with _exhausted(link_requests_per_domain) as exceeded:
+        assert rate_limit_link_request(domain, _a_contact()) is True
+
+    assert exceeded.call_args.args == (f'domain:{domain}',)
 
 
 @use('db', limiter_on)
 def test_exhausted_ip_limit_blocks_requests_based_on_ip():
     with _exhausted(link_requests_per_ip) as exceeded:
-        assert rate_limit_link_request(_a_contact()) is True
+        assert rate_limit_link_request(_a_domain(), _a_contact()) is True
 
     # the address the request came from, not the contact it named
     assert exceeded.call_args.args == ('ip:203.0.113.7',)
@@ -82,21 +99,24 @@ def test_exhausted_ip_limit_blocks_requests_based_on_ip():
 @use('db', limiter_on)
 def test_exhausted_global_limit_blocks_everything():
     with _exhausted(link_requests_global):
-        assert rate_limit_link_request(_a_contact()) is True
+        assert rate_limit_link_request(_a_domain(), _a_contact()) is True
 
 
 @use('db', limiter_on)
 def test_accepted_request_counts_toward_all_limits():
     contact = _a_contact()
+    domain = _a_domain()
 
     with (
         mock.patch.object(link_requests_global, 'report_usage') as globally,
+        mock.patch.object(link_requests_per_domain, 'report_usage') as per_domain,
         mock.patch.object(link_requests_per_ip, 'report_usage') as per_ip,
         mock.patch.object(link_requests_per_contact, 'report_usage') as per_contact,
     ):
-        rate_limit_link_request(contact)
+        rate_limit_link_request(domain, contact)
 
     assert globally.called
+    assert per_domain.call_args.args == (f'domain:{domain}',)
     assert per_ip.call_args.args == ('ip:203.0.113.7',)
     assert per_contact.call_args.args == (f'contact:{contact}',)
 
@@ -107,6 +127,6 @@ def test_refused_request_does_not_count_toward_limits():
         with mock.patch.object(
             link_requests_per_contact, 'report_usage'
         ) as per_contact:
-            rate_limit_link_request(_a_contact())
+            rate_limit_link_request(_a_domain(), _a_contact())
 
     assert not per_contact.called

--- a/corehq/apps/public_webforms/tests/test_submissions.py
+++ b/corehq/apps/public_webforms/tests/test_submissions.py
@@ -19,6 +19,7 @@ from corehq.apps.public_webforms.submissions import (
     public_form_session_already_submitted,
     validate_public_form_submission,
 )
+from corehq.apps.public_webforms.tests.utils import create_session
 from corehq.apps.users.util import PUBLIC_USER_ID
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, sharded
 from corehq.form_processor.utils.xform import convert_xform_to_json
@@ -158,10 +159,7 @@ def consumable_session():
         allow_email=True,
         expires_at=future_expiration,
     )
-    yield PublicFormSession.objects.create(
-        public_webform=webform,
-        expires_at=future_expiration,
-    )
+    yield create_session(webform, expires_at=future_expiration)
 
 
 @use(consumable_session)
@@ -243,8 +241,10 @@ class TestPublicFormReceiverIntegration:
     session on success."""
 
     def _session(self):
-        return PublicFormSession.objects.create(
-            public_webform=receiver_webform(), expires_at=datetime.datetime.today() + datetime.timedelta(days=30))
+        return create_session(
+            receiver_webform(),
+            expires_at=datetime.datetime.today() + datetime.timedelta(days=30),
+        )
 
     def _submit(self, session, case_block_xml=''):
         form_xml = (

--- a/corehq/apps/public_webforms/tests/test_views.py
+++ b/corehq/apps/public_webforms/tests/test_views.py
@@ -8,13 +8,13 @@ from django.test import RequestFactory
 from django.urls import reverse
 from django.utils import timezone
 
-from corehq.apps.public_webforms.models import PublicFormSession
 from corehq.apps.public_webforms.tables import PublicWebformTable
 from corehq.apps.public_webforms.tests.utils import (
     DOMAIN,
     NORMAL_USER,
     OTHER_DOMAIN,
     PublicWebformViewTestCase,
+    create_session,
     create_webform,
 )
 from corehq.apps.public_webforms.views import PublicWebformTableView
@@ -28,14 +28,6 @@ def _table_view(domain=DOMAIN, **params):
     view.kwargs = {}
     view.request = RequestFactory().get('/', params)
     return view
-
-
-def _create_session(webform, **kwargs):
-    return PublicFormSession.objects.create(
-        public_webform=webform,
-        expires_at=timezone.now() + datetime.timedelta(days=1),
-        **kwargs,
-    )
 
 
 @use('db')
@@ -58,8 +50,8 @@ def test_table_lists_webforms_sorted_by_expiration():
 @use('db')
 def test_table_counts_webforms_submissions():
     webform = create_webform()
-    _create_session(webform, submitted_at=timezone.now())
-    _create_session(webform)
+    create_session(webform, submitted_at=timezone.now())
+    create_session(webform)
 
     [row] = _table_view().get_queryset()
 
@@ -72,7 +64,7 @@ def test_every_column_renders_from_the_queryset():
     """The columns are fed by annotations, so they break away from the table."""
     webform = create_webform(
         expires_at=datetime.datetime(2026, 9, 1, 21, 0), is_disabled=False)
-    _create_session(webform, submitted_at=timezone.now())
+    create_session(webform, submitted_at=timezone.now())
     table = PublicWebformTable(
         data=_table_view().get_queryset(), domain=DOMAIN, timezone=pytz.UTC)
 

--- a/corehq/apps/public_webforms/tests/utils.py
+++ b/corehq/apps/public_webforms/tests/utils.py
@@ -1,7 +1,9 @@
 import datetime
 
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.utils import timezone
+
+from unmagic import fixture
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.public_webforms.models import PublicWebform
@@ -12,6 +14,12 @@ OTHER_DOMAIN = 'public-forms-other-domain'
 PASSWORD = 'Passw0rd!'
 ADMIN_USER = 'webform-admin@example.com'
 NORMAL_USER = 'normal-user@example.com'
+
+
+@fixture
+def skip_turnstile():
+    with override_settings(TURNSTILE_SECRET_KEY=''):
+        yield
 
 
 def create_webform(**kwargs):

--- a/corehq/apps/public_webforms/tests/utils.py
+++ b/corehq/apps/public_webforms/tests/utils.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from unmagic import fixture
 
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.public_webforms.models import PublicWebform
+from corehq.apps.public_webforms.models import PublicFormSession, PublicWebform
 from corehq.apps.users.models import HqPermissions, UserRole, WebUser
 
 DOMAIN = 'public-forms-domain'
@@ -34,6 +34,14 @@ def create_webform(**kwargs):
         'allow_sms': False,
         'allow_email': True,
         'expires_at': timezone.now() + datetime.timedelta(days=30),
+        **kwargs,
+    })
+
+
+def create_session(webform, **kwargs):
+    return PublicFormSession.objects.create(**{
+        'public_webform': webform,
+        'expires_at': timezone.now() + datetime.timedelta(hours=1),
         **kwargs,
     })
 

--- a/corehq/apps/public_webforms/tests/utils.py
+++ b/corehq/apps/public_webforms/tests/utils.py
@@ -8,12 +8,20 @@ from unmagic import fixture, use
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.public_webforms.models import PublicFormSession, PublicWebform
 from corehq.apps.users.models import HqPermissions, UserRole, WebUser
+from corehq.privileges import PUBLIC_WEBFORMS
+from corehq.util.test_utils import flag_enabled, privilege_enabled
 
 DOMAIN = 'public-forms-domain'
 OTHER_DOMAIN = 'public-forms-other-domain'
 PASSWORD = 'Passw0rd!'
 ADMIN_USER = 'webform-admin@example.com'
 NORMAL_USER = 'normal-user@example.com'
+
+
+@fixture
+def public_webforms_available():
+    with flag_enabled('PUBLIC_WEBFORMS'), privilege_enabled(PUBLIC_WEBFORMS):
+        yield
 
 
 @fixture

--- a/corehq/apps/public_webforms/tests/utils.py
+++ b/corehq/apps/public_webforms/tests/utils.py
@@ -3,7 +3,7 @@ import datetime
 from django.test import Client, TestCase, override_settings
 from django.utils import timezone
 
-from unmagic import fixture
+from unmagic import fixture, use
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.public_webforms.models import PublicFormSession, PublicWebform
@@ -44,6 +44,16 @@ def create_session(webform, **kwargs):
         'expires_at': timezone.now() + datetime.timedelta(hours=1),
         **kwargs,
     })
+
+
+@use('db')
+@fixture
+def webform_domain():
+    domain_obj = create_domain(DOMAIN)
+    try:
+        yield domain_obj
+    finally:
+        domain_obj.delete()
 
 
 class PublicWebformViewTestCase(TestCase):

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -237,6 +237,7 @@ class privilege_enabled:
         'corehq.apps.domain.auth.domain_has_privilege',
         'corehq.apps.export.views.list.domain_has_privilege',
         'corehq.apps.export.views.new.domain_has_privilege',
+        'corehq.apps.public_webforms.public.views.domain_has_privilege',
         'corehq.apps.users.landing_pages.domain_has_privilege',
         'corehq.apps.users.permissions.domain_has_privilege',
         'corehq.apps.users.views.mobile.users.domain_has_privilege',

--- a/urls.py
+++ b/urls.py
@@ -118,6 +118,7 @@ urlpatterns = [
     url(r'^analytics/', include('corehq.apps.analytics.urls')),
     url(r'^api/', include(user_api_urlpatterns)),
     url(r'^register/', include('corehq.apps.registration.urls')),
+    url(r'^webforms/', include('corehq.apps.public_webforms.public.urls')),
     url(r'^a/(?P<domain>%s)/' % legacy_domain_re, include(domain_specific)),
     url(r'^account/', include('corehq.apps.settings.urls')),
     url(r'', include('corehq.apps.hqwebapp.urls')),


### PR DESCRIPTION
## Product Description
Adds new views, form, and email templates for requesting a one-time link to complete a public webform. This currently uses a placeholder link; it does not implement the page(s) for respondents to complete the webform yet.

<img width="1512" height="862" alt="image" src="https://github.com/user-attachments/assets/dedbcd55-2dde-40e7-9138-512ad6457b0b" />

<img width="1512" height="862" alt="image" src="https://github.com/user-attachments/assets/c508e475-3921-4aaa-a146-b2c1cad140e8" />

<img width="1030" height="663" alt="image" src="https://github.com/user-attachments/assets/31bf866e-34c6-4ff5-abd1-d98d6cfd515c" />



## Technical Summary
[SAAS-19921](https://dimagi.atlassian.net/browse/SAAS-19921), [SAAS-19922](https://dimagi.atlassian.net/browse/SAAS-19922) , [SAAS-19923](https://dimagi.atlassian.net/browse/SAAS-19923)
This implements the workflow for a user to request a one-time link to complete a public webform. A user sees a form where, if both are enabled on the webform, they may choose their contact method (phone or email), enter their contact information, and receive an email or SMS with a one-time link to complete the actual form. This link does not yet go anywhere as the feature is currently in development.

Noting that I have not included the link shortening mentioned in SAAS-19923 as it's not a hard requirement for this page to work, but it should be done before this is made public to ensure SMS messages are kept to a reasonable length.

Included on this page are a Cloudflare Turnstile widget for bot mitigation, rate limiting to help protect against spam, and re-sending of an existing one-time link if one already exists for the contact info entered. These pages are only accessible when the project that owns the public webform has access to the public webforms feature, to prevent public webforms staying open if a project space is downgraded.

As a note, users who are not logged in will see a language selector widget on the page, which will change the page text and, if the form is available in the chosen language, the title of the form. Users who _are_ logged in will not see this, because they select their language in user settings.

## Feature Flag
PUBLIC_WEBFORMS

## Safety Assurance

### Safety story
As a truly public-facing page, safety is particularly important. Links to public webform pages should not generally be guessable, as a UUID, so there is some amount of security by obscurity, but links and QR codes are easy to leak to a broader public than the form creator intended.

The usage of Turnstile for bot mitigation is useful but not perfect, as AI agents can sometimes bypass these on their own. Rate limiting is then particularly important (by contact info, globally, and by IP) to avoid spamming email or SMS or mass-creating `PublicFormSession` instances. 

Re-use of the same link for contact info protects against impatient users repeatedly requesting new links to be sent, or someone trying to harvest links at a particular email address or phone number. SMS is likely the riskier of contact choices, since these cost money per message sent for the project space that created the public webform.

If there are additional protections that seem useful or needed here, I'd ask reviewers to raise and block approval on it. 

Noting that I've manually added the "risk: medium" tag because of everything mentioned above.

### Automated test coverage
Automated tests are added for most of these changes in their respective commits.

### QA Plan
Public Webforms will get QA holistically - this page will be a focus as a strictly public-facing page.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19921]: https://dimagi.atlassian.net/browse/SAAS-19921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-19922]: https://dimagi.atlassian.net/browse/SAAS-19922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-19923]: https://dimagi.atlassian.net/browse/SAAS-19923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ