### PR TITLE
Run SQL in projectdb case search endpoints

### DIFF
--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -196,3 +196,98 @@ class TestCaseSearchEndpoint(TestCase):
     def test_unknown_endpoint_id_raises(self):
         with self.assertRaises(CaseSearchUserError):
             self._run_query(['person'], [], endpoint_id=404)
+
+
+SQL_DOMAIN = 'test-endpoint-sql'
+PETS = [
+    ('p1', 'Fido', 'brown'),
+    ('p2', 'Rex', 'black'),
+]
+
+
+@fixture
+def pet_table():
+    with project_db_table(SQL_DOMAIN, 'pet', {'color': 'plain'}):
+        yield
+
+
+def _make_sql_endpoint(sql):
+    endpoint = CaseSearchEndpoint.objects.create(
+        domain=SQL_DOMAIN,
+        name='pets',
+        target_type=CaseSearchEndpoint.TargetType.PROJECT_DB,
+    )
+    version = CaseSearchEndpointVersion.objects.create(
+        endpoint=endpoint,
+        version_number=1,
+        case_type='pet',
+        dangerous_sql=sql,
+        action=CaseSearchEndpointVersion.Action.CREATE,
+    )
+    endpoint.current_version = version
+    endpoint.save(update_fields=['current_version'])
+    return endpoint
+
+
+def _populate_pets():
+    send_to_project_db(SQL_DOMAIN, 'pet', [
+        CommCareCase(
+            case_id=case_id,
+            domain=SQL_DOMAIN,
+            type='pet',
+            name=name,
+            owner_id='owner1',
+            opened_on=datetime.datetime(2025, 1, 1),
+            modified_on=datetime.datetime(2025, 6, 1),
+            server_modified_on=datetime.datetime(2025, 6, 1),
+            closed=False,
+            external_id='',
+            case_json={'color': color},
+            indices=[],
+        ) for case_id, name, color in PETS
+    ])
+
+
+def _run_sql_query(endpoint, criteria):
+    config = CaseSearchRequestConfig(
+        criteria=criteria, case_types=['pet'], endpoint_id=endpoint.id)
+    return get_case_search_results(SQL_DOMAIN, config)
+
+
+@use('db', pet_table)
+@flag_enabled('CASE_SEARCH_ENDPOINTS')
+def test_sql_endpoint_without_parameters():
+    _populate_pets()
+    endpoint = _make_sql_endpoint('SELECT * FROM pet')
+
+    cases = sorted(_run_sql_query(endpoint, []), key=lambda case: case.name)
+
+    assert [case.name for case in cases] == ['Fido', 'Rex']
+    assert [case.case_id for case in cases] == ['p1', 'p2']
+    assert [case.case_json for case in cases] == [{'color': 'brown'}, {'color': 'black'}]
+    assert all(case.domain == SQL_DOMAIN and case.type == 'pet' for case in cases)
+
+
+COLOR_SQL = (
+    "SELECT * FROM pet "
+    "WHERE (:color IS NULL OR :color = '' OR prop__color = :color)"
+)
+
+
+@pytest.mark.parametrize('criteria, expected', [
+    ([SearchCriteria('color', 'brown')], ['Fido']),
+    ([SearchCriteria('color', 'black')], ['Rex']),
+    ([SearchCriteria('color', 'chartreuse')], []),
+    # an unsupplied parameter is passed as '', which the query treats as "any"
+    ([], ['Fido', 'Rex']),
+    ([SearchCriteria('color', '')], ['Fido', 'Rex']),
+])
+@use('db', pet_table)
+@flag_enabled('CASE_SEARCH_ENDPOINTS')
+def test_sql_endpoint_with_text_parameter(criteria, expected):
+    _populate_pets()
+    endpoint = _make_sql_endpoint(COLOR_SQL)
+
+    cases = _run_sql_query(endpoint, criteria)
+
+    assert sorted(case.name for case in cases) == expected

--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -1,7 +1,11 @@
+import datetime
 import uuid
 from unittest import mock
 
 from django.test import TestCase
+
+import pytest
+from unmagic import fixture, use
 
 from casexml.apps.case.mock import CaseBlock, IndexAttrs
 
@@ -12,7 +16,7 @@ from corehq.apps.app_manager.models import (
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.case_search.const import IS_RELATED_CASE
-from corehq.apps.data_dictionary.models import CaseType
+from corehq.apps.data_dictionary.models import CaseProperty, CaseType
 from corehq.apps.case_search.exceptions import CaseSearchUserError
 from corehq.apps.case_search.models import (
     CaseSearchConfig,
@@ -27,6 +31,9 @@ from corehq.apps.es.tests.utils import (
     case_search_es_setup,
     es_test,
 )
+from corehq.apps.project_db.populate import send_to_project_db
+from corehq.apps.project_db.tests.util import project_db_table
+from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.util.test_utils import flag_enabled
 
@@ -44,6 +51,12 @@ class TestCaseSearchEndpoint(TestCase):
         CaseSearchConfig.objects.create(domain=cls.domain, enabled=True)
         cls.person_case_type = CaseType.objects.create(domain=cls.domain, name='person')
         cls.addClassCleanup(cls.person_case_type.delete)
+        # the endpoint query builder validates fields against the data dictionary
+        CaseProperty.objects.create(
+            case_type=cls.person_case_type,
+            name='family',
+            data_type=CaseProperty.DataType.PLAIN,
+        )
         cls.household_1 = str(uuid.uuid4())
         case_blocks = [CaseBlock(
             case_id=cls.household_1,
@@ -115,25 +128,69 @@ class TestCaseSearchEndpoint(TestCase):
             ("Villanueva", "true"),
         ])
 
-    @flag_enabled('CASE_SEARCH_ENDPOINTS')
-    def test_endpoint_id_runs_query(self):
+    def _make_es_endpoint(self, query, parameters=None):
         endpoint = CaseSearchEndpoint.objects.create(
-            domain=self.domain, name='people')
+            domain=self.domain,
+            name='people',
+            target_type=CaseSearchEndpoint.TargetType.ELASTICSEARCH,
+        )
         version = CaseSearchEndpointVersion.objects.create(
             endpoint=endpoint,
             version_number=1,
             case_type='person',
-            query={'type': 'all', 'children': []},
-            parameters=[],
+            query=query,
+            parameters=parameters or [],
             action=CaseSearchEndpointVersion.Action.CREATE,
         )
         endpoint.current_version = version
         endpoint.save(update_fields=['current_version'])
-        # TODO: pass criteria once CaseSearchEndpointQueryBuilder applies them.
-        # res = self._run_query(['person'], [SearchCriteria('family', 'Ramos')], endpoint_id=endpoint.id)
-        # self.assertItemsEqual(["Jane"], [case.name for case in res])
+        return endpoint
+
+    @flag_enabled('CASE_SEARCH_ENDPOINTS')
+    def test_endpoint_id_runs_query(self):
+        endpoint = self._make_es_endpoint({'type': 'all', 'children': []})
         res = self._run_query(['person'], [], endpoint_id=endpoint.id)
-        self.assertGreater(len(res), 0)
+        self.assertItemsEqual(["Jane", "Xiomara", "Alba", "Rogelio", "Jane"], [
+            case.name for case in res
+        ])
+
+    @flag_enabled('CASE_SEARCH_ENDPOINTS')
+    def test_endpoint_text_parameter(self):
+        endpoint = self._make_es_endpoint(
+            query={
+                'type': 'all',
+                'children': [{
+                    'type': 'component',
+                    'field': 'family',
+                    'operator': 'equals',
+                    'inputs': {'value': {'type': 'parameter', 'value': 'family'}},
+                }],
+            },
+            parameters=[{'name': 'family', 'type': 'text'}],
+        )
+        res = self._run_query(
+            ['person'], [SearchCriteria('family', 'Ramos')], endpoint_id=endpoint.id)
+        self.assertItemsEqual(["Jane"], [case.name for case in res])
+
+    @flag_enabled('CASE_SEARCH_ENDPOINTS')
+    def test_endpoint_text_parameter_not_supplied(self):
+        # an unsupplied parameter drops its condition rather than filtering on ''
+        endpoint = self._make_es_endpoint(
+            query={
+                'type': 'all',
+                'children': [{
+                    'type': 'component',
+                    'field': 'family',
+                    'operator': 'equals',
+                    'inputs': {'value': {'type': 'parameter', 'value': 'family'}},
+                }],
+            },
+            parameters=[{'name': 'family', 'type': 'text'}],
+        )
+        res = self._run_query(['person'], [], endpoint_id=endpoint.id)
+        self.assertItemsEqual(["Jane", "Xiomara", "Alba", "Rogelio", "Jane"], [
+            case.name for case in res
+        ])
 
     @flag_enabled('CASE_SEARCH_ENDPOINTS')
     def test_unknown_endpoint_id_raises(self):

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -8,13 +8,13 @@ from django.conf import settings
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
-from couchforms.geopoint import GeoPoint
 from jsonobject.exceptions import BadValueError
 
 from casexml.apps.case.fixtures import CaseDBFixture
 from casexml.apps.phone.data_providers.case.livequery import (
     get_all_related_live_cases,
 )
+from couchforms.geopoint import GeoPoint
 from dimagi.utils.logging import notify_exception
 
 from corehq import toggles
@@ -33,6 +33,11 @@ from corehq.apps.case_search.endpoint_capability import (
     FIELD_TYPE_SELECT,
     get_capability,
 )
+from corehq.apps.case_search.endpoint_query_spec import (
+    ParameterInput,
+    parse_parameter_spec,
+    parse_query_spec,
+)
 from corehq.apps.case_search.exceptions import (
     CaseFilterError,
     CaseSearchUserError,
@@ -50,8 +55,10 @@ from corehq.apps.case_search.models import (
     CaseSearchEndpoint,
     extract_search_request_config,
 )
-from corehq.apps.case_search.endpoint_query_spec import ParameterInput, parse_parameter_spec, parse_query_spec
-from corehq.apps.case_search.xpath_functions.query_functions import date_permutations, validate_date
+from corehq.apps.case_search.xpath_functions.query_functions import (
+    date_permutations,
+    validate_date,
+)
 from corehq.apps.es import HQESQuery, case_search
 from corehq.apps.es import cases as case_es
 from corehq.apps.es import filters, queries
@@ -68,11 +75,14 @@ from corehq.apps.es.case_search import (
     wrap_case_search_hit,
 )
 from corehq.apps.es.profiling import ESQueryProfiler
+from corehq.apps.project_db.table_ddl import CaseTable
+from corehq.apps.project_db.user_sql import UserSQL
 from corehq.apps.registry.exceptions import (
     RegistryAccessException,
     RegistryNotFound,
 )
 from corehq.apps.registry.helper import DataRegistryHelper
+from corehq.form_processor.models.cases import CommCareCase
 from corehq.util.quickcache import quickcache
 
 
@@ -136,6 +146,9 @@ def get_endpoint_results(helper, config):
     if not endpoint.is_active:
         raise CaseSearchUserError(_("Endpoint '{}' not found").format(config.endpoint_id))
 
+    if endpoint.target_type == CaseSearchEndpoint.TargetType.PROJECT_DB:
+        return get_project_db_results(endpoint, helper, config)
+
     parameters, errors = parse_parameter_spec(endpoint.current_version.parameters)
     query_root = None
     if not errors:
@@ -155,6 +168,39 @@ def get_endpoint_results(helper, config):
         [endpoint.current_version.case_type],
         config.criteria,
         query_root)
+
+
+def get_project_db_results(endpoint, helper, config):
+    user_sql = UserSQL(helper.domain, endpoint.current_version.dangerous_sql)
+    all_params = {c.key: c.value for c in config.criteria}
+    query_params = {p: all_params.get(p, '') for p in user_sql.parameters}
+    result = user_sql.run(query_params, max_rows=CASE_SEARCH_MAX_RESULTS)
+    return _rows_to_cases(result, helper.domain, config.case_types[0])
+
+
+def _rows_to_cases(result, domain, case_type):
+    table = CaseTable(domain, case_type).reflect()
+    prop_columns = [col for col in table.columns if col.name.startswith('prop__')
+                    and col.name in result.columns]
+    return [
+        CommCareCase(
+            case_id=row['case_id'],
+            domain=domain,
+            type=case_type,
+            name=row['case_name'],
+            owner_id=row['owner_id'],
+            opened_on=row['opened_on'],
+            closed_on=row['closed_on'],
+            closed=row['closed'],
+            modified_on=row['modified_on'],
+            server_modified_on=row['server_modified_on'],
+            external_id=row['external_id'],
+            # The column comment has the raw, untruncated property name
+            case_json={col.comment: str(row[col.name]) for col in prop_columns
+                       if row[col.name]},
+        ) for row in result.rows
+    ]
+
 
 @time_function()
 def get_primary_case_search_endpoint_results(helper, case_types, criteria, endpoint_query, limit=None):


### PR DESCRIPTION
## Product Description

Add support for SQL based case search endpoints to the code that run case search.
Support basic string parameters. If they are not provided by the user set them to empty strings.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6608

## Feature Flag

CASE_SEARCH_ENDPOINTS

## Safety Assurance

### Safety story

Feature in progress behind FF.

### Automated test coverage

Added tests

### QA Plan

Will get tested when feature is complete

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
