### PR TITLE
Add invoice number filter to Wire and Customer Invoice reports

### DIFF
--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -14,6 +14,7 @@ from corehq.apps.accounting.models import (
     Subscriber,
     Subscription,
     CustomerInvoice,
+    WireInvoice,
 )
 from corehq.apps.accounting.utils import (
     fmt_feature_rate_dict,
@@ -490,6 +491,18 @@ class CustomerInvoiceNumberAsyncHandler(BaseInvoiceNumberAsyncHandler):
 
     @property
     def customer_invoice_number_response(self):
+        return self.base_response
+
+
+class WireInvoiceNumberAsyncHandler(BaseInvoiceNumberAsyncHandler):
+    slug = 'wire_invoice_number_filter'
+    allowed_actions = [
+        'wire_invoice_number',
+    ]
+    invoice_class = WireInvoice
+
+    @property
+    def wire_invoice_number_response(self):
         return self.base_response
 
 

--- a/corehq/apps/accounting/filters.py
+++ b/corehq/apps/accounting/filters.py
@@ -19,6 +19,7 @@ from corehq.apps.accounting.async_handlers import (
     SubscriberFilterAsyncHandler,
     SubscriptionFilterAsyncHandler,
     CustomerInvoiceNumberAsyncHandler,
+    WireInvoiceNumberAsyncHandler,
 )
 from corehq.apps.accounting.models import (
     BillingAccountType,
@@ -441,6 +442,14 @@ class CustomerInvoiceNumberFilter(BaseAccountingSingleOptionFilter):
     default_text = 'All'
     async_handler = CustomerInvoiceNumberAsyncHandler
     async_action = 'customer_invoice_number'
+
+
+class WireInvoiceNumberFilter(BaseAccountingSingleOptionFilter):
+    slug = 'wire_invoice_number'
+    label = 'Invoice Number'
+    default_text = 'All'
+    async_handler = WireInvoiceNumberAsyncHandler
+    async_action = 'wire_invoice_number'
 
 
 class InvoiceBalanceFilter(BaseAccountingSingleOptionFilter):

--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -942,6 +942,7 @@ class CustomerInvoiceInterface(InvoiceInterfaceBase):
     description = "List of all customer invoices"
     slug = "customer_invoices"
     fields = [
+        'corehq.apps.accounting.interface.CustomerInvoiceNumberFilter',
         'corehq.apps.accounting.interface.NameFilter',
         'corehq.apps.accounting.interface.SubscriberFilter',
         'corehq.apps.accounting.interface.PaymentStatusFilter',
@@ -1081,6 +1082,10 @@ class CustomerInvoiceInterface(InvoiceInterfaceBase):
     @memoized
     def _invoices(self):
         queryset = CustomerInvoice.objects.all()
+
+        customer_invoice_id = CustomerInvoiceNumberFilter.get_value(self.request, self.domain)
+        if customer_invoice_id is not None:
+            queryset = queryset.filter(id=int(customer_invoice_id))
 
         if self.subscription:
             queryset = queryset.filter(subscriptions=self.subscription)

--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -56,6 +56,7 @@ from .filters import (
     SubscriberFilter,
     SubscriptionTypeFilter,
     TrialStatusFilter,
+    WireInvoiceNumberFilter,
 )
 from .forms import AdjustBalanceForm
 from .models import (
@@ -499,6 +500,7 @@ class WireInvoiceInterface(InvoiceInterfaceBase):
     description = "List of all wire invoices"
     slug = "wire_invoices"
     fields = [
+        'corehq.apps.accounting.interface.WireInvoiceNumberFilter',
         'corehq.apps.accounting.interface.DomainFilter',
         'corehq.apps.accounting.interface.PaymentStatusFilter',
         'corehq.apps.accounting.interface.StatementPeriodFilter',
@@ -588,6 +590,10 @@ class WireInvoiceInterface(InvoiceInterfaceBase):
     @memoized
     def _invoices(self):
         queryset = WireInvoice.objects.all()
+
+        wire_invoice_id = WireInvoiceNumberFilter.get_value(self.request, self.domain)
+        if wire_invoice_id is not None:
+            queryset = queryset.filter(id=int(wire_invoice_id))
 
         domain_name = DomainFilter.get_value(self.request, self.domain)
         if domain_name is not None:

--- a/corehq/apps/accounting/tests/test_async_handlers.py
+++ b/corehq/apps/accounting/tests/test_async_handlers.py
@@ -1,0 +1,54 @@
+import datetime
+
+from django.test import RequestFactory
+
+from corehq.apps.accounting.async_handlers import WireInvoiceNumberAsyncHandler
+from corehq.apps.accounting.models import WireInvoice
+from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
+
+
+class TestWireInvoiceNumberAsyncHandler(BaseAccountingTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.invoice1 = WireInvoice.objects.create(
+            domain='wire-domain-1',
+            date_start=datetime.date(2024, 1, 1),
+            date_end=datetime.date(2024, 1, 31),
+        )
+        cls.invoice2 = WireInvoice.objects.create(
+            domain='wire-domain-2',
+            date_start=datetime.date(2024, 2, 1),
+            date_end=datetime.date(2024, 2, 29),
+        )
+
+    def test_query_without_search_string_returns_all_wire_invoices(self):
+        handler = self._make_handler()
+        self.assertEqual(
+            {invoice.pk for invoice in handler.query},
+            {self.invoice1.pk, self.invoice2.pk},
+        )
+
+    def test_query_filters_by_search_string(self):
+        handler = self._make_handler(search_string=str(self.invoice1.invoice_number))
+        self.assertEqual(list(handler.query), [self.invoice1])
+
+    def test_query_with_no_matching_search_string_returns_empty(self):
+        handler = self._make_handler(search_string='does-not-exist')
+        self.assertEqual(list(handler.query), [])
+
+    def test_wire_invoice_number_response_returns_select2_formatted_data(self):
+        handler = self._make_handler(search_string=str(self.invoice1.invoice_number))
+        self.assertEqual(
+            handler.wire_invoice_number_response,
+            [{'id': str(self.invoice1.pk), 'text': str(self.invoice1.invoice_number)}],
+        )
+
+    @staticmethod
+    def _make_handler(search_string=None):
+        data = {'action': 'wire_invoice_number'}
+        if search_string is not None:
+            data['q'] = search_string
+        request = RequestFactory().post('/test', data=data)
+        return WireInvoiceNumberAsyncHandler(request)

--- a/corehq/apps/accounting/tests/test_interface_invoice_number_filters.py
+++ b/corehq/apps/accounting/tests/test_interface_invoice_number_filters.py
@@ -2,8 +2,12 @@ import datetime
 
 from django.test import RequestFactory
 
-from corehq.apps.accounting.interface import WireInvoiceInterface
-from corehq.apps.accounting.models import WireInvoice
+from corehq.apps.accounting.interface import (
+    CustomerInvoiceInterface,
+    WireInvoiceInterface,
+)
+from corehq.apps.accounting.models import CustomerInvoice, WireInvoice
+from corehq.apps.accounting.tests import generator
 from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
 
 
@@ -48,6 +52,57 @@ class TestWireInvoiceInterfaceNumberFilter(BaseAccountingTest):
         # request (couch_user, domain document, etc.) unrelated to the
         # queryset-filtering logic under test here.
         interface = WireInvoiceInterface.__new__(WireInvoiceInterface)
+        interface.request = request
+        interface.domain = None
+        return interface
+
+
+class TestCustomerInvoiceInterfaceNumberFilter(BaseAccountingTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        generator.init_default_currency()
+        cls.account = generator.billing_account(
+            generator.create_arbitrary_web_user_name(is_dimagi=True),
+            generator.create_arbitrary_web_user_name(),
+        )
+        cls.invoice1 = CustomerInvoice.objects.create(
+            account=cls.account,
+            date_start=datetime.date(2024, 1, 1),
+            date_end=datetime.date(2024, 1, 31),
+        )
+        cls.invoice2 = CustomerInvoice.objects.create(
+            account=cls.account,
+            date_start=datetime.date(2024, 2, 1),
+            date_end=datetime.date(2024, 2, 29),
+        )
+
+    def test_no_filter_returns_all_invoices(self):
+        interface = self._make_interface()
+        self.assertEqual(
+            {invoice.pk for invoice in interface._invoices},
+            {self.invoice1.pk, self.invoice2.pk},
+        )
+
+    def test_filter_by_invoice_number_returns_matching_invoice(self):
+        interface = self._make_interface(customer_invoice_number=str(self.invoice1.pk))
+        self.assertEqual(list(interface._invoices), [self.invoice1])
+
+    def test_filter_by_nonexistent_invoice_number_returns_empty(self):
+        interface = self._make_interface(customer_invoice_number='999999999')
+        self.assertEqual(list(interface._invoices), [])
+
+    @staticmethod
+    def _make_interface(customer_invoice_number=None):
+        params = {}
+        if customer_invoice_number is not None:
+            params['customer_invoice_number'] = customer_invoice_number
+        request = RequestFactory().get('/test', data=params)
+        # Bypass GenericReportView.__init__, which requires a fully set up
+        # request (couch_user, domain document, etc.) unrelated to the
+        # queryset-filtering logic under test here.
+        interface = CustomerInvoiceInterface.__new__(CustomerInvoiceInterface)
         interface.request = request
         interface.domain = None
         return interface

--- a/corehq/apps/accounting/tests/test_interface_invoice_number_filters.py
+++ b/corehq/apps/accounting/tests/test_interface_invoice_number_filters.py
@@ -1,0 +1,53 @@
+import datetime
+
+from django.test import RequestFactory
+
+from corehq.apps.accounting.interface import WireInvoiceInterface
+from corehq.apps.accounting.models import WireInvoice
+from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
+
+
+class TestWireInvoiceInterfaceNumberFilter(BaseAccountingTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.invoice1 = WireInvoice.objects.create(
+            domain='wire-interface-domain-1',
+            date_start=datetime.date(2024, 1, 1),
+            date_end=datetime.date(2024, 1, 31),
+        )
+        cls.invoice2 = WireInvoice.objects.create(
+            domain='wire-interface-domain-2',
+            date_start=datetime.date(2024, 2, 1),
+            date_end=datetime.date(2024, 2, 29),
+        )
+
+    def test_no_filter_returns_all_invoices(self):
+        interface = self._make_interface()
+        self.assertEqual(
+            {invoice.pk for invoice in interface._invoices},
+            {self.invoice1.pk, self.invoice2.pk},
+        )
+
+    def test_filter_by_invoice_number_returns_matching_invoice(self):
+        interface = self._make_interface(wire_invoice_number=str(self.invoice1.pk))
+        self.assertEqual(list(interface._invoices), [self.invoice1])
+
+    def test_filter_by_nonexistent_invoice_number_returns_empty(self):
+        interface = self._make_interface(wire_invoice_number='999999999')
+        self.assertEqual(list(interface._invoices), [])
+
+    @staticmethod
+    def _make_interface(wire_invoice_number=None):
+        params = {}
+        if wire_invoice_number is not None:
+            params['wire_invoice_number'] = wire_invoice_number
+        request = RequestFactory().get('/test', data=params)
+        # Bypass GenericReportView.__init__, which requires a fully set up
+        # request (couch_user, domain document, etc.) unrelated to the
+        # queryset-filtering logic under test here.
+        interface = WireInvoiceInterface.__new__(WireInvoiceInterface)
+        interface.request = request
+        interface.domain = None
+        return interface

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -45,6 +45,7 @@ from corehq.apps.accounting.async_handlers import (
     SoftwareProductRateAsyncHandler,
     SubscriberFilterAsyncHandler,
     SubscriptionFilterAsyncHandler,
+    WireInvoiceNumberAsyncHandler,
 )
 from corehq.apps.accounting.exceptions import (
     CreateAccountingAdminError,
@@ -1204,6 +1205,7 @@ class AccountingSingleOptionResponseView(View, AsyncHandlerMixin):
         SoftwarePlanAsyncHandler,
         InvoiceNumberAsyncHandler,
         CustomerInvoiceNumberAsyncHandler,
+        WireInvoiceNumberAsyncHandler,
         InvoiceBalanceAsyncHandler,
     ]
 


### PR DESCRIPTION
The Wire Invoices and Customer Invoices admin reports (`/hq/accounting/wire_invoices/` and `/hq/accounting/customer_invoices/`) previously had no way to search for a specific invoice by its invoice number, making it hard for the accounting team to look up individual invoices. Both reports now have an "Invoice Number" filter, matching the search already available on the regular Invoices report.

https://dimagi.atlassian.net/browse/SAAS-20018

## Safety Assurance

### Safety story
This is an additive, admin-only reporting change. It adds an optional filter field and a corresponding `queryset.filter(id=...)` clause that only applies when a value is selected. No existing filters, queries, or data are affected when the new filter is left unset.

Tested on staging.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
