### PR TITLE
Only Include Downstream Domains with Release Management as Linkable

### DIFF
--- a/corehq/apps/linked_domain/tests/test_linked_domain_utils.py
+++ b/corehq/apps/linked_domain/tests/test_linked_domain_utils.py
@@ -61,46 +61,61 @@ class TestIsDomainAvailableToLink(SimpleTestCase):
 
     @patch('corehq.apps.users.models.CouchUser')
     def test_none_upstream_domain_returns_false(self, mock_user):
-        result = is_domain_available_to_link(None, 'domain', mock_user)
+        with self._available_to_link_patch():
+            result = is_domain_available_to_link(None, 'domain', mock_user)
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
     def test_none_candidate_domain_returns_false(self, mock_user):
-        result = is_domain_available_to_link('domain', None, mock_user)
+        with self._available_to_link_patch():
+            result = is_domain_available_to_link('domain', None, mock_user)
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
     def test_none_upstream_and_none_candidate_domain_returns_false(self, mock_user):
-        result = is_domain_available_to_link(None, None, mock_user)
+        with self._available_to_link_patch():
+            result = is_domain_available_to_link(None, None, mock_user)
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
     def test_same_domain_returns_false(self, mock_user):
-        result = is_domain_available_to_link('domain', 'domain', mock_user)
+        with self._available_to_link_patch():
+            result = is_domain_available_to_link('domain', 'domain', mock_user)
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
     def test_domain_in_active_link_returns_false(self, mock_user):
-        with patch('corehq.apps.linked_domain.util.is_domain_in_active_link') as mock_active_link:
-            mock_active_link.return_value = True
+        with self._available_to_link_patch(is_domain_in_active_link=True):
             result = is_domain_available_to_link('upstream', 'downstream', mock_user)
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
     def test_user_without_access_returns_false(self, mock_user):
-        with patch('corehq.apps.linked_domain.util.is_domain_in_active_link') as mock_active_link,\
-             patch('corehq.apps.linked_domain.util.user_has_access_in_all_domains') as mock_access:
-            mock_active_link.return_value = False
-            mock_access.return_value = False
+        with self._available_to_link_patch(user_has_access_in_all_domains=False):
             result = is_domain_available_to_link('upstream', 'downstream', mock_user)
         self.assertFalse(result)
 
     @patch('corehq.apps.users.models.CouchUser')
-    def test_user_with_access_returns_true(self, mock_user):
-        with patch('corehq.apps.linked_domain.util.is_domain_in_active_link') as mock_active_link, \
-            patch(
-                'corehq.apps.linked_domain.util.user_has_access_in_all_domains') as mock_access:
-            mock_active_link.return_value = False
-            mock_access.return_value = True
+    def test_candidate_domain_without_access_returns_false(self, mock_user):
+        with self._available_to_link_patch(can_domain_access_linked_domains=False):
+            result = is_domain_available_to_link('upstream', 'downstream', mock_user)
+        self.assertFalse(result)
+
+    @patch('corehq.apps.users.models.CouchUser')
+    def test_linkable_domain_returns_true(self, mock_user):
+        with self._available_to_link_patch():
             result = is_domain_available_to_link('upstream', 'downstream', mock_user)
         self.assertTrue(result)
+
+    def _available_to_link_patch(
+            self,
+            is_domain_in_active_link=False,
+            user_has_access_in_all_domains=True,
+            can_domain_access_linked_domains=True,
+        ):
+        return patch.multiple(
+            'corehq.apps.linked_domain.util',
+            is_domain_in_active_link=lambda *args: is_domain_in_active_link,
+            user_has_access_in_all_domains=lambda *args: user_has_access_in_all_domains,
+            can_domain_access_linked_domains=lambda *args: can_domain_access_linked_domains,
+        )

--- a/corehq/apps/linked_domain/tests/test_linked_domain_utils.py
+++ b/corehq/apps/linked_domain/tests/test_linked_domain_utils.py
@@ -1,52 +1,44 @@
 from unittest.mock import patch
 
-from django.test import SimpleTestCase
-
 from corehq.apps.linked_domain.util import (
     is_available_upstream_domain,
     is_domain_available_to_link,
 )
 
 
-class TestIsAvailableUpstreamDomain(SimpleTestCase):
+@patch('corehq.apps.users.models.CouchUser')
+class TestIsAvailableUpstreamDomain:
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_none_potential_upstream_domain_returns_false(self, mock_user):
         result = is_available_upstream_domain(None, 'downstream', mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_none_downstream_domain_returns_false(self, mock_user):
         result = is_available_upstream_domain('potential-upstream', None, mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_none_potential_upstream_and_none_downstream_returns_false(self, mock_user):
         result = is_available_upstream_domain(None, None, mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_same_domain_returns_false(self, mock_user):
         result = is_available_upstream_domain('domain', 'domain', mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_not_active_upstream_domain_returns_false(self, mock_user):
         with patch('corehq.apps.linked_domain.dbaccessors.is_active_upstream_domain') as mock_active_upstream:
             mock_active_upstream.return_value = False
             result = is_available_upstream_domain('potential-upstream', 'downstream', mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_user_without_access_returns_false(self, mock_user):
         with patch('corehq.apps.linked_domain.dbaccessors.is_active_upstream_domain') as mock_active_upstream,\
              patch('corehq.apps.linked_domain.util.user_has_access_in_all_domains') as mock_access:
             mock_active_upstream.return_value = True
             mock_access.return_value = False
             result = is_available_upstream_domain('potential-upstream', 'downstream', mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_user_with_access_returns_true(self, mock_user):
         with patch('corehq.apps.linked_domain.dbaccessors.is_active_upstream_domain') as mock_active_upstream, \
             patch(
@@ -54,58 +46,51 @@ class TestIsAvailableUpstreamDomain(SimpleTestCase):
             mock_active_upstream.return_value = True
             mock_access.return_value = True
             result = is_available_upstream_domain('potential-upstream', 'downstream', mock_user)
-        self.assertTrue(result)
+        assert result is True
 
 
-class TestIsDomainAvailableToLink(SimpleTestCase):
+@patch('corehq.apps.users.models.CouchUser')
+class TestIsDomainAvailableToLink:
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_none_upstream_domain_returns_false(self, mock_user):
         with self._available_to_link_patch():
             result = is_domain_available_to_link(None, 'domain', mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_none_candidate_domain_returns_false(self, mock_user):
         with self._available_to_link_patch():
             result = is_domain_available_to_link('domain', None, mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_none_upstream_and_none_candidate_domain_returns_false(self, mock_user):
         with self._available_to_link_patch():
             result = is_domain_available_to_link(None, None, mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_same_domain_returns_false(self, mock_user):
         with self._available_to_link_patch():
             result = is_domain_available_to_link('domain', 'domain', mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_domain_in_active_link_returns_false(self, mock_user):
         with self._available_to_link_patch(is_domain_in_active_link=True):
             result = is_domain_available_to_link('upstream', 'downstream', mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_user_without_access_returns_false(self, mock_user):
         with self._available_to_link_patch(user_has_access_in_all_domains=False):
             result = is_domain_available_to_link('upstream', 'downstream', mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_candidate_domain_without_access_returns_false(self, mock_user):
         with self._available_to_link_patch(can_domain_access_linked_domains=False):
             result = is_domain_available_to_link('upstream', 'downstream', mock_user)
-        self.assertFalse(result)
+        assert result is False
 
-    @patch('corehq.apps.users.models.CouchUser')
     def test_linkable_domain_returns_true(self, mock_user):
         with self._available_to_link_patch():
             result = is_domain_available_to_link('upstream', 'downstream', mock_user)
-        self.assertTrue(result)
+        assert result is True
 
     def _available_to_link_patch(
             self,

--- a/corehq/apps/linked_domain/util.py
+++ b/corehq/apps/linked_domain/util.py
@@ -171,7 +171,10 @@ def is_domain_available_to_link(upstream_domain_name, candidate_name, user):
         # cannot link to an already linked project
         return False
 
-    return user_has_access_in_all_domains(user, [upstream_domain_name, candidate_name])
+    return (
+        can_domain_access_linked_domains(candidate_name)
+        and user_has_access_in_all_domains(user, [upstream_domain_name, candidate_name])
+    )
 
 
 def is_available_upstream_domain(potential_upstream_domain, downstream_domain, user):


### PR DESCRIPTION
## Product Description
Prevents project spaces without the correct privileges from being shown as eligible Linked Project Spaces in MRM/ERM choices.
<img width="602" height="201" alt="image" src="https://github.com/user-attachments/assets/688edc52-2d7d-420a-99fd-6ef38bb876a7" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19882
We already check whether the upstream domain has the correct privilege to link domains - this just adds a check that the downstream ("candidate") domain has the right privilege as well.

## Safety Assurance

### Safety story
This is a one-line addition making the check for whether a domain is linkable more strict. Automated testing shows that a domain that should be linkable, still is. Tested on staging that the projects without the privilege are excluded from the list of linkable projects.

### Automated test coverage
Added a test case to see that candidate domains that fail the `can_domain_access_linked_domains` check are not given as available to link. Restructures these tests a bit to patch the aspects that are not currently under test, making sure they're testing what we think we are.

### QA Plan
Not for this change.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
