### PR TITLE
Exclude Autopay Accounts from Flagged Pay Annually Invoice Alerts

### DIFF
--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -469,36 +469,31 @@ class TestFlaggedPayAnnuallyPrepayInvoice(BaseInvoiceTestCase):
             is_product=True,
         )
 
-    def test_monthly_invoice_product_fully_paid(self):
+    def test_no_prepayment_invoice(self):
+        invoice = self.create_invoices().first()
+        assert get_flagged_pay_annually_prepay_invoice(invoice) is None
+
+    def test_monthly_invoice_product_fully_paid_is_ignored(self):
         prepay_invoice = self.create_prepayment_invoice(self.subscription.date_start)
         self.create_product_credit(prepay_invoice.balance)
         invoice = self.create_invoices().first()
-        flagged_invoice = get_flagged_pay_annually_prepay_invoice(invoice)
-        self.assertIsNone(flagged_invoice)
+        assert get_flagged_pay_annually_prepay_invoice(invoice) is None
 
-    def test_no_prepayment_invoice(self):
-        invoice = self.create_invoices().first()
-        flagged_invoice = get_flagged_pay_annually_prepay_invoice(invoice)
-        self.assertIsNone(flagged_invoice)
-
-    def test_prepayment_invoice_not_due_yet(self):
+    def test_prepayment_invoice_not_due_yet_is_ignored(self):
         self.create_prepayment_invoice(datetime.date.today() + relativedelta(days=1))
         invoice = self.create_invoices().first()
-        result = get_flagged_pay_annually_prepay_invoice(invoice)
-        self.assertIsNone(result)
+        assert get_flagged_pay_annually_prepay_invoice(invoice) is None
 
     def test_account_on_autopay_is_ignored(self):
         self.create_prepayment_invoice(self.subscription.date_start)
         invoice = self.create_invoices().first()
         invoice.account.auto_pay_user = self.billing_contact
-        result = get_flagged_pay_annually_prepay_invoice(invoice)
-        self.assertIsNone(result)
+        assert get_flagged_pay_annually_prepay_invoice(invoice) is None
 
-    def test_matching_prepayment_invoice_exists(self):
+    def test_matching_prepayment_invoice_is_flagged(self):
         prepay_invoice = self.create_prepayment_invoice(self.subscription.date_start)
         invoice = self.create_invoices().first()
-        result = get_flagged_pay_annually_prepay_invoice(invoice)
-        self.assertEqual(result, prepay_invoice)
+        assert get_flagged_pay_annually_prepay_invoice(invoice) == prepay_invoice
 
 
 class TestGetProratedSoftwarePlanCost(SimpleTestCase):

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -487,6 +487,13 @@ class TestFlaggedPayAnnuallyPrepayInvoice(BaseInvoiceTestCase):
         result = get_flagged_pay_annually_prepay_invoice(invoice)
         self.assertIsNone(result)
 
+    def test_account_on_autopay_is_ignored(self):
+        self.create_prepayment_invoice(self.subscription.date_start)
+        invoice = self.create_invoices().first()
+        invoice.account.auto_pay_user = self.billing_contact
+        result = get_flagged_pay_annually_prepay_invoice(invoice)
+        self.assertIsNone(result)
+
     def test_matching_prepayment_invoice_exists(self):
         prepay_invoice = self.create_prepayment_invoice(self.subscription.date_start)
         invoice = self.create_invoices().first()

--- a/corehq/apps/accounting/utils/invoicing.py
+++ b/corehq/apps/accounting/utils/invoicing.py
@@ -128,8 +128,11 @@ def _get_accounts_over_threshold_in_daterange(date_start, date_end):
 
 
 def get_flagged_pay_annually_prepay_invoice(invoice):
-    plan = invoice.subscription.plan_version.plan
-    if not plan.is_annual_plan:
+    subscription = invoice.subscription
+    if (
+        subscription.account.auto_pay_enabled
+        or not subscription.plan_version.plan.is_annual_plan
+    ):
         return None
 
     product_line_item = invoice.lineitem_set.get_products().first()


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-20005
Skips invoices belonging to accounts that have autopay enabled when determining which invoices should be "flagged" and send an alert to the `SUBSCRIPTION_CHANGE_EMAIL` address. The purpose of this alert is to notify internal staff when a customer appears to have skipped the initial payment for their Pay Annually subscription.


## Safety Assurance

### Safety story
This functionality only sends an email to internal email addresses, nothing is customer-facing. The change itself is simple and well-tested.

### Automated test coverage
Adds a test case to see that accounts with autopay enabled are skipped for the "flagged" invoice alert.

### QA Plan
Not for this change.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
