### PR TITLE
Don't Send Emails on $0 Monthly Invoices for Pay Annually Subscriptions

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2594,9 +2594,11 @@ class BillingRecord(BillingRecordBase):
         autogenerate = (subscription.auto_generate_credits and not self.invoice.balance)
         small_contracted = (self.invoice.balance <= SMALL_INVOICE_THRESHOLD
                             and subscription.service_type == SubscriptionType.IMPLEMENTATION)
+        zero_dollar_annual = (self.invoice.balance <= 0
+                              and subscription.plan_version.plan.is_annual_plan)
         hidden = self.invoice.is_hidden
         do_not_email_invoice = self.invoice.subscription.do_not_email_invoice
-        return not (autogenerate or small_contracted or hidden or do_not_email_invoice)
+        return not (autogenerate  or small_contracted or zero_dollar_annual or hidden or do_not_email_invoice)
 
     def is_email_throttled(self):
         month = self.invoice.date_start.month

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -255,8 +255,6 @@ class TestBillingRecord(BaseAccountingTest):
 
     def test_should_send_email_contracted(self):
         self.subscription.service_type = SubscriptionType.IMPLEMENTATION
-        assert not self.billing_record.should_send_email
-
         self.invoice.balance = Decimal(SMALL_INVOICE_THRESHOLD)
         assert not self.billing_record.should_send_email
 
@@ -265,13 +263,15 @@ class TestBillingRecord(BaseAccountingTest):
 
     def test_should_send_email_autogenerate_credits(self):
         self.subscription.auto_generate_credits = True
+        assert self.invoice.balance == 0
         assert not self.billing_record.should_send_email
 
-        self.invoice.balance = Decimal(SMALL_INVOICE_THRESHOLD + 0.01)
+        self.invoice.balance = Decimal(0.01)
         assert self.billing_record.should_send_email
 
     def test_should_send_email_pay_annually(self):
         self.subscription.plan_version.plan.is_annual_plan = True
+        assert self.invoice.balance == 0
         assert not self.billing_record.should_send_email
 
         self.invoice.balance = Decimal(0.01)

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -223,11 +223,12 @@ class TestSubscription(BaseAccountingTest):
 class TestBillingRecord(BaseAccountingTest):
 
     def setUp(self):
-        super(TestBillingRecord, self).setUp()
+        super().setUp()
         self.billing_contact = generator.create_arbitrary_web_user_name()
         self.dimagi_user = generator.create_arbitrary_web_user_name(is_dimagi=True)
         self.domain = Domain(name='test')
         self.domain.save()
+        self.addCleanup(self.domain.delete)
         self.invoice_start, self.invoice_end = get_previous_month_date_range()
         self.currency = generator.init_default_currency()
         self.account = generator.billing_account(self.dimagi_user, self.billing_contact)
@@ -249,42 +250,38 @@ class TestBillingRecord(BaseAccountingTest):
         )
         self.billing_record = BillingRecord(invoice=self.invoice)
 
-    def tearDown(self):
-        self.domain.delete()
-        super(TestBillingRecord, self).tearDown()
-
     def test_should_send_email(self):
-        self.assertTrue(self.billing_record.should_send_email)
+        assert self.billing_record.should_send_email
 
     def test_should_send_email_contracted(self):
         self.subscription.service_type = SubscriptionType.IMPLEMENTATION
-        self.assertFalse(self.billing_record.should_send_email)
+        assert not self.billing_record.should_send_email
 
-        self.invoice.balance = Decimal(SMALL_INVOICE_THRESHOLD - 1)
-        self.assertFalse(self.billing_record.should_send_email)
+        self.invoice.balance = Decimal(SMALL_INVOICE_THRESHOLD)
+        assert not self.billing_record.should_send_email
 
-        self.invoice.balance = Decimal(SMALL_INVOICE_THRESHOLD + 1)
-        self.assertTrue(self.billing_record.should_send_email)
+        self.invoice.balance = Decimal(SMALL_INVOICE_THRESHOLD + 0.01)
+        assert self.billing_record.should_send_email
 
     def test_should_send_email_autogenerate_credits(self):
         self.subscription.auto_generate_credits = True
-        self.assertFalse(self.billing_record.should_send_email)
+        assert not self.billing_record.should_send_email
 
-        self.invoice.balance = Decimal(SMALL_INVOICE_THRESHOLD + 1)
-        self.assertTrue(self.billing_record.should_send_email)
+        self.invoice.balance = Decimal(SMALL_INVOICE_THRESHOLD + 0.01)
+        assert self.billing_record.should_send_email
 
     def test_should_send_email_pay_annually(self):
         self.subscription.plan_version.plan.is_annual_plan = True
-        self.assertFalse(self.billing_record.should_send_email)
+        assert not self.billing_record.should_send_email
 
         self.invoice.balance = Decimal(0.01)
-        self.assertTrue(self.billing_record.should_send_email)
+        assert self.billing_record.should_send_email
 
     def test_should_send_email_hidden(self):
-        self.assertTrue(self.billing_record.should_send_email)
+        assert self.billing_record.should_send_email
 
         self.invoice.is_hidden = True
-        self.assertFalse(self.billing_record.should_send_email)
+        assert not self.billing_record.should_send_email
 
 
 class TestCustomerBillingRecord(BaseAccountingTest):

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -273,6 +273,13 @@ class TestBillingRecord(BaseAccountingTest):
         self.invoice.balance = Decimal(SMALL_INVOICE_THRESHOLD + 1)
         self.assertTrue(self.billing_record.should_send_email)
 
+    def test_should_send_email_pay_annually(self):
+        self.subscription.plan_version.plan.is_annual_plan = True
+        self.assertFalse(self.billing_record.should_send_email)
+
+        self.invoice.balance = Decimal(0.01)
+        self.assertTrue(self.billing_record.should_send_email)
+
     def test_should_send_email_hidden(self):
         self.assertTrue(self.billing_record.should_send_email)
 


### PR DESCRIPTION
## Product Description
Will no longer send monthly invoice emails to customers on Pay Annually subscriptions when that monthly invoice has a $0 balance at generation (e.g. it was fully paid by credits).

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19999
Adds a check (one of a few checks) in `BillingRecord.should_send_email` to avoid sending the email in situations where: the generated invoice has a balance of $0 (or less, which probably shouldn't happen) and the related subscription is a Pay Annually plan.

## Safety Assurance

### Safety story
Automated testing covers this logic cleanly, and the functional change itself is quite small. This limits the situations under which a user would receive an email for an invoice - in the worst case scenario the invoice is still generated and able to be resent by internal staff.

### Automated test coverage
Added a test case with asserts to see that `should_send_email` is correctly set when the related subscription is a Pay Annually plan.

### QA Plan
Not for this change.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
