### PR TITLE
Report Connect Message send failures in messaging reports

### DIFF
--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -1004,19 +1004,22 @@ class MessageEventDetailReport(BaseMessagingEventReport):
                 timestamp = ServerTime(messaging_subevent.date).user_time(self.timezone).done()
                 status = get_status_display(messaging_subevent)
                 content = '-'
-                recipient_address = '-'
+                recipient = '-'
+                direction = '-'
                 try:
                     msg = ConnectMessage.objects.get(messaging_subevent=messaging_subevent.pk)
                 except ConnectMessage.DoesNotExist:
-                    pass
-                content = msg.text
-                recipient = msg.couch_recipient
+                    msg = None
+                if msg:
+                    content = msg.text
+                    recipient = msg.couch_recipient
+                    direction = msg.direction
                 result.append([
                     self._fmt_timestamp(timestamp),
                     self._fmt_contact_link(messaging_subevent.recipient_id, doc_info),
                     self._fmt(content),
                     self._fmt(recipient),
-                    self._fmt_direction(msg.direction),
+                    self._fmt_direction(direction),
                     self._fmt(_('Connect Message')),
                     self._fmt(status),
                 ])

--- a/corehq/apps/reports/tests/test_message_event_detail_report.py
+++ b/corehq/apps/reports/tests/test_message_event_detail_report.py
@@ -1,0 +1,74 @@
+import uuid
+from datetime import datetime, timedelta
+
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.reports.standard.sms import MessageEventDetailReport
+from corehq.apps.sms.tests.data_generator import (
+    make_connect_message_event_for_test,
+)
+from corehq.apps.users.models import CommCareUser, WebUser
+from dimagi.utils.dates import DateSpan
+
+
+class TestMessageEventDetailReportConnectMessage(TestCase):
+    domain = uuid.uuid4().hex
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+        cls.factory = RequestFactory()
+
+        cls.web_user = WebUser.create(None, f'web-user-{cls.domain}', 'foobar', None, None)
+        cls.web_user.add_domain_membership(cls.domain, is_admin=True)
+        cls.web_user.save()
+        cls.addClassCleanup(cls.web_user.delete, cls.domain, deleted_by=None)
+
+        cls.recipient = CommCareUser.create(cls.domain, f'connect-recipient-{cls.domain}', 'foobar', None, None)
+        cls.addClassCleanup(cls.recipient.delete, cls.domain, deleted_by=None)
+
+    def test_row_uses_the_connect_message_log(self):
+        event, __, __ = make_connect_message_event_for_test(
+            self.domain, self.recipient.get_id, text='Check out the new API.'
+        )
+
+        row = self.get_report_row(event)
+
+        assert row['Content'] == 'Check out the new API.'
+        assert row['ConnectID'] == self.recipient.get_id
+        assert row['Direction'] == 'Outgoing'
+        assert row['Gateway'] == 'Connect Message'
+        assert row['Status'] == 'Completed'
+
+    def test_row_falls_back_to_placeholders_when_message_log_is_missing(self):
+        # A subevent can exist without a ConnectMessage, e.g. when the send
+        # failed before the message was logged.
+        event, __, __ = make_connect_message_event_for_test(self.domain, self.recipient.get_id)
+
+        row = self.get_report_row(event)
+
+        assert row['Content'] == '-'
+        assert row['ConnectID'] == '-'
+        assert row['Direction'] == '-'
+        assert row['Gateway'] == 'Connect Message'
+
+    def get_report_row(self, event):
+        request = self.factory.get('/', {'id': event.pk})
+        request.couch_user = self.web_user
+        request.datespan = DateSpan(
+            startdate=datetime.utcnow() - timedelta(days=30),
+            enddate=datetime.utcnow(),
+        )
+        report = MessageEventDetailReport(request, domain=self.domain)
+        headers = [column.html for column in report.headers.header]
+        rows = report.rows
+        assert len(rows) == 1, rows
+        return dict(zip(headers, [_cell_value(cell) for cell in rows[0]]))
+
+
+def _cell_value(cell):
+    return cell['html'] if isinstance(cell, dict) else cell

--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -26,7 +26,10 @@ from corehq.apps.sms.messages import (
     MSG_USERNAME_TOO_LONG,
     get_message,
 )
-from corehq.apps.sms.mixin import BadSMSConfigException
+from corehq.apps.sms.mixin import (
+    BackendProcessingException,
+    BadSMSConfigException,
+)
 from corehq.apps.sms.models import (
     ConnectMessage,
     INCOMING,
@@ -52,7 +55,7 @@ from corehq.apps.smsforms.models import (
     SMSChannel,
     XFormsSessionSynchronization,
 )
-from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.apps.users.models import CommCareUser, ConnectIDUserLink, WebUser
 from corehq.const import USER_CHANGE_VIA_SMS
 from corehq.form_processor.utils import is_commcarecase
 from corehq.util.metrics import metrics_counter
@@ -411,11 +414,19 @@ def send_connect_message(message, backend, logged_subevent=None):
         log_sms_exception(message)
         if logged_subevent:
             logged_subevent.error(
-                MessagingEvent.ERROR_CONNECT_GATEWAY,
+                get_connect_error_code(error),
                 additional_error_text=str(error),
             )
         return False
     return True
+
+
+def get_connect_error_code(error):
+    if isinstance(error, BackendProcessingException):
+        return MessagingEvent.ERROR_CONNECT_GATEWAY
+    if isinstance(error, ConnectIDUserLink.DoesNotExist):
+        return MessagingEvent.ERROR_CONNECT_USER_NOT_FOUND
+    return MessagingEvent.ERROR_INTERNAL_SERVER_ERROR
 
 
 def register_sms_user(

--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -110,10 +110,12 @@ def add_msg_tags(msg, metadata):
 def log_sms_exception(msg):
     direction = "OUT" if msg.direction == OUTGOING else "IN"
     message = "[SMS %s] Error processing SMS" % direction
+    # ConnectMessage identifies itself with a message_id, where SMS uses a couch_id
+    message_id = getattr(msg, 'couch_id', None) or getattr(msg, 'message_id', None)
     notify_exception(None, message=message, details={
         'domain': msg.domain,
         'date': msg.date,
-        'message_id': msg.couch_id,
+        'message_id': message_id,
     })
 
 
@@ -227,7 +229,7 @@ def send_message_to_verified_number(verified_number, text, metadata=None, logged
     if verified_number.is_sms:
         return queue_outgoing_sms(msg)
     else:
-        return send_connect_message(msg, backend)
+        return send_connect_message(msg, backend, logged_subevent=logged_subevent)
 
 
 def send_sms_with_backend(domain, phone_number, text, backend_id, metadata=None):
@@ -402,13 +404,18 @@ def should_log_exception_for_backend(backend, exception):
         return True
 
 
-def send_connect_message(message, backend):
+def send_connect_message(message, backend, logged_subevent=None):
     try:
         backend.send(message)
-        return True
-    except Exception:
+    except Exception as error:
         log_sms_exception(message)
+        if logged_subevent:
+            logged_subevent.error(
+                MessagingEvent.ERROR_CONNECT_GATEWAY,
+                additional_error_text=str(error),
+            )
         return False
+    return True
 
 
 def register_sms_user(

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1115,6 +1115,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
     ERROR_NO_FCM_TOKENS = 'NO_FCM_TOKENS'
     FILTER_MISMATCH = 'FILTER_MISMATCH'
     ERROR_CONNECT_USER_NOT_FOUND = 'CONNECT_USER_NOT_FOUND'
+    ERROR_CONNECT_GATEWAY = 'CONNECT_GATEWAY_ERROR'
     ERROR_USER_NOT_SUPPORTED = 'USER_NOT_SUPPORTED'
 
     ERROR_MESSAGES = {
@@ -1174,6 +1175,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
         ERROR_NO_FCM_TOKENS: gettext_noop("No FCM tokens found for recipient."),
         FILTER_MISMATCH: gettext_noop("Recipient did not match filters:"),
         ERROR_CONNECT_USER_NOT_FOUND: gettext_noop("Connect user not found for recipient."),
+        ERROR_CONNECT_GATEWAY: gettext_noop("Connect Messaging Gateway Error"),
         ERROR_USER_NOT_SUPPORTED:
             gettext_noop("Only Mobile workers with Connect accounts are supported as recipients "
                 "for Connect Message and Surveys."),

--- a/corehq/apps/sms/tests/data_generator.py
+++ b/corehq/apps/sms/tests/data_generator.py
@@ -7,7 +7,7 @@ from corehq.tests.tools import nottest
 
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.apps.sms.event_handlers import handle_email_messaging_subevent
-from corehq.apps.sms.models import MessagingEvent, MessagingSubEvent, SMS
+from corehq.apps.sms.models import ConnectMessage, MessagingEvent, MessagingSubEvent, SMS
 from corehq.apps.sms.models import OUTGOING
 from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.messaging.scheduling.models import ImmediateBroadcast, EmailContent, AlertSchedule
@@ -240,3 +240,45 @@ def make_email_event_for_test(domain, schedule_name, user_ids, utcnow=None):
             subevent.refresh_from_db()
             subevents[subevent.recipient_id] = subevent
     return subevents
+
+
+@nottest
+def make_connect_message_event_for_test(domain, recipient_id, text=None, utcnow=None):
+    """
+    Create a Connect Message event and its subevent.
+
+    `ConnectMessage` is only created, and linked to the subevent, if
+    ``text`` is given. Callers can omit it to simulate a subevent whose message
+    log is missing.
+    """
+    message_date = utcnow or datetime.utcnow()
+    event = MessagingEvent.objects.create(
+        domain=domain,
+        date=message_date,
+        source=MessagingEvent.SOURCE_OTHER,
+        content_type=MessagingEvent.CONTENT_CONNECT,
+        status=MessagingEvent.STATUS_COMPLETED,
+        recipient_type=MessagingEvent.RECIPIENT_MOBILE_WORKER,
+        recipient_id=recipient_id,
+    )
+    subevent = MessagingSubEvent.objects.create(
+        parent=event,
+        domain=domain,
+        date=message_date,
+        recipient_type=MessagingEvent.RECIPIENT_MOBILE_WORKER,
+        recipient_id=recipient_id,
+        content_type=MessagingEvent.CONTENT_CONNECT,
+        status=MessagingEvent.STATUS_COMPLETED,
+    )
+    message = None
+    if text is not None:
+        message = ConnectMessage.objects.create(
+            domain=domain,
+            date=message_date,
+            couch_recipient_doc_type='CommCareUser',
+            couch_recipient=recipient_id,
+            direction=OUTGOING,
+            text=text,
+            messaging_subevent=subevent,
+        )
+    return event, subevent, message

--- a/corehq/apps/sms/tests/test_api.py
+++ b/corehq/apps/sms/tests/test_api.py
@@ -1,0 +1,24 @@
+import pytest
+
+from corehq.apps.sms.api import get_connect_error_code
+from corehq.apps.sms.mixin import BackendProcessingException
+from corehq.apps.sms.models import MessagingEvent
+from corehq.apps.users.models import ConnectIDUserLink
+
+
+@pytest.mark.parametrize('error, expected_code', [
+    (
+        BackendProcessingException('HTTP 400: {"error": "invalid channel"}'),
+        MessagingEvent.ERROR_CONNECT_GATEWAY,
+    ),
+    (
+        ConnectIDUserLink.DoesNotExist(),
+        MessagingEvent.ERROR_CONNECT_USER_NOT_FOUND,
+    ),
+    (
+        AttributeError("'NoneType' object has no attribute 'get_django_user'"),
+        MessagingEvent.ERROR_INTERNAL_SERVER_ERROR,
+    ),
+])
+def test_get_connect_error_code(error, expected_code):
+    assert get_connect_error_code(error) == expected_code

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -531,6 +531,9 @@ class ConnectMessageContent(Content):
             logged_subevent.error(MessagingEvent.ERROR_CONNECT_USER_NOT_FOUND)
             return
 
+        # completed is a no-op if the send already errored the subevent
+        logged_subevent.completed()
+
 
 class ConnectMessageSurveyContent(SurveyContent):
 

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -525,8 +525,14 @@ class ConnectMessageContent(Content):
             recipient.get_language_code()
         )
         connect_number = ConnectMessagingNumber(recipient)
+        metadata = self.get_sms_message_metadata(logged_subevent)
         try:
-            send_message_to_verified_number(connect_number, message, logged_subevent=logged_subevent)
+            send_message_to_verified_number(
+                connect_number,
+                message,
+                metadata=metadata,
+                logged_subevent=logged_subevent,
+            )
         except ConnectIDUserLink.DoesNotExist:
             logged_subevent.error(MessagingEvent.ERROR_CONNECT_USER_NOT_FOUND)
             return

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -512,7 +512,7 @@ class ConnectMessageContent(Content):
         logged_subevent = logged_event.create_subevent_from_contact_and_content(
             recipient,
             self,
-            case_id=None,
+            case_id=self.case.case_id if self.case else None,
         )
 
         if not isinstance(recipient, CommCareUser):

--- a/corehq/messaging/scheduling/tests/test_content.py
+++ b/corehq/messaging/scheduling/tests/test_content.py
@@ -280,6 +280,11 @@ class TestConnectMessageContentSend(TestCase):
         message = ConnectMessage.objects.get(domain=self.domain)
         assert message.messaging_subevent_id == subevent.pk
 
+    def test_subevent_records_the_case(self):
+        subevent = self.send_message(status_code=200, case=Mock(case_id='case-1'))
+
+        assert subevent.case_id == 'case-1'
+
     def test_failed_send_errors_the_subevent(self):
         subevent = self.send_message(status_code=400, text='{"error": "invalid channel"}')
 
@@ -290,7 +295,7 @@ class TestConnectMessageContentSend(TestCase):
         # the parent event is errored by MessagingSubEvent.save()
         assert subevent.parent.refresh().status == MessagingEvent.STATUS_ERROR
 
-    def send_message(self, status_code, text=''):
+    def send_message(self, status_code, text='', case=None):
         logged_event = MessagingEvent.objects.create(
             domain=self.domain,
             date=datetime.utcnow(),
@@ -301,6 +306,7 @@ class TestConnectMessageContentSend(TestCase):
             recipient_id=self.recipient.get_id,
         )
         content = ConnectMessageContent(message={'*': 'Hello'})
+        content.set_context(case=case)
         response = Mock(status_code=status_code, text=text)
         with patch('corehq.messaging.smsbackends.connectid.backend.requests.post',
                    return_value=response):

--- a/corehq/messaging/scheduling/tests/test_content.py
+++ b/corehq/messaging/scheduling/tests/test_content.py
@@ -1,4 +1,6 @@
-from unittest.mock import Mock
+import uuid
+from datetime import datetime
+from unittest.mock import Mock, patch
 
 from django.test import TestCase, override_settings
 
@@ -9,11 +11,19 @@ from corehq.apps.sms.forms import (
     LANGUAGE_FALLBACK_SCHEDULE,
     LANGUAGE_FALLBACK_UNTRANSLATED,
 )
-from corehq.apps.sms.models import MessagingEvent
-from corehq.apps.users.models import CommCareUser
+from corehq.apps.sms.models import (
+    ConnectMessage,
+    MessagingEvent,
+    MessagingSubEvent,
+)
+from corehq.apps.users.models import CommCareUser, ConnectIDUserLink
 from corehq.messaging.scheduling.exceptions import EmailValidationException
 from corehq.messaging.scheduling.models import Content as AbstractContent
-from corehq.messaging.scheduling.models import CustomContent, EmailContent
+from corehq.messaging.scheduling.models import (
+    ConnectMessageContent,
+    CustomContent,
+    EmailContent,
+)
 from corehq.messaging.scheduling.models import Schedule as AbstractSchedule
 from corehq.messaging.scheduling.scheduling_partitioned.models import (
     AlertScheduleInstance,
@@ -233,6 +243,63 @@ class TestContent(TestCase):
         with self.assertRaises(EmailValidationException) as e:
             EmailContent().get_recipient_email(recipient)
         self.assertEqual(e.exception.error_type, MessagingEvent.ERROR_INVALID_EMAIL_ADDRESS)
+
+
+class TestConnectMessageContentSend(TestCase):
+    domain = uuid.uuid4().hex
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain_obj = create_domain(cls.domain)
+        cls.addClassCleanup(cls.domain_obj.delete)
+        cls.recipient = CommCareUser.create(cls.domain, f'connect-user-{cls.domain}', 'foobar', None, None)
+        cls.addClassCleanup(cls.recipient.delete, cls.domain, deleted_by=None)
+
+    def setUp(self):
+        super().setUp()
+        ConnectIDUserLink.objects.create(
+            connectid_username='connect-user',
+            commcare_user=self.recipient.get_django_user(),
+            domain=self.domain,
+            messaging_consent=True,
+            channel_id='channel-1',
+        )
+
+    def test_successful_send_completes_the_subevent(self):
+        subevent = self.send_message(status_code=200)
+
+        assert subevent.status == MessagingEvent.STATUS_COMPLETED
+        assert subevent.error_code is None
+        message = ConnectMessage.objects.get(domain=self.domain)
+        assert message.text == 'Hello'
+
+    def test_failed_send_errors_the_subevent(self):
+        subevent = self.send_message(status_code=400, text='{"error": "invalid channel"}')
+
+        assert subevent.status == MessagingEvent.STATUS_ERROR
+        assert subevent.error_code == MessagingEvent.ERROR_CONNECT_GATEWAY
+        assert 'HTTP 400' in subevent.additional_error_text
+        assert 'invalid channel' in subevent.additional_error_text
+        # the parent event is errored by MessagingSubEvent.save()
+        assert subevent.parent.refresh().status == MessagingEvent.STATUS_ERROR
+
+    def send_message(self, status_code, text=''):
+        logged_event = MessagingEvent.objects.create(
+            domain=self.domain,
+            date=datetime.utcnow(),
+            source=MessagingEvent.SOURCE_OTHER,
+            content_type=MessagingEvent.CONTENT_CONNECT,
+            status=MessagingEvent.STATUS_IN_PROGRESS,
+            recipient_type=MessagingEvent.RECIPIENT_MOBILE_WORKER,
+            recipient_id=self.recipient.get_id,
+        )
+        content = ConnectMessageContent(message={'*': 'Hello'})
+        response = Mock(status_code=status_code, text=text)
+        with patch('corehq.messaging.smsbackends.connectid.backend.requests.post',
+                   return_value=response):
+            content.send(self.recipient, logged_event)
+        return MessagingSubEvent.objects.get(parent=logged_event)
 
 
 @unregistered_django_model

--- a/corehq/messaging/scheduling/tests/test_content.py
+++ b/corehq/messaging/scheduling/tests/test_content.py
@@ -274,6 +274,12 @@ class TestConnectMessageContentSend(TestCase):
         message = ConnectMessage.objects.get(domain=self.domain)
         assert message.text == 'Hello'
 
+    def test_message_log_is_linked_to_the_subevent(self):
+        subevent = self.send_message(status_code=200)
+
+        message = ConnectMessage.objects.get(domain=self.domain)
+        assert message.messaging_subevent_id == subevent.pk
+
     def test_failed_send_errors_the_subevent(self):
         subevent = self.send_message(status_code=400, text='{"error": "invalid channel"}')
 

--- a/corehq/messaging/smsbackends/connectid/backend.py
+++ b/corehq/messaging/smsbackends/connectid/backend.py
@@ -29,16 +29,19 @@ class ConnectBackend:
             "nonce": base64.b64encode(cipher.nonce).decode("utf-8"),
             "ciphertext": base64.b64encode(data).decode("utf-8"),
         }
-        response = requests.post(
-            settings.CONNECTID_MESSAGE_URL,
-            json={
-                "channel": user_link.messaging_channel,
-                "content": content,
-                "message_id": str(message.message_id),
-                "fcm_options": {"analytics_label": FCM_ANALYTICS_LABEL}
-            },
-            auth=(settings.CONNECTID_CLIENT_ID, settings.CONNECTID_SECRET_KEY)
-        )
+        try:
+            response = requests.post(
+                settings.CONNECTID_MESSAGE_URL,
+                json={
+                    "channel": user_link.messaging_channel,
+                    "content": content,
+                    "message_id": str(message.message_id),
+                    "fcm_options": {"analytics_label": FCM_ANALYTICS_LABEL}
+                },
+                auth=(settings.CONNECTID_CLIENT_ID, settings.CONNECTID_SECRET_KEY)
+            )
+        except requests.RequestException as err:
+            raise BackendProcessingException(f"Request failed: {err}") from err
         if response.status_code != requests.codes.OK:
             raise BackendProcessingException(
                 f"HTTP {response.status_code}: {response.text}"

--- a/corehq/messaging/smsbackends/connectid/backend.py
+++ b/corehq/messaging/smsbackends/connectid/backend.py
@@ -5,6 +5,7 @@ from Crypto.Cipher import AES
 from django.conf import settings
 
 from corehq.apps.domain.models import Domain
+from corehq.apps.sms.mixin import BackendProcessingException
 from corehq.apps.users.models import ConnectIDUserLink, CouchUser
 
 FCM_ANALYTICS_LABEL = "commcare-hq-message-notification"
@@ -38,7 +39,10 @@ class ConnectBackend:
             },
             auth=(settings.CONNECTID_CLIENT_ID, settings.CONNECTID_SECRET_KEY)
         )
-        return response.status_code == requests.codes.OK
+        if response.status_code != requests.codes.OK:
+            raise BackendProcessingException(
+                f"HTTP {response.status_code}: {response.text}"
+            )
 
     def create_channel(self, user_link):
         domain_obj = Domain.get_by_name(user_link.domain)


### PR DESCRIPTION
## Product Description

No user facing change.

Bug fixes to the Connect Message path: a send rejected by the Connect API is now recorded as an error on the messaging event instead of being reported as completed, and the Message Event Detail page renders Connect Message rows instead of erroring.

## Technical Summary

https://dimagi.atlassian.net/browse/CI-910 - Observed while working on this ticket

Six issues in the Connect Message path:

1. `MessageEventDetailReport.rows` dereferenced `msg` after `ConnectMessage.DoesNotExist`, and never initialised `recipient`.
   *Fix:* initialise the placeholders before the lookup, as the `CONTENT_EMAIL` branch does.
2. `ConnectBackend.send` returned a bool that `send_connect_message` discarded, so a rejected send reported success — the subevent stayed `IN_PROGRESS` and the parent event was marked `COMPLETED`.
   *Fix:* the backend raises `BackendProcessingException` with the status code and body, `send_connect_message` errors the subevent, and `ConnectMessageContent.send` completes it.
3. `ConnectMessage.messaging_subevent` was never set, so the detail report's lookup always missed — why 1 (above point 1) was reachable at all.
   *Fix:* pass `get_sms_message_metadata(logged_subevent)`, as `SMSContent` does.
4. `log_sms_exception` reads `msg.couch_id`, which `ConnectMessage` doesn't have, so real exceptions raised `AttributeError` instead of logging.
   *Fix:* fall back to `message_id`.
5. Every send failure was labelled `ERROR_CONNECT_GATEWAY`, including a missing `ConnectIDUserLink` or absent couch user.
   *Fix:* `get_connect_error_code` maps by exception type; the backend wraps `RequestException` so network failures still count as gateway errors.
6. `ConnectMessageContent` hardcoded `case_id=None`, losing the case association on its subevent.
   *Fix:* take it from `self.case`.

`ConnectMessageSurveyContent` needs no change — it sends via `send_first_message`, which already passes both `metadata` and `logged_subevent`.


## Feature Flag

`COMMCARE_CONNECT`

## Safety Assurance

### Safety story

Low risk, scoped to the `CONTENT_CONNECT` path. No migrations.

`ConnectBackend.send` now raises where it returned `False`; its only caller already caught `Exception`, so nothing new escapes. `ERROR_CONNECT_GATEWAY` is a new value in a `CharField` with no choices constraint, so existing rows are unaffected.

Verified on a local dev domain against all four row shapes — delivered with and without a linked message, gateway 400 with and without one.

### Automated test coverage

- `corehq/apps/reports/tests/test_message_event_detail_report.py` — detail rows with and without a linked `ConnectMessage`; the second reproduces the `UnboundLocalError`.
- `corehq/messaging/scheduling/tests/test_content.py::TestConnectMessageContentSend` — subevent completed on a 200, errored with the response body on a 400 and propagated to the parent event, message linked to the subevent, case recorded.
- `corehq/apps/sms/tests/test_api.py` — `get_connect_error_code` over all three exception classes.

Each test was confirmed to fail on the unfixed code.

### QA Plan
None

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
