### PR TITLE
ProjectDB: Sync and populate automatically

### DIFF
--- a/corehq/apps/case_search/tests/test_case_search_endpoint.py
+++ b/corehq/apps/case_search/tests/test_case_search_endpoint.py
@@ -31,7 +31,7 @@ from corehq.apps.es.tests.utils import (
     case_search_es_setup,
     es_test,
 )
-from corehq.apps.project_db.populate import send_to_project_db
+from corehq.apps.project_db.populate import populate_case_type
 from corehq.apps.project_db.tests.util import project_db_table
 from corehq.form_processor.models import CommCareCase
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
@@ -230,7 +230,7 @@ def _make_sql_endpoint(sql):
 
 
 def _populate_pets():
-    send_to_project_db(SQL_DOMAIN, 'pet', [
+    populate_case_type(SQL_DOMAIN, 'pet', [
         CommCareCase(
             case_id=case_id,
             domain=SQL_DOMAIN,

--- a/corehq/apps/project_db/README.rst
+++ b/corehq/apps/project_db/README.rst
@@ -30,10 +30,11 @@ for the ``project_db`` engine (the default database unless
 Evolution
 ---------
 
-Provisioning is **append-only** and idempotent: a domain's schema and tables are
+Tables are created and synced automatically as the data dictionary is modified.
+Provisioning is append-only and idempotent: a domain's schema and tables are
 created if absent, and new columns and indexes are added, but existing ones are
-never dropped or rewritten. A new case property becomes a new column; a new case
-type becomes a new table.
+never dropped or rewritten. A new case property becomes a new column; a new
+case type becomes a new table.
 
 Status
 ------
@@ -59,5 +60,4 @@ TODOs
 - Index external ID.
 - Put limit on number of property columns
 - Add a SQL user per domain with only access to that domain's schema
-- Set up automatic update call on data dictionary change, and auto population
-  on case update
+- Set up auto population on case update

--- a/corehq/apps/project_db/README.rst
+++ b/corehq/apps/project_db/README.rst
@@ -39,8 +39,11 @@ case type becomes a new table.
 Status
 ------
 
-This module currently defines and provisions the table structure only.
-Populating the tables with case data and querying them are not yet implemented.
+Turning on the ``PROJECT_DB`` feature flag sets up the tables for the domain,
+and thereafter they stay in sync automatically when the data dictionary is
+modified.  New cases are sychronously sent to the ProjectDB during form
+submission.  Pre-existing cases must be manually back-populated using
+``manage_project_db --populate``
 
 TODOs
 ----
@@ -60,4 +63,3 @@ TODOs
 - Index external ID.
 - Put limit on number of property columns
 - Add a SQL user per domain with only access to that domain's schema
-- Set up auto population on case update

--- a/corehq/apps/project_db/apps.py
+++ b/corehq/apps/project_db/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class ProjectDBAppConfig(AppConfig):
+    name = 'corehq.apps.project_db'
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/corehq/apps/project_db/management/commands/manage_project_db.py
+++ b/corehq/apps/project_db/management/commands/manage_project_db.py
@@ -6,7 +6,7 @@ import sqlalchemy
 
 from corehq.apps.data_dictionary.models import CaseType
 from corehq.apps.project_db.describe import describe_project_db
-from corehq.apps.project_db.populate import send_to_project_db
+from corehq.apps.project_db.populate import populate_case_type
 from corehq.apps.project_db.table_ddl import (
     DomainSchema,
     create_or_update_project_db,
@@ -109,4 +109,4 @@ def _populate_case_type(domain, case_type, start_date, prefix):
     total = sum(accessor.query(db).count() for db in accessor.sql_db_aliases)
     cases = with_progress_bar(iter_all_rows(accessor), length=total,
                               oneline='concise', prefix=f"{prefix}: {case_type}")
-    send_to_project_db(domain, case_type, cases)
+    populate_case_type(domain, case_type, cases)

--- a/corehq/apps/project_db/populate.py
+++ b/corehq/apps/project_db/populate.py
@@ -1,5 +1,6 @@
 import datetime
 import math
+from collections import defaultdict
 from decimal import Decimal, InvalidOperation
 
 from jsonobject.exceptions import BadValueError
@@ -12,6 +13,15 @@ from dimagi.utils.chunked import chunked
 from corehq.apps.data_dictionary.models import CaseProperty
 
 from .table_ddl import CaseTable, get_project_db_engine, property_column
+
+
+def send_cases_to_project_db(domain, cases):
+    """Bulk upsert CommCareCases"""
+    cases_by_type = defaultdict(list)
+    for case in cases:
+        cases_by_type[case.type].append(case)
+    for case_type, case_type_cases in cases_by_type.items():
+        populate_case_type(domain, case_type, case_type_cases)
 
 
 def populate_case_type(domain, case_type, cases):

--- a/corehq/apps/project_db/populate.py
+++ b/corehq/apps/project_db/populate.py
@@ -2,21 +2,20 @@ import datetime
 import math
 from decimal import Decimal, InvalidOperation
 
+from jsonobject.exceptions import BadValueError
 from sqlalchemy import ARRAY, Text
 from sqlalchemy.dialects.postgresql import insert
 
-from jsonobject.exceptions import BadValueError
-
+from couchforms.geopoint import GeoPoint
 from dimagi.utils.chunked import chunked
 
 from corehq.apps.data_dictionary.models import CaseProperty
-from couchforms.geopoint import GeoPoint
 
 from .table_ddl import CaseTable, get_project_db_engine, property_column
 
 
-def send_to_project_db(domain, case_type, cases):
-    """Bulk upsert CommCareCases of a single case type"""
+def populate_case_type(domain, case_type, cases):
+    """Chunked upsert CommCareCases of a single case type"""
     engine = get_project_db_engine()
     table = CaseTable(domain, case_type).reflect()
     if table is not None:

--- a/corehq/apps/project_db/signals.py
+++ b/corehq/apps/project_db/signals.py
@@ -1,0 +1,23 @@
+from django.db import transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from corehq import toggles
+from corehq.apps.data_dictionary.models import CaseProperty, CaseType
+
+from .tasks import schedule_project_db_sync
+
+
+@receiver(post_save, sender=CaseType)
+def case_type_saved(sender, instance, **kwargs):
+    _sync_domain(instance.domain)
+
+
+@receiver(post_save, sender=CaseProperty)
+def case_property_saved(sender, instance, **kwargs):
+    _sync_domain(instance.case_type.domain)
+
+
+def _sync_domain(domain):
+    if toggles.PROJECT_DB.enabled(domain):
+        transaction.on_commit(lambda: schedule_project_db_sync(domain))

--- a/corehq/apps/project_db/tasks.py
+++ b/corehq/apps/project_db/tasks.py
@@ -1,0 +1,17 @@
+from corehq.apps.celery import serial_task
+from corehq.util.quickcache import quickcache
+
+from .table_ddl import create_or_update_project_db
+
+
+@quickcache(['domain'], timeout=60 * 60, memoize_timeout=20)
+def schedule_project_db_sync(domain):
+    """Queue a schema sync unless one is already queued for the domain"""
+    # Schedule the task with a 30 second debounce delay
+    update_project_db_schema.apply_async([domain], countdown=30)
+
+
+@serial_task('{domain}', timeout=30 * 60)
+def update_project_db_schema(domain):
+    schedule_project_db_sync.clear(domain)
+    create_or_update_project_db(domain)

--- a/corehq/apps/project_db/tests/test_populate.py
+++ b/corehq/apps/project_db/tests/test_populate.py
@@ -14,6 +14,7 @@ from corehq.apps.project_db.populate import (
     coerce_to_number,
     coerce_to_select,
     populate_case_type,
+    send_cases_to_project_db,
     upsert_cases,
 )
 from corehq.apps.project_db.table_ddl import (
@@ -293,3 +294,22 @@ def test_send_to_project_db_bad_type():
             _make_case({'first_name': 'Bob'}, type='patient'),
             _make_case({}, type='clinic'),
         ])
+
+
+@use('db')
+def test_send_cases_to_project_db():
+    domain = 'test-mixed'
+    with project_db_table(domain, 'patient', {'first_name': 'plain'}), \
+         project_db_table(domain, 'clinic', {'city': 'plain'}):
+        send_cases_to_project_db(domain, [
+            _make_case({'first_name': 'Alice'}, case_id='c1', type='patient'),
+            _make_case({'city': 'Boston'}, case_id='c2', type='clinic'),
+            _make_case({'first_name': 'Bob'}, case_id='c3', type='patient'),
+            _make_case({}, case_id='c4', type='no-such-table'),  # skipped
+        ])
+        with get_project_db_engine().begin() as conn:
+            patients = conn.execute(CaseTable(domain, 'patient').reflect().select()).fetchall()
+            clinics = conn.execute(CaseTable(domain, 'clinic').reflect().select()).fetchall()
+
+    assert sorted(r['case_id'] for r in patients) == ['c1', 'c3']
+    assert [r['case_id'] for r in clinics] == ['c2']

--- a/corehq/apps/project_db/tests/test_populate.py
+++ b/corehq/apps/project_db/tests/test_populate.py
@@ -13,7 +13,7 @@ from corehq.apps.project_db.populate import (
     coerce_to_gps,
     coerce_to_number,
     coerce_to_select,
-    send_to_project_db,
+    populate_case_type,
     upsert_cases,
 )
 from corehq.apps.project_db.table_ddl import (
@@ -213,8 +213,8 @@ def test_upsert():
 
 
 @use('db', project_db_table('test-send', 'patient', {'first_name': 'plain'}))
-def test_send_to_project_db():
-    send_to_project_db('test-send', 'patient', [
+def test_populate_case_type():
+    populate_case_type('test-send', 'patient', [
         _make_case({'first_name': 'Alice'}, type='patient'),
         _make_case({'first_name': 'Bob'}, type='patient'),
         _make_case({}, type='patient'),
@@ -229,7 +229,7 @@ def test_send_to_project_db():
 
 @use('db', project_db_table('test-select', 'patient', {'interests': 'select'}))
 def test_send_select_property_round_trip():
-    send_to_project_db('test-select', 'patient', [
+    populate_case_type('test-select', 'patient', [
         _make_case({'interests': 'sports music'}, case_id='c1', type='patient'),
         _make_case({}, case_id='c2', type='patient'),  # absent -> empty array, not NULL
     ])
@@ -249,7 +249,7 @@ def test_send_gps_property_round_trip():
     # Python cube formula stays in sync with the earthdistance extension.
     domain = 'test-gps'
     with project_db_table(domain, 'patient', {'location': 'gps'}):
-        send_to_project_db(domain, 'patient', [
+        populate_case_type(domain, 'patient', [
             _make_case({'location': '40.7128 -74.006 10 5'}, case_id='c1', type='patient'),
             _make_case({'location': 'garbage'}, case_id='c2', type='patient'),
             _make_case({}, case_id='c3', type='patient'),  # absent -> NULL
@@ -272,7 +272,7 @@ def test_send_long_property_name_round_trip():
     # A property whose column name exceeds Postgres's 63-byte limit must survive
     # create -> reflect -> upsert with the DDL and populate sides agreeing.
     long_name = 'x' * 100
-    send_to_project_db('test-long-prop', 'patient', [
+    populate_case_type('test-long-prop', 'patient', [
         _make_case({long_name: '1990-05-20'}, type='patient'),
     ])
 
@@ -288,7 +288,7 @@ def test_send_long_property_name_round_trip():
 @use('db', project_db_table('test-send', 'patient', {'first_name': 'plain'}))
 def test_send_to_project_db_bad_type():
     with pytest.raises(ValueError):
-        send_to_project_db('test-send', 'patient', [
+        populate_case_type('test-send', 'patient', [
             _make_case({'first_name': 'Alice'}, type='patient'),
             _make_case({'first_name': 'Bob'}, type='patient'),
             _make_case({}, type='clinic'),

--- a/corehq/apps/project_db/tests/test_populate.py
+++ b/corehq/apps/project_db/tests/test_populate.py
@@ -287,7 +287,7 @@ def test_send_long_property_name_round_trip():
 
 
 @use('db', project_db_table('test-send', 'patient', {'first_name': 'plain'}))
-def test_send_to_project_db_bad_type():
+def test_populate_case_type_bad_type():
     with pytest.raises(ValueError):
         populate_case_type('test-send', 'patient', [
             _make_case({'first_name': 'Alice'}, type='patient'),

--- a/corehq/apps/project_db/tests/test_signals.py
+++ b/corehq/apps/project_db/tests/test_signals.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+
+from unmagic import fixture
+
+from corehq.apps.project_db.tasks import (
+    schedule_project_db_sync,
+    update_project_db_schema,
+)
+
+DOMAIN = 'project-db-signals-test'
+
+
+@fixture(autouse=__file__)
+def clear_sync_flag():
+    schedule_project_db_sync.clear(DOMAIN)
+    yield
+    schedule_project_db_sync.clear(DOMAIN)
+
+
+def test_schedule_one_at_a_time():
+    with patch.object(update_project_db_schema, 'apply_async') as apply_mock:
+        schedule_project_db_sync(DOMAIN)
+        assert apply_mock.call_count == 1
+
+        # Second call noops
+        schedule_project_db_sync(DOMAIN)
+        assert apply_mock.call_count == 1
+
+        with patch('corehq.apps.project_db.tasks.create_or_update_project_db'):
+            # This should clear the cache and allow another `apply` to go through
+            update_project_db_schema(DOMAIN)
+
+        schedule_project_db_sync(DOMAIN)
+        assert apply_mock.call_count == 2

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -21,12 +21,19 @@ from casexml.apps.case.exceptions import PhoneDateValueError, IllegalCaseId, Use
 from corehq.apps.receiverwrapper.rate_limiter import report_case_usage, report_submission_usage
 from corehq.const import OPENROSA_VERSION_3
 from corehq.middleware import OPENROSA_VERSION_HEADER
-from corehq.toggles import ASYNC_RESTORE, BLOCK_SUMOLOGIC_LOGS, NAMESPACE_OTHER, SUMOLOGIC_LOGS
+from corehq.toggles import (
+    ASYNC_RESTORE,
+    BLOCK_SUMOLOGIC_LOGS,
+    NAMESPACE_OTHER,
+    PROJECT_DB,
+    SUMOLOGIC_LOGS,
+)
 from corehq.apps.app_manager.dbaccessors import get_current_app
 from corehq.apps.cloudcare.const import DEVICE_ID as FORMPLAYER_DEVICE_ID
 from corehq.apps.commtrack.exceptions import MissingProductId
 from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
 from corehq.apps.es.client import BulkActionItem
+from corehq.apps.project_db.populate import send_cases_to_project_db
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.permissions import SUBMISSION_HISTORY_PERMISSION, has_permission_to_view_report
 from corehq.form_processor.exceptions import PostSaveError, XFormSaveError
@@ -475,6 +482,9 @@ class SubmissionPost(object):
             with timing_context("index_case_search"):
                 SubmissionPost.index_case_search(instance, case_stock_result.case_models)
 
+            with timing_context("update_project_db"):
+                SubmissionPost.update_project_db(instance, case_stock_result.case_models)
+
             with timing_context("_fire_post_save_signals"):
                 SubmissionPost._fire_post_save_signals(instance, case_stock_result.case_models, timing_context)
 
@@ -520,6 +530,18 @@ class SubmissionPost(object):
                 'domain': instance.domain,
                 'errors': errors,
             })
+
+    @staticmethod
+    def update_project_db(instance, case_models):
+        if PROJECT_DB.enabled(instance.domain):
+            try:
+                send_cases_to_project_db(instance.domain, case_models)
+            except Exception as e:
+                notify_exception(None, "Error updating ProjectDB during form processing", details={
+                    'domain': instance.domain,
+                    'form_id': instance.form_id,
+                    'error': str(e),
+                })
 
     @staticmethod
     @tracer.wrap(name='submission.process_cases_and_stock')

--- a/corehq/form_processor/tests/test_basics.py
+++ b/corehq/form_processor/tests/test_basics.py
@@ -499,6 +499,12 @@ class FundamentalCaseTests(FundamentalBaseTests):
         with patch.object(get_blob_db(), 'get', side_effect=Exception('unexpected blobdb read')):
             _submit_case_block(True, uuid.uuid4().hex, user_id='user2', update={})
 
+    @flag_enabled('PROJECT_DB')
+    def test_cases_are_sent_to_project_db(self):
+        with patch('corehq.form_processor.submission_post.send_cases_to_project_db') as send:
+            _submit_case_block(True, uuid.uuid4().hex, user_id='user1', update={})
+        send.assert_called()
+
 
 @flag_enabled('SYNC_SEARCH_CASE_CLAIM')
 @patch('corehq.motech.repeaters.models.domain_has_privilege', lambda x, y: True)

--- a/corehq/toggles/__init__.py
+++ b/corehq/toggles/__init__.py
@@ -1025,12 +1025,20 @@ CASE_SEARCH_ENDPOINTS = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
+
+def _sync_project_db_schema(domain, is_enabled):
+    from corehq.apps.project_db.tasks import schedule_project_db_sync
+    if is_enabled:
+        schedule_project_db_sync(domain)
+
+
 PROJECT_DB = StaticToggle(
     'project_db',
     'ProjectDB: Auto-managed SQL database of project case data',
     TAG_INTERNAL,
     [NAMESPACE_DOMAIN],
     description="Note that this is in testing and will not work without a dev helping.",
+    save_fn=_sync_project_db_schema,
 )
 
 GEOCODER_MY_LOCATION_BUTTON = StaticToggle(


### PR DESCRIPTION
## Product Description
Make ProjectDB evolve automatically with the data dictionary.  Populate new cases into the DB automatically as well.

## Technical Summary
Go commit-by-commit for details, it should be pretty self-explanatory.

## Feature Flag
ProjectDB

## Safety Assurance
Not yet in use in production.  Hooks to live code are gated on the feature flag.

Note that any attempt to access this stuff on an environment where it's not yet set up (including production) will result in an error (`get_project_db_engine` will raise `ImproperlyConfigured`)

### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
