### PR TITLE
Wrap Longitude in Web Apps GPS Entry Questions

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -975,7 +975,7 @@ FileEntry.prototype.onAnswerChange = function (newValue) {
     if (newValue !== constants.NO_ANSWER && newValue !== "") {
         var $input = $('#' + self.entryId);
         self.file($input[0].files[0]);
-        let badExtension = false;
+        let badExtension;
         let badMime = true;
         const ext = newValue.slice(newValue.lastIndexOf(".") + 1);
         let acceptedExts = self.extensionsMap[self.accept];
@@ -1259,11 +1259,11 @@ function getEntry(question) {
     var hasGeocoderPrivs = initialPageData.get("has_geocoder_privs");
     var entry = null;
     var options = {};
-    var isMinimal = false;
-    var isCombobox = false;
-    var isButton = false;
-    var isChoiceLabel = false;
-    var hideLabel = false;
+    var isMinimal;
+    var isCombobox;
+    var isButton;
+    var isChoiceLabel;
+    var hideLabel;
 
     var displayOptions = _getDisplayOptions(question);
     var isPhoneMode = ko.utils.unwrapObservable(displayOptions.phoneMode);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entries.js
@@ -1215,8 +1215,9 @@ function GeoPointEntry(question, options) {
 
     self.updateCenter = function () {
         var center = self.map.getCenter();
+        var wrapped = center.wrap();
         self.centerMarker.setLatLng(center);
-        self.rawAnswer([center.lat, center.lng]);
+        self.rawAnswer([wrapped.lat, wrapped.lng]);
     };
 
     self.formatLat = function () {


### PR DESCRIPTION
## Product Description
Prevents GPS questions from displaying or saving longitudes over 180.

Before:

https://github.com/user-attachments/assets/24b9197c-3a8b-4149-9e71-b4aaa0906079

After:

https://github.com/user-attachments/assets/d72760b9-2095-4e49-b680-baed259e3a65


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-20025
Adds a call to `wrap()`, which sets longitude to its correct <180 value, before setting the shown map position as `rawAnswer`. We can call this directly on `center` because it is a `LatLng` instance. https://leafletjs.com/reference.html#latlng-wrap

## Safety Assurance

### Safety story
This is a small change to the values displayed and saved by an input, using a documented method for a Leaflet `LatLng` instance. Tested locally to see that the value displays correctly, and saves as expected (i.e. not using potentially >180 values in the background).

### Automated test coverage
There is automated javascript testing to ensure the geopoint entry renders in general; anything terribly broken would show up there.

### QA Plan
Not for this change.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
