### PR TITLE
Require view_apps/edit_apps on App Manager views

### DIFF
--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -22,7 +22,6 @@ from corehq.apps.app_manager.exceptions import (
     CaseError,
 )
 from corehq.apps.app_manager.util import get_latest_app_release_by_location
-from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import CommCareUser, HqPermissions
@@ -231,4 +230,3 @@ require_can_edit_apps = require_permission(HqPermissions.edit_apps)
 require_can_edit_or_view_apps = require_permission(
     'edit_apps', view_only_permission='view_apps'
 )
-require_deploy_apps = login_and_domain_required  # todo: can fix this when it is better supported

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -40,7 +40,7 @@ from corehq.apps.app_manager.dbaccessors import (
 from corehq.apps.app_manager.decorators import (
     no_conflict_require_POST,
     require_can_edit_apps,
-    require_deploy_apps,
+    require_can_edit_or_view_apps,
 )
 from corehq.apps.app_manager.exceptions import (
     AppLinkError,
@@ -619,14 +619,14 @@ def _valid_exchange_record_exists_helper(app_id, records):
 
 
 @require_GET
-@require_deploy_apps
+@require_can_edit_or_view_apps
 def app_settings(request, domain, app_id):
     from corehq.apps.app_manager.views.view_generic import view_generic
     return view_generic(request, domain, app_id)
 
 
 @require_GET
-@require_deploy_apps
+@require_can_edit_or_view_apps
 def view_app(request, domain, app_id):
     from corehq.apps.app_manager.views.view_generic import view_generic
     return view_generic(request, domain, app_id, release_manager=True)

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -47,7 +47,7 @@ from corehq.apps.app_manager.dbaccessors import get_app, get_apps_in_domain
 from corehq.apps.app_manager.decorators import (
     no_conflict_require_POST,
     require_can_edit_apps,
-    require_deploy_apps,
+    require_can_edit_or_view_apps,
 )
 from corehq.apps.app_manager.exceptions import (
     AppEditingError,
@@ -1273,7 +1273,7 @@ def _get_form_datums(domain, app_id, form_id):
 
 
 @require_GET
-@require_deploy_apps
+@require_can_edit_or_view_apps
 def view_form_legacy(request, domain, app_id, module_id, form_id):
     """
     This view has been kept around to not break any documentation on example apps
@@ -1285,7 +1285,7 @@ def view_form_legacy(request, domain, app_id, module_id, form_id):
 
 
 @require_GET
-@require_deploy_apps
+@require_can_edit_or_view_apps
 def view_form(request, domain, app_id, form_unique_id):
     from corehq.apps.app_manager.views.view_generic import view_generic
     return view_generic(

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -43,7 +43,7 @@ from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.decorators import (
     no_conflict_require_POST,
     require_can_edit_apps,
-    require_deploy_apps,
+    require_can_edit_or_view_apps,
 )
 from corehq.apps.app_manager.exceptions import (
     AppMisconfigurationError,
@@ -1694,14 +1694,14 @@ def _init_biometrics_identify_module(app, lang, enroll_form_id):
 
 
 @require_GET
-@require_deploy_apps
+@require_can_edit_or_view_apps
 def view_module(request, domain, app_id, module_unique_id):
     from corehq.apps.app_manager.views.view_generic import view_generic
     return view_generic(request, domain, app_id, module_unique_id=module_unique_id)
 
 
 @require_GET
-@require_deploy_apps
+@require_can_edit_or_view_apps
 def view_module_legacy(request, domain, app_id, module_id):
     """
     This view has been kept around to not break any documentation on example apps

--- a/corehq/apps/app_manager/views/multimedia.py
+++ b/corehq/apps/app_manager/views/multimedia.py
@@ -4,7 +4,7 @@ from django.template.defaultfilters import filesizeformat
 from django.utils.translation import gettext as _
 
 from corehq.apps.app_manager.dbaccessors import get_app, get_apps_in_domain, get_app_cached
-from corehq.apps.app_manager.decorators import require_deploy_apps
+from corehq.apps.app_manager.decorators import require_can_edit_or_view_apps
 from corehq.apps.app_manager.util import is_linked_app, is_remote_app
 from corehq.apps.app_manager.views.utils import (
     get_multimedia_sizes_for_build,
@@ -16,7 +16,7 @@ from corehq import toggles
 from corehq.util.quickcache import quickcache
 
 
-@require_deploy_apps
+@require_can_edit_or_view_apps
 @use_bootstrap5
 def multimedia_ajax(request, domain, app_id):
     app = get_app(domain, app_id)
@@ -63,7 +63,7 @@ def _update_mm_sizes(mm_sizes):
     return mm_sizes
 
 
-@require_deploy_apps
+@require_can_edit_or_view_apps
 @quickcache(['domain', 'app_id', 'build_profile_id'], timeout=60 * 60)
 def get_multimedia_sizes(request, domain, app_id, build_profile_id=None):
     """
@@ -80,7 +80,7 @@ def get_multimedia_sizes(request, domain, app_id, build_profile_id=None):
     return JsonResponse(mm_sizes)
 
 
-@require_deploy_apps
+@require_can_edit_or_view_apps
 @quickcache(['domain', 'app_id', 'other_build_id', 'build_profile_id'], timeout=60 * 60)
 def compare_multimedia_sizes(request, domain, app_id, other_build_id, build_profile_id=None):
     mm_sizes = get_new_multimedia_between_builds(domain, app_id, other_build_id, build_profile_id)

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -46,7 +46,7 @@ from corehq.apps.app_manager.decorators import (
     avoid_parallel_build_request,
     no_conflict_require_POST,
     require_can_edit_apps,
-    require_deploy_apps,
+    require_can_edit_or_view_apps,
 )
 from corehq.apps.app_manager.exceptions import (
     AppValidationError,
@@ -113,7 +113,7 @@ def _get_error_counts(domain, app_id, version_numbers):
 
 
 @cache_control(no_cache=True, no_store=True)
-@require_deploy_apps
+@require_can_edit_or_view_apps
 def paginate_releases(request, domain, app_id):
     limit = request.GET.get('limit')
     only_show_released = json.loads(request.GET.get('only_show_released', 'false'))
@@ -554,7 +554,7 @@ def short_odk_url(request, domain, app_id, with_media=False):
     return HttpResponse(short_url)
 
 
-@require_deploy_apps
+@require_can_edit_apps
 def update_build_comment(request, domain, app_id):
     build_id = request.POST.get('build_id')
     try:
@@ -712,7 +712,7 @@ class LanguageProfilesView(View):
         return HttpResponse()
 
 
-@require_deploy_apps
+@require_can_edit_or_view_apps
 def paginate_release_logs(request, domain, app_id):
     limit = request.GET.get('limit')
     page = int(request.GET.get('page', 1))

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -23,7 +23,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_current_app,
     wrap_app,
 )
-from corehq.apps.app_manager.decorators import require_deploy_apps
+from corehq.apps.app_manager.decorators import require_can_edit_or_view_apps
 from corehq.apps.app_manager.exceptions import (
     AppEditingError,
     AppLinkError,
@@ -61,7 +61,7 @@ CASE_TYPE_CONFLICT_MSG = (
 )
 
 
-@require_deploy_apps
+@require_can_edit_or_view_apps
 def back_to_main(request, domain, app_id, module_id=None, form_id=None,
                  form_unique_id=None, module_unique_id=None):
     """

--- a/custom/ucla/views.py
+++ b/custom/ucla/views.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from django.http import HttpResponse
 
 from corehq.apps.app_manager.dbaccessors import get_app
-from corehq.apps.app_manager.decorators import require_deploy_apps
+from corehq.apps.app_manager.decorators import require_can_edit_apps
 from corehq.apps.app_manager.models import (
     ConditionalCaseUpdate,
     FormActionCondition,
@@ -18,7 +18,7 @@ from corehq.apps.app_manager.app_schemas.app_case_metadata import (
 from custom.ucla.forms import TaskCreationForm
 
 
-@require_deploy_apps
+@require_can_edit_apps
 def task_creation(request, domain, app_id, module_id, form_id):
     '''
     This view is meant to be run as a one-off script to support a specific

--- a/custom/ucla/views.py
+++ b/custom/ucla/views.py
@@ -21,9 +21,9 @@ from custom.ucla.forms import TaskCreationForm
 @require_deploy_apps
 def task_creation(request, domain, app_id, module_id, form_id):
     '''
-    This view is meant to be a run as a one-off script to support a specific
+    This view is meant to be run as a one-off script to support a specific
     app that Jeremy is writing. Running this script subsequent times on the
-    same form will not have adverse affects.
+    same form will not have adverse effects.
     :param request:
     :param domain:
     :param app_id:
@@ -42,12 +42,16 @@ def task_creation(request, domain, app_id, module_id, form_id):
             message = _ucla_form_modifier(form, questions)
             return HttpResponse(message, content_type="text/plain")
 
-        return HttpResponse("Soemthing was wrong with the form you submitted. Your CommCare form is unchanged.", content_type="text/plain")
+        return HttpResponse(
+            "Something was wrong with the form you submitted. Your CommCare form is unchanged.",
+            content_type="text/plain",
+        )
 
     elif request.method == 'GET':
         html_form = TaskCreationForm()
         response = HttpResponse()
-        response.write('<form action="'+reverse('ucla_task_creation', args=(domain, app_id, module_id, form_id))+'" method="post">')
+        action = reverse('ucla_task_creation', args=(domain, app_id, module_id, form_id))
+        response.write('<form action="' + action + '" method="post">')
         response.write(html_form.as_p())
         response.write('<p><input type="submit" value="Process Form"></p>')
         response.write("</form>")


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/SAAS-19979 

A web user whose role has neither the **Edit Applications** nor **View Applications** permission can currently open any App Manager page (app, module, form, settings, releases) by navigating directly to its URL. 

After this change those pages return 403 for such users. Users with **View Applications** still get the read-only App Manager, and users with **Edit Applications** are unaffected.

One deliberate behaviour change: web users with **no** Application permission lose access to the releases page,  deploy links and QR codes.  I don't anticipate this too be an issue, if this becomes problem for any user then their role permissions were not properly configured and it should be given `view_application` permission.

## Technical Summary

`require_deploy_apps` in was a bare alias for `login_and_domain_required`. I had the option of updating it to `require_can_edit_or_view_apps` which would have fixed the issue but I felt that having a decorator which is basically alias for other decorator confusing and there are no specific permissions in HQ that would allow you to deploy an app.

This PR removes the alias and uses the existing permission decorators, chosen per route by whether it reads or writes:

- read-only routes get `require_can_edit_or_view_apps`, which also sets `request.is_view_only` for `view_apps`-only users
- `update_build_comment` and the UCLA `task_creation` script both write to the app, so they get `require_can_edit_apps`. I am not sure if this is actually used but did not want to strip out anything before confirming. 

## Feature Flag

None.

## Safety Assurance

### Safety story

The decorators used here are the same ones already guarding the App Summary views and every editing endpoint in App Manager, so the permission semantics are well exercised. Editing UI was already gated client side on `can_edit_apps`, so `view_apps`-only users see the same read-only pages as before.

Verified locally with a non-superuser web user in a role with 
(a) neither permission: 403 on all 12 read-only URLs and on `update_build_comment`; 
(b) `view_apps` only: 200 on the read-only URLs, 403 on `update_build_comment`; 
(c) `edit_apps`: `update_build_comment` succeeds.

Superusers bypass the check as before. No data is touched.

### Automated test coverage

No new tests. Existing `corehq/apps/app_manager/tests/test_views.py`, `tests/views/test_paginate_releases.py`, `tests/test_apps.py` and `custom/ucla` tests pass.

### QA Plan
N/A
### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
