### PR TITLE
Show all domains when copying an app

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -76,7 +76,11 @@ class CopyApplicationForm(forms.Form):
             ),
             crispy.Hidden('app', app.get_id),
             crispy.Div(
-                StrictButton(_('Copy'), type='button', css_class='btn-primary'),
+                StrictButton(
+                    _('Copy'),
+                    type='button',
+                    css_class='btn-primary disable-on-submit',
+                ),
                 css_class="card-footer py-3",
             ),
         )

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -51,8 +51,6 @@ from corehq.apps.hqmedia.views import (
 from corehq.apps.hqwebapp.utils.bootstrap import set_bootstrap_version5
 from corehq.apps.linked_domain.dbaccessors import (
     get_accessible_downstream_domains,
-    get_upstream_domain_link,
-    is_active_downstream_domain,
 )
 from corehq.apps.linked_domain.util import can_domain_access_linked_domains
 from corehq.util.soft_assert import soft_assert
@@ -437,15 +435,7 @@ def _get_specific_media(
 
 
 def _get_domain_context(domain, request_domain, couch_user):
-    domain_names = {
-        d.name
-        for d in Domain.active_for_user(couch_user)
-        if not (
-            is_active_downstream_domain(request_domain)
-            and get_upstream_domain_link(request_domain).master_domain
-            == d.name
-        )
-    }
+    domain_names = {d.name for d in Domain.active_for_user(couch_user)}
     domain_names.add(request_domain)
     # NOTE: The CopyApplicationForm checks for access to linked domains
     #       before displaying


### PR DESCRIPTION
## Product Description

Currently users are not allowed to copy an app from a downstream project space to its upstream project space. This change resolves that limitation.

## Technical Summary

Also added "disable-on-submit" to the "Copy" button to prevent multiple copies on multiple clicks.

Jira: [SAAS-20185](https://dimagi.atlassian.net/browse/SAAS-20185) (This is a DEET Week ticket.)

This PR reverses PR https://github.com/dimagi/commcare-hq/pull/22105 made in 2018. That PR claims to disable "linking" apps, but it disables _copying_ apps. (The limitation was not enforced on submit, so superusers could always copy apps upstream, and linking another domain downstream of the downstream allows copying to the upstream upstream.)

## Safety Assurance

### Safety story

* Small change
* Tested locally and on Staging.

### Automated test coverage

No

### QA Plan

No QA planned

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-20185]: https://dimagi.atlassian.net/browse/SAAS-20185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ