### PR TITLE
Reset Report an issue form after submission

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/email-request.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap3/email-request.js
@@ -85,6 +85,12 @@ var EmailRequest = function (modalId, formId) {
     };
 
     self.resetForm = function () {
+        self.$formElement.get(0).reset();
+        self.subjectText('');
+        self.descriptionText('');
+        self.emailInput('');
+        self.recipientEmailsText('');
+        self.isReportSent = false;
         self.$formElement.find("button[type='submit']").button('reset');
         self.cancelBtnEnabled(true);
         self.$submitBtn.button('reset');

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/email-request.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/bootstrap5/email-request.js
@@ -86,6 +86,12 @@ var EmailRequest = function (modalId, formId) {
     };
 
     self.resetForm = function () {
+        self.$formElement.get(0).reset();
+        self.subjectText('');
+        self.descriptionText('');
+        self.emailInput('');
+        self.recipientEmailsText('');
+        self.isReportSent = false;
         self.$formElement.find("button[type='submit']").changeButtonState('reset');
         self.cancelBtnEnabled(true);
         self.$submitBtn.changeButtonState('reset');

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/email-request.js.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/javascript/hqwebapp/js/email-request.js.diff.txt
@@ -28,10 +28,10 @@
              self.cancelBtnEnabled(false);
              self.reportUrl(location.href);
              self.isRequestReportSubmitting = true;
-@@ -85,9 +86,9 @@
-     };
- 
-     self.resetForm = function () {
+@@ -91,9 +92,9 @@
+         self.emailInput('');
+         self.recipientEmailsText('');
+         self.isReportSent = false;
 -        self.$formElement.find("button[type='submit']").button('reset');
 +        self.$formElement.find("button[type='submit']").changeButtonState('reset');
          self.cancelBtnEnabled(true);
@@ -40,7 +40,7 @@
          resetErrors();
      };
  
-@@ -110,12 +111,12 @@
+@@ -116,12 +117,12 @@
      function hqwebappRequestReportSucccess() {
          self.isRequestReportSubmitting = false;
          self.isReportSent = true;


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The Report an Issue modal retained values from the previous report after it was closed and reopened.

<img width="803" height="590" alt="Screenshot 2026-09-02 at 9 46 25 PM" src="https://github.com/user-attachments/assets/1e384872-d54d-4283-b455-6afd07610a48" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket https://dimagi.atlassian.net/browse/SAAS-19759

The existing `resetForm` handler reset validation and button state, but did not reset either the HTML form controls or their Knockout observables. This change resets both:
  - Native `form.reset()` clears controls not managed by Knockout, particularly the file input
  - Clearing the observables resets the subject, description, email, and recipient fields.

I'm aware that this is clumsy. A better solution is migrating this to Django form, which requires more effort. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. The change is straightforward.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
