### PR TITLE
Discard stale export_instances_by_domain view rows

### DIFF
--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -1,8 +1,14 @@
+import logging
 from itertools import chain
+
+from couchdbkit import ResourceNotFound
 from dimagi.utils.couch.database import safe_delete
+from dimagi.utils.logging import notify_exception
 from dimagi.utils.parsing import json_format_datetime
 
 from corehq.util.test_utils import unit_testing_only
+
+logger = logging.getLogger(__name__)
 
 
 def get_latest_case_export_schema(domain, case_type):
@@ -135,8 +141,34 @@ def _get_export_instance(cls, key, include_docs=True):
         reduce=False,
     ).all()
     if include_docs:
-        return [cls.wrap(result['doc']) for result in results]
+        return list(_iter_export_instances_by_domain_docs(cls, results))
     return [result['value'] for result in results]
+
+
+def _iter_export_instances_by_domain_docs(cls, results):
+    """Wrap a row docs, discarding stale docs that no longer exist
+
+    The view has been observed to return a row for a doc that was
+    deleted from every CouchDB node, causing ``cls.wrap(None)`` to
+    raise. Verify the doc is actually gone before discarding the row,
+    so a row that's missing its doc for some other reason is not
+    silently dropped.
+    """
+    for result in results:
+        doc = result['doc']
+        if doc is None:
+            doc_id = result['id']
+            try:
+                doc = cls.get_db().get(doc_id)
+            except ResourceNotFound:
+                logger.warning("Discarding stale export_instances_by_domain view row for deleted doc %s", doc_id)
+                continue
+            notify_exception(
+                None,
+                "export_instances_by_domain view returned doc=None for a document that still exists",
+                details={'doc_id': doc_id},
+            )
+        yield cls.wrap(doc)
 
 
 def get_daily_saved_export_ids_for_auto_rebuild(accessed_after):
@@ -172,9 +204,7 @@ def get_properly_wrapped_export_instance(doc_id):
 
 
 def _properly_wrap_export_instance(doc):
-    from .models import FormExportInstance
-    from .models import CaseExportInstance
-    from .models import ExportInstance
+    from .models import CaseExportInstance, ExportInstance, FormExportInstance
     class_ = {
         "FormExportInstance": FormExportInstance,
         "CaseExportInstance": CaseExportInstance,

--- a/corehq/apps/export/tests/test_dbaccessors.py
+++ b/corehq/apps/export/tests/test_dbaccessors.py
@@ -1,9 +1,13 @@
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytest
+from couchdbkit import ResourceNotFound
 from django.test import TestCase
 
 from corehq.apps.export.dbaccessors import (
+    ODataExportFetcher,
+    _iter_export_instances_by_domain_docs,
     get_brief_deid_exports,
     get_brief_exports,
     get_case_exports_by_domain,
@@ -16,7 +20,6 @@ from corehq.apps.export.dbaccessors import (
     get_latest_case_export_schema,
     get_latest_form_export_schema,
     get_properly_wrapped_export_instance,
-    ODataExportFetcher
 )
 from corehq.apps.export.models import (
     CaseExportDataSchema,
@@ -227,6 +230,41 @@ class TestExportInstanceDBAccessors(TestCase):
 
         stubs = get_brief_deid_exports(self.domain, form_or_case=None)
         self.assertEqual(len(stubs), 2)
+
+
+def test_iter_export_instances_by_domain_docs_yields_wrapped_doc():
+    doc = {'_id': 'abc123', 'doc_type': 'CaseExportInstance', 'domain': 'my-domain'}
+    results = [{'id': 'abc123', 'doc': doc}]
+
+    instance, = list(_iter_export_instances_by_domain_docs(CaseExportInstance, results))
+
+    assert isinstance(instance, CaseExportInstance)
+    assert instance._id == 'abc123'
+
+
+@patch.object(CaseExportInstance, 'get_db')
+def test_iter_export_instances_by_domain_docs_discards_stale_row_for_deleted_doc(get_db_mock):
+    get_db_mock.return_value.get.side_effect = ResourceNotFound
+    results = [{'id': 'deleted-id', 'doc': None}]
+
+    docs = list(_iter_export_instances_by_domain_docs(CaseExportInstance, results))
+
+    assert not docs
+    get_db_mock.return_value.get.assert_called_once_with('deleted-id')
+
+
+@patch('corehq.apps.export.dbaccessors.notify_exception')
+@patch.object(CaseExportInstance, 'get_db')
+def test_iter_export_instances_by_domain_docs_notifies_when_doc_unexpectedly_still_exists(
+    get_db_mock, notify_exception_mock
+):
+    get_db_mock.return_value.get.return_value = {'_id': 'still-there'}
+    results = [{'id': 'still-there', 'doc': None}]
+
+    instance, = list(_iter_export_instances_by_domain_docs(CaseExportInstance, results))
+
+    assert instance._id == 'still-there'
+    assert notify_exception_mock.called
 
 
 class TestInferredSchemasDBAccessors(TestCase):


### PR DESCRIPTION
Fixes a server error on the Case/Form Exports list page ([SAAS-19437](https://dimagi.atlassian.net/browse/SAAS-19437)). A stale CouchDB view row was pointing at an export that had already been deleted, which crashed the exports list whenever that row was paged in. The page now silently skips rows like this instead of erroring out.

### Safety story
The change is read-only — it only decides which rows to include when listing exports. Worst case for a false-positive match is an export instance is dropped from a list view where it would have crashed before; nothing is deleted or mutated.

### Automated test coverage

Yes.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations


[SAAS-19437]: https://dimagi.atlassian.net/browse/SAAS-19437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ