### PR TITLE
Implement front-end subscription check in back-end form validation

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -2120,6 +2120,13 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
     def clean(self):
         if self.is_autopay_required() and not self.account.auto_pay_enabled:
             raise ValidationError(_("Please provide an autopay card before continuing."))
+        if (self.current_is_annual_plan() and (
+            self.is_downgrade_from_paid_plan() or self.is_same_edition()
+        )):
+            raise ValidationError(_(
+                "You cannot downgrade or make a lateral plan change while "
+                "subscribed to an annual plan."
+            ))
 
 
 class ConfirmSubscriptionRenewalForm(EditBillingAccountInfoForm):

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -223,38 +223,69 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
         args = (self.account, self.domain.name, self.user.username, new_plan_version, self.subscription)
         return ConfirmNewSubscriptionForm(*args, **kwargs)
 
+    def set_current_subscription(
+        self,
+        edition,
+        is_annual_plan=False,
+        date_start=None
+    ):
+        self.subscription.delete()
+        self.subscription = generator.generate_domain_subscription(
+            self.account,
+            self.domain,
+            date_start or date.today(),
+            None,
+            plan_version=DefaultProductPlan.get_default_plan_version(
+                edition,
+                is_annual_plan=is_annual_plan,
+            ),
+            is_active=True,
+        )
+        return self.subscription
+
     def test_form_initial_values(self):
-        plan_version = DefaultProductPlan.get_default_plan_version(SoftwarePlanEdition.STANDARD)
+        plan_version = DefaultProductPlan.get_default_plan_version(
+            SoftwarePlanEdition.STANDARD,
+        )
         form = self.create_form(plan_version)
         assert form['plan_edition'].value() == plan_version.plan.edition
 
     def test_pay_monthly_subscription(self):
         new_plan_version = DefaultProductPlan.get_default_plan_version(
-            SoftwarePlanEdition.STANDARD, is_annual_plan=False
+            SoftwarePlanEdition.STANDARD,
+            is_annual_plan=False,
         )
         form = self.create_form_for_submission(new_plan_version)
         form.save()
         assert form.is_valid()
         assert self.subscription.date_end == date.today()
 
-        new_subscription = Subscription.get_active_subscription_by_domain(self.domain)
+        new_subscription = Subscription.get_active_subscription_by_domain(
+            self.domain,
+        )
         assert new_subscription.plan_version == new_plan_version
         assert new_subscription.date_start == date.today()
         assert new_subscription.date_end is None
 
     def test_pay_annually_subscription(self):
         new_plan_version = DefaultProductPlan.get_default_plan_version(
-            SoftwarePlanEdition.STANDARD, is_annual_plan=True
+            SoftwarePlanEdition.STANDARD,
+            is_annual_plan=True,
         )
         form = self.create_form_for_submission(new_plan_version)
         form.save()
         assert form.is_valid()
         assert self.subscription.date_end == date.today()
 
-        new_subscription = Subscription.get_active_subscription_by_domain(self.domain)
+        new_subscription = Subscription.get_active_subscription_by_domain(
+            self.domain,
+        )
         assert new_subscription.plan_version == new_plan_version
         assert new_subscription.date_start == date.today()
-        assert new_subscription.date_end == new_subscription.date_start + relativedelta(years=1)
+        assert new_subscription.date_end == (
+            new_subscription.date_start
+            + relativedelta(years=1)
+        )
 
     def test_pay_annually_creates_prepayment_invoice(self):
         new_plan_version = DefaultProductPlan.get_default_plan_version(
@@ -264,45 +295,51 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
         form.save()
         assert form.is_valid()
 
-        prepayment_invoice = WirePrepaymentInvoice.objects.get(domain=self.domain.name)
-        new_subscription = Subscription.get_active_subscription_by_domain(self.domain)
+        prepayment_invoice = WirePrepaymentInvoice.objects.get(
+            domain=self.domain.name,
+        )
+        new_subscription = Subscription.get_active_subscription_by_domain(
+            self.domain,
+        )
         assert prepayment_invoice.date_start == new_subscription.date_start
         assert prepayment_invoice.date_end == new_subscription.date_end
-        assert prepayment_invoice.date_due == date.today() + timedelta(days=SUBSCRIPTION_PREPAY_MIN_DAYS_UNTIL_DUE)
-        assert (prepayment_invoice.balance
-                == new_plan_version.product_rate.monthly_fee * PAY_ANNUALLY_SUBSCRIPTION_MONTHS)
-
-    def test_downgrade_minimum_subscription_length(self):
-        self.subscription.delete()
-        old_plan_version = DefaultProductPlan.get_default_plan_version(SoftwarePlanEdition.PRO)
-        old_date_start = date.today()
-        self.subscription = generator.generate_domain_subscription(
-            self.account, self.domain, old_date_start, None, plan_version=old_plan_version, is_active=True,
+        assert prepayment_invoice.date_due == (
+            date.today()
+            + timedelta(days=SUBSCRIPTION_PREPAY_MIN_DAYS_UNTIL_DUE)
+        )
+        assert (
+            prepayment_invoice.balance
+            == new_plan_version.product_rate.monthly_fee * PAY_ANNUALLY_SUBSCRIPTION_MONTHS
         )
 
-        new_plan_version = DefaultProductPlan.get_default_plan_version(SoftwarePlanEdition.STANDARD)
+    def test_downgrade_minimum_subscription_length(self):
+        old_date_start = date.today()
+        self.set_current_subscription(
+            SoftwarePlanEdition.PRO,
+            date_start=old_date_start,
+        )
+        new_plan_version = DefaultProductPlan.get_default_plan_version(
+            SoftwarePlanEdition.STANDARD,
+        )
         form = self.create_form_for_submission(new_plan_version)
         form.save()
         assert form.is_valid()
-        assert self.subscription.date_end == old_date_start + timedelta(days=30)
+        assert (
+            self.subscription.date_end
+            == old_date_start + timedelta(days=30)
+        )
 
         next_subscription = self.subscription.next_subscription
         assert next_subscription.plan_version == new_plan_version
-        assert next_subscription.date_start == old_date_start + timedelta(days=30)
+        assert (
+            next_subscription.date_start
+            == old_date_start + timedelta(days=30)
+        )
 
     def test_cannot_downgrade_from_annual_plan(self):
-        self.subscription.delete()
-        old_plan_version = DefaultProductPlan.get_default_plan_version(
+        self.set_current_subscription(
             SoftwarePlanEdition.PRO,
             is_annual_plan=True,
-        )
-        self.subscription = generator.generate_domain_subscription(
-            self.account,
-            self.domain,
-            date.today(),
-            None,
-            plan_version=old_plan_version,
-            is_active=True,
         )
         new_plan_version = DefaultProductPlan.get_default_plan_version(
             SoftwarePlanEdition.STANDARD,
@@ -313,20 +350,10 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
         assert not form.is_valid()
 
     def test_cannot_switch_to_same_edition_monthly_from_annual(self):
-        self.subscription.delete()
-        old_plan_version = DefaultProductPlan.get_default_plan_version(
+        self.set_current_subscription(
             SoftwarePlanEdition.PRO,
             is_annual_plan=True,
         )
-        self.subscription = generator.generate_domain_subscription(
-            self.account,
-            self.domain,
-            date.today(),
-            None,
-            plan_version=old_plan_version,
-            is_active=True,
-        )
-
         new_plan_version = DefaultProductPlan.get_default_plan_version(
             SoftwarePlanEdition.PRO,
             is_annual_plan=False,
@@ -336,20 +363,10 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
         assert not form.is_valid()
 
     def test_can_upgrade_from_annual_plan(self):
-        self.subscription.delete()
-        old_plan_version = DefaultProductPlan.get_default_plan_version(
+        self.set_current_subscription(
             SoftwarePlanEdition.STANDARD,
             is_annual_plan=True,
         )
-        self.subscription = generator.generate_domain_subscription(
-            self.account,
-            self.domain,
-            date.today(),
-            None,
-            plan_version=old_plan_version,
-            is_active=True,
-        )
-
         new_plan_version = DefaultProductPlan.get_default_plan_version(
             SoftwarePlanEdition.PRO,
             is_annual_plan=True,
@@ -360,7 +377,8 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
 
     def test_autopay_required_for_monthly_plan(self):
         new_plan_version = DefaultProductPlan.get_default_plan_version(
-            SoftwarePlanEdition.STANDARD, is_annual_plan=False
+            SoftwarePlanEdition.STANDARD,
+            is_annual_plan=False,
         )
         self.account.auto_pay_user = None
         self.account.save()
@@ -375,7 +393,8 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
 
     def test_autopay_required_if_set_on_account(self):
         new_plan_version = DefaultProductPlan.get_default_plan_version(
-            SoftwarePlanEdition.STANDARD, is_annual_plan=True
+            SoftwarePlanEdition.STANDARD,
+            is_annual_plan=True,
         )
         self.account.require_auto_pay = True
         self.account.auto_pay_user = None

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -290,6 +290,74 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
         assert next_subscription.plan_version == new_plan_version
         assert next_subscription.date_start == old_date_start + timedelta(days=30)
 
+    def test_cannot_downgrade_from_annual_plan(self):
+        self.subscription.delete()
+        old_plan_version = DefaultProductPlan.get_default_plan_version(
+            SoftwarePlanEdition.PRO,
+            is_annual_plan=True,
+        )
+        self.subscription = generator.generate_domain_subscription(
+            self.account,
+            self.domain,
+            date.today(),
+            None,
+            plan_version=old_plan_version,
+            is_active=True,
+        )
+        new_plan_version = DefaultProductPlan.get_default_plan_version(
+            SoftwarePlanEdition.STANDARD,
+            is_annual_plan=False,
+        )
+        form = self.create_form_for_submission(new_plan_version)
+        form.full_clean()
+        assert not form.is_valid()
+
+    def test_cannot_switch_to_same_edition_monthly_from_annual(self):
+        self.subscription.delete()
+        old_plan_version = DefaultProductPlan.get_default_plan_version(
+            SoftwarePlanEdition.PRO,
+            is_annual_plan=True,
+        )
+        self.subscription = generator.generate_domain_subscription(
+            self.account,
+            self.domain,
+            date.today(),
+            None,
+            plan_version=old_plan_version,
+            is_active=True,
+        )
+
+        new_plan_version = DefaultProductPlan.get_default_plan_version(
+            SoftwarePlanEdition.PRO,
+            is_annual_plan=False,
+        )
+        form = self.create_form_for_submission(new_plan_version)
+        form.full_clean()
+        assert not form.is_valid()
+
+    def test_can_upgrade_from_annual_plan(self):
+        self.subscription.delete()
+        old_plan_version = DefaultProductPlan.get_default_plan_version(
+            SoftwarePlanEdition.STANDARD,
+            is_annual_plan=True,
+        )
+        self.subscription = generator.generate_domain_subscription(
+            self.account,
+            self.domain,
+            date.today(),
+            None,
+            plan_version=old_plan_version,
+            is_active=True,
+        )
+
+        new_plan_version = DefaultProductPlan.get_default_plan_version(
+            SoftwarePlanEdition.PRO,
+            is_annual_plan=True,
+        )
+        form = self.create_form_for_submission(new_plan_version)
+        form.full_clean()
+        assert form.is_valid()
+
     def test_autopay_required_for_monthly_plan(self):
         new_plan_version = DefaultProductPlan.get_default_plan_version(
             SoftwarePlanEdition.STANDARD, is_annual_plan=False


### PR DESCRIPTION
## Product Description

Currently a rule for downgrading annual subscriptions is implemented in JavaScript only. (If you are currently on an annual plan, you cannot downgrade or switch to the monthly equivalent of the same plan.) This change implements that rule in the back-end form validation, preventing users from accidentally or intentionally circumnavigating the front-end check.

## Technical Summary

DEET Week ticket: [SAAS-19821](https://dimagi.atlassian.net/browse/SAAS-19821)

Adds some tests for form validation, and cleans the test class up a little.

## Safety Assurance

### Safety story

Only adds missing form validation. Unless JavaScript is disabled, users would never encounter this validation check.

### Automated test coverage

Yes

### QA Plan

No QA planned.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19821]: https://dimagi.atlassian.net/browse/SAAS-19821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ