### PR TITLE
Show a lockout banner and clear the lockout on password change

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/alerts.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/alerts.less
@@ -12,7 +12,8 @@
 }
 
 .alert-maintenance,
-.alert-trial {
+.alert-trial,
+.alert-lockout {
   z-index: @zindex-navbar;
   position: relative;
   text-align: center;

--- a/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_alert.scss
+++ b/corehq/apps/hqwebapp/static/hqwebapp/scss/commcarehq/_alert.scss
@@ -12,7 +12,8 @@
 }
 
 .alert-maintenance,
-.alert-trial {
+.alert-trial,
+.alert-lockout {
   z-index: $zindex-navbar;
   position: relative;
   text-align: center;

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap3/base_navigation.html
@@ -14,6 +14,9 @@
   {% if show_free_edition_banner %}
     {% include "hqwebapp/partials/free_edition_banner.html" %}
   {% endif %}
+  {% if show_lockout_banner %}
+    {% include "hqwebapp/partials/lockout_banner.html" %}
+  {% endif %}
 {% endblock pre_navigation_content %}
 
 {% block navigation %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/bootstrap5/base_navigation.html
@@ -14,6 +14,9 @@
   {% if show_free_edition_banner %}
     {% include "hqwebapp/partials/free_edition_banner.html" %}
   {% endif %}
+  {% if show_lockout_banner %}
+    {% include "hqwebapp/partials/lockout_banner.html" %}
+  {% endif %}
 {% endblock pre_navigation_content %}
 
 {% block navigation %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/lockout_banner.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/lockout_banner.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+
+<div class="alert alert-warning alert-lockout" id="lockout-banner">
+  <i class="fa fa-exclamation-triangle"></i>
+  {% if lockout_banner_can_change_password %}
+    {% url 'change_my_password' as url_change_password %}
+    {% blocktrans trimmed %}
+      Your account is locked because of too many failed password attempts. This
+      blocks OData feeds and other integrations that sign in with your password.
+      <a href="{{ url_change_password }}">Change your password</a> to unlock
+      your account.
+    {% endblocktrans %}
+  {% else %}
+    {% blocktrans trimmed %}
+      Your account is locked because of too many failed password attempts. This
+      blocks OData feeds and other integrations that sign in with your password.
+      Log out and log back in to unlock your account.
+    {% endblocktrans %}
+  {% endif %}
+</div>

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/hqwebapp/base_navigation.html.diff.txt
@@ -9,7 +9,7 @@
    {% if show_trial_banner %}
      {% include "hqwebapp/partials/trial_banner.html" %}
    {% endif %}
-@@ -17,38 +17,62 @@
+@@ -20,38 +20,62 @@
  {% endblock pre_navigation_content %}
  
  {% block navigation %}
@@ -91,7 +91,7 @@
                </button>
                <ul class="dropdown-menu">
                  {% for lang_code, name in LANGUAGES %}
-@@ -56,6 +80,7 @@
+@@ -59,6 +83,7 @@
                      <form action="{% url 'set_language' %}" method="post">
                        {% csrf_token %}
                        <button
@@ -99,7 +99,7 @@
                          type="submit"
                          name="language"
                          value="{{ lang_code }}"
-@@ -67,15 +92,15 @@
+@@ -70,15 +95,15 @@
                  {% endfor %}
                </ul>
              </div>
@@ -118,7 +118,7 @@
                >
                  {% trans 'Schedule a Demo' %}
                </a>
-@@ -83,59 +108,17 @@
+@@ -86,59 +111,17 @@
            </div>
          </nav>
        {% endif %}
@@ -181,7 +181,7 @@
  {% endblock post_navigation_content %}
  
  {% block messages %}
-@@ -145,10 +128,15 @@
+@@ -148,10 +131,15 @@
          {% if messages %}
            {% for message in messages %}
              <div
@@ -199,7 +199,7 @@
              </div>
            {% endfor %}
          {% endif %}
-@@ -157,9 +145,17 @@
+@@ -160,9 +148,17 @@
            class="ko-template"
            data-bind="foreach: {data: alerts, beforeRemove: fadeOut}"
          >
@@ -219,7 +219,7 @@
            </div>
          </div>
        </div>
-@@ -169,16 +165,16 @@
+@@ -172,16 +168,16 @@
  
  {% block footer %}
    {% if not enterprise_mode %}

--- a/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/alerts._alert.style.diff.txt
+++ b/corehq/apps/hqwebapp/tests/data/bootstrap5_diffs/stylesheets/imports/alerts._alert.style.diff.txt
@@ -1,6 +1,6 @@
 --- 
 +++ 
-@@ -8,19 +8,19 @@
+@@ -8,20 +8,20 @@
  
  .alert-neutral {
    background-color: #ffffff;
@@ -9,7 +9,8 @@
  }
  
  .alert-maintenance,
- .alert-trial {
+ .alert-trial,
+ .alert-lockout {
 -  z-index: @zindex-navbar;
 +  z-index: $zindex-navbar;
    position: relative;
@@ -23,7 +24,7 @@
    color: #ffffff;
    border: none;
  
-@@ -28,11 +28,15 @@
+@@ -29,11 +29,15 @@
    a:active,
    a:hover,
    a:link {
@@ -41,7 +42,7 @@
      border: 1px solid #ffffff;
  
      &:active,
-@@ -47,8 +51,8 @@
+@@ -48,8 +52,8 @@
  }
  
  .alert-trial {
@@ -52,7 +53,7 @@
    border: none;
    border-radius: 0;
    font-size: 1.1em;
-@@ -60,18 +64,18 @@
+@@ -61,18 +65,18 @@
      text-decoration: underline;
    }
    a:hover {

--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -69,6 +69,8 @@ class HQPasswordChangeForm(PasswordChangeForm):
         user = super(HQPasswordChangeForm, self).save(commit)
         couch_user = CouchUser.from_django_user(user)
         couch_user.last_password_set = datetime.utcnow()
+        # a new password also lifts the lockout from too many failed attempts
+        couch_user.login_attempts = 0
         if commit:
             couch_user.save()
         return user

--- a/corehq/apps/settings/tests/test_forms.py
+++ b/corehq/apps/settings/tests/test_forms.py
@@ -1,12 +1,19 @@
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from time_machine import travel
 from two_factor.forms import totp
 
-from ..forms import HQApiKeyForm, HQTOTPDeviceForm, HQTwoFactorMethodForm
+from corehq.apps.users.models import CouchUser, WebUser
+
+from ..forms import (
+    HQApiKeyForm,
+    HQPasswordChangeForm,
+    HQTOTPDeviceForm,
+    HQTwoFactorMethodForm,
+)
 
 
 @override_settings(TWO_FACTOR_CALL_GATEWAY=True, TWO_FACTOR_SMS_GATEWAY=True)
@@ -174,3 +181,41 @@ class HQApiKeyTests(SimpleTestCase):
             data['expiration_date'] = expiration_date
 
         return data
+
+
+class TestHQPasswordChangeForm(TestCase):
+    username = 'locked@example.com'
+    old_password = 'old-password-1234'
+    new_password = 'new-password-5678'
+
+    def setUp(self):
+        super().setUp()
+        self.couch_user = WebUser.create(None, self.username, self.old_password, None, None)
+        self.addCleanup(self.couch_user.delete, None, deleted_by=None)
+
+    def _change_password(self):
+        form = HQPasswordChangeForm(user=self.couch_user.get_django_user(), data={
+            'old_password': self.old_password,
+            'new_password1': self.new_password,
+            'new_password2': self.new_password,
+        })
+        assert form.is_valid(), form.errors
+        form.save()
+
+    def test_save_clears_login_lockout(self):
+        self.couch_user.login_attempts = 5
+        self.couch_user.save()
+        assert self.couch_user.is_locked_out()
+
+        self._change_password()
+
+        couch_user = CouchUser.get_by_username(self.username)
+        assert couch_user.login_attempts == 0
+        assert not couch_user.is_locked_out()
+
+    def test_save_records_last_password_set(self):
+        self._change_password()
+
+        couch_user = CouchUser.get_by_username(self.username)
+        assert couch_user.last_password_set is not None
+        assert couch_user.get_django_user().check_password(self.new_password)

--- a/corehq/apps/settings/tests/test_views.py
+++ b/corehq/apps/settings/tests/test_views.py
@@ -310,6 +310,48 @@ class TestMyAccountSettingsView(TestCase):
         self.assertEqual(user_history_log.changed_via, USER_CHANGE_VIA_WEB)
 
 
+class TestChangeMyPasswordView(TestCase):
+    username = 'changepw@example.com'
+    old_password = 'old-password-1234'
+    new_password = 'new-password-5678'
+
+    def setUp(self):
+        super().setUp()
+        self.couch_user = WebUser.create(None, self.username, self.old_password, None, None)
+        self.addCleanup(self.couch_user.delete, None, deleted_by=None)
+        self.url = reverse('change_my_password')
+        self.client.login(username=self.username, password=self.old_password)
+
+    def test_successful_change_redirects(self):
+        response = self.client.post(self.url, {
+            'old_password': self.old_password,
+            'new_password1': self.new_password,
+            'new_password2': self.new_password,
+        })
+        assert response.status_code == 302
+        assert response.url == self.url
+        assert WebUser.get_by_username(self.username).get_django_user().check_password(self.new_password)
+
+    def test_successful_change_keeps_user_logged_in(self):
+        self.client.post(self.url, {
+            'old_password': self.old_password,
+            'new_password1': self.new_password,
+            'new_password2': self.new_password,
+        })
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert response.wsgi_request.user.is_authenticated
+
+    def test_invalid_change_rerenders_form(self):
+        response = self.client.post(self.url, {
+            'old_password': 'not-the-password',
+            'new_password1': self.new_password,
+            'new_password2': self.new_password,
+        })
+        assert response.status_code == 200
+        assert not WebUser.get_by_username(self.username).get_django_user().check_password(self.new_password)
+
+
 @disable_quickcache
 class TestQrCode(SimpleTestCase):
     """Generates a URL QR code PNG file and ensures it matches the reference

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import update_session_auth_hash
 from django.core.exceptions import ValidationError
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import redirect
@@ -363,7 +364,10 @@ class ChangeMyPasswordView(BaseMyAccountView):
             try:
                 clean_password(request.POST['new_password1'])
                 self.password_change_form.save()
+                # keep the current session valid; other sessions are invalidated
+                update_session_auth_hash(request, self.password_change_form.user)
                 messages.success(request, _("Your password was successfully changed!"))
+                return HttpResponseRedirect(self.page_url)
             except ValidationError as e:
                 messages.error(request, _(e.message))
         return self.get(request, *args, **kwargs)

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -12,6 +12,7 @@ from corehq.apps.analytics.utils.hubspot import is_hubspot_js_allowed_for_reques
 from corehq.apps.hqwebapp.models import ServerLocation
 from corehq.apps.hqwebapp.utils import get_environment_friendly_name
 from corehq.apps.hqwebapp.utils import bootstrap
+from corehq.apps.sso.utils.request_helpers import is_request_using_sso
 
 COMMCARE = 'commcare'
 COMMTRACK = 'commtrack'
@@ -263,6 +264,25 @@ def subscription_banners(request):
             'show_free_edition_banner': True,
         })
     return context
+
+
+def lockout_banner(request):
+    """
+    Flags an authenticated web user whose account is locked after too many
+    failed password attempts. The lock only blocks password-based logins
+    (login form, Basic-auth APIs such as OData), so a user with an existing
+    session would otherwise never find out about it.
+    """
+    couch_user = getattr(request, 'couch_user', None)
+    is_logged_in_user = hasattr(request, 'user') and request.user.is_authenticated
+    if not (is_logged_in_user and couch_user and couch_user.is_web_user()):
+        return {}
+    if not couch_user.is_locked_out():
+        return {}
+    return {
+        'show_lockout_banner': True,
+        'lockout_banner_can_change_password': not is_request_using_sso(request),
+    }
 
 
 def get_demo(request):

--- a/settings.py
+++ b/settings.py
@@ -1309,6 +1309,7 @@ TEMPLATES = [
                 'corehq.util.context_processors.enterprise_mode',
                 'corehq.util.context_processors.get_demo',
                 'corehq.util.context_processors.subscription_banners',
+                'corehq.util.context_processors.lockout_banner',
                 'corehq.util.context_processors.js_api_keys',
                 'corehq.util.context_processors.js_toggles',
                 'corehq.util.context_processors.commcare_hq_names',


### PR DESCRIPTION
## Product Description

Ticket: https://dimagi.atlassian.net/browse/SAAS-19943


After five failed password attempts an account is locked for password-based auth. Because the lock is only checked by the login form and by Basic-auth API requests, a web user with an existing session keeps browsing HQ normally and has no way of knowing that their OData feed (or any other integration that signs in with their password) has stopped authenticating. They only find out after logging out and trying to log back in.

This PR:

- Shows a banner on every page while the account is locked, explaining that integrations are blocked and linking to **Change My Password**.
- Makes the in-session **Change My Password** form actually lift the lock. Previously only the login form and the emailed reset link cleared the failed-attempt counter, so a locked user who changed their password from My Account stayed locked for API access.
- SSO sessions can't change a password, so they are told to log out and back in instead.

Review by commit 🐡 

**Dashboard :**

<img width="1200" height="728" alt="lockout-banner-dashboard" src="https://github.com/user-attachments/assets/59579032-d69e-4fcf-8666-2f3338fa3ed8" />


## Feature Flag

None.

## Safety Assurance

### Safety story

- The context processor is read-only and only returns a flag for authenticated web users whose account is already locked; it returns `{}` in every other case.
- Clearing `login_attempts` on password change mirrors what the login form and the password-reset-by-email flow already do.
- Verified locally end to end: web login, five bad Basic-auth attempts on an OData feed (correct password then returns `maximum password attempts exceeded`), banner appears on Bootstrap 3 and Bootstrap 5 pages, changing the password in-session removes the banner and the API accepts the new password.

### Automated test coverage
 
Added some tests for the changes made.

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
