### PR TITLE
Add tests for the wire prepayment invoice workflow

### DIFF
--- a/corehq/apps/accounting/tests/test_wire_prepayment_view.py
+++ b/corehq/apps/accounting/tests/test_wire_prepayment_view.py
@@ -1,0 +1,94 @@
+import datetime
+from decimal import Decimal
+
+from django.urls import reverse
+
+from corehq.apps.accounting.models import (
+    WirePrepaymentBillingRecord,
+    WirePrepaymentInvoice,
+)
+from corehq.apps.accounting.tests.wire_invoice_base import (
+    WirePrepaymentTestCase,
+)
+
+
+class WirePrepaymentViewTest(WirePrepaymentTestCase):
+    def post_prepayment(self, **overrides):
+        data = {
+            'email_to': 'billing@example.com',
+            'email_cc': 'ap@example.com',
+            'credit_label': '12 month prepayment',
+            'unit_cost': '1000.00',
+            'quantity': '12',
+            'invoice_amount': '12000.00',
+            'prepay_date_start': '2027-01-01',
+            'prepay_date_end': '2028-01-01',
+        }
+        data.update(overrides)
+        url = reverse('domain_wire_payment', args=[self.domain_obj.name])
+        return self.admin_client.post(url, data)
+
+    def get_invoices(self):
+        return WirePrepaymentInvoice.objects.filter(
+            domain=self.domain_obj.name
+        )
+
+    def test_creates_invoice_with_posted_amount(self):
+        response = self.post_prepayment()
+
+        assert response.status_code == 200
+        assert response.json() == {'success': True}
+        invoice = self.get_invoices().get()
+        assert invoice.balance == Decimal('12000.0000')
+        assert invoice.date_start == datetime.date(2027, 1, 1)
+        assert invoice.date_end == datetime.date(2028, 1, 1)
+
+    def test_due_date_is_thirty_days_after_generation(self):
+        self.post_prepayment()
+
+        invoice = self.get_invoices().get()
+        assert invoice.date_due == datetime.date.today() + datetime.timedelta(
+            days=30
+        )
+
+    def test_emails_the_posted_recipients(self):
+        self.post_prepayment()
+
+        record = WirePrepaymentBillingRecord.objects.get(
+            invoice=self.get_invoices().get()
+        )
+        assert set(record.emailed_to_list) == {
+            'billing@example.com',
+            'ap@example.com',
+        }
+        assert not record.skipped_email
+
+    def test_rejects_malformed_email(self):
+        response = self.post_prepayment(email_to='not an email')
+
+        assert 'error' in response.json()
+        assert not self.get_invoices().exists()
+
+    def test_rejects_end_date_before_start_date(self):
+        response = self.post_prepayment(
+            prepay_date_start='2028-01-01',
+            prepay_date_end='2027-01-01',
+        )
+
+        assert (
+            response.json()['error']['message']
+            == 'Prepayment end date must be after start date.'
+        )
+        assert not self.get_invoices().exists()
+
+    def test_rejects_negative_unit_cost(self):
+        response = self.post_prepayment(unit_cost='-5.00')
+
+        assert 'error' in response.json()
+        assert not self.get_invoices().exists()
+
+    def test_rejects_negative_quantity(self):
+        response = self.post_prepayment(quantity='-1')
+
+        assert 'error' in response.json()
+        assert not self.get_invoices().exists()

--- a/corehq/apps/accounting/tests/wire_invoice_base.py
+++ b/corehq/apps/accounting/tests/wire_invoice_base.py
@@ -1,0 +1,59 @@
+"""Shared setup for tests covering the wire prepayment invoice workflow."""
+
+import datetime
+
+from django.test import Client, TestCase
+
+from django_prbac.models import Role
+
+from corehq.apps.accounting import utils
+from corehq.apps.accounting.models import SoftwarePlanEdition, SubscriptionType
+from corehq.apps.accounting.tests import generator
+from corehq.apps.users.models import WebUser
+
+
+class WirePrepaymentTestCase(TestCase):
+    """A domain on an active paid subscription, with a logged-in billing admin"""
+
+    plan_edition = SoftwarePlanEdition.ADVANCED
+    username = 'prepay-admin@example.com'
+    password = 'testpwd'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Role.get_cache().clear()
+        generator.bootstrap_test_software_plan_versions()
+        generator.init_default_currency()
+        cls.addClassCleanup(utils.clear_plan_version_cache)
+
+        cls.domain_obj = generator.arbitrary_domain()
+        cls.addClassCleanup(cls.domain_obj.delete)
+
+        cls.web_user = WebUser.create(
+            cls.domain_obj.name,
+            cls.username,
+            cls.password,
+            None,
+            None,
+            is_admin=True,
+        )
+        cls.addClassCleanup(
+            cls.web_user.delete, cls.domain_obj.name, deleted_by=None
+        )
+
+        cls.account = generator.billing_account(cls.username, cls.username)
+        cls.subscription = generator.generate_domain_subscription(
+            cls.account,
+            cls.domain_obj,
+            date_start=datetime.date.today() - datetime.timedelta(days=30),
+            date_end=None,
+            plan_version=generator.subscribable_plan_version(cls.plan_edition),
+            service_type=SubscriptionType.PRODUCT,
+            is_active=True,
+        )
+
+        # named to avoid shadowing the fresh, anonymous self.client that
+        # SimpleTestCase builds for each test
+        cls.admin_client = Client()
+        cls.admin_client.login(username=cls.username, password=cls.password)


### PR DESCRIPTION
## Product Description

No user-facing change. Tests only.

## Technical Summary

https://dimagi.atlassian.net/browse/SAAS-20141

First of three stacked PRs adding a "schedule for later" option to the Generate Prepayment Invoice modal. This one adds tests for the *existing* send now path to prevent any regressions after refactoring in PR 3.

1. **This PR** — tests for existing behavior
2. #38119 — `ScheduledPrepaymentInvoice` model + migration
3. (held) — the scheduling behavior

The stack is split this way because PR 3 moves `CreditsWireInvoiceView`'s validators to the module level so that a new endpoint can share them. That refactor is only safe if current behavior is pinned first, and these tests didn't exist yet.

## Feature Flag

N/A

## Safety Assurance

### Safety story

Test-only change — no production code is touched.

### Automated test coverage

This PR *is* the test coverage. Seven tests over the existing `CreditsWireInvoiceView`:

- invoice is created with the posted amount and prepayment term
- due date is 30 days after generation
- both `email_to` and `email_cc` recipients are saved on the billing record
- malformed email, end-date-before-start, negative unit cost, and negative quantity are all rejected without creating an invoice

### QA Plan

N/A

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
