### PR TITLE
Render module settings page when Select Parent First module was deleted

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -500,7 +500,7 @@ def _case_list_form_options(app, module, lang=None):
         'is_registration_form': True,
     } for f in reg_forms})
     if (hasattr(module, 'parent_select')  # AdvancedModule doesn't have parent_select
-            and toggles.FOLLOWUP_FORMS_AS_CASE_LIST_FORM
+            and toggles.FOLLOWUP_FORMS_AS_CASE_LIST_FORM.enabled(app.domain)
             and module.parent_select.active):
         followup_forms = get_parent_select_followup_forms(app, module)
         if followup_forms:

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -533,11 +533,10 @@ def _form_endpoint_options(app, module, lang=None):
 def get_parent_select_followup_forms(app, module):
     if not module.parent_select.active or not module.parent_select.module_id:
         return []
-    parent_module = app.get_module_by_unique_id(
-        module.parent_select.module_id,
-        error=_("Case list used by Select Parent First in '{}' not found").format(
-            module.default_name()),
-    )
+    try:
+        parent_module = app.get_module_by_unique_id(module.parent_select.module_id)
+    except ModuleNotFoundException:
+        return []
     parent_case_type = parent_module.case_type
     rel = module.parent_select.relationship
     if (rel == 'parent' and parent_case_type != module.case_type) or rel is None:

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -899,6 +899,18 @@ def delete_module(request, domain, app_id, module_unique_id):
                                       'you can delete it.').format(module.default_name()))
             return back_to_main(request, domain, app_id)
 
+    dependents = [
+        m.default_name(app=app) for m in app.get_modules()
+        if hasattr(m, 'parent_select') and m.parent_select.active
+        and m.parent_select.module_id == module_unique_id
+    ]
+    if dependents:
+        messages.error(request, _(
+            '"{module}" is used by "{dependents}" for Parent Child Selection. '
+            'Change or turn off that setting before you can delete it.'
+        ).format(module=module.default_name(), dependents=', '.join(dependents)))
+        return back_to_main(request, domain, app_id)
+
     shadow_children = [
         m.unique_id for m in app.get_modules()
         if m.module_type == 'shadow' and m.source_module_id == module_unique_id and m.root_module_id is not None

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -907,7 +907,7 @@ def delete_module(request, domain, app_id, module_unique_id):
     if dependents:
         messages.error(request, _(
             '"{module}" is used by "{dependents}" for Parent Child Selection. '
-            'Change or turn off that setting before you can delete it.'
+            'Change or turn off that setting before deleting it.'
         ).format(module=module.default_name(), dependents=', '.join(dependents)))
         return back_to_main(request, domain, app_id)
 


### PR DESCRIPTION
## Product Description

A case list module that has **Select Parent First** turned on keeps pointing at the parent case list after that case list is deleted. Opening the child module's settings page then failed with a 500, so the builder could not open the page to fix or turn off the setting. With this change the page loads, the "Use Case List from" dropdown shows its existing "Unknown menu … may have been deleted" state, and the build validator reports "invalid parent select id" as before.

To prevent the above situation from happening now while deleting a case list that another module uses for Parent Child Selection is now refused with an error.

## Technical Summary
Ticket: [SAAS-20234](https://dimagi.atlassian.net/browse/SAAS-20234)

## Feature Flag

## Safety Assurance

### Safety story
Reproduced locally through the UI using the steps described in the ticket, ensure that -
- I was able to repro the issue locally.
- After the fix, I was able to open up the settings page of the module.
- I was not able to create a new version until I fixed my config.
<img width="657" height="210" alt="Screenshot 2026-09-06 at 7 44 22 AM" src="https://github.com/user-attachments/assets/e26c4ce5-2e0a-46ee-815b-e775c8ef2591" />

- Trying to delete a caselist which has dependency would not allow deletes to go through. 
<img width="957" height="111" alt="Screenshot 2026-09-06 at 8 12 56 AM" src="https://github.com/user-attachments/assets/77f99213-c50b-4be9-90b0-3cc1a4624d94" />

### Automated test coverage
N/A

### QA Plan
N/A

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-20234]: https://dimagi.atlassian.net/browse/SAAS-20234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ