### PR TITLE
Fix wrong subscription adjusstment message

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1752,24 +1752,7 @@ class Subscription(models.Model):
                                 date_start=None, date_end=None, note=None,
                                 web_user=None, adjustment_method=None, internal_change=False,
                                 **kwargs):
-        if plan_version.plan.at_max_domains():
-            raise NewSubscriptionError(
-                'The maximum number of project spaces has been reached for %(plan_version)s. ' % {
-                    'plan_version': plan_version,
-                }
-            )
-
-        if plan_version.plan.is_customer_software_plan != account.is_customer_billing_account:
-            if plan_version.plan.is_customer_software_plan:
-                raise NewSubscriptionError(
-                    'You are trying to add a Customer Software Plan to a regular Billing Account. '
-                    'Both or neither must be customer-level.'
-                )
-            else:
-                raise NewSubscriptionError(
-                    'You are trying to add a regular Software Plan to a Customer Billing Account. '
-                    'Both or neither must be customer-level.'
-                )
+        cls._raise_if_plan_or_account_rejects_new_subscription(account, plan_version)
 
         subscriber = Subscriber.objects.get_or_create(domain=domain)[0]
         today = datetime.date.today()
@@ -1847,6 +1830,28 @@ class Subscription(models.Model):
         subscription.set_billing_account_entry_point()
 
         return subscription
+
+    @classmethod
+    def _raise_if_plan_or_account_rejects_new_subscription(cls, account, plan_version):
+        if plan_version.plan.at_max_domains():
+            raise NewSubscriptionError(
+                'The maximum number of project spaces has been reached for %(plan_version)s. ' % {
+                    'plan_version': plan_version,
+                }
+            )
+
+        if plan_version.plan.is_customer_software_plan != account.is_customer_billing_account:
+            if plan_version.plan.is_customer_software_plan:
+                raise NewSubscriptionError(
+                    'You are trying to add a Customer Software Plan to a regular Billing Account. '
+                    'Both or neither must be customer-level.'
+                )
+            else:
+                raise NewSubscriptionError(
+                    'You are trying to add a regular Software Plan to a Customer Billing Account. '
+                    'Both or neither must be customer-level.'
+                )
+
 
     @classmethod
     def can_reactivate_domain_subscription(cls, account, domain, plan_version,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1758,41 +1758,7 @@ class Subscription(models.Model):
         today = datetime.date.today()
         date_start = date_start or today
 
-        # find subscriptions that end in the future / after this subscription
-        available_subs = Subscription.visible_objects.filter(
-            subscriber=subscriber,
-        )
-
-        future_subscription_no_end = available_subs.filter(
-            date_end__exact=None,
-        )
-        if date_end is not None:
-            future_subscription_no_end = future_subscription_no_end.filter(date_start__lt=date_end)
-        if future_subscription_no_end.exists():
-            raise NewSubscriptionError(_(
-                "There is already a subscription '%s' with no end date "
-                "that conflicts with the start and end dates of this "
-                "subscription.") %
-                future_subscription_no_end.latest('date_created')
-            )
-
-        future_subscriptions = available_subs.filter(
-            date_end__gt=date_start
-        )
-        if date_end is not None:
-            future_subscriptions = future_subscriptions.filter(date_start__lt=date_end)
-        if future_subscriptions.exists():
-            raise NewSubscriptionError(str(
-                _(
-                    "There is already a subscription '%(sub)s' that has an end date "
-                    "that conflicts with the start and end dates of this "
-                    "subscription %(start)s - %(end)s."
-                ) % {
-                    'sub': future_subscriptions.latest('date_created'),
-                    'start': date_start,
-                    'end': date_end
-                }
-            ))
+        cls._raise_if_subscription_dates_conflict(subscriber, date_start, date_end)
 
         can_reactivate, last_subscription = cls.can_reactivate_domain_subscription(
             account, domain, plan_version, date_start=date_start
@@ -1852,6 +1818,43 @@ class Subscription(models.Model):
                     'Both or neither must be customer-level.'
                 )
 
+    @classmethod
+    def _raise_if_subscription_dates_conflict(cls, subscriber, date_start, date_end):
+        # find subscriptions that end in the future / after this subscription
+        available_subs = Subscription.visible_objects.filter(
+            subscriber=subscriber,
+        )
+
+        future_subscription_no_end = available_subs.filter(
+            date_end__exact=None,
+        )
+        if date_end is not None:
+            future_subscription_no_end = future_subscription_no_end.filter(date_start__lt=date_end)
+        if future_subscription_no_end.exists():
+            raise NewSubscriptionError(_(
+                "There is already a subscription '%s' with no end date "
+                "that conflicts with the start and end dates of this "
+                "subscription.") %
+                future_subscription_no_end.latest('date_created')
+            )
+
+        future_subscriptions = available_subs.filter(
+            date_end__gt=date_start
+        )
+        if date_end is not None:
+            future_subscriptions = future_subscriptions.filter(date_start__lt=date_end)
+        if future_subscriptions.exists():
+            raise NewSubscriptionError(str(
+                _(
+                    "There is already a subscription '%(sub)s' that has an end date "
+                    "that conflicts with the start and end dates of this "
+                    "subscription %(start)s - %(end)s."
+                ) % {
+                    'sub': future_subscriptions.latest('date_created'),
+                    'start': date_start,
+                    'end': date_end
+                }
+            ))
 
     @classmethod
     def can_reactivate_domain_subscription(cls, account, domain, plan_version,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1785,7 +1785,7 @@ class Subscription(models.Model):
         )
         if date_end is not None:
             future_subscription_no_end = future_subscription_no_end.filter(date_start__lt=date_end)
-        if future_subscription_no_end.count() > 0:
+        if future_subscription_no_end.exists():
             raise NewSubscriptionError(_(
                 "There is already a subscription '%s' with no end date "
                 "that conflicts with the start and end dates of this "
@@ -1798,7 +1798,7 @@ class Subscription(models.Model):
         )
         if date_end is not None:
             future_subscriptions = future_subscriptions.filter(date_start__lt=date_end)
-        if future_subscriptions.count() > 0:
+        if future_subscriptions.exists():
             raise NewSubscriptionError(str(
                 _(
                     "There is already a subscription '%(sub)s' that has an end date "

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1755,8 +1755,8 @@ class Subscription(models.Model):
         cls._raise_if_plan_or_account_rejects_new_subscription(account, plan_version)
 
         subscriber = Subscriber.objects.get_or_create(domain=domain)[0]
-        today = datetime.date.today()
-        date_start = date_start or today
+
+        date_start = date_start or datetime.date.today()
 
         cls._raise_if_subscription_dates_conflict(subscriber, date_start, date_end)
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1470,22 +1470,26 @@ class Subscription(models.Model):
                     do_not_email_invoice=False, do_not_email_reminder=False,
                     skip_invoicing_if_no_feature_charges=False,
                     skip_auto_downgrade=False, skip_auto_downgrade_reason=None,
-                    skip_auto_downgrade_until=None, auto_renew=None):
+                    skip_auto_downgrade_until=None, auto_renew=None,
+                    effective_date=None):
         """
         Changing a plan TERMINATES the current subscription and
         creates a NEW SUBSCRIPTION where the old plan left off.
         This is not the same thing as simply updating the subscription.
 
-        date_end is a date in the future and only applies to the NEW
-        subscription. The current subscription will always end immediately
-        (today) and the date_start of the new subscription will always be today.
+        effective_date controls when the replacement takes effect and defaults
+        to today. date_end is a date in the future and only applies to the NEW
+        subscription.
         """
         from corehq.apps.analytics.tasks import track_workflow_noop
         adjustment_method = adjustment_method or SubscriptionAdjustmentMethod.INTERNAL
 
         today = datetime.date.today()
+        effective_date = effective_date or today
+        is_immediate_change = effective_date == today
         assert self.is_active
-        assert date_end is None or date_end >= today
+        assert effective_date >= today
+        assert date_end is None or date_end >= effective_date
 
         if new_plan_version.plan.at_max_domains() and self.plan_version.plan != new_plan_version.plan:
             raise SubscriptionAdjustmentError(
@@ -1494,8 +1498,8 @@ class Subscription(models.Model):
                 }
             )
 
-        self.date_end = today
-        self.is_active = False
+        self.date_end = effective_date
+        self.is_active = not is_immediate_change
         self.save()
 
         new_subscription = Subscription(
@@ -1503,9 +1507,9 @@ class Subscription(models.Model):
             plan_version=new_plan_version,
             subscriber=self.subscriber,
             salesforce_contract_id=self.salesforce_contract_id,
-            date_start=today,
+            date_start=effective_date,
             date_end=date_end,
-            is_active=True,
+            is_active=is_immediate_change,
             do_not_invoice=do_not_invoice if do_not_invoice is not None else self.do_not_invoice,
             no_invoice_reason=no_invoice_reason if no_invoice_reason is not None else self.no_invoice_reason,
             do_not_email_invoice=do_not_email_invoice,
@@ -1528,18 +1532,19 @@ class Subscription(models.Model):
         new_subscription.set_billing_account_entry_point()
 
         change_status_result = get_change_status(self.plan_version, new_plan_version)
-        self.subscriber.change_subscription(
-            downgraded_privileges=change_status_result.downgraded_privs,
-            upgraded_privileges=change_status_result.upgraded_privs,
-            new_plan_version=new_plan_version,
-            old_subscription=self,
-            new_subscription=new_subscription,
-            internal_change=internal_change,
-        )
+        if is_immediate_change:
+            self.subscriber.change_subscription(
+                downgraded_privileges=change_status_result.downgraded_privs,
+                upgraded_privileges=change_status_result.upgraded_privs,
+                new_plan_version=new_plan_version,
+                old_subscription=self,
+                new_subscription=new_subscription,
+                internal_change=internal_change,
+            )
 
-        # transfer existing credit lines to the new subscription
-        if transfer_credits:
-            self.transfer_credits(new_subscription)
+            # transfer existing credit lines to the new subscription
+            if transfer_credits:
+                self.transfer_credits(new_subscription)
 
         # record transfer from old subscription
         SubscriptionAdjustment.record_adjustment(

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date, time
+from datetime import date, time, timedelta
 from unittest.mock import Mock, call, patch
 
 from django.test import SimpleTestCase, TestCase, TransactionTestCase
@@ -10,9 +10,12 @@ from corehq.apps.accounting.exceptions import SubscriptionAdjustmentError
 from corehq.apps.accounting.models import (
     BillingAccount,
     DefaultProductPlan,
+    MINIMUM_SUBSCRIPTION_LENGTH,
     SoftwarePlanEdition,
     Subscriber,
     Subscription,
+    SubscriptionAdjustment,
+    SubscriptionAdjustmentReason,
 )
 from corehq.apps.accounting.subscription_changes import (
     DomainDowngradeActionHandler,
@@ -20,6 +23,7 @@ from corehq.apps.accounting.subscription_changes import (
 )
 from corehq.apps.accounting.tests import generator
 from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
+from corehq.apps.accounting.utils import pause_current_subscription
 from corehq.apps.data_interfaces.models import (
     AutomaticUpdateRule,
     CreateScheduleInstanceActionDefinition,
@@ -262,6 +266,89 @@ class TestSoftwarePlanChanges(BaseAccountingTest):
             self.account, self.domain2.name, self.free_plan
         )
         self.assertRaises(SubscriptionAdjustmentError, lambda: sub2.change_plan(self.advanced_plan))
+
+    def test_downgrade_below_minimum_defers_until_minimum_ends(self):
+        today = date.today()
+        subscription = Subscription.new_domain_subscription(
+            self.account,
+            self.domain.name,
+            self.advanced_plan,
+            date_start=today,
+        )
+        assert subscription.is_below_minimum_subscription
+
+        downgraded = pause_current_subscription(
+            self.domain.name, self.admin_username, subscription
+        )
+
+        subscription.refresh_from_db()
+        expected_effective_date = today + timedelta(days=MINIMUM_SUBSCRIPTION_LENGTH)
+        assert subscription.is_active
+        assert subscription.date_end == expected_effective_date
+        assert downgraded.date_start == expected_effective_date
+        assert not downgraded.is_active
+        assert downgraded.plan_version.plan.edition == SoftwarePlanEdition.PAUSED
+        self._assert_downgrade_creates_correct_subscription_adjustment(subscription, downgraded)
+
+    def test_downgrade_after_minimum_takes_effect_immediately(self):
+        today = date.today()
+        subscription = Subscription.new_domain_subscription(
+            self.account,
+            self.domain.name,
+            self.advanced_plan,
+            date_start=today - timedelta(days=MINIMUM_SUBSCRIPTION_LENGTH + 1),
+        )
+        assert not subscription.is_below_minimum_subscription
+
+        downgraded = pause_current_subscription(
+            self.domain.name, self.admin_username, subscription
+        )
+
+        subscription.refresh_from_db()
+        assert not subscription.is_active
+        assert subscription.date_end == today
+        assert downgraded.is_active
+        assert downgraded.date_start == today
+        assert downgraded.plan_version.plan.edition == SoftwarePlanEdition.PAUSED
+        self._assert_downgrade_creates_correct_subscription_adjustment(subscription, downgraded)
+
+    def test_downgrade_cancels_future_subscriptions(self):
+        today = date.today()
+        subscription = Subscription.new_domain_subscription(
+            self.account,
+            self.domain.name,
+            self.advanced_plan,
+            date_start=today - timedelta(days=MINIMUM_SUBSCRIPTION_LENGTH + 1),
+            date_end=today + timedelta(days=10),
+        )
+        future = Subscription.new_domain_subscription(
+            self.account,
+            self.domain.name,
+            self.free_plan,
+            date_start=today + timedelta(days=10),
+        )
+
+        pause_current_subscription(self.domain.name, self.admin_username, subscription)
+
+        future.refresh_from_db()
+        assert future.date_end == future.date_start
+        cancel_adjustment = SubscriptionAdjustment.objects.get(
+            subscription=future,
+            reason=SubscriptionAdjustmentReason.CANCEL,
+        )
+        assert cancel_adjustment.web_user == self.admin_username
+
+    def _assert_downgrade_creates_correct_subscription_adjustment(self, old_subscription, new_subscription):
+        downgrade_adjustment = SubscriptionAdjustment.objects.get(
+            subscription=old_subscription,
+            reason=SubscriptionAdjustmentReason.DOWNGRADE,
+        )
+        assert downgrade_adjustment.related_subscription_id == new_subscription.id
+
+        assert SubscriptionAdjustment.objects.filter(
+            subscription=new_subscription,
+            reason=SubscriptionAdjustmentReason.CREATE,
+        ).exists()
 
 
 class DeactivateScheduleTest(TransactionTestCase):

--- a/corehq/apps/accounting/tests/test_utils.py
+++ b/corehq/apps/accounting/tests/test_utils.py
@@ -1,8 +1,32 @@
 from datetime import date
+from unittest.mock import patch
 
+import pytest
 from django.test import SimpleTestCase
 
-from corehq.apps.accounting.utils import is_date_range_overlapping
+from corehq.apps.accounting.models import SubscriptionAdjustmentReason
+from corehq.apps.accounting.utils import get_change_status, is_date_range_overlapping
+
+
+@pytest.mark.parametrize(
+    ("from_privileges", "to_privileges", "expected_reason"),
+    [
+        ({"a", "b"}, {"a"}, SubscriptionAdjustmentReason.DOWNGRADE),
+        ({"a"}, set(), SubscriptionAdjustmentReason.DOWNGRADE),
+        ({"a"}, {"a", "b"}, SubscriptionAdjustmentReason.UPGRADE),
+        ({"a", "b"}, {"b", "c"}, SubscriptionAdjustmentReason.SWITCH),
+    ],
+)
+def test_get_change_status_reason(from_privileges, to_privileges, expected_reason):
+    with patch(
+        "corehq.apps.accounting.utils.get_privileges",
+        side_effect=[from_privileges, to_privileges],
+    ):
+        result = get_change_status(object(), object())
+
+    assert result.adjustment_reason == expected_reason
+    assert result.downgraded_privs == from_privileges - to_privileges
+    assert result.upgraded_privs == to_privileges
 
 
 class TestIsDateRangeOverlapping(SimpleTestCase):

--- a/corehq/apps/accounting/utils/__init__.py
+++ b/corehq/apps/accounting/utils/__init__.py
@@ -400,7 +400,6 @@ def pause_current_subscription(domain_name, web_user, current_subscription):
         FundingSource,
         ProBonoStatus,
         SoftwarePlanEdition,
-        Subscription,
         SubscriptionAdjustmentMethod,
         SubscriptionType,
     )
@@ -409,15 +408,9 @@ def pause_current_subscription(domain_name, web_user, current_subscription):
         SoftwarePlanEdition.PAUSED
     )
     if current_subscription.is_below_minimum_subscription:
-        current_subscription.update_subscription(
-            date_start=current_subscription.date_start,
-            date_end=current_subscription.date_start + datetime.timedelta(days=30)
-        )
-        return Subscription.new_domain_subscription(
-            account=current_subscription.account,
-            domain=domain_name,
-            plan_version=paused_plan_version,
-            date_start=current_subscription.date_start + datetime.timedelta(days=30),
+        return current_subscription.change_plan(
+            paused_plan_version,
+            effective_date=current_subscription.date_start + datetime.timedelta(days=30),
             web_user=web_user,
             adjustment_method=SubscriptionAdjustmentMethod.USER,
             service_type=SubscriptionType.PRODUCT,

--- a/corehq/apps/accounting/utils/__init__.py
+++ b/corehq/apps/accounting/utils/__init__.py
@@ -100,7 +100,6 @@ def get_change_status(from_plan_version, to_plan_version):
     to_privs = get_privileges(to_plan_version) if to_plan_version is not None else set()
 
     downgraded_privs = from_privs.difference(to_privs)
-    upgraded_privs = to_privs
 
     from corehq.apps.accounting.models import \
         SubscriptionAdjustmentReason as Reason
@@ -108,11 +107,11 @@ def get_change_status(from_plan_version, to_plan_version):
         adjustment_reason = Reason.CREATE
     else:
         adjustment_reason = Reason.SWITCH
-        if len(downgraded_privs) == 0 and len(upgraded_privs) > 0:
+        if len(downgraded_privs) == 0 and len(to_privs) > 0:
             adjustment_reason = Reason.UPGRADE
-        elif len(upgraded_privs) == 0 and len(downgraded_privs) > 0:
+        elif len(to_privs) == 0 and len(downgraded_privs) > 0:
             adjustment_reason = Reason.DOWNGRADE
-    return ChangeStatusResult(adjustment_reason, downgraded_privs, upgraded_privs)
+    return ChangeStatusResult(adjustment_reason, downgraded_privs, to_privs)
 
 
 def domain_has_privilege_cache_args(domain, privilege_slug, **assignment):

--- a/corehq/apps/accounting/utils/__init__.py
+++ b/corehq/apps/accounting/utils/__init__.py
@@ -100,6 +100,7 @@ def get_change_status(from_plan_version, to_plan_version):
     to_privs = get_privileges(to_plan_version) if to_plan_version is not None else set()
 
     downgraded_privs = from_privs.difference(to_privs)
+    newly_upgraded_privs = to_privs.difference(from_privs)
 
     from corehq.apps.accounting.models import \
         SubscriptionAdjustmentReason as Reason
@@ -107,9 +108,9 @@ def get_change_status(from_plan_version, to_plan_version):
         adjustment_reason = Reason.CREATE
     else:
         adjustment_reason = Reason.SWITCH
-        if len(downgraded_privs) == 0 and len(to_privs) > 0:
+        if not downgraded_privs and newly_upgraded_privs:
             adjustment_reason = Reason.UPGRADE
-        elif len(to_privs) == 0 and len(downgraded_privs) > 0:
+        elif not newly_upgraded_privs and downgraded_privs:
             adjustment_reason = Reason.DOWNGRADE
     return ChangeStatusResult(adjustment_reason, downgraded_privs, to_privs)
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -2023,16 +2023,11 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
                     self.is_downgrade_from_paid_plan()
                     and self.current_subscription.is_below_minimum_subscription
                 ):
-                    self.current_subscription.update_subscription(
-                        date_start=self.current_subscription.date_start,
-                        date_end=new_sub_date_start
-                    )
-                    Subscription.new_domain_subscription(
-                        account=self.account,
-                        domain=self.domain,
-                        plan_version=self.plan_version,
-                        date_start=new_sub_date_start,
+                    self.current_subscription.change_plan(
+                        self.plan_version,
+                        effective_date=new_sub_date_start,
                         date_end=new_sub_date_end,
+                        account=self.account,
                         web_user=self.creating_user,
                         adjustment_method=SubscriptionAdjustmentMethod.USER,
                         service_type=SubscriptionType.PRODUCT,

--- a/corehq/apps/domain/tests/test_forms.py
+++ b/corehq/apps/domain/tests/test_forms.py
@@ -14,6 +14,9 @@ from corehq.apps.accounting.models import (
     DefaultProductPlan,
     SoftwarePlanEdition,
     Subscription,
+    SubscriptionAdjustment,
+    SubscriptionAdjustmentMethod,
+    SubscriptionAdjustmentReason,
     WirePrepaymentInvoice,
 )
 from corehq.apps.accounting.tests import generator
@@ -284,11 +287,22 @@ class TestConfirmNewSubscriptionForm(BaseTestSubscriptionForm):
         form = self.create_form_for_submission(new_plan_version)
         form.save()
         assert form.is_valid()
+        self.subscription.refresh_from_db()
         assert self.subscription.date_end == old_date_start + timedelta(days=30)
+        assert self.subscription.is_active
 
         next_subscription = self.subscription.next_subscription
         assert next_subscription.plan_version == new_plan_version
         assert next_subscription.date_start == old_date_start + timedelta(days=30)
+        assert not next_subscription.is_active
+
+        old_adjustment = SubscriptionAdjustment.objects.get(subscription=self.subscription)
+        assert old_adjustment.reason == SubscriptionAdjustmentReason.DOWNGRADE
+        assert old_adjustment.method == SubscriptionAdjustmentMethod.USER
+        assert old_adjustment.related_subscription == next_subscription
+
+        new_adjustment = SubscriptionAdjustment.objects.get(subscription=next_subscription)
+        assert new_adjustment.reason == SubscriptionAdjustmentReason.CREATE
 
     def test_autopay_required_for_monthly_plan(self):
         new_plan_version = DefaultProductPlan.get_default_plan_version(


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
There are two seperated bugs in Subscription Adjustment records when a downgrade happens
<img width="1025" height="209" alt="Screenshot 2026-09-07 at 2 43 57 PM" src="https://github.com/user-attachments/assets/1a9a7891-71fd-4919-857b-66d2fe8a3290" />

In the above screenshot, in the first pair of highlighted records, when subscription `Annual Pro` downgraded to `Monthly Standard`, the Reason is `MODIFY` instead of `DOWNGRADE`, and the Method for first record is `Ops` while for the second record is `User`, they should be consistent because a downgrade action will generate two paired records. The third pair of highlighted records have the same issue, though it is downgrading from `Monthly Standard` to `Paused`.

The second pair of highlighted records is operated by Ops using the downgrading tool, but the Reason column is `SWITCH`. There is a bug in the logic of telling if the plan change is an `UPGRADE`, or `DOWNGRADE` or `SWITCH`.

This PR will fix both.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19821

🐠 Review by commit. 

The first bug is due to, when user tries to downgrade a subscription within 30 days, we call `update_subscription` to only update current subscription's `end_date`, and this function always assign `MODIFY` as adjustment reason. When downgrade a subscription that has been active more than 30 days, the downgrade happens immediately so we call `change_plan`, which has logic to tell if the logic is a downgrade, or upgrade, or just a switch.

The second bug is a logic bug, please see the code change.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Test added. Tested on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
`corehq/apps/accounting/tests/test_subscription_changes.py`
`corehq/apps/domain/tests/test_forms.py`
`corehq/apps/accounting/tests/test_utils.py`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
