### PR TITLE
Disallow annual plan downgrade in backend

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -89,7 +89,7 @@ const PricingTable = function (options) {
         self.form = $(e.currentTarget).closest("form");
 
         const invoicingContact = _.escape(self.invoicingContact);
-        if (self.oIsDowngrade() && self.subscriptionBelowMinimum) {
+        if (!self.currentIsAnnualPlan && self.oIsDowngrade() && self.subscriptionBelowMinimum) {
             const oldPlan = utils.capitalize(self.currentEdition);
             const newPlan = utils.capitalize(self.oSelectedEdition());
             const newStartDate = self.startDateAfterMinimumSubscription;

--- a/corehq/apps/domain/tests/test_views.py
+++ b/corehq/apps/domain/tests/test_views.py
@@ -13,6 +13,7 @@ from corehq import privileges
 from corehq.apps.accounting.models import (
     DefaultProductPlan,
     SoftwarePlanEdition,
+    Subscription,
     SubscriptionAdjustmentMethod,
 )
 from corehq.apps.accounting.tests import generator
@@ -72,6 +73,27 @@ class TestDomainViews(TestCase, DomainSubscriptionMixin):
         self.domain.delete()
         clear_plan_version_cache()
         super().tearDown()
+
+    def test_annual_pro_cannot_downgrade_to_monthly_standard(self):
+        self.setup_subscription(self.domain.name, SoftwarePlanEdition.PRO, use_annual_plan=True)
+        subscription = Subscription.get_active_subscription_by_domain(self.domain.name)
+        self.client.force_login(self.user.get_django_user())
+
+        response = self.client.post(reverse('confirm_selected_plan', args=[self.domain.name]), {
+            'plan_edition': SoftwarePlanEdition.STANDARD,
+            'is_annual_plan': 'false',
+        })
+
+        self.assertRedirects(
+            response, reverse('domain_select_plan', args=[self.domain.name]), fetch_redirect_response=False
+        )
+        banner, = get_messages(response.wsgi_request)
+        assert banner.level == ERROR
+        assert 'Your annual subscription only allows upgrades.' in str(banner)
+        assert Subscription.get_active_subscription_by_domain(self.domain.name) == subscription
+        subscription.refresh_from_db()
+        assert subscription.plan_version.plan.edition == SoftwarePlanEdition.PRO
+        assert subscription.plan_version.plan.is_annual_plan
 
     def test_allow_domain_requests(self):
         self.client.login(username=self.username, password=self.password)

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1587,6 +1587,15 @@ class ConfirmSelectedPlanView(PlanViewBase):
         return HttpResponseRedirect(reverse(SelectPlanView.urlname, args=[self.domain]))
 
     def post(self, request, *args, **kwargs):
+        if self.current_subscription.plan_version.plan.is_annual_plan and (
+            self.is_downgrade or self.is_same_edition
+        ):
+            messages.error(
+                request,
+                _("Your annual subscription only allows upgrades. "
+                  "You cannot downgrade, pause, or switch to the same edition during your annual commitment.")
+            )
+            return HttpResponseRedirect(reverse(SelectPlanView.urlname, args=[self.domain]))
         if not self.can_domain_unpause:
             return HttpResponseRedirect(reverse(SelectPlanView.urlname, args=[self.domain]))
         return super(ConfirmSelectedPlanView, self).get(request, *args, **kwargs)


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Currently, when a user tries to downgrade from an annual plan, the "Next" button is already disabled, however user can manipulate the DOM to remove the `disabled` flag of the "Next" button and proceed with the downgrade.
<img width="802" height="652" alt="Screenshot 2026-09-07 at 9 45 46 PM" src="https://github.com/user-attachments/assets/1c69c662-ef30-4695-a7d0-67ef753e133d" />

This PR is to add backend validation. If a user manipulate the DOM again, when annual plan downgrade is detected, redirect back to the Select plan page and show an error message:
<img width="821" height="69" alt="Screenshot 2026-09-07 at 9 47 45 PM" src="https://github.com/user-attachments/assets/aacad60f-7da5-4dc6-bdda-a8409f8020ec" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19821

The modal mentioned in commit 0f06c9eda4c3bd8004562aa6728d545e03c04917 is as below, this modal's content only applies to monthly subscription, annual subscription cannot be downgraded, thus it doesn't make sense to display it.
<img width="605" height="253" alt="Screenshot 2026-09-07 at 9 49 57 PM" src="https://github.com/user-attachments/assets/b2424896-87b4-45ae-b939-328a7829ad9f" />

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Tested locally. The logic in backend is an exact mirror of frontend's [isDisallowedPayAnnuallyChange](https://github.com/dimagi/commcare-hq/blob/912ddcc6bc5da155fb41cdced1ffc2857878839a/corehq/apps/accounting/static/accounting/js/pricing_table.js#L67)

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
corehq/apps/domain/tests/test_views.py
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->



### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
