### PR TITLE
Update SECURITY.md to include instructions on joining the Maintainers Group on the Forum

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,13 @@ Dimagi, the maker of CommCare, takes the security of our software products and s
 
 For more information about CommCare’s security policies, please visit the [Dimagi Trust Center](https://dimagi.safebase.us/).
 
+## Security update notifications
+
+If you host CommCare HQ yourself, request to join the
+[Maintainers group](https://forum.dimagi.com/g/maintainers) on the CommCare
+forum. Members are automatically subscribed to a private category where we
+post when a security update is available, ahead of the full advisory.
+
 ## Reporting a vulnerability
 
 Please report suspected security vulnerabilities **privately**. Do not open a


### PR DESCRIPTION
## Product Description
Adds a paragraph to SECURITY.md explaining to self hosters how they can subscribe to early security notifications. 

## Technical Summary
N/A

## Feature Flag
N/A

## Safety Assurance

### Safety story
N/A

### Automated test coverage
N/A

### QA Plan
N/A

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
