### PR TITLE
Add ProjectDB operations to datadog

### DIFF
--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -82,6 +82,7 @@ from corehq.apps.registry.exceptions import (
     RegistryNotFound,
 )
 from corehq.apps.registry.helper import DataRegistryHelper
+from corehq.util.metrics import metrics_histogram_timer
 from corehq.util.quickcache import quickcache
 from corehq.util.xml_utils import serialize
 
@@ -188,7 +189,12 @@ def get_project_db_fixture(domain, endpoint, config):
     user_sql = UserSQL(domain, endpoint.current_version.dangerous_sql)
     all_params = {c.key: c.value for c in config.criteria}
     query_params = {p: all_params.get(p) or None for p in user_sql.parameters}
-    result = user_sql.run(query_params, max_rows=CASE_SEARCH_MAX_RESULTS)
+    with metrics_histogram_timer(
+        'commcare.project_db.endpoint_query.duration',
+        timing_buckets=(.1, .5, 1, 2, 5, 10),
+        tags={'domain': domain, 'endpoint_id': str(endpoint.id)},
+    ):
+        result = user_sql.run(query_params, max_rows=CASE_SEARCH_MAX_RESULTS)
     return _rows_to_fixture(result.rows)
 
 

--- a/corehq/apps/project_db/populate.py
+++ b/corehq/apps/project_db/populate.py
@@ -11,17 +11,20 @@ from couchforms.geopoint import GeoPoint
 from dimagi.utils.chunked import chunked
 
 from corehq.apps.data_dictionary.models import CaseProperty
+from corehq.util.metrics import metrics_histogram_timer
 
 from .table_ddl import CaseTable, get_project_db_engine, property_column
 
 
 def send_cases_to_project_db(domain, cases):
     """Bulk upsert CommCareCases"""
-    cases_by_type = defaultdict(list)
-    for case in cases:
-        cases_by_type[case.type].append(case)
-    for case_type, case_type_cases in cases_by_type.items():
-        populate_case_type(domain, case_type, case_type_cases)
+    metric = 'commcare.project_db.populate.duration'
+    with metrics_histogram_timer(metric, timing_buckets=(.1, .5, 1, 2, 5), tags={'domain': domain}):
+        cases_by_type = defaultdict(list)
+        for case in cases:
+            cases_by_type[case.type].append(case)
+        for case_type, case_type_cases in cases_by_type.items():
+            populate_case_type(domain, case_type, case_type_cases)
 
 
 def populate_case_type(domain, case_type, cases):

--- a/corehq/apps/project_db/table_ddl.py
+++ b/corehq/apps/project_db/table_ddl.py
@@ -10,6 +10,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.types import UserDefinedType
 
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
+from corehq.util.metrics import metrics_histogram_timer
 from corehq.sql_db.connections import PROJECT_DB_ENGINE_ID, connection_manager
 
 MAX_IDENTIFIER_LENGTH = 63
@@ -199,11 +200,19 @@ class CaseTable:
 
 
 def create_or_update_project_db(domain):
-    metadata = sqlalchemy.MetaData()
+    with metrics_histogram_timer(
+        'commcare.project_db.schema_sync.duration',
+        timing_buckets=(.5, 1, 5, 20, 60),
+        tags={'domain': domain},
+    ):
+        _create_or_update_project_db(domain)
 
+
+def _create_or_update_project_db(domain):
     case_types = _get_case_types(domain)
     if not case_types:
         return
+    metadata = sqlalchemy.MetaData()
     case_tables = [
         CaseTable(domain, case_type).build_definition(metadata)
         for case_type in case_types

--- a/corehq/apps/project_db/tests/test_populate.py
+++ b/corehq/apps/project_db/tests/test_populate.py
@@ -23,6 +23,7 @@ from corehq.apps.project_db.table_ddl import (
     truncate_identifier,
 )
 from corehq.form_processor.models import CommCareCase
+from corehq.util.metrics.tests.utils import capture_metrics
 
 from .util import project_db_table
 
@@ -300,7 +301,8 @@ def test_populate_case_type_bad_type():
 def test_send_cases_to_project_db():
     domain = 'test-mixed'
     with project_db_table(domain, 'patient', {'first_name': 'plain'}), \
-         project_db_table(domain, 'clinic', {'city': 'plain'}):
+         project_db_table(domain, 'clinic', {'city': 'plain'}), \
+         capture_metrics() as metrics:
         send_cases_to_project_db(domain, [
             _make_case({'first_name': 'Alice'}, case_id='c1', type='patient'),
             _make_case({'city': 'Boston'}, case_id='c2', type='clinic'),
@@ -313,3 +315,4 @@ def test_send_cases_to_project_db():
 
     assert sorted(r['case_id'] for r in patients) == ['c1', 'c3']
     assert [r['case_id'] for r in clinics] == ['c2']
+    assert metrics.list('commcare.project_db.populate.duration', domain=domain), metrics

--- a/corehq/apps/project_db/tests/test_table_ddl.py
+++ b/corehq/apps/project_db/tests/test_table_ddl.py
@@ -18,6 +18,7 @@ from corehq.apps.project_db.table_ddl import (
     update_table,
 )
 from corehq.sql_db.connections import ConnectionManager
+from corehq.util.metrics.tests.utils import capture_metrics
 
 from .util import project_db_table
 
@@ -223,8 +224,12 @@ def test_create_project_db(get_dd_properties, get_case_types):
     get_case_types.return_value = ['patient']
     get_dd_properties.return_value = [
         ('nickname', 'plain'), ('dob', 'plain'), ('interests', 'select')]
-    create_or_update_project_db(domain)
+    with capture_metrics() as metrics:
+        create_or_update_project_db(domain)
     _assert_db_created_as_expected(schema.name)
+    assert metrics.list(
+        'commcare.project_db.schema_sync.duration.seconds', domain=domain
+    ), metrics
 
     # Drop nickname, make dob a date, add a new prop
     get_dd_properties.return_value = [('favorite_color', 'plain'), ('dob', 'date')]


### PR DESCRIPTION
## Product Description
no user-facing changes

## Technical Summary
Add a few metrics to datadog for key ProjectDB operations

## Feature Flag


## Safety Assurance


### Safety story


### Automated test coverage


### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
