### PR TITLE
Validate case search endpoint belongs to app domain

### DIFF
--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -31,6 +31,7 @@ from corehq.apps.app_manager.views.forms import (
     get_apps_modules,
 )
 from corehq.apps.builds.models import BuildSpec
+from corehq.apps.case_search.models import CaseSearchEndpoint
 from corehq.apps.domain.models import Domain
 from corehq.apps.es.apps import app_adapter
 from corehq.apps.es.tests.utils import es_test
@@ -780,6 +781,58 @@ class TestModuleViewsBase(ViewsBase):
 
 
 class TestEditModuleDetailScreens(TestModuleViewsBase):
+    def _post_case_search_endpoint(self, endpoint_id):
+        url = reverse('edit_module_detail_screens', kwargs={
+            'domain': self.app.domain,
+            'app_id': self.app.id,
+            'module_unique_id': self.module.unique_id,
+        })
+        return self.client.post(url, {
+            "type": "case",
+            "search_properties": json.dumps({
+                "properties": [{"name": "name", "label": "Name"}],
+                "default_properties": [],
+                "custom_sort_properties": [],
+                "case_search_endpoint_id": endpoint_id,
+            }),
+        })
+
+    @flag_enabled("CASE_SEARCH_ENDPOINTS")
+    def test_case_search_endpoint_in_domain(self):
+        endpoint = CaseSearchEndpoint.objects.create(domain=self.domain, name='mine')
+        self.addCleanup(endpoint.delete)
+
+        response = self._post_case_search_endpoint(endpoint.id)
+
+        assert response.status_code == 200
+        module = Application.get(self.app.id).get_module_by_unique_id(self.module.unique_id)
+        assert module.search_config.case_search_endpoint_id == endpoint.id
+
+    @flag_enabled("CASE_SEARCH_ENDPOINTS")
+    def test_case_search_endpoint_in_other_domain_is_rejected(self):
+        endpoint = CaseSearchEndpoint.objects.create(domain='other-domain', name='theirs')
+        self.addCleanup(endpoint.delete)
+
+        response = self._post_case_search_endpoint(endpoint.id)
+
+        assert response.status_code == 400
+
+    @flag_enabled("CASE_SEARCH_ENDPOINTS")
+    def test_inactive_case_search_endpoint_is_rejected(self):
+        endpoint = CaseSearchEndpoint.objects.create(
+            domain=self.domain, name='inactive', is_active=False)
+        self.addCleanup(endpoint.delete)
+
+        response = self._post_case_search_endpoint(endpoint.id)
+
+        assert response.status_code == 400
+
+    @flag_enabled("CASE_SEARCH_ENDPOINTS")
+    def test_non_numeric_case_search_endpoint_is_rejected(self):
+        response = self._post_case_search_endpoint("not-a-number")
+
+        assert response.status_code == 400
+
     def test_edit_module_detail_screens(self, *args):
         url = reverse('edit_module_detail_screens', kwargs={
             'domain': self.app.domain,

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -1246,7 +1246,9 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
     if fixture_select is not None:
         module.fixture_select = FixtureSelect.wrap(fixture_select)
 
-    _gather_and_update_search_properties(params, app, module, lang)
+    error_response = _gather_and_update_search_properties(params, app, module, lang)
+    if error_response:
+        return error_response
 
     resp = {}
     app.save(resp)
@@ -1359,11 +1361,18 @@ def _gather_and_update_search_properties(params, app, module, lang):
                 "'{}' is an invalid instance name. It can contain only letters, numbers, and underscores."
             ).format(instance_name))
 
+        case_search_endpoint_id = None
         if toggles.CASE_SEARCH_ENDPOINTS.enabled(app.domain):
             endpoint_id_raw = search_properties.get('case_search_endpoint_id')
-            case_search_endpoint_id = int(endpoint_id_raw) if endpoint_id_raw else None
-        else:
-            case_search_endpoint_id = None
+            if endpoint_id_raw:
+                try:
+                    case_search_endpoint_id = int(endpoint_id_raw)
+                except (TypeError, ValueError):
+                    return HttpResponseBadRequest(_("Invalid case search endpoint."))
+                if not CaseSearchEndpoint.objects.filter(
+                    id=case_search_endpoint_id, domain=app.domain, is_active=True
+                ).exists():
+                    return HttpResponseBadRequest(_("Invalid case search endpoint."))
 
         module.search_config = CaseSearch(
             title_label=title_label,


### PR DESCRIPTION
## Product Description

Add some validation to app manager case list. Selecting an illegal endpoint through the UI was already
not possible. This just guards agains malicious actors.

Errors will get passed through properly.

## Technical Summary

Two problems in `edit_module_detail_screens`:

## Feature Flag

CASE_SEARCH_ENDPOINTS

## Safety Assurance

### Safety story

Small, local change to one view. Low risk.

### Automated test coverage

Added test.

### QA Plan

QA is already under way

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
