### PR TITLE
Set default LIMIT on user SQL queries

### DIFF
--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -171,10 +171,10 @@ def get_endpoint_results(helper, config):
 
 
 def get_project_db_results(endpoint, helper, config):
-    user_sql = UserSQL(helper.domain, endpoint.current_version.dangerous_sql)
+    user_sql = UserSQL(helper.domain, endpoint.current_version.dangerous_sql, CASE_SEARCH_MAX_RESULTS)
     all_params = {c.key: c.value for c in config.criteria}
     query_params = {p: all_params.get(p) or None for p in user_sql.parameters}
-    result = user_sql.run(query_params, max_rows=CASE_SEARCH_MAX_RESULTS)
+    result = user_sql.run(query_params)
     return _rows_to_cases(result, helper.domain, config.case_types[0])
 
 

--- a/corehq/apps/project_db/tests/test_user_sql.py
+++ b/corehq/apps/project_db/tests/test_user_sql.py
@@ -314,7 +314,7 @@ def test_query_parameters_are_left_unbound():
 
 def _user_sql(sql):
     """A ``UserSQL`` over the test tables, with the domain lookup already done"""
-    user_sql = UserSQL('test-domain', sql)
+    user_sql = UserSQL('test-domain', sql, max_rows=None)
     with patch('corehq.apps.project_db.user_sql.get_domain_tables', return_value=TABLES):
         user_sql.query  # a cached_property, so the tables are resolved just once
     return user_sql
@@ -418,5 +418,13 @@ def test_run_reports_a_database_error():
     with patch('corehq.apps.project_db.user_sql.get_project_db_engine',
                return_value=engine):
         with pytest.raises(UserSQLProgrammingError) as error:
-            user_sql.run({}, max_rows=10)
+            user_sql.run({})
     assert msg in error.value.msg
+
+
+def test_max_rows_applies_limit():
+    user_sql = UserSQL('test-domain', 'SELECT name FROM client', max_rows=5)
+    with patch('corehq.apps.project_db.user_sql.get_domain_tables', return_value=TABLES):
+        actual = _compiled(user_sql.query)
+    expected = _compiled(select([CLIENT.c.name]).limit(_bind(5)))
+    assert actual == expected

--- a/corehq/apps/project_db/user_sql.py
+++ b/corehq/apps/project_db/user_sql.py
@@ -68,13 +68,18 @@ QueryResult = namedtuple('QueryResult', 'columns rows duration')
 
 
 class UserSQL:
-    def __init__(self, domain, raw_sql):
+    def __init__(self, domain, raw_sql, max_rows=100):
+        """Set max_rows to None to prevent a limit from being applied"""
         self.domain = domain
         self.raw_sql = raw_sql
+        self.max_rows = max_rows
 
     @cached_property
     def query(self):
-        return translate(self.raw_sql, get_domain_tables(self.domain))
+        q = translate(self.raw_sql, get_domain_tables(self.domain))
+        if self.max_rows is not None:
+            q = q.limit(_bind(self.max_rows))
+        return q
 
     @cached_property
     def _compiled(self):
@@ -97,7 +102,7 @@ class UserSQL:
         """Return the parameters a translated query leaves for the caller to supply"""
         return [name for name, bind in self._compiled.binds.items() if bind.required]
 
-    def run(self, parameter_values, max_rows):
+    def run(self, parameter_values):
         params = self._clean_parameters(parameter_values)
         with get_project_db_engine().connect() as conn:
             start = time.perf_counter()
@@ -105,7 +110,7 @@ class UserSQL:
                 result = conn.execute(self.query, params)
             except ProgrammingError as e:
                 raise UserSQLProgrammingError(str(e.orig)) from e
-            rows = result.fetchmany(max_rows)
+            rows = result.fetchall()
             return QueryResult(
                 columns=list(result.keys()),
                 rows=rows,

--- a/corehq/apps/project_db/views.py
+++ b/corehq/apps/project_db/views.py
@@ -50,11 +50,11 @@ class QueryProjectDBView(HqHtmxActionMixin, BaseProjectDataView):
             if name.startswith('param:')
         }
         context = {'max_rows': MAX_ROWS}
-        user_sql = UserSQL(self.domain, request.POST.get('sql', ''))
+        user_sql = UserSQL(self.domain, request.POST.get('sql', ''), MAX_ROWS)
         try:
             context['query'] = user_sql.get_info()
             if always_run or not user_sql.parameters:
-                context['result'] = user_sql.run(submitted_params, MAX_ROWS)
+                context['result'] = user_sql.run(submitted_params)
         except UserSQLValidationError as error:
             context['error'] = error.msg
         else:


### PR DESCRIPTION
## Product Description
Set default `LIMIT` on user SQL queries

<img width="400" alt="image" src="https://github.com/user-attachments/assets/4974fc65-e41e-4308-ac7a-b9dcf290feb6" />

## Technical Summary
Previously this used `fetchmany` to limit results returned, but that operates only in Python, and doesn't actually limit the size of the SQL query (shout out to @MartinRiese for identifying that).  Here I'm adding a limit to the query up-front.

This will require some reworking if/when we allow users to specify a `LIMIT` in their queries, but that is as-yet unsupported, so I'll cross that bridge when we get there.  Though I'd be interested to hear if anyone's got any good ideas about how to do that.  I'm guessing something where we inspect the query and add a limit if one isn't present, keep it if it is present, and error if it's present and above the feature-specified limit.  Might be tricky to do that with the way the code is currently structured though.

## Feature Flag
Project DB

## Safety Assurance


### Safety story


### Automated test coverage
yep

### QA Plan


### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
