### PR TITLE
Public Webforms: Shorten the one-time link texted to a respondent

### DIFF
--- a/corehq/apps/public_webforms/messaging.py
+++ b/corehq/apps/public_webforms/messaging.py
@@ -5,7 +5,11 @@ from django.utils.translation import gettext as _
 from dimagi.utils.web import get_static_url_prefix
 
 from corehq.apps.hqwebapp.tasks import send_html_email_async
+from corehq.apps.short_links.models import ShortLink
 from corehq.apps.sms.api import send_sms
+
+
+MAX_SMS_FORM_NAME_LENGTH = 45
 
 
 def send_one_time_link(session, form_name):
@@ -36,10 +40,20 @@ def _email_one_time_link(session, form_name):
 
 
 def _text_one_time_link(session, form_name):
+    domain = session.public_webform.domain
+    short_link = ShortLink.shorten(domain, session.one_time_link, expires_at=session.expires_at)
     send_sms(
-        session.public_webform.domain,
+        domain,
         None,  # the respondent is not a contact this project knows
         session.phone_number,
-        _("Your one-time link for {form_name} is: {url}").format(
-            form_name=form_name, url=session.one_time_link),
+        _("Your one-time link for {form_name}:\n{url}").format(
+            form_name=_truncate_for_sms(form_name),
+            url=short_link.short_url,
+        )
     )
+
+
+def _truncate_for_sms(form_name):
+    if len(form_name) <= MAX_SMS_FORM_NAME_LENGTH:
+        return form_name
+    return form_name[:MAX_SMS_FORM_NAME_LENGTH - 3] + '...'

--- a/corehq/apps/public_webforms/tests/test_messaging.py
+++ b/corehq/apps/public_webforms/tests/test_messaging.py
@@ -1,13 +1,24 @@
+import re
 from unittest import mock
 
+import pytest
 from unmagic import fixture, use
 
-from corehq.apps.public_webforms.messaging import send_one_time_link
+from corehq.apps.public_webforms.messaging import (
+    MAX_SMS_FORM_NAME_LENGTH,
+    _truncate_for_sms,
+    send_one_time_link,
+)
 from corehq.apps.public_webforms.tests.utils import (
     create_session,
     create_webform,
     webform_domain,
 )
+from corehq.apps.short_links.models import ShortLink
+
+
+def short_link_in(text):
+    return ShortLink.objects.get(code=re.search(r'/s/(\w+)', text).group(1))
 
 
 @fixture
@@ -48,4 +59,23 @@ class TestSendOneTimeLink:
         assert sms[1] is None  # the respondent is nobody this project knows
         assert sms[2] == '15551234567'
         assert "Test Form Name" in sms[3]
-        assert session.one_time_link in sms[3]
+        assert session.one_time_link not in sms[3]
+        assert short_link_in(sms[3]).target_url == session.one_time_link
+
+    def test_a_long_form_name_is_truncated_in_the_message(self):
+        session = create_session(create_webform(), phone_number='15551234567')
+
+        send_one_time_link(
+            session, "Maternal Health Screening and Follow-Up Visit Form")
+
+        sms = outbound().sms.call_args.args
+        assert "Maternal Health Screening and Follow-Up Vi..." in sms[3]
+
+
+@pytest.mark.parametrize('form_name, expected', [
+    ('Postnatal Visit', 'Postnatal Visit'),
+    ('M' * MAX_SMS_FORM_NAME_LENGTH, 'M' * MAX_SMS_FORM_NAME_LENGTH),
+    ('M' * (MAX_SMS_FORM_NAME_LENGTH + 1), 'M' * 42 + '...'),
+])
+def test_a_form_name_is_truncated_only_past_the_cap(form_name, expected):
+    assert _truncate_for_sms(form_name) == expected


### PR DESCRIPTION
## Product Description
Shortens the SMS message sent for a public webform from something like

```
Your one-time link for Registration For a Program With a Very Long Name is: https://www.commcarehq.org/webforms/1234567890abcdef1234567890abcdef/0987654321fedcba0987654321fedcba/
```

to

```
Your one-time link for Registration For a Program With a Very Lo...:
https://www.commcarehq.org/s/abcABC012345
```

## Technical Summary
Uses the `ShortLink` link shortener to shorten the link to complete a public webform, when sent by SMS. Also truncates the form name, to keep it to a relatively small message length.

## Feature Flag
`PUBLIC_WEBFORMS` and advanced plan privileges.

## Safety Assurance

### Safety story
This PR uses existing (pending approval) functionality for shortening links in HQ. Beyond that, it is essentially doing string operations, the only effect of which is to change the context of a single SMS message.

### Automated test coverage
Added tests for form name truncation - shortlink tests are in its own PR.

### QA Plan
Not for this change in particular.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
